### PR TITLE
Removed --enable-experiment flag for non-function type aliases

### DIFF
--- a/accepted/future-releases/generalized-typedef-2018/implementation-plan.md
+++ b/accepted/future-releases/generalized-typedef-2018/implementation-plan.md
@@ -7,20 +7,10 @@ Relevant documents:
 ## Implementation and Release plan
 
 This feature is non-breaking, because it is concerned with the introduction of
-support for new syntactic forms.
-Still, we will introduce it using an
-[experiments flag](https://github.com/dart-lang/sdk/blob/master/docs/process/experimental-flags.md)
-in order to enable a controlled deployment.
-
+support for new syntactic forms. 
+Hence, there is no `--enable-experiment` flag for it.
 
 ### Phase 0 (Preliminaries)
-
-#### Release Flag
-
-The flag
-`--enable-experiment=nonfunction-type-aliases`
-must be passed for the changes to be enabled.
-In this phase, support for that flag is added to all tools.
 
 #### Tests
 


### PR DESCRIPTION
Cf. discussion by email 'Re: New DartK crash on 2 co19 tests': This CL removes the 'nonfunction-type-aliases' flag from the [implementation plan](https://github.com/dart-lang/language/blob/master/accepted/future-releases/generalized-typedef-2018/implementation-plan.md#release-flag).

The intention is that we use this issue to clarify whether we will have that flag. It is not currently implemented by the vm nor by the analyzer, but it is mentioned in some co19 tests, e.g., [this one](https://github.com/dart-lang/co19/blob/3755b2251b57dc216bc45c9a572896cad4f9152d/Language/Types/Type_Aliases/syntax_t01.dart#L17).

If we wish to have the flag then we just drop this CL and tools should then have it; if we wish to remove the flag then we land this CL.