### PR TITLE
Update the implementation plan for control flow collections

### DIFF
--- a/accepted/future-releases/control-flow-collections/implementation-plan.md
+++ b/accepted/future-releases/control-flow-collections/implementation-plan.md
@@ -66,9 +66,15 @@ for this.
 DDC may need to support canonicalizing constant collections with spread
 operators.
 
-### IntelliJ/Grok
+### IntelliJ
 
 Update the IntelliJ parser to support the new syntax.
+
+### Grok
+
+Update Grok to handle the new AST.
+
+### Analysis server
 
 Update to use the latest analyzer with support for the feature. There are a
 handful of usability features that would be nice.
@@ -148,6 +154,11 @@ Atom. This same grammar is also used for syntax highlighting on GitHub. Update
 this to handle the new syntax.
 
 [atom]: https://github.com/dart-atom/dart
+
+### VS Code
+
+Update the syntax highlighting grammer to support the control flow syntax (and,
+likely apply a very similar diff to the Atom grammer above).
 
 ### VM
 

--- a/accepted/future-releases/control-flow-collections/implementation-plan.md
+++ b/accepted/future-releases/control-flow-collections/implementation-plan.md
@@ -157,8 +157,8 @@ this to handle the new syntax.
 
 ### VS Code
 
-Update the syntax highlighting grammer to support the control flow syntax (and,
-likely apply a very similar diff to the Atom grammer above).
+Update the syntax highlighting grammar to support the control flow syntax (and,
+likely apply a very similar diff to the Atom grammar above).
 
 ### VM
 


### PR DESCRIPTION
- split the Grok work out from IntelliJ (they're pretty disjoint)
- refactor categories to call out where the work will happen
- also mention VS Code (its syntax highlighting grammar is based on the one from Atom; if one needs as update, they both will, and the files are similar enough that a fix into one can be used as the basis for a fix into the other)