### PR TITLE
Perform runtime checks on each element, key, and value when spreading.

### DIFF
--- a/accepted/future-releases/unified-collections/feature-specification.md
+++ b/accepted/future-releases/unified-collections/feature-specification.md
@@ -744,7 +744,8 @@ appropriately for the given collection type.
 
                 An implementation is free to execute the previous four
                 operations in any order, except that obviously the key must be
-                evaluated by its type is checked, and likewise for the value.
+                evaluated before its type is checked, and likewise for the
+                value.
 
                 1.  Append an entry *key*: *value* to *result*.
 

--- a/accepted/future-releases/unified-collections/feature-specification.md
+++ b/accepted/future-releases/unified-collections/feature-specification.md
@@ -736,6 +736,16 @@ appropriately for the given collection type.
 
                 1.  Evaluate `entry.value` to a value *value*.
 
+                1.  If *key* is not a subtype of the map's key type, throw a
+                    dynamic error.
+
+                1.  If *value* is not a subtype of the map's value type, throw a
+                    dynamic error.
+
+                An implementation is free to execute the previous four
+                operations in any order, except that obviously the key must be
+                evaluated by its type is checked, and likewise for the value.
+
                 1.  Append an entry *key*: *value* to *result*.
 
             1.  Else, if `hasValue` is `false`, exit the loop.
@@ -755,8 +765,12 @@ appropriately for the given collection type.
 
             1.  If `hasValue` is `true`:
 
-                1.  Evaluate `iterator.current` and append the result to
-                    *result*.
+                1.  Evaluate `iterator.current` to a value *value*.
+
+                1.  If *value* is not a subtype of the collection's element
+                    type, throw a dynamic error.
+
+                1.  Append *value* to *result*.
 
             1.  Else, if `hasValue` is `false`, exit the loop.
 


### PR DESCRIPTION
If you spread a collection whose static type is dynamic or where the
element types are supertypes of the collection literal's type, implicit
downcasts need to be inserted since they can fail, as in:

```dart
List<num> n = [1.2];
List<int> i = [...n];
```

Or:

```dart
dynamic d = {"s": 1};
Map<bool, double> m = {...d};
```

cc @nshahan @jmesserly @MichaelRFairhurst 