### PR TITLE
Update section "Constant Constructors"

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -3430,7 +3430,9 @@ Constant constructors have stronger constraints than other constructors.
 For instance, all the work of a non-redirecting generative constant constructor
 must be done in its initializers
 and in the initializing expressions of
-the instance variables of the enclosing class.%
+the instance variables of the enclosing class
+(and the latter may already have happened earlier,
+because those initializing expressions must be constant).%
 }
 
 \LMHash{}%
@@ -3449,15 +3451,18 @@ The above refers to both locally declared and inherited instance variables.%
 }
 
 \LMHash{}%
-If a non-redirecting generative constant constructor is declared by a class $C$,
+If a non-redirecting generative constant constructor $k$
+is declared by a class $C$,
 it is a compile-time error
 for an instance variable declared in $C$
 to have an initializing expression that is not a constant expression.
 
 \commentary{%
-A superclass of $C$ cannot have such an initializing expression either,
-because it must necessarily declare
-a non-redirecting generative constant constructor.%
+A superclass of $C$ cannot have such an initializing expression $e$ either.
+If it has a non-redirecting generative constant constructor
+then $e$ is an error,
+and if it does not have such a constructor
+then the (implicit or explicit) superinitializer in $k$ is an error.%
 }
 
 \LMHash{}%
@@ -5983,7 +5988,7 @@ The rules for identity make it impossible for a Dart programmer to observe wheth
 \commentary{%
 All usages of 'constant' in Dart are associated with compile time.
 A potentially constant expression is an expression that will generally yield
-a constant value when the value of certain parameters is given.
+a constant value when the values of certain parameters are given.
 The constant expressions is a subset of the potentially constant expressions
 that \emph{can} be evaluated at compile time.%
 }
@@ -6075,7 +6080,7 @@ not a constant expression (\ref{const}).
 that occurs in a constant context, is a potentially constant expression if $T$ is a constant type expression, and $e_1$, \ldots{} , $e_n$ are constant expressions.
 It is further a constant expression if the list literal evaluates to an object.
 
-\item A constant set literal (\ref{set}),
+\item A constant set literal (\ref{sets}),
 \code{\CONST{} <$T$>\{$e_1$, \ldots{}, $e_n$\}}, or
 \code{<$T$>\{$e_1$, \ldots{}, $e_n$\}}
 that occurs in a constant context, is a potentially constant expression if $T$ is a constant type expression, and $e_1$, \ldots{} , $e_n$ are constant expressions.
@@ -6382,11 +6387,18 @@ For instance:
 \end{dartCode}
 
 \commentary{
-The assignment to \code{x} is allowed under the assumption that \code{q} is constant (even though \code{q} is not, in general a compile-time constant).
+The assignment to \code{x} is allowed under the assumption
+that \code{q} is constant
+(even though \code{q} is not, in general a compile-time constant).
 The assignment to \code{y} is similar, but raises additional questions.
-In this case, the superexpression of \code{p} is \code{p + 100}, and it requires that \code{p} be a numeric constant expression for the entire expression to be considered constant.
-The wording of the specification allows us to assume that \code{p} evaluates to an integer.
-A similar argument holds for \code{p} and \code{q} in the assignment to \code{z}.
+In this case, the superexpression of \code{p} is \code{p + 100},
+and it requires that \code{p} be a numeric constant expression
+for the entire expression to be considered constant.
+The wording of the specification allows us to assume
+that \code{p} evaluates to an integer,
+for an invocation of this constructor in a constant expression.
+A similar argument holds for \code{p} and \code{q}
+in the assignment to \code{z}.
 
 However, the following constructors are disallowed:
 }
@@ -6410,10 +6422,15 @@ constant expressions.%
 }
 
 \rationale{%
-All of the illegal constructors of \code{D} above could not be sensibly invoked via \NEW{}, because an expression that must be constant cannot depend on a formal parameter, which may or may not be constant.
-In contrast, the legal examples make sense regardless of whether the constructor is invoked via \CONST{} or via \NEW{}.
+All of the illegal constructors of \code{D} above
+could not be sensibly invoked via \NEW{},
+because an expression that must be constant cannot depend on
+a formal parameter, which may or may not be constant.
+In contrast, the legal examples make sense regardless of
+whether the constructor is invoked via \CONST{} or via \NEW{}.
 
-Careful readers will of course worry about cases where the actual arguments to \code{C()} are constants, but are not numeric.
+Careful readers will of course worry about cases where
+the actual arguments to \code{C()} are constants, but are not numeric.
 This is precluded by the rules on constant constructors
 (\ref{constantConstructors}),
 combined with the rules for evaluating constant objects (\ref{const}).%

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -3420,89 +3420,54 @@ A constant constructor is prefixed by the reserved word \CONST{}.
 <constantConstructorSignature> ::= \CONST{} <qualified> <formalParameterList>
 \end{grammar}
 
-%\commentary{Spell out subtleties: a constant constructor call within the initializer of a constant constructor is treated as a ordinary constructor call (a new), because the arguments cannot be assumed constant anymore. In practice, this means two versions are compiled and analyzed. One for new and one for const.}
-
-\commentary{
-All the work of a constant constructor must be handled via its initializers.
+\commentary{%
+Constant constructors have stronger constraints than other constructors.
+For instance, all the work of a non-redirecting generative constant constructor
+must be done in its initializers
+and in the initializing expressions of
+the instance variables of the enclosing class.%
 }
 
 \LMHash{}%
-It is a compile-time error if a constant constructor is declared by a class that has a mutable instance variable.
+Constant redirecting generative and factory constructors are specified elsewhere
+(p.\,\pageref{redirectingGenerativeConstructors},
+p.\,\pageref{redirectingFactoryConstructors}).
+This section is henceforth concerned with
+non-redirecting generative constant constructors.
 
-\commentary{
-The above refers to both locally declared and inherited instance variables.
+\LMHash{}%
+It is a compile-time error if a non-redirecting generative constant constructor
+is declared by a class that has a mutable instance variable.
+
+\commentary{%
+The above refers to both locally declared and inherited instance variables.%
 }
 
 \LMHash{}%
-It is a compile-time error if a constant constructor is declared by a class $C$ if any instance variable declared in $C$ is initialized with an expression that is not a constant expression.
+If a non-redirecting generative constant constructor is declared by a class $C$,
+it is a compile-time error
+for an instance variable declared in $C$
+to have an initializing expression that is not a constant expression.
 
-\commentary{
-A superclass of $C$ cannot declare such an initializer either, because it must necessarily declare constant constructor as well (unless it is \code{Object}, which declares no instance variables).
+\commentary{%
+A superclass of $C$ cannot have such an initializing expression either,
+because it must necessarily declare
+a non-redirecting generative constant constructor.%
 }
 
 \LMHash{}%
-The superinitializer that appears, explicitly or implicitly, in the initializer list of a constant constructor must specify a constant constructor of the superclass of the immediately enclosing class or a compile-time error occurs.
+The superinitializer that appears, explicitly or implicitly, 
+in the initializer list of a constant constructor
+must specify a constant constructor of
+the superclass of the immediately enclosing class,
+or a compile-time error occurs.
 
 \LMHash{}%
-Any expression that appears within the initializer list of a constant constructor must be a potentially constant expression, or a compile-time error occurs.
-
-\LMHash{}%
-A \Index{potentially constant expression} is an expression $e$ that could be a valid constant expression if all formal parameters of $e$'s immediately enclosing constant constructor were treated as compile-time constants of appropriate types, and where $e$ is also a valid expression if all the formal parameters are treated as non-constant variables.
-
-\commentary{
-The difference between a potentially constant expression and a constant expression (\ref{const}) deserves some explanation.
-
-The key issue is how one treats the formal parameters of a constructor.
-
-If a constant constructor is invoked from a constant object expression, the actual arguments will be required to be constant expressions.
-Therefore, if we were assured that constant constructors were always invoked from constant object expressions, we could assume that the formal parameters of a constructor were compile-time constants.
-
-However, constant constructors can also be invoked from ordinary instance creation expressions (\ref{new}), and so the above assumption is not generally valid.
-
-Nevertheless, the use of the formal parameters of a constant constructor within the constructor is of considerable utility.
-The concept of potentially constant expressions is introduced to facilitate limited use of such formal parameters.
-Specifically, we allow the usage of the formal parameters of a constant constructor for expressions that involve built-in operators, but not for constant objects, lists and maps.
-This allows for constructors such as:
-}
-
-\begin{dartCode}
-\CLASS{} C \{
-  \FINAL{} x; \FINAL{} y; \FINAL{} z;
-  \CONST{} C(p, q): x = q, y = p + 100, z = p + q;
-\}
-\end{dartCode}
-
-\commentary{
-The assignment to \code{x} is allowed under the assumption that \code{q} is constant (even though \code{q} is not, in general a compile-time constant).
-The assignment to \code{y} is similar, but raises additional questions.
-In this case, the superexpression of \code{p} is \code{p + 100}, and it requires that \code{p} be a numeric constant expression for the entire expression to be considered constant.
-The wording of the specification allows us to assume that \code{p} evaluates to an integer.
-A similar argument holds for \code{p} and \code{q} in the assignment to \code{z}.
-
-However, the following constructors are disallowed:
-}
-
-\begin{dartCode}
-\CLASS{} D \{
-  \FINAL{} w;
-  \CONST{} D.makeList(p): w = \CONST{} [p]; // \comment{compile-time error}
-  \CONST{} D.makeMap(p): w = \CONST{} \{"help": q\}; // \comment{compile-time error}
-  \CONST{} D.makeC(p): w = \CONST{} C(p, 12); // \comment{compile-time error}
-\}
-\end{dartCode}
-
-\commentary{
-The problem is not that the assignments to \code{w} are not potentially constant; they are.
-However, all these run afoul of the rules for constant lists (\ref{lists}), maps (\ref{maps}) and objects (\ref{const}), all of which independently require their subexpressions to be constant expressions.
-}
-
-\rationale{
-All of the illegal constructors of \code{D} above could not be sensibly invoked via \NEW{}, because an expression that must be constant cannot depend on a formal parameter, which may or may not be constant.
-In contrast, the legal examples make sense regardless of whether the constructor is invoked via \CONST{} or via \NEW{}.
-
-Careful readers will of course worry about cases where the actual arguments to \code{C()} are constants, but are not numeric.
-This is precluded by the following rule, combined with the rules for evaluating constant objects (\ref{const}).
-}
+Any expression that appears within
+the initializer list of a constant constructor
+must be a potentially constant expression
+(\ref{constants}),
+or a compile-time error occurs.
 
 \LMHash{}%
 When a constant constructor $k$ is invoked from a constant object expression,
@@ -5909,6 +5874,16 @@ Every object has an associated dynamic type (\ref{dynamicTypeSystem}).
   \alt <newExpression>
   \alt <constObjectExpression>
   \alt `(' <expression> `)'
+
+<literal> ::= <nullLiteral>
+  \alt <booleanLiteral>
+  \alt <numericLiteral>
+  \alt <stringLiteral>
+  \alt <symbolLiteral>
+  \alt <mapLiteral>
+  \alt <setLiteral>
+  \alt <setOrMapLiteral>
+  \alt <listLiteral>
 \end{grammar}
 
 \LMHash{}%
@@ -6000,19 +5975,23 @@ The rules for identity make it impossible for a Dart programmer to observe wheth
 \subsection{Constants}
 \LMLabel{constants}
 
-\commentary{
-All usages of the word 'constant' in Dart are associated with compile time.
+\commentary{%
+All usages of 'constant' in Dart are associated with compile time.
 A potentially constant expression is an expression that will generally yield
 a constant value when the value of certain parameters is given.
 The constant expressions is a subset of the potentially constant expressions
-that \emph{can} be evaluated entirely at compile time.
+that \emph{can} be evaluated at compile time.%
 }
 
 \rationale{
 The constant expressions are restricted to expressions that
-perform only simple arithmetic operations, boolean conditions, and string and instance creation.
-No user written function body is executed during constant expression evaluation,
-only members of the system classes \code{int}, \code{double}, \code{bool}, \code{String} or \code{Null}.
+perform only simple arithmetic operations, boolean conditions,
+and string and instance creation.
+No user-written function body is executed
+during constant expression evaluation,
+only members of the system classes
+\code{Object}, \code{bool}, \code{int}, \code{double},
+\code{String}, \code{Type}, \code{Symbol}, or \code{Null}.
 }
 
 \LMHash{}%
@@ -6034,7 +6013,8 @@ are the following:
   if $e_1$, \ldots{}, $e_n$ are potentially constant expressions.
   The literal is further a constant expression
   if $e_1$, \ldots{}, $e_n$ are constant expressions
-  evaluating to instances of \code{int}, \code{double} \code{String}, \code{bool} or \code{Null}.
+  evaluating to instances of \code{int}, \code{double},
+  \code{String}, \code{bool}, or \code{Null}.
 \commentary{These requirements hold trivially if there are no interpolations in the string}.
 \rationale{It would be tempting to allow string interpolation where the
 interpolated value is any compile-time constant. However, this would require
@@ -6189,7 +6169,7 @@ It is further a constant expression if the map literal evaluates to an object.
   evaluates to an instance of \code{String}.
 
 % New in 2.1.
-\item An expression of the form \code{$e$ as $T$} is potentially constant
+\item An expression of the form \code{$e$\,\,as\,\,$T$} is potentially constant
   if $e$ is a potentially constant expression
   and $T$ is a constant type expression,
   and it is further constant if $e$ is constant.
@@ -6200,15 +6180,15 @@ if $e$ evaluates to an object which is not the null object and not of type $T$.
 }
 
 % New in 2.1.
-\item An expression of the form \code{$e$ is $T$} is potentially constant
+\item An expression of the form \code{$e$\,\,is\,\,$T$} is potentially constant
   if $e$ is a potentially constant expression
   and $T$ is a constant type expression,
   and it is further constant if $e$ is constant.
 
 % New in 2.1.
 \item{}
-  An expression of the form \code{$e$ is! $T$}
-  is equivalent to \code{!($e$ is $T$)} in every way,
+  An expression of the form \code{$e$\,\,is!\,\,$T$}
+  is equivalent to \code{!($e$\,\,is\,\,$T$)} in every way,
   including whether it's potentially constant or constant.
 \end{itemize}
 
@@ -6253,23 +6233,52 @@ is one of:
 % If that happens in a const invociation, it's a compile-time error.
 
 \LMHash{}%
-It is a compile-time error if an expression is required to be a constant expression but its evaluation would throw an exception.
-It is a compile-time error if an assertion is evaluated as part of a constant object expression evaluation, and the assertion would throw an exception.
+It is a compile-time error if an expression is required to be a constant expression,
+but its evaluation would throw an exception.
+It is a compile-time error if an assertion is evaluated as part of a constant object expression evaluation,
+and the assertion would throw an exception.
+
+\LMHash{}%
+It is a compile-time error if the value of a constant expression
+depends on itself.
 
 \commentary{
-Note that there is no requirement that every constant expression evaluate correctly.
+As an example, consider:
+}
+
+\begin{dartCode}
+\CLASS{} CircularConsts \{
+  // \comment{Illegal program - mutually recursive compile-time constants}
+  \STATIC{} \CONST{} i = j; // \comment{a compile-time constant}
+  \STATIC{} \CONST{} j = i; // \comment{a compile-time constant}
+\}
+\end{dartCode}
+
+
+\subsubsection{Further Remarks on Constants and Potential Constants}
+\LMLabel{furtherCommentsOnConstantsAndPotentiallyConstants}
+
+\rationale{%
+There is no requirement that
+every constant expression evaluate correctly.
 Only when a constant expression is required
 (e.g., to initialize a constant variable,
 or as a default value of a formal parameter,
 or as metadata)
 do we insist that a constant expression actually
-be evaluated successfully at compile time.
+be evaluated successfully at compile time.%
+}
 
+\commentary{%
 The above is not dependent on program control-flow.
-The mere presence of a required compile-time constant whose evaluation would fail within a program is an error.
-This also holds recursively: since compound constants are composed out of constants, if any subpart of a constant would throw an exception when evaluated, that is an error.
-
-On the other hand, since implementations are free to compile code late, some compile-time errors may manifest quite late.
+The mere presence of a required compile-time constant
+whose evaluation would fail within a program is an error.
+This also holds recursively:
+since compound constants are composed out of constants,
+if any subpart of a constant would throw an exception when evaluated,
+that is an error.
+On the other hand, since implementations are free to compile code late,
+some compile-time errors may manifest quite late:%
 }
 
 \begin{dartCode}
@@ -6290,66 +6299,120 @@ On the other hand, since implementations are free to compile code late, some com
 \}
 \end{dartCode}
 
-\commentary{
-An implementation is free to immediately issue a compilation error for \code{x}, but it is not required to do so.
-It could defer errors if it does not immediately compile the declarations that reference \code{x}.
-For example, it could delay giving a compilation error about the method \code{m1} until the first invocation of \code{m1}.
-However, it could not choose to execute \code{m1}, see that the branch that refers to \code{x} is not taken and return 2 successfully.
+\commentary{%
+An implementation is free to immediately issue a compilation error for \code{x},
+but it is not required to do so.
+It could defer errors if it does not immediately compile
+the declarations that reference \code{x}.
+For example, it could delay giving a compilation error
+about the method \code{m1} until the first invocation of \code{m1}.
+However, it could not choose to execute \code{m1},
+see that the branch that refers to \code{x} is not taken,
+and return 2 successfully.
 
-The situation with respect to an invocation \code{m2} is different.
-Because \code{y} is not a compile-time constant (even though its value is), one need not give a compile-time error upon compiling \code{m2}.
-An implementation may run the code, which will cause the getter for \code{y} to be invoked.
-At that point, the initialization of \code{y} must take place, which requires the initializer to be compiled, which will cause a compilation error.
+The situation with respect to an invocation of \code{m2} is different.
+Because \code{y} is not a compile-time constant (even though its value is),
+one need not give a compile-time error upon compiling \code{m2}.
+An implementation may run the code,
+which will cause the getter for \code{y} to be invoked.
+At that point, the initialization of \code{y} must take place,
+which requires the initializer to be compiled,
+which will cause a compilation error.%
 }
 
-\rationale{
+\rationale{%
 The treatment of \code{\NULL{}} merits some discussion.
 Consider \code{\NULL{} + 2}.
 This expression always causes an error.
 We could have chosen not to treat it as a constant expression (and in general, not to allow \code{\NULL{}} as a subexpression of numeric or boolean constant expressions).
 There are two arguments for including it:
-\begin{enumerate}
-\item It is constant.
-We can evaluate it at compile time.
-\item It seems more useful to give the error stemming from the evaluation explicitly.
-\end{enumerate}
+First, it is constant so we \emph{can} evaluate it at compile time.
+Second, it seems more useful to give
+the error stemming from the evaluation explicitly.%
 }
 
 \rationale{
-One might reasonably ask why $e_1$\,?\,$e_1$\,:\,$e_3$ and $e_1$\,??\,$e_2$ have constant forms.
-For example, if $e_1$ is known statically, why do we need to test it?
-The answer is that there are contexts where $e_1$ is a variable.
-In particular, constant constructor initializers such as
-
-\code{\CONST{} C(foo): \THIS.foo = foo ?? someDefaultValue;}
+One might reasonably ask why
+$e_1$\,?\,\,$e_2$\,:\,$e_3$ and $e_1$\,??\,\,$e_2$
+have constant forms.
+If $e_1$ is known statically, why do we need to test it?
+The answer is that there are contexts where $e_1$ is a variable,
+e.g., in constant constructor initializers such as
+\code{\CONST{} C(foo):\ \THIS.foo = foo ??\ someDefaultValue;}
 }
 
-\LMHash{}%
-It is a compile-time error if the value of a constant expression depends on itself.
-
 \commentary{
-As an example, consider:
+The difference between
+a potentially constant expression and a constant expression
+deserves some explanation.
+The key issue is how one treats the formal parameters of a constructor.
+
+If a constant constructor is invoked from a constant object expression,
+the actual arguments will be required to be constant expressions.
+Therefore, if we were assured that
+constant constructors were always invoked from constant object expressions,
+we could assume that the formal parameters of a constructor were
+compile-time constants.
+
+However, constant constructors can also be invoked from
+ordinary instance creation expressions (\ref{new}),
+and so the above assumption is not generally valid.
+
+Nevertheless, the use of the formal parameters of a constant constructor
+is of considerable utility.
+The concept of potentially constant expressions is introduced to facilitate
+limited use of such formal parameters.
+Specifically, we allow the usage of
+the formal parameters of a constant constructor
+for expressions that involve built-in operators,
+but not for constant objects, lists and maps.
+For instance:
 }
 
 \begin{dartCode}
-\CLASS{} CircularConsts \{
-  // \comment{Illegal program - mutually recursive compile-time constants}
-  \STATIC{} \CONST{} i = j; // \comment{a compile-time constant}
-  \STATIC{} \CONST{} j = i; // \comment{a compile-time constant}
+\CLASS{} C \{
+  \FINAL{} x, y, z;
+  \CONST{} C(p, q): x = q, y = p + 100, z = p + q;
 \}
 \end{dartCode}
 
-\begin{grammar}
-<literal> ::= <nullLiteral>
-  \alt <booleanLiteral>
-  \alt <numericLiteral>
-  \alt <stringLiteral>
-  \alt <symbolLiteral>
-  \alt <mapLiteral>
-  \alt <setLiteral>
-  \alt <setOrMapLiteral>
-  \alt <listLiteral>
-\end{grammar}
+\commentary{
+The assignment to \code{x} is allowed under the assumption that \code{q} is constant (even though \code{q} is not, in general a compile-time constant).
+The assignment to \code{y} is similar, but raises additional questions.
+In this case, the superexpression of \code{p} is \code{p + 100}, and it requires that \code{p} be a numeric constant expression for the entire expression to be considered constant.
+The wording of the specification allows us to assume that \code{p} evaluates to an integer.
+A similar argument holds for \code{p} and \code{q} in the assignment to \code{z}.
+
+However, the following constructors are disallowed:
+}
+
+\begin{dartCode}
+\CLASS{} D \{
+  \FINAL{} w;
+  \CONST{} D.makeList(p): w = \CONST{} [p]; // \comment{compile-time error}
+  \CONST{} D.makeMap(p): w = \CONST{} \{"help": q\}; // \comment{compile-time error}
+  \CONST{} D.makeC(p): w = \CONST{} C(p, 12); // \comment{compile-time error}
+\}
+\end{dartCode}
+
+\commentary{%
+The problem is that all these run afoul of the rules for
+constant lists (\ref{lists}),
+maps (\ref{maps}),
+and objects (\ref{const}),
+all of which independently require their subexpressions to be
+constant expressions.%
+}
+
+\rationale{%
+All of the illegal constructors of \code{D} above could not be sensibly invoked via \NEW{}, because an expression that must be constant cannot depend on a formal parameter, which may or may not be constant.
+In contrast, the legal examples make sense regardless of whether the constructor is invoked via \CONST{} or via \NEW{}.
+
+Careful readers will of course worry about cases where the actual arguments to \code{C()} are constants, but are not numeric.
+This is precluded by the rules on constant constructors
+(\ref{constantConstructors}),
+combined with the rules for evaluating constant objects (\ref{const}).%
+}
 
 
 \subsubsection{Constant Contexts}

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -30,6 +30,9 @@
 % 2.3
 % - Added requirement that the iterator of a for-in statement must have
 %   type `Iterator`.
+% - Clarified which constructors are covered by the section 'Constant
+%   Constructors' and removed confusing redundancy in definiton of
+%   potentially constant expressions.
 %
 % 2.2
 % - Specify whether the values of literal expressions override Object.==.
@@ -42,6 +45,8 @@
 %   Function.
 % - Generalize specification of type aliases such that they can denote any
 %   type, not just function types.
+% - Clarify that 'Constant Constructors' is concerned with non-redirecting
+%   generative constructors only.
 %
 % 2.1
 % - Remove 64-bit constraint on integer literals compiled to JavaScript numbers.


### PR DESCRIPTION
This CL updates the language specification section 'Constant Constructors' to cover the right kinds of constructors only, and moves a long commentary on potentially constant expressions to the section 'Constants' where potentially constant expressions are defined. This resolves #289.

Note that the grammar rule for `<literal>` was also moved as well: From 'Constants' (where there was no justification for having it) to just before the rule for `<primary>`, which is the place where `<literal>` occurs in the grammar. The individual kinds of literals (such as `<booleanLiteral>` and `<setLiteral>`) have always been defined elsewhere, each in their own section on the associated kind of object.