### PR TITLE
Adjusted .travis.yml logic for skipping PDF generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,7 @@ node_js:
   - "node"
 before_install:
   - |
-    if git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE 'dartLangSpec.tex|.travis.yml|dart.sty'; then
-      echo "dartLangSpex.tex wasn't changed; skipping spec PDF build"
-      exit 0
-    else
+    if git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qE 'dartLangSpec.tex|.travis.yml|dart.sty|Makefile'; then
       npm install -g firebase-tools@7.2.0
       sudo apt-get update -qq
       sudo apt-get install \
@@ -15,6 +12,9 @@ before_install:
         texlive-latex-extra \
         texlive-fonts-recommended \
         lmodern
+    else
+      echo "dartLangSpex.tex wasn't changed; skipping spec PDF build"
+      exit 0
     fi
   - echo '* install completed'
 script:


### PR DESCRIPTION
The existing logic for skipping the generation of a PDF spec file would skip if there exists a file which differs (across `$TRAVIS_COMMIT_RANGE`) which is not 'significant' (that is, we expect that this change does not matter for the PDF). In particular, any change which _also_ changes the `Makefile` would cause the PDF generation to be skipped, even in the case where `dartLangSpec.tex` is changed as well.

This PR changes the logic such that the PDF is generated whenever any of the significant files changes, and it does not matter whether any insignificant files are changed as well.

It also changes the `Makefile` to be a significant file, which is needed because changes to this file could certainly give rise to changes in the generated PDF.