### PR TITLE
Correct and clarify potentially non-nullable definition

### DIFF
--- a/accepted/future-releases/nnbd/feature-specification.md
+++ b/accepted/future-releases/nnbd/feature-specification.md
@@ -129,9 +129,10 @@ We say that a type `T` is **potentially nullable** if `T` is not non-nullable.
 Note that this is different from saying that `T` is nullable.  For example, a
 type variable `X extends Object?` is a type which is potentially nullable but
 not nullable.  Note that `T*` is potentially nullable by this definition if `T`
-is potentially nullable.  The potentially nullable types include all of the
-types which are either definitely nullable, potentially instantiable to a
-nullable type, or which may be migrated to a nullable type.
+is potentially nullable - so `int*` is not potentially nullable, but `X*` where
+`X extends int?` is.  The potentially nullable types include all of the types
+which are either definitely nullable, potentially instantiable to a nullable
+type, or for which any migration results in a potentially nullable type.
 
 We say that a type `T` is **potentially non-nullable** if `T` is not nullable.
 Note that this is different from saying that `T` is non-nullable.  For example,

--- a/accepted/future-releases/nnbd/feature-specification.md
+++ b/accepted/future-releases/nnbd/feature-specification.md
@@ -103,15 +103,23 @@ This is equivalent to the syntactic criterion that `T` is any of:
   - `dynamic`
   - `void`
 
+Nullable types are types which are definitively known to be nullable, regardless
+of instantiation of type variables, and regardless of any choice of replacement
+for the `*` positions (with `?` or nothing).
+
 We say that a type `T` is **non-nullable** if `T <: Object`.
 This is equivalent to the syntactic criterion that `T` is any of:
   - `Never`
   - Any function type (including `Function`)
-  - Any interface type except `dynamic`, `void`, and `Null`.
+  - Any interface type except `Null`.
   - `S*` for some `S` where `S` is non-nullable
   - `FutureOr<S>` where `S` is non-nullable
   - `X extends S` where `S` is non-nullable
   - `X & S` where `S` is non-nullable
+
+Non-nullable types are types which are either definitively known to be
+non-nullable regardless of instantiation of type variables, or for which
+replacing the `*` positions with nothing will result in a non-nullable type.
 
 Note that there are types which are neither nullable nor non-nullable.  For
 example `X extends T` where `T` is nullable is neither nullable nor
@@ -121,7 +129,9 @@ We say that a type `T` is **potentially nullable** if `T` is not non-nullable.
 Note that this is different from saying that `T` is nullable.  For example, a
 type variable `X extends Object?` is a type which is potentially nullable but
 not nullable.  Note that `T*` is potentially nullable by this definition if `T`
-is potentially nullable.
+is potentially nullable.  The potentially nullable types include all of the
+types which are either definitely nullable, potentially instantiable to a
+nullable type, or which may be migrated to a nullable type.
 
 We say that a type `T` is **potentially non-nullable** if `T` is not nullable.
 Note that this is different from saying that `T` is non-nullable.  For example,
@@ -164,8 +174,11 @@ bound to an argument at a call site.
 It is an error to call the default `List` constructor with a length argument and
 a type argument which is potentially non-nullable.
 
-For the purposes of errors and warnings, the null aware operators `?.` and `?..`
-are checked as if the receiver of the operator had non-nullable type.
+For the purposes of errors and warnings, the null aware operators `?.`, `?..`,
+and `?.[]` are checked as if the receiver of the operator had non-nullable type.
+More specifically, if the type of the receiver of a null aware operator is `T`,
+then the operator is checked as if the receiver had type **NonNull**(`T`) (see
+definition below).
 
 It is an error for a class to extend, implement, or mixin a type of the form
 `T?` for any `T`.

--- a/accepted/future-releases/nnbd/feature-specification.md
+++ b/accepted/future-releases/nnbd/feature-specification.md
@@ -94,8 +94,8 @@ library section below.
 
 ### Static errors
 
-We say that a type `T` is **nullable** if `Null <: T`.  This is equivalent to
-the syntactic criterion that `T` is any of:
+We say that a type `T` is **nullable** if `Null <: T` and not `T <: Object`.
+This is equivalent to the syntactic criterion that `T` is any of:
   - `Null`
   - `S?` for some `S`
   - `S*` for some `S` where `S` is nullable
@@ -103,11 +103,12 @@ the syntactic criterion that `T` is any of:
   - `dynamic`
   - `void`
 
-We say that a type `T` is **non-nullable** if `T <: Object`.  This is equivalent
-to the syntactic criterion that `T` is any of:
-  - `Object`, `int`, `bool`, `Never`, `Function`
-  - Any function type
-  - Any class type or generic class type
+We say that a type `T` is **non-nullable** if `T <: Object`.
+This is equivalent to the syntactic criterion that `T` is any of:
+  - `Never`
+  - Any function type (including `Function`)
+  - Any interface type except `dynamic`, `void`, and `Null`.
+  - `S*` for some `S` where `S` is non-nullable
   - `FutureOr<S>` where `S` is non-nullable
   - `X extends S` where `S` is non-nullable
   - `X & S` where `S` is non-nullable
@@ -119,7 +120,8 @@ non-nullable.
 We say that a type `T` is **potentially nullable** if `T` is not non-nullable.
 Note that this is different from saying that `T` is nullable.  For example, a
 type variable `X extends Object?` is a type which is potentially nullable but
-not nullable.  Note that `T*` is always potentially nullable by this definition.
+not nullable.  Note that `T*` is potentially nullable by this definition if `T`
+is potentially nullable.
 
 We say that a type `T` is **potentially non-nullable** if `T` is not nullable.
 Note that this is different from saying that `T` is non-nullable.  For example,

--- a/resources/type-system/subtyping.md
+++ b/resources/type-system/subtyping.md
@@ -141,6 +141,9 @@ We say that a type `T0` is a subtype of a type `T1` (written `T0 <: T1`) when:
 - **Right Top**: if `T1` is a top type (i.e. `dynamic`, or `void`, or `Object?`)
   then `T0 <: T1`
 
+- **Left Top**: if `T0` is `dynamic` or `void`
+  then `T0 <: T1` if `Object? <: T1`
+
 - **Left Bottom**: if `T0` is `Never` then `T0 <: T1`
 
 - **Right Object**: if `T1` is `Object` then:
@@ -149,6 +152,7 @@ We say that a type `T0` is a subtype of a type `T1` (written `T0 <: T1`) when:
     - if `T0` is a promoted type variable `X & S` then `T0 <: T1` iff `S <:
       Object`
     - if `T0` is `FutureOr<S>` for some `S`, then `T0 <: T1` iff `S <: Object`.
+    - if `T0` is `S*` for any `S`, then `T0 <: T1` iff `S <: T1`
     - if `T0` is `Null`, `dynamic`, `void`, or `S?` for any `S`, then the
       subtyping does not hold (per above, the result of the subtyping query is
       false).
@@ -624,7 +628,6 @@ instances of `X & T`, `T <: S` will be true, and hence `S <: M => T <: M`.
       turn requires that `Null <: X`.
 
 **Observation 4**: The following are derivable for any `T`:
-  - `T*` <: `Object`, since it suffices to show that `T <: Object`.
   - `Null <: T?`, since it suffices to show that `Null <: Null`
   - `Null <: T*`, since it suffices to show that `Null <: T?`
 
@@ -661,9 +664,9 @@ If `T1` is `Object`:
   - If `T0` is `Null`, `dynamic`, `void`, or `S?` for any `S`, the query is
     false.
     - By Observation 3 above
+  - If `T0` is `S*` for any `S`, the query is true iff `S <: Object` by lemma 3.
   - Otherwise the query is true.
-    - In this case, `T0` must be `Object`, a function type, interface type, or
-      of the form `S*` for some `S` in which case Observation 4 applies.
+    - In this case, `T0` must be `Object`, a function type, or interface type. 
 
 #### `Null` 
 


### PR DESCRIPTION
Adding the constraint that to be considered nullable, a type `T` must not be a subtype of `Object` (in other words, not a * of a nullable type).

Also adding S* to the syntactic list of non-nullable types, as implied by the semantic definition.