### PR TITLE
Clarify implementation step for validating codegen

### DIFF
--- a/templates/implementation_meta_issue.txt
+++ b/templates/implementation_meta_issue.txt
@@ -23,9 +23,8 @@ The implementation plan for this issue is <link to implementation plan>.
 - [ ] Issue for implementation in Cider:
 - [ ] Issue for implementation in Dartfmt:
 - [ ] Issue for implementation in Dartdoc:
-- [ ] Issue for implementation in Angular compiler:
+- [ ] Issue for implementation in build systems and Angular compiler:
 - [ ] Issue for language tests:
 - [ ] Issue for documentation:
 - [ ] Issue for specification:
 - [ ] Issue for code cleanup:
-- [ ] Issue for validating behavior of codegen:

--- a/templates/implementation_meta_issue.txt
+++ b/templates/implementation_meta_issue.txt
@@ -28,3 +28,4 @@ The implementation plan for this issue is <link to implementation plan>.
 - [ ] Issue for documentation:
 - [ ] Issue for specification:
 - [ ] Issue for code cleanup:
+- [ ] Issue for validating behavior of codegen:


### PR DESCRIPTION
We need to make sure that the build systems which use the analyzer to
resolve code work correctly with the new feature - if it requires adding
a flag when we construct the `AnalysisDriver` we need to know about it.