### PR TITLE
Adjusted `Makefile` to use an extra iteration when generating PDF

### DIFF
--- a/specification/Makefile
+++ b/specification/Makefile
@@ -9,10 +9,12 @@ pdf:
 	makeindex $(NAME).idx
 	pdflatex $(SPEC)
 	pdflatex $(SPEC)
+	pdflatex $(SPEC)
 
 pdfhash: hash_and_list
 	pdflatex $(HASH)
 	makeindex $(NAME)-hash.idx
+	pdflatex $(HASH)
 	pdflatex $(HASH)
 	pdflatex $(HASH)
 
@@ -21,10 +23,12 @@ dvi:
 	makeindex $(NAME).idx
 	latex $(SPEC)
 	latex $(SPEC)
+	latex $(SPEC)
 
 dvihash: hash_and_list
 	latex $(HASH)
 	makeindex $(NAME)-hash.idx
+	latex $(HASH)
 	latex $(HASH)
 	latex $(HASH)
 
@@ -39,7 +43,7 @@ help:
 	@echo "  clean: remove all generated files"
 
 cleanish:
-	rm -f *.aux *.log *.toc *.out
+	rm -f *.aux *.log *.toc *.out *.idx *.ilg *.ind
 
 clean: cleanish
 	rm -f *.dvi *.pdf $(HASH) $(LIST)


### PR DESCRIPTION
It now uses 4 iterations, which may eliminate the issue where index references refer to an incorrect page (e.g., it says page 11, but it is on page 15).

Also added a couple of file patterns to the `cleanish` goal, to maintain the property that it removes all intermediate generated files.

Addresses https://github.com/dart-lang/site-www/issues/1735.