### PR TITLE
Typo correction

### DIFF
--- a/accepted/future-releases/static-extension-methods/feature-specification.md
+++ b/accepted/future-releases/static-extension-methods/feature-specification.md
@@ -224,7 +224,7 @@ The extension type parameter can also occur as a parameter type for the method.
 Example:
 
 ```dart
-extension TypedEquals<T> {
+extension TypedEquals<T> on T {
   bool equals(T value) => this == value;
 }
 ```


### PR DESCRIPTION
The `TypedEquals` example needs an `on T` clause in order to conform to the grammar and define `T` as described.