### PR TITLE
Transferred several grammar adjustments from Dart.g to the spec

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -1833,7 +1833,8 @@ A \Index{class} defines the form and behavior of a set of objects which are its
 Classes may be defined by class declarations as described below, or via mixin applications (\ref{mixinApplication}).
 
 \begin{grammar}
-<classDefinition> ::= <metadata> \ABSTRACT{}? \CLASS{} <identifier> <typeParameters>?
+<classDefinition> ::=
+  \ABSTRACT{}? \CLASS{} <identifier> <typeParameters>?
   \gnewline{} <superclass>? <interfaces>?
   \gnewline{} `{' (<metadata> <classMemberDefinition>)* `}'
   \alt <metadata> \ABSTRACT{}? \CLASS{} <mixinApplicationClass>
@@ -1850,20 +1851,21 @@ Classes may be defined by class declarations as described below, or via mixin ap
   \alt \STATIC{}? <setterSignature>
   \alt <operatorSignature>
 
-<declaration> ::= <constantConstructorSignature> (<redirection> | <initializers>)?
-  \alt <constructorSignature> (<redirection> | <initializers>)?
+<declaration> ::= \EXTERNAL{} <factoryConstructorSignature>
   \alt \EXTERNAL{} <constantConstructorSignature>
   \alt \EXTERNAL{} <constructorSignature>
   \alt (\EXTERNAL{} \STATIC{}?)? <getterSignature>
   \alt (\EXTERNAL{} \STATIC{}?)? <setterSignature>
-  \alt \EXTERNAL{}? <operatorSignature>
   \alt (\EXTERNAL{} \STATIC{}?)? <functionSignature>
-  \alt \STATIC{} \LATE{}? \FINAL{} <type>? <staticFinalDeclarationList>
-  \alt \STATIC{} \LATE{}? (\VAR{} | <type>) <initializedIdentifierList>
-  \alt \STATIC{} \CONST{} <type>? <staticFinalDeclarationList>
-  \alt \COVARIANT{} \LATE{}? (\VAR{} | <type>) <initializedIdentifierList>
-  \alt \LATE{}? \FINAL{} <type>? <initializedIdentifierList>
-  \alt \LATE{}? (\VAR{} | <type>) <initializedIdentifierList>
+  \alt \EXTERNAL{}? <operatorSignature>
+  \alt \STATIC{} (\FINAL{} | \CONST{}) <type>? <staticFinalDeclarationList>
+  \alt \STATIC{} \LATE{} \FINAL{} <type>? <initializedIdentifierList>
+  \alt (\STATIC{} | \COVARIANT{}) \LATE{}? <varOrType>
+       <initializedIdentifierList>
+  \alt \LATE{}? (\FINAL{} <type>? | <varOrType>) <initializedIdentifierList>
+  \alt <redirectingFactoryConstructorSignature>
+  \alt <constantConstructorSignature> (<redirection> | <initializers>)?
+  \alt <constructorSignature> (<redirection> | <initializers>)?
 
 <staticFinalDeclarationList> ::= \gnewline{}
   <staticFinalDeclaration> (`,' <staticFinalDeclaration>)*
@@ -4459,7 +4461,7 @@ A mixin declaration introduces a mixin and provides a scope
 for static member declarations.
 
 \begin{grammar}
-<mixinDeclaration> ::= <metadata> \MIXIN{} <identifier> <typeParameters>?
+<mixinDeclaration> ::= \MIXIN{} <identifier> <typeParameters>?
   \gnewline{} (\ON{} <typeNotVoidList>)? <interfaces>?
   \gnewline{} `\{' (<metadata> <classMemberDefinition>)* `\}'
 \end{grammar}
@@ -4641,7 +4643,7 @@ fields, $C_q$ is also a const constructor.
 An \Index{enumerated type}, or \Index{enum}, is used to represent a fixed number of constant values.
 
 \begin{grammar}
-<enumType> ::= <metadata> \ENUM{} <identifier>
+<enumType> ::= \ENUM{} <identifier>
   \gnewline{} `{' <enumEntry> (`,' <enumEntry>)* (`,')? `}'
 
 <enumEntry> ::= <metadata> <identifier>
@@ -11583,12 +11585,12 @@ and therefore must be evaluated.
 }
 
 \begin{grammar}
-<assignableExpression> ::= <primary> <assignableSelectorPart>+
+<assignableExpression> ::= <primary> <assignableSelectorPart>
   \alt \SUPER{} <unconditionalAssignableSelector>
-  \alt <constructorInvocation> <assignableSelectorPart>+
+  \alt <constructorInvocation> <assignableSelectorPart>
   \alt <identifier>
  
-<assignableSelectorPart> ::= (<argumentPart> \alt `!')* <assignableSelector>
+<assignableSelectorPart> ::= <selector>* <assignableSelector>
 
 <unconditionalAssignableSelector> ::= `[' <expression> `]'
   \alt `.' <identifier>
@@ -13536,23 +13538,26 @@ The members of a library $L$ are those top level declarations given within $L$.
 
 \begin{grammar}
 <topLevelDefinition> ::= <classDefinition>
+  \alt <mixinDeclaration>
   \alt <enumType>
   \alt <typeAlias>
   \alt \EXTERNAL{}? <functionSignature> `;'
   \alt \EXTERNAL{}? <getterSignature> `;'
   \alt \EXTERNAL{}? <setterSignature> `;'
   \alt <functionSignature> <functionBody>
-  \alt <type>? \GET{} <identifier> <functionBody>
-  \alt <type>? \SET{} <identifier> <formalParameterList> <functionBody>
-  \alt (\FINAL{} | \CONST{}) <type> <staticFinalDeclarationList> `;'
-  \alt <variableDeclaration> `;'
+  \alt <getterSignature> <functionBody>
+  \alt <setterSignature> <functionBody>
+  \alt (\FINAL{} | \CONST{}) <type>? <staticFinalDeclarationList> `;'
+  \alt \LATE{} \FINAL{} <type>? <initializedIdentifierList> `;'
+  \alt <topLevelVariableDeclaration> `;'
 
-<getOrSet> ::= \GET{}
-  \alt \SET{}
+<topLevelVariableDeclaration> ::=
+  \LATE{}? <varOrType> <identifier> (`=' <expression>)?
+  (',' <initializedIdentifier>)*
 
 <libraryDefinition> ::= \gnewline{}
   <scriptTag>? <libraryName>? <importOrExport>* <partDirective>*
-  \gnewline{} <topLevelDefinition>*
+  \gnewline{} <metadata> <topLevelDefinition>*
 
 <scriptTag> ::= `#!' (\~{}<NEWLINE>)* <NEWLINE>
 
@@ -14472,8 +14477,8 @@ because of the prominent occurrence of the token \TYPEDEF.
 
 \begin{grammar}
 <typeAlias> ::= \gnewline{}
-  <metadata> \TYPEDEF{} <typeIdentifier> <typeParameters>? `=' <functionType> `;'
-  \alt <metadata> \TYPEDEF{} <functionTypeAlias>
+  \TYPEDEF{} <typeIdentifier> <typeParameters>? `=' <functionType> `;'
+  \alt \TYPEDEF{} <functionTypeAlias>
 
 <functionTypeAlias> ::= <functionPrefix> <formalParameterPart> `;'
 

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -27,10 +27,21 @@
 %
 % Significant changes to the specification.
 %
+% 2.4
+% - Clarify the section 'Exports'.
+% - Update grammar rules for <declaration>, to support `static late final`
+%   variables with no initializer; for several top-level declarations,
+%   to correct the existence and placement of <metadata>; for
+%   <assignableSelectorPart>, to simplify the grammar (preserving the
+%   derivable terms); for <topLevelDefinition>, to allow top-level final
+%   and const variables with no type, and to allow `late final` top-level
+%   variables, to allow `late` on a top-level variable declaration; and
+%   adding <namedParameterType> to allow `required` parameters.
+%
 % 2.3
-% - Added requirement that the iterator of a for-in statement must have
+% - Add requirement that the iterator of a for-in statement must have
 %   type `Iterator`.
-% - Clarified which constructors are covered by the section 'Constant
+% - Clarify which constructors are covered by the section 'Constant
 %   Constructors' and removed confusing redundancy in definiton of
 %   potentially constant expressions.
 %
@@ -1858,11 +1869,13 @@ Classes may be defined by class declarations as described below, or via mixin ap
   \alt (\EXTERNAL{} \STATIC{}?)? <setterSignature>
   \alt (\EXTERNAL{} \STATIC{}?)? <functionSignature>
   \alt \EXTERNAL{}? <operatorSignature>
-  \alt \STATIC{} (\FINAL{} | \CONST{}) <type>? <staticFinalDeclarationList>
+  \alt \STATIC{} \CONST{} <type>? <staticFinalDeclarationList>
+  \alt \STATIC{} \FINAL{} <type>? <staticFinalDeclarationList>
   \alt \STATIC{} \LATE{} \FINAL{} <type>? <initializedIdentifierList>
-  \alt (\STATIC{} | \COVARIANT{}) \LATE{}? <varOrType>
-       <initializedIdentifierList>
-  \alt \LATE{}? (\FINAL{} <type>? | <varOrType>) <initializedIdentifierList>
+  \alt \STATIC{} \LATE{}? <varOrType> <initializedIdentifierList>
+  \alt \COVARIANT{} \LATE{}? <varOrType> <initializedIdentifierList>
+  \alt \LATE{}? \FINAL{} <type>? <initializedIdentifierList>
+  \alt \LATE{}? <varOrType> <initializedIdentifierList>
   \alt <redirectingFactoryConstructorSignature>
   \alt <constantConstructorSignature> (<redirection> | <initializers>)?
   \alt <constructorSignature> (<redirection> | <initializers>)?
@@ -13550,11 +13563,7 @@ The members of a library $L$ are those top level declarations given within $L$.
   \alt <setterSignature> <functionBody>
   \alt (\FINAL{} | \CONST{}) <type>? <staticFinalDeclarationList> `;'
   \alt \LATE{} \FINAL{} <type>? <initializedIdentifierList> `;'
-  \alt <topLevelVariableDeclaration> `;'
-
-<topLevelVariableDeclaration> ::=
-  \LATE{}? <varOrType> <identifier> (`=' <expression>)?
-  (',' <initializedIdentifier>)*
+  \alt \LATE{}? <varOrType> <initializedIdentifierList> `;'
 
 <libraryDefinition> ::= \gnewline{}
   <scriptTag>? <libraryName>? <importOrExport>* <partDirective>*

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -9575,14 +9575,15 @@ has the form \code{$e$..\metavar{suffix}}
 where $e$ is an expression and \metavar{suffix} is a sequence of operator, method, getter or setter invocations.
 
 \begin{grammar}
-<cascadeSequence> ::= (`?..' \alt `..') <cascadeSection> (`..' <cascadeSection>)*
+<cascadeSequence> ::= (`?..' | `..') <cascadeSection> (`..' <cascadeSection>)*
 
-<cascadeSection> ::= <cascadeSelector> 
-\gnewline{} (cascadeAssignment \alt
-             <selector>* (<assignableSelector> <cascadeAssignment>)?)
+<cascadeSection> ::= <cascadeSelector> <cascadeSectionTail>
 
 <cascadeSelector> ::= `[' <expression> `]'
   \alt <identifier>
+
+<cascadeSectionTail> ::= <cascadeAssignment>
+  \alt <selector>* (<assignableSelector> <cascadeAssignment>)?
 
 <cascadeAssignment> ::= <assignmentOperator> <expressionWithoutCascade>
 
@@ -14270,7 +14271,10 @@ but it is the least upper bound of all function types.
 <optionalPositionalParameterTypes> ::= `[' <normalParameterTypes> `,'? `]'
 
 <namedParameterTypes> ::=
-  `\{' <typedIdentifier> (`,' <typedIdentifier>)* `,'? `\}'
+  `\{' <namedParameterType> (`,' <namedParameterType>)* `,'? `\}'
+
+<namedParameterType> ::=
+  \REQUIRED{}? <typedIdentifier>
 
 <typedIdentifier> ::= <type> <identifier>
 \end{grammar}


### PR DESCRIPTION
This is a language specification update that transfers several elements from Dart.g to the language specification.

The grammar rule for `<declaration>` contains a correction which makes a difference: It allows for `late final x;` as well as `late final x = 42;`, which wasn't allowed previously.

A `<topLevelVariableDeclaration>` has been added, because the use of `<variableDeclaration>` created the problem that it allowed `const x;` and `final x;` as top level declarations, and we already have a separate alternative in `<topLevelDefinition>` to allow for `const` and `final` variables as we want to allow them at the top level.

At the same time, a handful of declarations do not have `<metadata>` at the beginning any more (because it's now handled `<metadata> <topLevelDefinition>` in general, such that we also allow metadata for `external <getterSignature>;` and several other cases where it was not supported, according to the spec).

The most controversial part could be the change to `<assignableSelectorPart>`, but I believe that the form I've used is simpler and capable of deriving the same terms: It uses the ability of `<selector>` to be a `!` also in an `<assignableSelectorPart>`, and this is something that `<selector>` can already do (without any changes from me).

Finally, the `<topLevelDefinition>` has also been adjusted to allow `late final x;` at top level.