### PR TITLE
Revise spec section Imports

### DIFF
--- a/specification/dart.sty
+++ b/specification/dart.sty
@@ -330,6 +330,9 @@
 \newcommand{\Show}[2]{\ensuremath{\ShowName({#1},{#2})}}
 \newcommand{\Hide}[2]{\ensuremath{\HideName({#1},{#2})}}
 
+% A special value in a namespace, used to indicate a conflict.
+\newcommand{\ConflictValue}{\mbox{NAME\_CONFLICT}}
+
 % ----------------------------------------------------------------------
 % Support for hash valued Location Markers
 

--- a/specification/dart.sty
+++ b/specification/dart.sty
@@ -320,7 +320,15 @@
 
 % Namespaces, needed in the specification of imports and exports, and
 % also used when specifying lookups and scope rules.
-\newcommand{\Namespace}[1]{\ensuremath{\metavar{NS}_{#1}}}
+\newcommand{\NamespaceName}[1]{\ensuremath{\metavar{NS}_{#1}}}
+\newcommand{\Namespace}[2]{\ensuremath{\NamespaceName{#1}({#2})}}
+
+% Functions used in the specification of the namespace combinators
+% `show` and `hide`.
+\newcommand{\ShowName}{\metavar{show}}
+\newcommand{\HideName}{\metavar{hide}}
+\newcommand{\Show}[2]{\ensuremath{\ShowName({#1},{#2})}}
+\newcommand{\Hide}[2]{\ensuremath{\HideName({#1},{#2})}}
 
 % ----------------------------------------------------------------------
 % Support for hash valued Location Markers

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -14550,6 +14550,13 @@ The deferred prefix object has the following members:
   an immediate import $I'$ to be executed at some future time,
   where $I'$ is derived from $I_i$ by eliding the word \DEFERRED{}
   and adding a \HIDE{} \code{loadLibrary} combinator clause.
+  % Weasel wording here: We may not want to insist that it must be a
+  % a dynamic error if an implementation loads a library where a comment
+  % was changed, or anything else that doesn't matter, or even the exact
+  % same source code was obtained from a different file. Hence the error
+  % "may be raised".
+  A dynamic error may be raised if $I'$ imports a different library
+  than the one that the specified URI referred to at compile-time.
   When $I'$ executes without error, $f$ completes successfully.
   If $I'$ executes without error,
   we say that the call to \code{loadLibrary} has succeeded,

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -14138,102 +14138,6 @@ the names introduced by all top-level declarations declared in $L$,
 and the names added by $L$'s imports (\ref{imports}).
 
 
-\subsection{Namespace Combinators}
-\LMLabel{namespaceCombinators}
-
-\LMHash{}%
-Imports (\ref{imports}) and exports (\ref{exports}) rely on
-\Index{namespace combinators}
-in order to adjust namespaces
-(\ref{scoping})
-and manage name clashes.
-The supported namespace combinators are \SHOW{} and \HIDE{}.
-
-\begin{grammar}
-<combinator> ::= \SHOW{} <identifierList> | \HIDE{} <identifierList>
-
-<identifierList> ::= <identifier> (`,' <identifier>)*
-\end{grammar}
-
-\LMHash{}%
-We define several operations that compute namespaces.
-The
-\IndexCustom{union of two namespaces}{namespace!union},
-\IndexCustom{$\NamespaceName{a}\cup\NamespaceName{b}$}{%
-  $\cup$@$\NamespaceName{a} \cup \NamespaceName{b}$},
-is defined when every key where both are defined is mapped to the same value.
-This union is the namespace that maps
-each key $n$ of \NamespaceName{a}
-to the corresponding value \Namespace{a}{n},
-and each key $n$ of \NamespaceName{b}
-to \Namespace{b}{n}.
-
-\commentary{%
-Note that this \emph{is} a namespace because the union is only defined
-when the mapping of any given key is unambiguous.%
-}
-
-\LMHash{}%
-The function
-\IndexCustom{\Hide{l}{\NamespaceName{a}}}{%
-  hide(l,NSa)@\Hide{l}{\NamespaceName{}}}
-takes a list of identifiers $l$ and a namespace \NamespaceName{a},
-and produces a namespace \NamespaceName{b} that is
-identical to \NamespaceName{a} except that for each identifier \id{} in $l$,
-\NamespaceName{b} is undefined at \id{} and at \code{\id=}.
-
-\LMHash{}%
-The function
-\IndexCustom{\Show{l}{\NamespaceName{a}}}{%
-  show(l,NSa)@\Show{l}{\NamespaceName{}}}
-takes a list of identifiers $l$ and a namespace \NamespaceName{a},
-and produces a namespace \NamespaceName{b} that
-maps each identifier \id{} in $l$
-where \NamespaceName{a} is defined
-to \Namespace{a}{n}.
-Furthermore, for each identifier \id{} in $l$
-where \NamespaceName{a} is defined at \code{\id=},
-\NamespaceName{b} maps \code{\id=} to \Namespace{a}{\code{\id=}}.
-Finally, \NamespaceName{b} is undefined at all other names.
-
-\LMHash{}%
-Let \List{C}{1}{n} be a sequence of combinator clauses.
-\commentary{They would come from an import or export directive.}
-The
-\IndexCustom{combinator clauses can be applied to}{%
-  combinator clauses!application to namespace}
-a given namespace \NamespaceName{\metavar{start}},
-which yields a namespace \NamespaceName{\metavar{end}},
-as follows.
-
-\LMHash{}%
-Let \NamespaceName{0} be \NamespaceName{\metavar{start}}.
-For each combinator clause $C_j$, $j \in 1 .. n$:
-If $C_j$ is of the form \code{\SHOW{} $\id_1, \ldots,\ \id_k$} then let
-$\NamespaceName{j} = \Show{[\List{\id}{1}{k}]}{\NamespaceName{j-1}}$.
-If $C_i$ is of the form \code{\HIDE{} $\id_1, \ldots,\ \id_k$} then let
-$\NamespaceName{j} = \Hide{[\List{id}{1}{k}]}{\NamespaceName{j-1}}$.
-Then \NamespaceName{\metavar{end}} is \NamespaceName{n}.
-
-\commentary{%
-\NamespaceName{\metavar{end}} will always agree with
-\NamespaceName{\metavar{start}} wherever both are defined,
-and the set of names where \NamespaceName{\metavar{end}} is defined
-is always a subset of that of \NamespaceName{\metavar{start}}.
-In that sense, this is a \emph{narrowing} procedure.%
-}
-
-\commentary{%
-It is possible to use \HIDE{} or \SHOW{} on an identifier
-which is not in the given namespace.%
-}
-\rationale{%
-This prevents situations where, e.g.,
-removing a declaration from a library $L$ would cause
-breakage in a library that imponts $L$.%
-}
-
-
 \subsection{Imports}
 \LMLabel{imports}
 
@@ -14258,12 +14162,14 @@ It is a compile-time error if the specified URI
 does not refer to a library declaration.
 
 \LMHash{}%
-Imports may be
-\IndexCustom{deferred}{import!deferred} or
-\IndexCustom{immediate}{import!immediate}.
-A deferred import is distinguished by the appearance of
+Imports may be deferred or immediate.
+A
+\IndexCustom{deferred import}{import!deferred}
+is distinguished by the appearance of
 the built-in identifier \DEFERRED{} after the URI.
-Any import that is not deferred is immediate.
+An
+\IndexCustom{immediate import}{import!immediate}
+is an import that is not deferred.
 
 \LMHash{}%
 An immediate import directive $I$ may optionally include
@@ -14277,6 +14183,46 @@ in another import clause.
 \LMHash{}%
 An import directive $I$ may optionally include namespace combinator clauses
 used to restrict the set of names imported by $I$.
+Their application and effect on namespaces is described elsewhere
+(\ref{theImportedNamespace}, \ref{namespaceCombinators}).
+
+\LMHash{}%
+It is a static warning to import two different libraries with the same name,
+unless their name is the empty string.
+
+\rationale{%
+If two different URIs are inadvertantly used to access the same library $L$,
+say, because of a symbolic link in the underlying file system,
+this may help explaining why there are two incompatible copies of
+the types declared in $L$.
+Developers may also choose to omit library names entirely,
+which motivates the exception for the empty name.%
+}
+
+\LMHash{}%
+The dart core library \code{dart:core}
+is implicitly imported into every dart library other than itself
+via an import clause of the form
+\code{\IMPORT{} 'dart:core';}
+unless the importing library explicitly imports \code{dart:core}.
+Any import of \code{dart:core},
+even if restricted via \SHOW{}, \HIDE{} or \AS{},
+preempts the automatic import.
+
+\rationale{%
+It would be nice if there was nothing special about \code{dart:core}.
+However, its use is pervasive,
+which leads to the decision to import it automatically.
+However, some library $L$ may wish to define entities
+with names used by \code{dart:core}
+(which it can easily do, as the names declared by a library take precedence).
+Other libraries may wish to use $L$,
+and may want to use members of $L$ that conflict with the core library
+without having to use a prefix and without encountering errors.
+The above rule makes this possible,
+essentially canceling \code{dart:core}'s special treatment
+by means of yet another special rule.%
+}
 
 
 \subsubsection{The Imported Namespace}
@@ -14286,6 +14232,31 @@ used to restrict the set of names imported by $I$.
 In the following, we specify the imported namespace of a library $L$,
 \NamespaceName{\metavar{import}},
 in two steps.
+
+\LMHash{}%
+We need to introduce system libraries because they have special rules.
+A \Index{system library} is a library that is part of the Dart implementation.
+Any other library is a \Index{non-system library}.
+
+\commentary{%
+A system library can generally be recognized by having
+a URI that starts with `\code{dart:}'.
+An exception is `\code{dart:ui}' which is not a system library.%
+}
+
+\rationale{%
+The special rules for system libraries exist for the following reason.
+Normal conflicts are resolved at deployment time,
+but the functionality of a system library is
+injected into an application at run time,
+and may vary over time as the platform is upgraded.
+Thus, conflicts with a system library can arise
+outside the developer's control.
+To avoid breaking deployed applications in this way,
+conflicts with the system libraries are treated specially.%
+}
+
+\LMHash{}%
 Let \NamespaceName{\metavar{local}} be the namespace that
 for each top-level declaration $D$ with name $n$ in $L$ maps $n$ to $D$.
 An import with a prefix $p$ is included among these top-level declarations,
@@ -14295,21 +14266,67 @@ and let \List{L}{1}{m} be libraries
 such that $I_i$ refers to $L_i$ for all $i \in 1 .. m$.
 
 \LMHash{}%
-In the first step we compute the namespace provided by each imported library.
 Let $i \in 1 .. m$.
+In the first step we compute the namespace provided by each imported library,
+\NamespaceName{\metavar{one},i}.
+
+\LMHash{}%
+\Case{Step one for imports without a prefix}
+When $I_i$ has no prefix, \NamespaceName{\metavar{one},i} is
+the namespace obtained from applying the namespace combinators of $I_i$ to
+the exported namespace of $L_i$
+(\ref{namespaceCombinators}).
+\EndCase
 
 \LMHash{}%
 \Case{Step one for prefixed imports}
 When $I_i$ has prefix $p_i$,
-let \NamespaceName{\metavar{prefix},i}
-be the namespace obtained from applying the namespace combinators of $I_i$ to
-the exported namespace of $L_i$
-(\ref{namespaceCombinators}),
-and let
-\NamespaceName{\metavar{narrowed},i}
-be the namespace that maps $p_i$ to a \Index{prefix object},
-which is a mapping that associates names with entities declared in $L_i$
-as follows:
+let \List{I'}{1}{k} be the subset of \List{I}{1}{m} that have prefix $p_i$,
+and let \List{L'}{1}{k} be the corresponding libraries
+(\commentary{which is a subset of \List{L}{1}{m}}).
+Let \NamespaceName{\metavar{exported},j}, $j \in 1 .. k$,
+be the namespace obtained from applying the namespace combinators of $I'_j$ to
+the exported namespace of $L'_j$
+(\ref{namespaceCombinators}).
+
+\LMHash{}%
+Let \NamespaceName{\metavar{narrowed},j} be the namespace which is identical to
+\NamespaceName{\metavar{exported},j} except that
+it is undefined at each name $n$ where one of the following holds:
+
+\begin{itemize}
+\item $L'_j$ is a system library,
+  there exists an $l \in 1 .. k$ such that $L'_l$ is not a system library,
+  \NamespaceName{\metavar{exported},l} is defined at $n'$,
+  and $n$ and $n'$ have the same basename.
+  \commentary{%
+    So an imported declaration from a non-system library shadows
+    imported declarations from system libraries.%
+  }
+\item There exists an $l \in 1 .. k$ such that
+  \NamespaceName{\metavar{exported},l} is defined at $n'$,
+  $L'_j$ and $L'_l$ are not the same library,
+  either none or both of $L'_j$ and $L'_l$ are system libraries,
+  $n$ and $n'$ have the same basename,
+  and \Namespace{\metavar{exported},j}{n}
+  and \Namespace{\metavar{exported},l}{n'}
+  is not the same declaration.
+  \commentary{%
+    So with two distinct imported declarations with the same basename,
+    both are eliminated.%
+  }
+  % We need 'not the same library', l != j is not enough: See comment on the
+  % corresponding case for step two below (search 'not the same library').
+\end{itemize}
+
+\LMHash{}%
+Let \NamespaceName{\metavar{prefix},i} be the namespace
+$\NamespaceName{\metavar{narrowed},1} \cup \ldots
+\NamespaceName{\metavar{narrowed},k}$.
+Then \NamespaceName{\metavar{one},i} is the namespace that
+maps $p_i$ to a \Index{prefix object},
+which is a mapping that associates names with entities declared in
+\List{L'}{1}{k} as follows:
 
 \begin{itemize}
 \item
@@ -14323,7 +14340,7 @@ as follows:
 \item
   For every top level setter $s$ named \code{\id=} in
   \NamespaceName{\metavar{prefix}, i},
-  \id{} is mapped to a setter with the same parameter type as $s$.
+  \code{\id=} is mapped to a setter with the same parameter type as $s$.
 \item
   For every type $T$ named \id{} in
   \NamespaceName{\metavar{prefix}, i},
@@ -14337,100 +14354,83 @@ during static analysis,
 and a mapping that is used to access the corresponding entities
 at run time.
 Consequently, any attempt to use a prefix object on its own
-is a compile-time error.%
+is a compile-time error.
+
+Note that if $l$ and $q$ are such that
+$I_l$ and $I_q$ both have the same prefix $p$
+then
+$\NamespaceName{\metavar{one},l} = \NamespaceName{\metavar{one},q} =
+\NamespaceName{\metavar{one},l} \cup \NamespaceName{\metavar{one},q}$.%
 }
 \EndCase
 
 \LMHash{}%
-\Case{Step one for imports without a prefix}
-When $I_i$ has no prefix,
-let \NamespaceName{\metavar{narrowed},i} be
-the namespace obtained from applying the namespace combinators of $I_i$ to
-the exported namespace of $L_i$.
-\EndCase
-
-\LMHash{}%
-\Case{Step two}
+{\bf Step two.}
 In the second step we resolve conflicts
 among the namespaces obtained in the first step.
-
-\LMHash{}%
-A \Index{system library} is a library that is part of the Dart implementation.
-Any other library is a \Index{non-system library}.
-
-\rationale{%
-There is a special rule for system libraries below.
-Normal conflicts are resolved at deployment time,
-but the functionality of a system library is
-injected into an application at run time,
-and may vary over time as the platform is upgraded.
-Thus, conflicts with a system library can arise
-outside the developer's control.
-To avoid breaking deployed applications in this way,
-conflicts with the system libraries are treated specially.%
-}
-
-% We do not spell out explicitly that 'dart:ui' is not a system library.
-\commentary{%
-A system library can generally be recognized by having
-a URI of the form `\code{dart:\ldots}'.%
-}
 
 \LMHash{}%
 For each $i \in 1 .. m$, the
 \Index{namespace imported from}
 $L_i$, \NamespaceName{\metavar{import},i},
-is identical to \NamespaceName{\metavar{narrowed},i},
+is identical to \NamespaceName{\metavar{one},i},
 except that it is undefined at each name $n$
-where one of the following conditions holds,
-where \id{} is the basename of $n$:
+where one of the following conditions holds:
 
 \begin{itemize}
 \item \NamespaceName{\metavar{local}} is defined at $n'$
-  such that the basename of $n'$ is \id.
+  such that $n$ and $n'$ have the same basename.
   \commentary{%
     In other words, a declaration in the current library shadows
-    imported declarations with the same basename.
+    imported declarations.
     Note that the prefix of an import also introduces a binding
-    into \NamespaceName{\metavar{local}}.%
+    into \NamespaceName{\metavar{local}},
+    so a prefix can also shadow an imported declaration.%
   }
 \item The first case does not apply, $L_i$ is a system library,
   there exists a $j \in 1 .. m$ such that $L_j$ is not a system library,
-  and \NamespaceName{\metavar{narrowed},j} is defined at $n'$
-  such that the basename of $n'$ is \id.
+  \NamespaceName{\metavar{one},j} is defined at $n'$,
+  and $n$ and $n'$ have the same basename.
   \commentary{%
     So an imported declaration from a non-system library shadows
     imported declarations from system libraries.%
   }
 \item The first case does not not apply,
-  there exists a $j \not= i$ in $1 .. m$ such
-  \NamespaceName{\metavar{narrowed},j} is defined at $n'$
-  and the basename of $n'$ is \id,
-  \Namespace{\metavar{narrowed},i}{n}
-  and \Namespace{\metavar{narrowed},j}{n'}
-  is not the same declaration,
-  and either none or both of $L_i$ and $L_j$ are system libraries.
+  there exists a $j \in 1 .. m$ such that
+  \NamespaceName{\metavar{one},j} is defined at $n'$,
+  $L_i$ and $L_j$ are not the same library,
+  either none or both of $L_i$ and $L_j$ are system libraries,
+  $n$ and $n'$ have the same basename,
+  and \Namespace{\metavar{one},i}{n}
+  and \Namespace{\metavar{one},j}{n'}
+  is not the same declaration.
   \commentary{%
     So with two distinct imported declarations with the same basename,
     both are eliminated.%
   }
+  % We need the 'not the same library' requirement (i != j is not enough),
+  % because otherwise we could have two imports of the same library (without
+  % a prefix here, but it works the same for two imports with the same
+  % prefix), and we could focus on a getter `x` from one import of a library
+  % Lx, and on a setter `x=` from the other import of Lx, and then we would
+  % eliminate both.
 \end{itemize}
 
 \commentary{%
 The removal of these bindings from
-\NamespaceName{\metavar{narrowed},i}
+\NamespaceName{\metavar{one},i}
 yields the namespace imported from $L_i$,
 \NamespaceName{\metavar{import},i},
 and ensures that each imported namespace has a
 key set which is disjoint with that of
 \NamespaceName{\metavar{local}},
 and where two imported namespaces only share a key $n$ when
-they both map $n$ to the same value $D$.%
+they both map $n$ to the same value.%
 }
 
 \commentary{%
 Note that it is not an error if a name $n$ is introduced by two or more imports
-but is never referred to.%
+but is never used.%
 }
 
 \rationale{%
@@ -14473,49 +14473,6 @@ We say that a declaration \Index{is imported by a library}
 (or equivalently, that a library
 \IndexCustom{imports a declaration}{imports!declaration})
 if the declaration is in the library's imported namespace.
-\EndCase
-
-
-\subsubsection{Auxiliary Concepts and Rules}
-\LMLabel{auxiliaryConceptsAndRules}
-
-\LMHash{}%
-The dart core library \code{dart:core}
-is implicitly imported into every dart library other than itself
-via an import clause of the form
-\code{\IMPORT{} 'dart:core';}
-unless the importing library explicitly imports \code{dart:core}.
-Any import of \code{dart:core},
-even if restricted via \SHOW{}, \HIDE{} or \AS{},
-preempts the automatic import.
-
-\rationale{%
-It would be nice if there was nothing special about \code{dart:core}.
-However, its use is pervasive,
-which leads to the decision to import it automatically.
-However, some library $L$ may wish to define entities
-with names used by \code{dart:core}
-(which it can easily do, as the names declared by a library take precedence).
-Other libraries may wish to use $L$,
-and may want to use members of $L$ that conflict with the core library
-without having to use a prefix and without encountering errors.
-The above rule makes this possible,
-essentially canceling \code{dart:core}'s special treatment
-by means of yet another special rule.%
-}
-
-\LMHash{}%
-It is a static warning to import two different libraries with the same name,
-unless their name is the empty string.
-
-\rationale{%
-If two different URIs are inadvertantly used to access the same library $L$,
-say, because of a symbolic link in the underlying file system,
-this may help explaining why there are two incompatible copies of
-the types declared in $L$.
-Developers may also choose to omit library names entirely,
-which motivates the exception for the empty name.%
-}
 
 
 \subsubsection{Evaluation of Imports}
@@ -14530,6 +14487,10 @@ Evaluation of $I_i$ proceeds as follows:
 If $I_i$ is a deferred import with prefix $p$, a mapping of $p$ to a
 \Index{deferred prefix object} is added to
 the scope of the current library $L$.
+Let \NamespaceName{\metavar{import},i} be
+the namespace imported from the library specified by $I_i$,
+as defined previously
+(\ref{theImportedNamespace}).
 The deferred prefix object has the following members:
 
 \begin{itemize}
@@ -14544,22 +14505,26 @@ The deferred prefix object has the following members:
   we say that the call to \code{loadLibrary} has succeeded,
   otherwise we say the call has failed.
 \item
-  For every top level function $f$ named \id{} in the imported library,
+  For every top level function $f$ named \id{} in
+  \NamespaceName{\metavar{import},i},
   a corresponding method named \id{} with the same signature as $f$.
   % This error can occur because being-loaded is a dynamic property.
   Calling the method results in a dynamic error.
 \item
-  For every top level getter $g$ named \id{} in the imported library,
+  For every top level getter $g$ named \id{} in
+  \NamespaceName{\metavar{import},i},
   a corresponding getter named \id{} with the same signature as $g$.
   % This error can occur because being-loaded is a dynamic property.
   Calling the getter results in a dynamic error.
 \item
-  For every top level setter $s$ named \id{} in the imported library,
-  a corresponding setter named \id{} with the same signature as $s$.
+  For every top level setter $s$ named \code{\id=} in
+  \NamespaceName{\metavar{import},i},
+  a corresponding setter named \code{\id=} with the same signature as $s$.
   % This error can occur because being-loaded is a dynamic property.
   Calling the setter results in a dynamic error.
 \item
-  For every type $T$ named \id{} in the imported library,
+  For every type $T$ named \id{} in
+  \NamespaceName{\metavar{import},i},
   a corresponding getter named \id{} with return type \code{Type}.
   % This error can occur because being-loaded is a dynamic property.
   Calling the getter results in a dynamic error.
@@ -14731,52 +14696,49 @@ Let $L$ be a library,
 let \List{E}{1}{m} be the export directives of $L$,
 and let \List{L}{1}{m} be libraries
 such that $E_i$ refers to $L_i$ for all $i \in 1 .. m$.
-
-\LMHash{}%
-In the first step we compute the namespace provided by each exported library.
 Let \NamespaceName{\metavar{local}} be the namespace that
 for each public top-level declaration $D$ with name $n$ in $L$ maps $n$ to $D$.
 Imports with a prefix do not introduce a binding in
 \NamespaceName{\metavar{local}}.
+
+\LMHash{}%
+In the first step we compute the namespace provided by each exported library:
 For each $i \in 1 .. m$,
-let \NamespaceName{\metavar{narrowed},i} be
+\NamespaceName{\metavar{one},i} is
 the namespace obtained from applying
 the namespace combinators of $E_i$ to
 the exported namespace of $L_i$
 (\ref{namespaceCombinators}).
 
 \LMHash{}%
-The second step starts from \NamespaceName{\metavar{narrowed},i}
+The second step starts from \NamespaceName{\metavar{one},i}
 and obtains the result, \NamespaceName{\metavar{export},i},
-by eliminating each key $n$, bound to declaration $D$,
-where one of the following conditions hold,
-where \id{} is the basename of $n$:
+by eliminating each key $n$ where one of the following conditions hold:
 
 \begin{itemize}
 \item \NamespaceName{\metavar{local}} is defined at $n'$
-  such that the basename of $n'$ is \id.
+  such that $n$ and $n'$ have the same basename.
   \commentary{%
-    In other words, a declaration in $L$ shadows
-    re-exported declarations with the same basename.
-    Import prefixes of $L$ are ignored, and do not shadow anything.%
+    In other words, a declaration in $L$ shadows re-exported declarations.
+    Import prefixes of $L$ are not exported, and do not shadow anything.%
   }
 \item The first case does not apply, $L_i$ is a system library,
   there exists a $j \in 1 .. m$ such that $L_j$ is not a system library,
-  and \NamespaceName{\metavar{narrowed},j} is defined at $n'$
-  such that the basename of $n'$ is \id.
+  and \NamespaceName{\metavar{one},j} is defined at $n'$
+  such that $n$ and $n'$ have the same basename.
   \commentary{%
     So a re-exported declaration from a non-system library shadows
     re-exported declarations from system libraries.%
   }
   \rationale{%
-    See the discussion in section \ref{imports} for
+    See the discussion in section \ref{theImportedNamespace} for
     the reasoning behind this rule.%
   }
 \end{itemize}
 
 \commentary{%
 The removal of these bindings from
-\NamespaceName{\metavar{narrowed},i}
+\NamespaceName{\metavar{one},i}
 yields the namespace exported from $L_i$,
 \NamespaceName{\metavar{export},i},
 and ensures that each exported namespace has a
@@ -14785,20 +14747,25 @@ key set which is disjoint with that of
 }
 
 \LMHash{}%
-Assume that $i$ and $j$ are distinct numbers in $1 .. m$.
-It is a compile-time error if there exists a key $n$ such that
-\NamespaceName{\metavar{export},i} maps $n$ to a declaration $D_i$,
-and \NamespaceName{\metavar{export},j} maps $n$ to a declaration $D_j$,
-and $D_i$ and $D_j$ are not the same declaration.%
+Assume that $i$ and $j$ are numbers in $1 .. m$.
+It is a compile-time error if there exists keys $n$ and $n'$ such that
+\NamespaceName{\metavar{export},i} is defined at $n$,
+\NamespaceName{\metavar{export},j} is defined at $n'$,
+$L_i$ and $L_j$ are not the same library,
+either none or both of $L_i$ and $L_j$ are system libraries,
+$n$ and $n'$ have the same basename,
+and \Namespace{\metavar{export},i}{n}
+and \Namespace{\metavar{export},j}{n'}
+is not the same declaration.
 
 \commentary{%
-It is possible for $D_i$ and $D_j$ to be the same declaration,
+It is possible for $n$ and $n'$ to be mapped to the same declaration,
 e.g., due to multiple re-exports.%
 }
 
 \LMHash{}%
 Finally, the \Index{exported namespace} of $L$ is
-$\NamespaceName{L} \cup
+$\NamespaceName{\metavar{local}} \cup
 \NamespaceName{\metavar{export},1} \cup
 \ldots \NamespaceName{\metavar{export},m}$.
 
@@ -14823,6 +14790,102 @@ that $L$ \NoIndex{re-exports} \NamespaceName{\metavar{export},i}.
 \LMHash{}%
 It is a static warning to export two different libraries with the same name,
 unless their name is the empty string.
+
+
+\subsection{Namespace Combinators}
+\LMLabel{namespaceCombinators}
+
+\LMHash{}%
+Imports (\ref{imports}) and exports (\ref{exports}) rely on
+\Index{namespace combinators}
+in order to adjust namespaces
+(\ref{scoping})
+and manage name clashes.
+The supported namespace combinators are \SHOW{} and \HIDE{}.
+
+\begin{grammar}
+<combinator> ::= \SHOW{} <identifierList> | \HIDE{} <identifierList>
+
+<identifierList> ::= <identifier> (`,' <identifier>)*
+\end{grammar}
+
+\LMHash{}%
+We define several operations that compute namespaces.
+The
+\IndexCustom{union of two namespaces}{namespace!union},
+\IndexCustom{$\NamespaceName{a}\cup\NamespaceName{b}$}{%
+  $\cup$@$\NamespaceName{a} \cup \NamespaceName{b}$},
+is defined when every key where both are defined is mapped to the same value.
+This union is the namespace that maps
+each key $n$ of \NamespaceName{a}
+to the corresponding value \Namespace{a}{n},
+and each key $n$ of \NamespaceName{b}
+to \Namespace{b}{n}.
+
+\commentary{%
+Note that this \emph{is} a namespace because the union is only defined
+when the mapping of any given key is unambiguous.%
+}
+
+\LMHash{}%
+The function
+\IndexCustom{\Hide{l}{\NamespaceName{a}}}{%
+  hide(l,NSa)@\Hide{l}{\NamespaceName{}}}
+takes a list of identifiers $l$ and a namespace \NamespaceName{a},
+and produces a namespace \NamespaceName{b} that is
+identical to \NamespaceName{a} except that for each identifier \id{} in $l$,
+\NamespaceName{b} is undefined at \id{} and at \code{\id=}.
+
+\LMHash{}%
+The function
+\IndexCustom{\Show{l}{\NamespaceName{a}}}{%
+  show(l,NSa)@\Show{l}{\NamespaceName{}}}
+takes a list of identifiers $l$ and a namespace \NamespaceName{a},
+and produces a namespace \NamespaceName{b} that
+maps each identifier \id{} in $l$
+where \NamespaceName{a} is defined
+to \Namespace{a}{n}.
+Furthermore, for each identifier \id{} in $l$
+where \NamespaceName{a} is defined at \code{\id=},
+\NamespaceName{b} maps \code{\id=} to \Namespace{a}{\code{\id=}}.
+Finally, \NamespaceName{b} is undefined at all other names.
+
+\LMHash{}%
+Let \List{C}{1}{n} be a sequence of combinator clauses.
+\commentary{They would come from an import or export directive.}
+The result of
+\IndexCustom{applying the combinator clauses}{%
+  combinator clauses!application to namespace}
+to a given namespace \NamespaceName{\metavar{start}}
+is a namespace \NamespaceName{\metavar{end}},
+which is computed as follows.
+
+\LMHash{}%
+Let \NamespaceName{0} be \NamespaceName{\metavar{start}}.
+For each combinator clause $C_j$, $j \in 1 .. n$:
+If $C_j$ is of the form \code{\SHOW{} $\id_1, \ldots,\ \id_k$} then let
+$\NamespaceName{j} = \Show{[\List{\id}{1}{k}]}{\NamespaceName{j-1}}$.
+If $C_i$ is of the form \code{\HIDE{} $\id_1, \ldots,\ \id_k$} then let
+$\NamespaceName{j} = \Hide{[\List{id}{1}{k}]}{\NamespaceName{j-1}}$.
+Then \NamespaceName{\metavar{end}} is \NamespaceName{n}.
+
+\commentary{%
+\NamespaceName{\metavar{end}} will always agree with
+\NamespaceName{\metavar{start}} wherever both are defined,
+and the set of names where \NamespaceName{\metavar{end}} is defined
+is always a subset of that of \NamespaceName{\metavar{start}}.
+In that sense, this is a \emph{narrowing} procedure.%
+}
+
+\commentary{%
+Note that it is possible to use \HIDE{} or \SHOW{} on an identifier
+which is not in the given namespace.%
+}
+\rationale{%
+Allowing this prevents situations where, e.g.,
+removing a declaration from a library $L$ would cause
+breakage in a library that imponts $L$.%
+}
 
 
 \subsection{Parts}

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -14175,16 +14175,23 @@ is an import that is not deferred.
 An immediate import directive $I$ may optionally include
 a prefix clause of the form \code{\AS{} \id} used to prefix
 names imported by $I$.
+In this case we say that \id{} is an \Index{import prefix},
+or simply a \Index{prefix}.
+
+\LMHash{}%
 A deferred import must include a prefix clause,
 or a compile-time error occurs.
 It is a compile-time error if a prefix used in a deferred import
 is also used as the prefix of another import clause.
+It is a compile-time error if \id{} is an import prefix and
+the current library declares a top-level member named \id{}.
 
 \LMHash{}%
 An import directive $I$ may optionally include namespace combinator clauses
 used to restrict the set of names imported by $I$.
 Their syntax, usage, and effect on namespaces is described elsewhere
-(\ref{namespaceCombinators}, \ref{theImportedNamespace}).
+(\ref{namespaceCombinators}, \ref{theImportedNamespace},
+\ref{exports}).
 
 \LMHash{}%
 It is a static warning to import two different libraries with the same name,
@@ -14320,7 +14327,11 @@ it is undefined at each name $n$ where one of the following holds:
   \commentary{%
     So with two distinct imported declarations with the same basename,
     both are eliminated,
-    except when it is a getter and a setter from the same library.%
+    except when it is a getter and a setter from the same library.
+    When a name $n$ has been eliminated for this reason and a usage
+    \code{$p_i$.$n$} is encountered in $L$,
+    it is recommended that the error message mentions the conflict,
+    rather than just reporting that $n$ does not exist.%
   }
   % We need 'not the same library', l != j is not enough: See comment on the
   % corresponding case for step two below (search 'not the same library').
@@ -14418,6 +14429,7 @@ where one of the following conditions holds:
   \Namespace{\metavar{one},j}{n} and
   \Namespace{\metavar{one},l}{n'}
   are declarations in a system library.
+  %
   \commentary{%
     So with two distinct imported declarations with the same basename,
     both are eliminated,
@@ -14433,7 +14445,20 @@ where one of the following conditions holds:
   % not possibly be a getter/setter pair from the same library: Such a pair
   % would be exported from NS_local together, and they would be re-exported
   % each time together (hide/show cannot distinguish).
+
+  In this situation we say that $n$ is a
+  \IndexCustom{conflicted imported name}{import!conflicted name}%
+  \index{conflicted imported name}.
 \end{itemize}
+
+\LMHash{}%
+Let \NamespaceName{\metavar{conflict}} be the namespace
+that maps each conflicted imported name to
+the special value \ConflictValue.
+A lookup for a conflicted imported name will succeed according to
+the normal rules for namespaces and lexical scoping,
+but it is a compile-time error at the location where the name is used
+that this name is mapped to \ConflictValue.
 
 \commentary{%
 The removal of these bindings from
@@ -14450,10 +14475,8 @@ they both map $n$ to the same value.%
 \commentary{%
 Note that it is not an error if a name $n$ is introduced by two or more imports
 but is never used.
-In this case the conflicted name is simply eliminated from the namespace.
-Tools may choose to retain the information that there was a name clash,
-in order to emit a more informative error message
-if the name is used.%
+It is recommended that error messages about usages of conflicted imported names
+include a reference to all the declarations that caused the conflict.%
 }
 
 \rationale{%
@@ -14485,7 +14508,9 @@ $\NamespaceName{\metavar{import}} =
 and the
 \Index{library namespace}
 of $L$ is
-$\NamespaceName{\metavar{local}} \cup \NamespaceName{\metavar{import}}$.
+$\NamespaceName{\metavar{local}} \cup
+\NamespaceName{\metavar{import}} \cup
+\NamespaceName{\metavar{conflict}}$.
 
 \LMHash{}%
 We say that a name is \Index{imported by a library}
@@ -14725,7 +14750,9 @@ and let \List{L}{1}{m} be libraries
 such that $E_i$ refers to $L_i$ for all $i \in 1 .. m$.
 Let \NamespaceName{\metavar{local}} be the namespace that
 for each public top-level declaration $D$ with name $n$ in $L$ maps $n$ to $D$.
-Imports with a prefix do not introduce a binding in
+An import prefix
+(\ref{imports})
+does not introduce a binding in
 \NamespaceName{\metavar{local}}.
 
 \LMHash{}%
@@ -14801,8 +14828,10 @@ This rule is more strict than the corresponding rule for imports:
 When two imported declarations have a name clash it is only an error to
 \emph{use} the conflicted name, it is not an error that the name clash exists.
 But with exported names it is an error that the name clash exists.
-The reason for this difference is that the conflict may affect clients silently.
-If a library $L'$ imports the current library $L$
+The reason for this difference is that
+the conflict could silently break importers of the current library $L$,
+if we were to use the same approach for exports as for imports:
+If a library $L'$ imports $L$
 and uses a name $n$ which is re-exported by $L$ from $L_n$
 then the addition of a declaration named $n$ to some other re-exported library
 will make the use of $n$ in $L'$ an error,
@@ -14939,7 +14968,7 @@ which is not in the given namespace.%
 \rationale{%
 Allowing this prevents situations where, e.g.,
 removing a declaration from a library $L$ would cause
-breakage in a library that imponts $L$.%
+breakage in a library that imports $L$.%
 }
 
 

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -14415,8 +14415,8 @@ where one of the following conditions holds:
   are not the same declaration,
   $L_i$ and $L_j$ are not the same library,
   and either none or both of
-  \Namespace{\metavar{exported},j}{n} and
-  \Namespace{\metavar{exported},l}{n'}
+  \Namespace{\metavar{one},j}{n} and
+  \Namespace{\metavar{one},l}{n'}
   are declarations in a system library.
   \commentary{%
     So with two distinct imported declarations with the same basename,
@@ -14774,16 +14774,17 @@ key set which is disjoint with that of
 }
 
 \LMHash{}%
-Assume that $i$ and $j$ are numbers in $1 .. m$.
-It is a compile-time error
-if $L_i$ and $L_j$ are not the same library,
-either none or both of $L_i$ and $L_j$ are system libraries,
-and there exist names $n$ and $n'$ with the same basename such that:
+Assume that $i$ and $j$ are numbers in $1 .. m$ and $n$ and $n'$ are names.
+It is a compile-time error if
 \NamespaceName{\metavar{export},i} is defined at $n$,
 \NamespaceName{\metavar{export},j} is defined at $n'$,
-and \Namespace{\metavar{export},i}{n}
-and \Namespace{\metavar{export},j}{n'}
-is not the same declaration.
+$n$ and $n'$ have the same basename,
+\Namespace{\metavar{export},i}{n} and
+\Namespace{\metavar{export},j}{n'}
+are not the same declaration,
+and $L_i$ and $L_j$ are not the same library.
+% We need 'not the same library', i != j is not enough: See comment on the
+% corresponding case for step two above (search 'not the same library').
 
 \commentary{%
 This means that it is an error when two distinct exported declarations have
@@ -14796,9 +14797,12 @@ This rule is more strict than the corresponding rule for imports:
 When two imported declarations have a name clash it is only an error to
 \emph{use} the conflicted name, it is not an error that the name clash exists.
 But with exported names it is an error that the name clash exists.
-The reason for this difference is that the error may affect
-a library $L_2$ that imports the current library $L$,
-and the maintainers of $L_2$ may not be in a position to change $L$.%
+The reason for this difference is that the conflict may affect clients silently.
+If a library $L'$ imports the current library $L$
+and uses a name $n$ which is re-exported by $L$ from $L_n$
+then the addition of a declaration named $n$ to some other re-exported library
+will make the use of $n$ in $L'$ an error,
+and the maintainers of $L'$ may not be in a position to change $L$.%
 }
 
 \LMHash{}%

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -14313,7 +14313,8 @@ it is undefined at each name $n$ where one of the following holds:
   is not the same declaration.
   \commentary{%
     So with two distinct imported declarations with the same basename,
-    both are eliminated.%
+    both are eliminated,
+    except when it is a getter and a setter from the same library.%
   }
   % We need 'not the same library', l != j is not enough: See comment on the
   % corresponding case for step two below (search 'not the same library').
@@ -14406,7 +14407,8 @@ where one of the following conditions holds:
   is not the same declaration.
   \commentary{%
     So with two distinct imported declarations with the same basename,
-    both are eliminated.%
+    both are eliminated,
+    except when it is a getter and a setter from the same library.%
   }
   % We need the 'not the same library' requirement (i != j is not enough),
   % because otherwise we could have two imports of the same library (without
@@ -14430,7 +14432,11 @@ they both map $n$ to the same value.%
 
 \commentary{%
 Note that it is not an error if a name $n$ is introduced by two or more imports
-but is never used.%
+but is never used.
+In this case the conflicted name is simply eliminated from the namespace.
+Tools may choose to retain the information that there was a name clash
+in order to emit a more informative error message,
+if the name is used.%
 }
 
 \rationale{%
@@ -14748,19 +14754,30 @@ key set which is disjoint with that of
 
 \LMHash{}%
 Assume that $i$ and $j$ are numbers in $1 .. m$.
-It is a compile-time error if there exists keys $n$ and $n'$ such that
+It is a compile-time error if there exist names $n$ and $n'$
+with the same basename such that
 \NamespaceName{\metavar{export},i} is defined at $n$,
 \NamespaceName{\metavar{export},j} is defined at $n'$,
 $L_i$ and $L_j$ are not the same library,
 either none or both of $L_i$ and $L_j$ are system libraries,
-$n$ and $n'$ have the same basename,
 and \Namespace{\metavar{export},i}{n}
 and \Namespace{\metavar{export},j}{n'}
 is not the same declaration.
 
 \commentary{%
-It is possible for $n$ and $n'$ to be mapped to the same declaration,
-e.g., due to multiple re-exports.%
+This means that it is an error when two distinct exported declarations have
+the same basename,
+except when it is a getter and a setter from the same library.%
+}
+
+\rationale{%
+This rule is more strict than the corresponding rule for imports:
+When two imported declarations have a name clash it is only an error to
+\emph{use} the conflicted name, it is not an error that the name clash exists.
+But with exported names it is an error that the name clash exists.
+The reason for this difference is that the error may affect
+a library $L_2$ that imports the current library $L$,
+and the maintainers of $L_2$ may not be in a position to change $L$.%
 }
 
 \LMHash{}%
@@ -14790,6 +14807,15 @@ that $L$ \NoIndex{re-exports} \NamespaceName{\metavar{export},i}.
 \LMHash{}%
 It is a static warning to export two different libraries with the same name,
 unless their name is the empty string.
+
+\rationale{%
+If two different URIs are inadvertantly used to access the same library $L$,
+say, because of a symbolic link in the underlying file system,
+this may help explaining why there are two incompatible copies of
+the types declared in $L$.
+Developers may also choose to omit library names entirely,
+which motivates the exception for the empty name.%
+}
 
 
 \subsection{Namespace Combinators}

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -633,25 +633,36 @@ to each binding as having a \NoIndex{key}
 which is mapped to a \NoIndex{value}.
 
 \LMHash{}%
-Let $NS$ be a namespace.
-We say that a name $n$ \Index{is in} $NS$ if $n$ is a key of $NS$.
-We say a declaration $d$ \NoIndex{is in} $NS$ if a key of $NS$ maps to $d$.
+Let \NamespaceName{} be a namespace.
+We say that a name $n$ \Index{is in} \NamespaceName{}
+if $n$ is a key of \NamespaceName{}.
+We say a declaration $d$ \NoIndex{is in} \NamespaceName{}
+if a key of \NamespaceName{} is mapped to $d$.
 
 \LMHash{}%
-A scope $S_0$ induces a namespace $NS_0$ that maps the simple name of each variable, type or function declaration $d$ declared in $S_0$ to $d$.
-Labels are not included in the induced namespace of a scope; instead they have their own dedicated namespace.
+A scope $S_0$ induces a namespace \NamespaceName{0} that maps
+the simple name of each variable, type or function declaration $d$
+declared in $S_0$ to $d$.
+Labels are not included in the induced namespace of a scope;
+instead they have their own dedicated namespace.
 
-\commentary{
-It is therefore impossible, e.g., to define a class that declares a method and a getter with the same name in Dart.
-Similarly one cannot declare a top-level function with the same name as a library variable or a class.
+\commentary{%
+It is therefore impossible, e.g., to define a class that declares
+a method and a getter with the same name in Dart.
+Similarly one cannot declare a top-level function with
+the same name as a library variable or a class.%
 }
 
 \LMHash{}%
-It is a compile-time error if there is more than one entity with the same name declared in the same scope.
+It is a compile-time error if there is more than one entity with the same name
+declared in the same scope.
 
-\commentary{
-In some cases, the name of the declaration differs from the identifier used to declare it.
-Setters have names that are distinct from the corresponding getters because they always have an = automatically added at the end, and unary minus has the special name unary-.
+\commentary{%
+In some cases, the name of the declaration differs from
+the identifier used to declare it.
+Setters have names that are distinct from the corresponding getters
+because they always have an \lit{=} automatically added at the end,
+and unary minus has the special name unary-.%
 }
 
 \LMHash{}%
@@ -14136,11 +14147,10 @@ Imports (\ref{imports}) and exports (\ref{exports}) rely on
 in order to adjust namespaces
 (\ref{scoping})
 and manage name clashes.
-The supported namespace combinators are \HIDE{} and \SHOW{}.
+The supported namespace combinators are \SHOW{} and \HIDE{}.
 
 \begin{grammar}
-<combinator> ::= \SHOW{} <identifierList>
-  \alt \HIDE{} <identifierList>
+<combinator> ::= \SHOW{} <identifierList> | \HIDE{} <identifierList>
 
 <identifierList> ::= <identifier> (`,' <identifier>)*
 \end{grammar}
@@ -14152,7 +14162,6 @@ The
 \IndexCustom{$\NamespaceName{a}\cup\NamespaceName{b}$}{%
   $\cup$@$\NamespaceName{a} \cup \NamespaceName{b}$},
 is defined when every key where both are defined is mapped to the same value.
-\commentary{In particular, when the two namespaces have disjoint keys.}
 This union is the namespace that maps
 each key $n$ of \NamespaceName{a}
 to the corresponding value \Namespace{a}{n},
@@ -14187,11 +14196,6 @@ where \NamespaceName{a} is defined at \code{\id=},
 \NamespaceName{b} maps \code{\id=} to \Namespace{a}{\code{\id=}}.
 Finally, \NamespaceName{b} is undefined at all other names.
 
-\commentary{%
-It is not an error to hide or show a non-existing name,
-but tools may choose to give a hint in such cases.%
-}
-
 \LMHash{}%
 Let \List{C}{1}{n} be a sequence of combinator clauses.
 \commentary{They would come from an import or export directive.}
@@ -14212,12 +14216,23 @@ $\NamespaceName{j} = \Hide{[\List{id}{1}{k}]}{\NamespaceName{j-1}}$.
 Then \NamespaceName{\metavar{end}} is \NamespaceName{n}.
 
 \commentary{%
-Note that \NamespaceName{\metavar{end}} will always agree with
+\NamespaceName{\metavar{end}} will always agree with
 \NamespaceName{\metavar{start}} wherever both are defined,
 and the set of names where \NamespaceName{\metavar{end}} is defined
 is always a subset of that of \NamespaceName{\metavar{start}}.
 In that sense, this is a \emph{narrowing} procedure.%
 }
+
+\commentary{%
+It is possible to use \HIDE{} or \SHOW{} on an identifier
+which is not in the given namespace.%
+}
+\rationale{%
+This prevents situations where, e.g.,
+removing a declaration from a library $L$ would cause
+breakage in a library that imponts $L$.%
+}
+
 
 \subsection{Imports}
 \LMLabel{imports}
@@ -14235,7 +14250,7 @@ the scope of another library.
 \end{grammar}
 
 \LMHash{}%
-An import specifies a URI $x$
+Syntactically, an import specifies a URI $x$
 where the declaration of an imported library is to be found.
 The interpretation of URIs is described elsewhere
 (\ref{uris}).
@@ -14261,35 +14276,107 @@ in another import clause.
 
 \LMHash{}%
 An import directive $I$ may optionally include namespace combinator clauses
-used to restrict the set of names imported by $I$
-(\ref{namespaceCombinators}),
-as specified below.
+used to restrict the set of names imported by $I$.
+
+
+\subsubsection{The Imported Namespace}
+\LMLabel{theImportedNamespace}
 
 \LMHash{}%
+In the following, we specify the imported namespace of a library $L$,
+\NamespaceName{\metavar{import}},
+in two steps.
 Let \NamespaceName{\metavar{local}} be the namespace that
 for each top-level declaration $D$ with name $n$ in $L$ maps $n$ to $D$.
-
-\LMHash{}%
-The imported namespace
-\NamespaceName{\metavar{import}}
-is then determined as follows, in two steps.
-Let $L$ be the current library,
-let \List{I}{1}{m} be the import directives of $L$,
+An import with a prefix $p$ is included among these top-level declarations,
+and it causes $p$ to be mapped to a prefix object as described below.
+Let \List{I}{1}{m} be the import directives of $L$,
 and let \List{L}{1}{m} be libraries
 such that $I_i$ refers to $L_i$ for all $i \in 1 .. m$.
 
 \LMHash{}%
 In the first step we compute the namespace provided by each imported library.
-For each $i \in 1 .. m$,
-let \NamespaceName{\metavar{narrowed},i} be
-the namespace obtained from applying
-the namespace combinators of $I_i$ to
-the exported namespace of $L_i$
-(\ref{namespaceCombinators}).
+Let $i \in 1 .. m$.
 
 \LMHash{}%
+\Case{Step one for prefixed imports}
+When $I_i$ has prefix $p_i$,
+let \NamespaceName{\metavar{prefix},i}
+be the namespace obtained from applying the namespace combinators of $I_i$ to
+the exported namespace of $L_i$
+(\ref{namespaceCombinators}),
+and let
+\NamespaceName{\metavar{narrowed},i}
+be the namespace that maps $p_i$ to a \Index{prefix object},
+which is a mapping that associates names with entities declared in $L_i$
+as follows:
+
+\begin{itemize}
+\item
+  For every top level function $f$ named \id{} in
+  \NamespaceName{\metavar{prefix}, i},
+  \id{} is mapped to a function with the same name and signature as $f$.
+\item
+  For every top level getter $g$ named \id{} in
+  \NamespaceName{\metavar{prefix}, i},
+  \id{} is mapped to a getter with the same return type as $g$.
+\item
+  For every top level setter $s$ named \code{\id=} in
+  \NamespaceName{\metavar{prefix}, i},
+  \id{} is mapped to a setter with the same parameter type as $s$.
+\item
+  For every type $T$ named \id{} in
+  \NamespaceName{\metavar{prefix}, i},
+  \id{} is mapped to the type $T$.
+\end{itemize}
+
+\commentary{%
+A prefix object is not a Dart object, it is merely a device which is
+used to manage names of the form \synt{qualified} and their types
+during static analysis,
+and a mapping that is used to access the corresponding entities
+at run time.
+Consequently, any attempt to use a prefix object on its own
+is a compile-time error.%
+}
+\EndCase
+
+\LMHash{}%
+\Case{Step one for imports without a prefix}
+When $I_i$ has no prefix,
+let \NamespaceName{\metavar{narrowed},i} be
+the namespace obtained from applying the namespace combinators of $I_i$ to
+the exported namespace of $L_i$.
+\EndCase
+
+\LMHash{}%
+\Case{Step two}
 In the second step we resolve conflicts
 among the namespaces obtained in the first step.
+
+\LMHash{}%
+A \Index{system library} is a library that is part of the Dart implementation.
+Any other library is a \Index{non-system library}.
+
+\rationale{%
+There is a special rule for system libraries below.
+Normal conflicts are resolved at deployment time,
+but the functionality of a system library is
+injected into an application at run time,
+and may vary over time as the platform is upgraded.
+Thus, conflicts with a system library can arise
+outside the developer's control.
+To avoid breaking deployed applications in this way,
+conflicts with the system libraries are treated specially.%
+}
+
+% We do not spell out explicitly that 'dart:ui' is not a system library.
+\commentary{%
+A system library can generally be recognized by having
+a URI of the form `\code{dart:\ldots}'.%
+}
+
+\LMHash{}%
 For each $i \in 1 .. m$, the
 \Index{namespace imported from}
 $L_i$, \NamespaceName{\metavar{import},i},
@@ -14303,7 +14390,9 @@ where \id{} is the basename of $n$:
   such that the basename of $n'$ is \id.
   \commentary{%
     In other words, a declaration in the current library shadows
-    imported declarations with the same basename.%
+    imported declarations with the same basename.
+    Note that the prefix of an import also introduces a binding
+    into \NamespaceName{\metavar{local}}.%
   }
 \item The first case does not apply, $L_i$ is a system library,
   there exists a $j \in 1 .. m$ such that $L_j$ is not a system library,
@@ -14335,8 +14424,32 @@ yields the namespace imported from $L_i$,
 and ensures that each imported namespace has a
 key set which is disjoint with that of
 \NamespaceName{\metavar{local}},
-and where two imported namespaces only share keys when
-they have the same corresponding value.%
+and where two imported namespaces only share a key $n$ when
+they both map $n$ to the same value $D$.%
+}
+
+\commentary{%
+Note that it is not an error if a name $n$ is introduced by two or more imports
+but is never referred to.%
+}
+
+\rationale{%
+The policy above makes libraries more robust
+in the face of additions made to their imports.
+
+A clear distinction needs to be made between this approach,
+and seemingly similar policies with respect to classes or interfaces.
+The use of a class or interface, and of its members,
+is separate from its declaration.
+The usage and declaration may occur in widely separated places in the code,
+and may in fact be authored by different people or organizations.
+It is important that errors are given at the offending declaration
+so that the party that receives the error can respond to it a meaningful way.
+
+In contrast, a library comprises both imports and their usage;
+the library is under the control of a single party and so
+any problem stemming from the import can be resolved
+even if it is reported at the use site.%
 }
 
 \LMHash{}%
@@ -14360,254 +14473,201 @@ We say that a declaration \Index{is imported by a library}
 (or equivalently, that a library
 \IndexCustom{imports a declaration}{imports!declaration})
 if the declaration is in the library's imported namespace.
+\EndCase
 
-% !!!TODO!!! ------------------------------------------------------------ BEGIN
+
+\subsubsection{Auxiliary Concepts and Rules}
+\LMLabel{auxiliaryConceptsAndRules}
 
 \LMHash{}%
-Let $I$ be an import directive that refers to a URI via the string $s_1$.
-Evaluation of $I$ proceeds as follows:
+The dart core library \code{dart:core}
+is implicitly imported into every dart library other than itself
+via an import clause of the form
+\code{\IMPORT{} 'dart:core';}
+unless the importing library explicitly imports \code{dart:core}.
+Any import of \code{dart:core},
+even if restricted via \SHOW{}, \HIDE{} or \AS{},
+preempts the automatic import.
+
+\rationale{%
+It would be nice if there was nothing special about \code{dart:core}.
+However, its use is pervasive,
+which leads to the decision to import it automatically.
+However, some library $L$ may wish to define entities
+with names used by \code{dart:core}
+(which it can easily do, as the names declared by a library take precedence).
+Other libraries may wish to use $L$,
+and may want to use members of $L$ that conflict with the core library
+without having to use a prefix and without encountering errors.
+The above rule makes this possible,
+essentially canceling \code{dart:core}'s special treatment
+by means of yet another special rule.%
+}
 
 \LMHash{}%
-If $I$ is a deferred import, no evaluation takes place.
-Instead, a mapping of the name of the prefix, $p$ to a
+It is a static warning to import two different libraries with the same name,
+unless their name is the empty string.
+
+\rationale{%
+If two different URIs are inadvertantly used to access the same library $L$,
+say, because of a symbolic link in the underlying file system,
+this may help explaining why there are two incompatible copies of
+the types declared in $L$.
+Developers may also choose to omit library names entirely,
+which motivates the exception for the empty name.%
+}
+
+
+\subsubsection{Evaluation of Imports}
+\LMLabel{evaluationOfImports}
+
+\LMHash{}%
+Let $I_i$ be an import directive that refers to a URI via the string $s_i$.
+Evaluation of $I_i$ proceeds as follows:
+
+\LMHash{}%
+\Case{Evaluation of deferred imports}
+If $I_i$ is a deferred import with prefix $p$, a mapping of $p$ to a
 \Index{deferred prefix object} is added to
 the scope of the current library $L$.
-The deferred prefix object has the following methods:
+The deferred prefix object has the following members:
 
 \begin{itemize}
-\item \code{loadLibrary}.
-This method returns a future $f$.
-When called, the method causes
-an immediate import $I'$ to be executed at some future time,
-where $I'$ is derived from $I$ by eliding the word \DEFERRED{}
-and adding a \HIDE{} \code{loadLibrary} combinator clause.
-When $I'$ executes without error, $f$ completes successfully.
-If $I'$ executes without error,
-we say that the call to \code{loadLibrary} has succeeded,
-otherwise we say the call has failed.
+\item \code{loadLibrary()}.
+  This method returns a future $f$.
+  When called, the method causes
+  an immediate import $I'$ to be executed at some future time,
+  where $I'$ is derived from $I_i$ by eliding the word \DEFERRED{}
+  and adding a \HIDE{} \code{loadLibrary} combinator clause.
+  When $I'$ executes without error, $f$ completes successfully.
+  If $I'$ executes without error,
+  we say that the call to \code{loadLibrary} has succeeded,
+  otherwise we say the call has failed.
 \item
-  For every top level function $f$ named \id{} in the imported library $B$,
+  For every top level function $f$ named \id{} in the imported library,
   a corresponding method named \id{} with the same signature as $f$.
   % This error can occur because being-loaded is a dynamic property.
   Calling the method results in a dynamic error.
 \item
-  For every top level getter $g$ named \id{} in $B$,
+  For every top level getter $g$ named \id{} in the imported library,
   a corresponding getter named \id{} with the same signature as $g$.
   % This error can occur because being-loaded is a dynamic property.
-  Calling the method results in a dynamic error.
+  Calling the getter results in a dynamic error.
 \item
-  For every top level setter $s$ named \id{} in $B$,
+  For every top level setter $s$ named \id{} in the imported library,
   a corresponding setter named \id{} with the same signature as $s$.
   % This error can occur because being-loaded is a dynamic property.
-  Calling the method results in a dynamic error.
+  Calling the setter results in a dynamic error.
 \item
-  For every type $T$ named \id{} in $B$,
+  For every type $T$ named \id{} in the imported library,
   a corresponding getter named \id{} with return type \code{Type}.
   % This error can occur because being-loaded is a dynamic property.
-  Calling the method results in a dynamic error.
+  Calling the getter results in a dynamic error.
 \end{itemize}
 
 \rationale{%
-The purpose of adding members of $B$ to $p$ is to ensure that
-any errors raised when using $p$ are correct,
-and no spurious errors are generated.
-In fact, at run time we cannot add these members until $B$ is loaded;
-but any such invocations will fail at run time
-as specified by virtue of being completely absent.%
+The purpose of adding members of the imported library to $p$
+is to ensure that usages of members that have not yet been loaded
+can be resolved normally and has a well-defined behavior,
+but will raise errors.%
 }
 
 \LMHash{}%
-The static type of the prefix object $p$ is a unique interface type
-that has those members whose names and signatures are listed above.
-
-\LMHash{}%
-After a call succeeds, the name $p$ is mapped to
-a non-deferred prefix object as described below.
-In addition, the prefix object also supports the \code{loadLibrary} method,
+After an invocation of \code{loadLibrary} succeeds,
+the name $p$ is mapped to a non-deferred prefix object,
+as described below.
+In addition, the prefix object also supports the \code{loadLibrary()} method,
 and so it is possible to call \code{loadLibrary} again.
-If a call fails, nothing happens, and one has
-the option to call \code{loadLibrary} again.
-Whether a repeated call to \code{loadLibrary} succeeds
-will vary as described below.
+If a call fails, nothing happens,
+and one has the option to call \code{loadLibrary} again.
+Whether a repeated call to \code{loadLibrary} succeeds will vary,
+as described below.
 
 \LMHash{}%
 The effect of a repeated call to \code{$p$.loadLibrary} is as follows:
 \begin{itemize}
 \item
-If another call to \code{$p$.loadLibrary} has already succeeded, the repeated call also succeeds.
-Otherwise,
+  If another call to \code{$p$.loadLibrary} has already succeeded,
+  the repeated call also succeeds.
+  Otherwise,
 \item
-If another call to \code{$p$.loadLibrary} has failed:
-\begin{itemize}
-\item
-If the failure is due to a compilation error, the repeated call fails for the same reason.
-\item
-If the failure is due to other causes, the repeated call behaves as if no previous call had been made.
-\end{itemize}
+  If another call to \code{$p$.loadLibrary} has failed:
+  \begin{itemize}
+  \item
+    If the failure is due to a compilation error,
+    the repeated call fails for the same reason.
+  \item
+    If the failure is due to other causes,
+    the repeated call behaves as if no previous call had been made.
+  \end{itemize}
 \end{itemize}
 
-\commentary{
+\commentary{%
 In other words, one can retry a deferred load after a network failure
 or because a file is absent,
 but once one finds some content and loads it, one can no longer reload.
-
 We do not specify which object the future returned resolves to.
 }
+\EndCase
 
 \LMHash{}%
-If $I$ is an immediate import then, first
+\Case{Evaluation of immediate imports}
+When $I_i$ is an immediate import:
 
 \begin{itemize}
 \item
-If the URI that is the value of $s_1$ has not yet been accessed by an import or export (\ref{exports}) directive in the current isolate then the contents of the URI are compiled to yield a library $B$.
-\commentary{
-Because libraries may have mutually recursive imports, care must be taken to avoid an infinite regress.
-}
-\item Otherwise, the contents of the URI denoted by $s_1$ have been compiled into a library $B$ within the current isolate.
+  If the URI that is the value of $s_i$ has not yet been accessed by
+  an import or export (\ref{exports}) directive in the current isolate 
+  then the contents of the URI are compiled to yield a library $L_i$.
+  \commentary{%
+    Because libraries may have mutually recursive imports,
+    care must be taken to avoid an infinite regress.%
+  }
+\item
+  Otherwise, the contents of the URI denoted by $s_i$ has been compiled into
+  a library $L_i$ within the current isolate.
 \end{itemize}
 
 \LMHash{}%
-Let $NS_0$ be the exported namespace (\ref{exports}) of $B$.
-Then, for each combinator clause $C_i, i \in 1 .. n$ in $I$:
-\begin{itemize}
-\item If $C_i$ is of the form
+Let \NamespaceName{\metavar{import}, i} be the namespace imported from $L_i$.
+The namespace \NamespaceName{i} will then have the following mappings:
 
-\code{\SHOW{} $\id_1, \ldots,\ \id_k$}
-
-then let $NS_i = \SHOW{}([\id_1, \ldots,\ \id_k], NS_{i-1}$)
-
-where $show(l,n)$ takes a list of identifiers $l$ and a namespace $n$, and produces a namespace that maps each name in $l$ to the same element that $n$ does.
-Furthermore, for each name $x$ in $l$, if $n$ defines the name \code{$x$=} then the new namespace maps \code{$x$=} to the same element that $n$ does.
-Otherwise the resulting mapping is undefined.
-
-\item If $C_i$ is of the form
-
-\code{\HIDE{} $\id_1, \ldots,\ \id_k$}
-
-then let $NS_i = \HIDE{}([\id_1, \ldots,\ \id_k], NS_{i-1}$)
-
-where $hide(l, n)$ takes a list of identifiers $l$ and a namespace $n$, and produces a namespace that is identical to $n$ except that for each name $k$ in $l$, $k$ and \code{$k$=} are undefined.
-\end{itemize}
-
-\LMHash{}%
-If $I$ includes a prefix clause of the form \AS{} $p$,
-let $NS = \{p: prefixObject(NS_n)\}$,
-where $prefixObject(NS_n)$ is a \Index{prefix object} for the namespace $NS_n$,
-which is an object that has the following members:
-
-\begin{itemize}
-\item For every top level function $f$ named \id{} in $NS_n$, a corresponding method with the same name and signature as $f$ that forwards (\ref{functionDeclarations}) to $f$.
-\item For every top level getter with the same name and signature as $g$ named \id{} in $NS_n$, a corresponding getter that forwards to $g$.
-\item For every top level setter $s$ with the same name and signature as named \id{} in $NS_n$, a corresponding setter that forwards to $s$.
-\item For every type $T$ named \id{} in $NS_n$, a corresponding getter named \id{} with return type \code{Type}, that, when invoked, returns the type object for $T$.
-\end{itemize}
-
-\LMHash{}%
-It is a compile-time error if the current library declares a top-level member named $p$.
-
-The static type of the prefix object $p$ is a unique interface type that has those members whose names and signatures are listed above.
-% What is the static type of a prefix object. Need to state that is a(n anonymous) type that has members with the same names as signatures as above.
-
-% This is problematic, because it implies that p.T would be available even in a scope that declared p. We really need to think of p as a single object with properties p.T etc., except it isn't really that
-% either. After all, p isn't actually available as a stand alone name.
-
-\LMHash{}%
-Otherwise (\commentary{when the import is not prefixed}), let $NS = NS_n$.
-
-\LMHash{}%
-Then, for each entry mapping key $k$ to declaration $d$ in $NS$, $d$ is made available in the top level scope of $L$ under the name $k$ unless either:
 \begin{itemize}
 \item
-a top-level declaration with the name $k$ exists in $L$, OR
-\item a prefix clause of the form \AS{} $k$ is used in $L$.
+  For every top level function $f$ named \id{} in
+  \NamespaceName{\metavar{import}, i},
+  a corresponding method with the same name and signature as $f$
+  that forwards (\ref{functionDeclarations}) to $f$.
+\item
+  For every top level getter $g$ named \id{} in
+  \NamespaceName{\metavar{import}, i},
+  a corresponding getter that forwards to $g$.
+\item
+  For every top level setter $s$ named \code{\id=} in
+  \NamespaceName{\metavar{import}, i},
+  a corresponding setter that forwards to $s$.
+\item
+  For every type $T$ named \id{} in
+  \NamespaceName{\metavar{import}, i},
+  a corresponding getter named \id{} with return type \code{Type}
+  that, when invoked, returns the type object for $T$.
 \end{itemize}
 
-\rationale{
-The greatly increases the chance that a member can be added to a library without breaking its importers.
-}
+\LMHash{}%
+If $I_i$ has prefix $p$ then a mapping from $p$ to a non-deferred prefix object
+with members determined by \NamespaceName{i} is introduced into the
+library namespace of the current library.
 
 \LMHash{}%
-A \Index{system library} is a library that is part of the Dart implementation.
-Any other library is a \Index{non-system library}.
+If $I_i$ does not have a prefix then each mapping in \NamespaceName{i}
+is introduced into the library namespace of the current library.
 
-If a name $N$ is referenced by a library $L$
-and $N$ would be introduced into the top level scope of $L$
-by imports of two libraries, $L_1$ and $L_2$,
-the exported namespace of $L_1$ binds $N$
-to a declaration originating in a system library,
-and the exported namespace of $L_2$ binds $N$ to a declaration
-that does not originate in a system library,
-then the import of $L_1$ is implicitly extended by a \code{\HIDE{} $N$} clause.
-
-\rationale{
-Whereas normal conflicts are resolved at deployment time, the functionality of \code{dart:} libraries is injected into an application at run time, and may vary over time as browsers are upgraded.
-Thus, conflicts with \code{dart:} libraries can arise at run time, outside the developer's control.
-To avoid breaking deployed applications in this way, conflicts with the \code{dart:} libraries are treated specially.
-
-It is recommended that tools that deploy Dart code produce output in which all imports use show clauses to ensure that additions to the namespace of a library never impact deployed code.
+\commentary{%
+Note that the dynamic construction of the library namespace
+cannot encounter any name conflicts,
+because such conflicts would have caused a compile-time error.%
 }
-
-\LMHash{}%
-If a name $N$ is referenced by a library $L$ and $N$ is introduced into the top level scope of $L$ by more than one import
-and not all the imports denote the same declaration,
-a compile-time error occurs.
-
-\LMHash{}%
-We say that the namespace $NS$
-\IndexCustom{has been imported into}{namespace!imported} $L$.
-
-\commentary{
-It is not an error if $N$ is introduced by two or more imports but never referred to.
-}
-
-\rationale{
-The policy above makes libraries more robust in the face of additions made to their imports.
-
-A clear distinction needs to be made between this approach, and seemingly similar policies with respect to classes or interfaces.
-The use of a class or interface, and of its members, is separate from its declaration.
-The usage and declaration may occur in widely separated places in the code, and may in fact be authored by different people or organizations.
-It is important that errors are given at the offending declaration so that the party that receives the error can respond to it a meaningful way.
-
-In contrast a library comprises both imports and their usage; the library is under the control of a single party and so any problem stemming from the import can be resolved even if it is reported at the use site.
-
-%On a related note, the provenance of the conflicting elements is not considered. An element that is imported via distinct paths may conflict with itself. This avoids variants of the well known "diamond" problem.
-}
-
-\LMHash{}%
-It is a static warning to import two different libraries with the same name unless their name is the empty string.
-
-\commentary{
-A widely disseminated library should be given a name that will not conflict with other such libraries.
-The preferred mechanism for this is using pub, the Dart package manager, which provides a global namespace for libraries, and conventions that leverage that namespace.
-}
-
-\commentary{
-Note that no errors are raised if one hides or shows a name that is not in a namespace.
-}
-\rationale{
-This prevents situations where removing a name from a library would cause breakage of a client library.
-}
-
-\LMHash{}%
-The dart core library \code{dart:core} is implicitly imported into every dart library other than itself via an import clause of the form
-
-\code{\IMPORT{} `dart:core';}
-
-unless the importing library explicitly imports \code{dart:core}.
-
-\commentary{
-Any import of \code{dart:core}, even if restricted via \SHOW{}, \HIDE{} or \AS{}, preempts the automatic import.
-}
-
-\rationale{
-It would be nice if there was nothing special about \code{dart:core}.
-However, its use is pervasive, which leads to the decision to import it automatically.
-However, some library $L$ may wish to define entities with names used by \code{dart:core} (which it can easily do, as the names declared by a library take precedence).
-Other libraries may wish to use $L$ and may want to use members of $L$ that conflict with the core library without having to use a prefix and without encountering errors.
-The above rule makes this possible, essentially canceling \code{dart:core}'s special treatment by means of yet another special rule.
-}
-
-% !!!TODO!!! ------------------------------------------------------------ END
+\EndCase
 
 
 \subsection{Exports}
@@ -14676,6 +14736,8 @@ such that $E_i$ refers to $L_i$ for all $i \in 1 .. m$.
 In the first step we compute the namespace provided by each exported library.
 Let \NamespaceName{\metavar{local}} be the namespace that
 for each public top-level declaration $D$ with name $n$ in $L$ maps $n$ to $D$.
+Imports with a prefix do not introduce a binding in
+\NamespaceName{\metavar{local}}.
 For each $i \in 1 .. m$,
 let \NamespaceName{\metavar{narrowed},i} be
 the namespace obtained from applying
@@ -14695,7 +14757,8 @@ where \id{} is the basename of $n$:
   such that the basename of $n'$ is \id.
   \commentary{%
     In other words, a declaration in $L$ shadows
-    re-exported declarations with the same basename.%
+    re-exported declarations with the same basename.
+    Import prefixes of $L$ are ignored, and do not shadow anything.%
   }
 \item The first case does not apply, $L_i$ is a system library,
   there exists a $j \in 1 .. m$ such that $L_j$ is not a system library,
@@ -14741,7 +14804,7 @@ $\NamespaceName{L} \cup
 
 \commentary{%
 Unions of namespaces are defined elsewhere
-(\ref{imports}).
+(\ref{namespaceCombinators}).
 This union is well-defined because all these namespaces only share
 keys where they have the same value.%
 }
@@ -14758,7 +14821,7 @@ that $L$ \NoIndex{re-exports} $L_i$, or
 that $L$ \NoIndex{re-exports} \NamespaceName{\metavar{export},i}.
 
 \LMHash{}%
-It is a compile-time error to export two different libraries with the same name
+It is a static warning to export two different libraries with the same name,
 unless their name is the empty string.
 
 

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -14295,22 +14295,28 @@ Let \NamespaceName{\metavar{narrowed},j} be the namespace which is identical to
 it is undefined at each name $n$ where one of the following holds:
 
 \begin{itemize}
-\item $L'_j$ is a system library,
-  there exists an $l \in 1 .. k$ such that $L'_l$ is not a system library,
+\item There exists an $l \in 1 .. k$ and name $n'$ such that
   \NamespaceName{\metavar{exported},l} is defined at $n'$,
-  and $n$ and $n'$ have the same basename.
+  $n$ and $n'$ have the same basename,
+  \Namespace{\metavar{exported},j}{n}
+  is a declaration in a system library,
+  and \Namespace{\metavar{exported},l}{n}
+  is a declaration in a non-system library.
   \commentary{%
     So an imported declaration from a non-system library shadows
     imported declarations from system libraries.%
   }
-\item There exists an $l \in 1 .. k$ such that
+\item There exists an $l \in 1 .. k$ and name $n'$ such that
   \NamespaceName{\metavar{exported},l} is defined at $n'$,
-  $L'_j$ and $L'_l$ are not the same library,
-  either none or both of $L'_j$ and $L'_l$ are system libraries,
   $n$ and $n'$ have the same basename,
-  and \Namespace{\metavar{exported},j}{n}
+  \Namespace{\metavar{exported},j}{n}
   and \Namespace{\metavar{exported},l}{n'}
-  is not the same declaration.
+  are not the same declaration,
+  $L'_j$ and $L'_l$ are not the same library,
+  and either none or both of
+  \Namespace{\metavar{exported},j}{n} and
+  \Namespace{\metavar{exported},l}{n'}
+  are declarations in a system library.
   \commentary{%
     So with two distinct imported declarations with the same basename,
     both are eliminated,
@@ -14388,23 +14394,30 @@ where one of the following conditions holds:
     into \NamespaceName{\metavar{local}},
     so a prefix can also shadow an imported declaration.%
   }
-\item The first case does not apply, $L_i$ is a system library,
-  there exists a $j \in 1 .. m$ such that $L_j$ is not a system library,
+\item The first case does not apply,
+  there exists a $j \in 1 .. m$ and name $n'$ such that
   \NamespaceName{\metavar{one},j} is defined at $n'$,
-  and $n$ and $n'$ have the same basename.
+  $n$ and $n'$ have the same basename,
+  \Namespace{\metavar{one},j}{n}
+  is a declaration in a system library,
+  and \Namespace{\metavar{one},l}{n'}
+  is a declaration in a non-system library.
   \commentary{%
     So an imported declaration from a non-system library shadows
     imported declarations from system libraries.%
   }
 \item The first case does not apply,
-  there exists a $j \in 1 .. m$ such that
+  there exists a $j \in 1 .. m$ and name $n'$ such that
   \NamespaceName{\metavar{one},j} is defined at $n'$,
-  $L_i$ and $L_j$ are not the same library,
-  either none or both of $L_i$ and $L_j$ are system libraries,
   $n$ and $n'$ have the same basename,
-  and \Namespace{\metavar{one},i}{n}
-  and \Namespace{\metavar{one},j}{n'}
-  is not the same declaration.
+  \Namespace{\metavar{one},i}{n} and
+  \Namespace{\metavar{one},j}{n'}
+  are not the same declaration,
+  $L_i$ and $L_j$ are not the same library,
+  and either none or both of
+  \Namespace{\metavar{exported},j}{n} and
+  \Namespace{\metavar{exported},l}{n'}
+  are declarations in a system library.
   \commentary{%
     So with two distinct imported declarations with the same basename,
     both are eliminated,
@@ -14416,6 +14429,10 @@ where one of the following conditions holds:
   % prefix), and we could focus on a getter `x` from one import of a library
   % Lx, and on a setter `x=` from the other import of Lx, and then we would
   % eliminate both.
+  % Conversely, when $L_i$ and $L_j$ are not the same library then it could
+  % not possibly be a getter/setter pair from the same library: Such a pair
+  % would be exported from NS_local together, and they would be re-exported
+  % each time together (hide/show cannot distinguish).
 \end{itemize}
 
 \commentary{%

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -14154,7 +14154,7 @@ the scope of another library.
 \end{grammar}
 
 \LMHash{}%
-Syntactically, an import specifies a URI $x$
+Syntactically, an import specifies a URI $s$
 where the declaration of an imported library is to be found.
 The interpretation of URIs is described elsewhere
 (\ref{uris}).
@@ -14177,21 +14177,21 @@ a prefix clause of the form \code{\AS{} \id} used to prefix
 names imported by $I$.
 A deferred import must include a prefix clause,
 or a compile-time error occurs.
-It is a compile-time error if a prefix used in a deferred import is used
-in another import clause.
+It is a compile-time error if a prefix used in a deferred import
+is also used as the prefix of another import clause.
 
 \LMHash{}%
 An import directive $I$ may optionally include namespace combinator clauses
 used to restrict the set of names imported by $I$.
-Their application and effect on namespaces is described elsewhere
-(\ref{theImportedNamespace}, \ref{namespaceCombinators}).
+Their syntax, usage, and effect on namespaces is described elsewhere
+(\ref{namespaceCombinators}, \ref{theImportedNamespace}).
 
 \LMHash{}%
 It is a static warning to import two different libraries with the same name,
 unless their name is the empty string.
 
 \rationale{%
-If two different URIs are inadvertantly used to access the same library $L$,
+If two different URIs are inadvertently used to access the same library $L$,
 say, because of a symbolic link in the underlying file system,
 this may help explaining why there are two incompatible copies of
 the types declared in $L$.
@@ -14396,7 +14396,7 @@ where one of the following conditions holds:
     So an imported declaration from a non-system library shadows
     imported declarations from system libraries.%
   }
-\item The first case does not not apply,
+\item The first case does not apply,
   there exists a $j \in 1 .. m$ such that
   \NamespaceName{\metavar{one},j} is defined at $n'$,
   $L_i$ and $L_j$ are not the same library,
@@ -14434,8 +14434,8 @@ they both map $n$ to the same value.%
 Note that it is not an error if a name $n$ is introduced by two or more imports
 but is never used.
 In this case the conflicted name is simply eliminated from the namespace.
-Tools may choose to retain the information that there was a name clash
-in order to emit a more informative error message,
+Tools may choose to retain the information that there was a name clash,
+in order to emit a more informative error message
 if the name is used.%
 }
 
@@ -14544,14 +14544,14 @@ but will raise errors.%
 }
 
 \LMHash{}%
-After an invocation of \code{loadLibrary} succeeds,
+After an invocation of \code{$p$.loadLibrary} succeeds,
 the name $p$ is mapped to a non-deferred prefix object,
 as described below.
 In addition, the prefix object also supports the \code{loadLibrary()} method,
-and so it is possible to call \code{loadLibrary} again.
+and so it is possible to call \code{$p$.loadLibrary} again.
 If a call fails, nothing happens,
-and one has the option to call \code{loadLibrary} again.
-Whether a repeated call to \code{loadLibrary} succeeds will vary,
+and one has the option to call \code{$p$.loadLibrary} again.
+Whether a repeated call to \code{$p$.loadLibrary} succeeds will vary,
 as described below.
 
 \LMHash{}%
@@ -14583,7 +14583,7 @@ We do not specify which object the future returned resolves to.
 
 \LMHash{}%
 \Case{Evaluation of immediate imports}
-When $I_i$ is an immediate import:
+When $I_i$ is an immediate import that refers to a URI via the string $s_i$:
 
 \begin{itemize}
 \item
@@ -14601,42 +14601,46 @@ When $I_i$ is an immediate import:
 
 \LMHash{}%
 Let \NamespaceName{\metavar{import}, i} be the namespace imported from $L_i$.
-The namespace \NamespaceName{i} will then have the following mappings:
+The namespace \NamespaceName{i} will then have the following bindings:
 
 \begin{itemize}
 \item
-  For every top level function $f$ named \id{} in
+  For every top level function, getter, or setter $m$ named $n$ in
   \NamespaceName{\metavar{import}, i},
-  a corresponding method with the same name and signature as $f$
-  that forwards (\ref{functionDeclarations}) to $f$.
-\item
-  For every top level getter $g$ named \id{} in
-  \NamespaceName{\metavar{import}, i},
-  a corresponding getter that forwards to $g$.
-\item
-  For every top level setter $s$ named \code{\id=} in
-  \NamespaceName{\metavar{import}, i},
-  a corresponding setter that forwards to $s$.
+  a binding from $n$ to the result of compiling $m$.
 \item
   For every type $T$ named \id{} in
   \NamespaceName{\metavar{import}, i},
-  a corresponding getter named \id{} with return type \code{Type}
+  a compiled getter named \id{} with return type \code{Type}
   that, when invoked, returns the type object for $T$.
 \end{itemize}
 
 \LMHash{}%
-If $I_i$ has prefix $p$ then a mapping from $p$ to a non-deferred prefix object
+If $I_i$ has prefix $p$,
+and the library namespace of the current library
+does not have a binding for $p$,
+then a mapping from $p$ to a non-deferred prefix object
 with members determined by \NamespaceName{i} is introduced into the
 library namespace of the current library.
+If $I_i$ has prefix $p$,
+and the library namespace of the current library
+binds $p$ to a non-deferred prefix object $o$,
+then $o$ is extended with members as determined by \NamespaceName{i}.
 
 \LMHash{}%
-If $I_i$ does not have a prefix then each mapping in \NamespaceName{i}
+Otherwise, when $I_i$ does not have a prefix, each mapping in \NamespaceName{i}
 is introduced into the library namespace of the current library.
 
 \commentary{%
-Note that the dynamic construction of the library namespace
+The dynamic construction of the library namespace
 cannot encounter any name conflicts,
-because such conflicts would have caused a compile-time error.%
+because such conflicts would have caused a compile-time error.
+
+Library namespace construction can be completed at compile time,
+and any accesses, prefixed or not, can be resolved statically.
+So an implementation does not need to extend prefix objects dynamically,
+or even have a run-time representation of prefix objects at all,
+as long as the observable behavior is preserved.%
 }
 \EndCase
 
@@ -14661,7 +14665,7 @@ via \Index{export directives}, often referred to simply as \Index{exports}:
 \end{grammar}
 
 \LMHash{}%
-An export specifies a URI $x$
+An export specifies a URI $s$
 where the declaration of an exported library is to be found.
 The interpretation of URIs is described elsewhere
 (\ref{uris}).
@@ -14754,12 +14758,12 @@ key set which is disjoint with that of
 
 \LMHash{}%
 Assume that $i$ and $j$ are numbers in $1 .. m$.
-It is a compile-time error if there exist names $n$ and $n'$
-with the same basename such that
+It is a compile-time error
+if $L_i$ and $L_j$ are not the same library,
+either none or both of $L_i$ and $L_j$ are system libraries,
+and there exist names $n$ and $n'$ with the same basename such that:
 \NamespaceName{\metavar{export},i} is defined at $n$,
 \NamespaceName{\metavar{export},j} is defined at $n'$,
-$L_i$ and $L_j$ are not the same library,
-either none or both of $L_i$ and $L_j$ are system libraries,
 and \Namespace{\metavar{export},i}{n}
 and \Namespace{\metavar{export},j}{n'}
 is not the same declaration.
@@ -14809,7 +14813,7 @@ It is a static warning to export two different libraries with the same name,
 unless their name is the empty string.
 
 \rationale{%
-If two different URIs are inadvertantly used to access the same library $L$,
+If two different URIs are inadvertently used to access the same library $L$,
 say, because of a symbolic link in the underlying file system,
 this may help explaining why there are two incompatible copies of
 the types declared in $L$.

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -14749,10 +14749,14 @@ by eliminating each key $n$ where one of the following conditions hold:
     In other words, a declaration in $L$ shadows re-exported declarations.
     Import prefixes of $L$ are not exported, and do not shadow anything.%
   }
-\item The first case does not apply, $L_i$ is a system library,
-  there exists a $j \in 1 .. m$ such that $L_j$ is not a system library,
-  and \NamespaceName{\metavar{one},j} is defined at $n'$
-  such that $n$ and $n'$ have the same basename.
+\item The first case does not apply,
+  there exists a $j \in 1 .. m$ and name $n'$ such that
+  \NamespaceName{\metavar{one},j} is defined at $n'$,
+  $n$ and $n'$ have the same basename,
+  \Namespace{\metavar{one},j}{n}
+  is a declaration in a system library,
+  and \Namespace{\metavar{one},l}{n'}
+  is a declaration in a non-system library.
   \commentary{%
     So a re-exported declaration from a non-system library shadows
     re-exported declarations from system libraries.%

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -40,6 +40,8 @@
 % - Make lexical identifier lookups use the rules for 'Identifier Reference'
 %   consistently; that is, always look up `id` as well as `id=`, and commit
 %   to the kind of declaration found by that lookup.
+% - Clarify the section 'Imports'; includes setter/getter bundling following
+%   the approach in 'Lexical Lookup'.
 %
 % 2.3
 % - Add requirement that the iterator of a for-in statement must have
@@ -619,7 +621,18 @@ The method used to enable or disable assertions is implementation specific.
 \LMLabel{scoping}
 
 \LMHash{}%
-A \Index{namespace} is a mapping of names denoting declarations to actual declarations.
+A \Index{namespace} is a mapping from names to declarations.
+It may be considered as a partial function.
+It may also be seen as a set of bindings from a name to a declaration,
+$n\mapsto{}D$,
+with the constraint that if a namespace has both
+$n\mapsto{}D_1$ and $n\mapsto{}D_2$
+then $D_1$ and $D_2$ is the same declaration.
+When a namespace is seen as a set of mappings we may also refer
+to each binding as having a \NoIndex{key}
+which is mapped to a \NoIndex{value}.
+
+\LMHash{}%
 Let $NS$ be a namespace.
 We say that a name $n$ \Index{is in} $NS$ if $n$ is a key of $NS$.
 We say a declaration $d$ \NoIndex{is in} $NS$ if a key of $NS$ maps to $d$.
@@ -1166,7 +1179,7 @@ Functions abstract over executable actions.
 
 \begin{grammar}
 <functionSignature> ::= \gnewline{}
-  <metadata> <type>? <identifier> <formalParameterPart>
+  <type>? <identifier> <formalParameterPart>
 
 <formalParameterPart> ::= <typeParameters>? <formalParameterList>
 
@@ -1754,7 +1767,7 @@ Then the static type of $F$ is
 \LMHash{}%
 Let $F$ be a function with
 type parameters \TypeParametersStd,
-required formal parameter types  \List{T}{1}{n},
+required formal parameter types \List{T}{1}{n},
 return type $T_0$
 and positional optional parameter types \List{T}{n+1}{n+k}.
 Then the static type of $F$ is
@@ -1851,7 +1864,7 @@ Classes may be defined by class declarations as described below, or via mixin ap
   \ABSTRACT{}? \CLASS{} <identifier> <typeParameters>?
   \gnewline{} <superclass>? <interfaces>?
   \gnewline{} `{' (<metadata> <classMemberDefinition>)* `}'
-  \alt <metadata> \ABSTRACT{}? \CLASS{} <mixinApplicationClass>
+  \alt \ABSTRACT{}? \CLASS{} <mixinApplicationClass>
 
 <typeNotVoidList> ::= <typeNotVoid> (`,' <typeNotVoid>)*
 
@@ -3136,7 +3149,7 @@ If $k$ is redirecting then its redirect clause has the form
 
 \code{\THIS{}.$g$($a_1, \ldots,\ a_n,\ x_{n+1}$: $a_{n+1}, \ldots,\ x_{n+k}$: $a_{n+k}$)}
 
-where $g$ identifies another  generative constructor of the immediately surrounding class.
+where $g$ identifies another generative constructor of the immediately surrounding class.
 Then execution of $k$ to initialize $i$ proceeds by evaluating the argument list
 \code{($a_1, \ldots,\ a_n,\ x_{n+1}$: $a_{n+1}, \ldots,\ x_{n+k}$: $a_{n+k}$)}
 to an actual argument list $a$ of the form
@@ -5703,7 +5716,7 @@ be determined by the following iterative process, where $V_m$ denotes
   Then, for all $i \in 1 .. k$,
   $U_{i,m+1}$ is obtained from $U_{i,m}$
   by substituting $U_{j,m}$ for every occurrence of $X_j$
-  that is in a position in $V_m$ which  is not contravariant,
+  that is in a position in $V_m$ which is not contravariant,
   and substituting \code{Null} for every occurrence of $X_j$
   which is in a contravariant position in $V_m$.
 
@@ -14053,7 +14066,7 @@ The members of a library $L$ are those top level declarations given within $L$.
 
 <libraryDefinition> ::= \gnewline{}
   <scriptTag>? <libraryName>? <importOrExport>* <partDirective>*
-  \gnewline{} <metadata> <topLevelDefinition>*
+  \gnewline{} (<metadata> <topLevelDefinition>)*
 
 <scriptTag> ::= `#!' (\~{}<NEWLINE>)* <NEWLINE>
 
@@ -14107,63 +14120,248 @@ Since top level privates are not imported, using the top level privates of anoth
 }
 
 \LMHash{}%
-The \Index{public namespace} of library $L$ is the mapping that maps the simple name of each public top-level member $m$ of $L$ to $m$.
-The scope of a library $L$ consists of the names introduced by all top-level declarations declared in $L$, and the names added by $L$'s imports (\ref{imports}).
+The \Index{public namespace} of library $L$ is the mapping that
+maps the simple name of each public top-level member $m$ of $L$ to $m$.
+The scope of a library $L$ consists of
+the names introduced by all top-level declarations declared in $L$,
+and the names added by $L$'s imports (\ref{imports}).
 
+
+\subsection{Namespace Combinators}
+\LMLabel{namespaceCombinators}
+
+\LMHash{}%
+Imports (\ref{imports}) and exports (\ref{exports}) rely on
+\Index{namespace combinators}
+in order to adjust namespaces
+(\ref{scoping})
+and manage name clashes.
+The supported namespace combinators are \HIDE{} and \SHOW{}.
+
+\begin{grammar}
+<combinator> ::= \SHOW{} <identifierList>
+  \alt \HIDE{} <identifierList>
+
+<identifierList> ::= <identifier> (`,' <identifier>)*
+\end{grammar}
+
+\LMHash{}%
+We define several operations that compute namespaces.
+The
+\IndexCustom{union of two namespaces}{namespace!union},
+\IndexCustom{$\NamespaceName{a}\cup\NamespaceName{b}$}{%
+  $\cup$@$\NamespaceName{a} \cup \NamespaceName{b}$},
+is defined when every key where both are defined is mapped to the same value.
+\commentary{In particular, when the two namespaces have disjoint keys.}
+This union is the namespace that maps
+each key $n$ of \NamespaceName{a}
+to the corresponding value \Namespace{a}{n},
+and each key $n$ of \NamespaceName{b}
+to \Namespace{b}{n}.
+
+\commentary{%
+Note that this \emph{is} a namespace because the union is only defined
+when the mapping of any given key is unambiguous.%
+}
+
+\LMHash{}%
+The function
+\IndexCustom{\Hide{l}{\NamespaceName{a}}}{%
+  hide(l,NSa)@\Hide{l}{\NamespaceName{}}}
+takes a list of identifiers $l$ and a namespace \NamespaceName{a},
+and produces a namespace \NamespaceName{b} that is
+identical to \NamespaceName{a} except that for each identifier \id{} in $l$,
+\NamespaceName{b} is undefined at \id{} and at \code{\id=}.
+
+\LMHash{}%
+The function
+\IndexCustom{\Show{l}{\NamespaceName{a}}}{%
+  show(l,NSa)@\Show{l}{\NamespaceName{}}}
+takes a list of identifiers $l$ and a namespace \NamespaceName{a},
+and produces a namespace \NamespaceName{b} that
+maps each identifier \id{} in $l$
+where \NamespaceName{a} is defined
+to \Namespace{a}{n}.
+Furthermore, for each identifier \id{} in $l$
+where \NamespaceName{a} is defined at \code{\id=},
+\NamespaceName{b} maps \code{\id=} to \Namespace{a}{\code{\id=}}.
+Finally, \NamespaceName{b} is undefined at all other names.
+
+\commentary{%
+It is not an error to hide or show a non-existing name,
+but tools may choose to give a hint in such cases.%
+}
+
+\LMHash{}%
+Let \List{C}{1}{n} be a sequence of combinator clauses.
+\commentary{They would come from an import or export directive.}
+The
+\IndexCustom{combinator clauses can be applied to}{%
+  combinator clauses!application to namespace}
+a given namespace \NamespaceName{\metavar{start}},
+which yields a namespace \NamespaceName{\metavar{end}},
+as follows.
+
+\LMHash{}%
+Let \NamespaceName{0} be \NamespaceName{\metavar{start}}.
+For each combinator clause $C_j$, $j \in 1 .. n$:
+If $C_j$ is of the form \code{\SHOW{} $\id_1, \ldots,\ \id_k$} then let
+$\NamespaceName{j} = \Show{[\List{\id}{1}{k}]}{\NamespaceName{j-1}}$.
+If $C_i$ is of the form \code{\HIDE{} $\id_1, \ldots,\ \id_k$} then let
+$\NamespaceName{j} = \Hide{[\List{id}{1}{k}]}{\NamespaceName{j-1}}$.
+Then \NamespaceName{\metavar{end}} is \NamespaceName{n}.
+
+\commentary{%
+Note that \NamespaceName{\metavar{end}} will always agree with
+\NamespaceName{\metavar{start}} wherever both are defined,
+and the set of names where \NamespaceName{\metavar{end}} is defined
+is always a subset of that of \NamespaceName{\metavar{start}}.
+In that sense, this is a \emph{narrowing} procedure.%
+}
 
 \subsection{Imports}
 \LMLabel{imports}
 
 \LMHash{}%
-An \Index{import} specifies a library to be used in the scope of another library.
+An \Index{import} specifies a library to be used in
+the scope of another library.
+
 \begin{grammar}
 <libraryImport> ::= <metadata> <importSpecification>
 
 <importSpecification> ::= \gnewline{}
   \IMPORT{} <configurableUri> (\AS{} <identifier>)? <combinator>* `;'
   \alt \IMPORT{} <uri> \DEFERRED{} \AS{} <identifier> <combinator>* `;'
-
-<combinator> ::= \SHOW{} <identifierList>
-  \alt \HIDE{} <identifierList>
-
-<identifierList> ::= <identifier> (, <identifier>)*
 \end{grammar}
 
 \LMHash{}%
-An import specifies a URI $x$ where the declaration of an imported library is to be found.
+An import specifies a URI $x$
+where the declaration of an imported library is to be found.
+The interpretation of URIs is described elsewhere
+(\ref{uris}).
+It is a compile-time error if the specified URI
+does not refer to a library declaration.
 
 \LMHash{}%
 Imports may be
 \IndexCustom{deferred}{import!deferred} or
 \IndexCustom{immediate}{import!immediate}.
-A deferred import is distinguished by the appearance of the built-in identifier \DEFERRED{} after the URI.
+A deferred import is distinguished by the appearance of
+the built-in identifier \DEFERRED{} after the URI.
 Any import that is not deferred is immediate.
 
 \LMHash{}%
-It is a compile-time error if the specified URI of an immediate import does not refer to a library declaration.
-The interpretation of URIs is described in section \ref{uris} below.
-
-\LMHash{}%
-It is a compile-time error if the specified URI of a deferred import does not refer to a library declaration.
-
-\rationale{
-One cannot detect the problem at compile time because compilation often occurs during execution and one does not know what the URI refers to.
-However the development environment should detect the problem.
-}
-
-\LMHash{}%
-The \Index{current library} is the library currently being compiled.
-The import modifies the namespace of the current library in a manner that is determined by the imported library and by the optional elements of the import.
-
-\LMHash{}%
-An immediate import directive $I$ may optionally include a prefix clause of the form \code{\AS{} \id} used to prefix names imported by $I$.
-A deferred import must include a prefix clause or a compile-time error occurs.
-It is a compile-time error if a prefix used in a deferred import is used in another import clause.
+An immediate import directive $I$ may optionally include
+a prefix clause of the form \code{\AS{} \id} used to prefix
+names imported by $I$.
+A deferred import must include a prefix clause,
+or a compile-time error occurs.
+It is a compile-time error if a prefix used in a deferred import is used
+in another import clause.
 
 \LMHash{}%
 An import directive $I$ may optionally include namespace combinator clauses
-used to restrict the set of names imported by $I$.
-Currently, two namespace combinators are supported: \HIDE{} and \SHOW{}.
+used to restrict the set of names imported by $I$
+(\ref{namespaceCombinators}),
+as specified below.
+
+\LMHash{}%
+Let \NamespaceName{\metavar{local}} be the namespace that
+for each top-level declaration $D$ with name $n$ in $L$ maps $n$ to $D$.
+
+\LMHash{}%
+The imported namespace
+\NamespaceName{\metavar{import}}
+is then determined as follows, in two steps.
+Let $L$ be the current library,
+let \List{I}{1}{m} be the import directives of $L$,
+and let \List{L}{1}{m} be libraries
+such that $I_i$ refers to $L_i$ for all $i \in 1 .. m$.
+
+\LMHash{}%
+In the first step we compute the namespace provided by each imported library.
+For each $i \in 1 .. m$,
+let \NamespaceName{\metavar{narrowed},i} be
+the namespace obtained from applying
+the namespace combinators of $I_i$ to
+the exported namespace of $L_i$
+(\ref{namespaceCombinators}).
+
+\LMHash{}%
+In the second step we resolve conflicts
+among the namespaces obtained in the first step.
+For each $i \in 1 .. m$, the
+\Index{namespace imported from}
+$L_i$, \NamespaceName{\metavar{import},i},
+is identical to \NamespaceName{\metavar{narrowed},i},
+except that it is undefined at each name $n$
+where one of the following conditions holds,
+where \id{} is the basename of $n$:
+
+\begin{itemize}
+\item \NamespaceName{\metavar{local}} is defined at $n'$
+  such that the basename of $n'$ is \id.
+  \commentary{%
+    In other words, a declaration in the current library shadows
+    imported declarations with the same basename.%
+  }
+\item The first case does not apply, $L_i$ is a system library,
+  there exists a $j \in 1 .. m$ such that $L_j$ is not a system library,
+  and \NamespaceName{\metavar{narrowed},j} is defined at $n'$
+  such that the basename of $n'$ is \id.
+  \commentary{%
+    So an imported declaration from a non-system library shadows
+    imported declarations from system libraries.%
+  }
+\item The first case does not not apply,
+  there exists a $j \not= i$ in $1 .. m$ such
+  \NamespaceName{\metavar{narrowed},j} is defined at $n'$
+  and the basename of $n'$ is \id,
+  \Namespace{\metavar{narrowed},i}{n}
+  and \Namespace{\metavar{narrowed},j}{n'}
+  is not the same declaration,
+  and either none or both of $L_i$ and $L_j$ are system libraries.
+  \commentary{%
+    So with two distinct imported declarations with the same basename,
+    both are eliminated.%
+  }
+\end{itemize}
+
+\commentary{%
+The removal of these bindings from
+\NamespaceName{\metavar{narrowed},i}
+yields the namespace imported from $L_i$,
+\NamespaceName{\metavar{import},i},
+and ensures that each imported namespace has a
+key set which is disjoint with that of
+\NamespaceName{\metavar{local}},
+and where two imported namespaces only share keys when
+they have the same corresponding value.%
+}
+
+\LMHash{}%
+The
+\Index{imported namespace}
+of $L$ is then
+$\NamespaceName{\metavar{import}} =
+\NamespaceName{\metavar{import},1} \cup
+\ldots \NamespaceName{\metavar{import},m}$,
+and the
+\Index{library namespace}
+of $L$ is
+$\NamespaceName{\metavar{local}} \cup \NamespaceName{\metavar{import}}$.
+
+\LMHash{}%
+We say that a name is \Index{imported by a library}
+(or equivalently, that a library
+\IndexCustom{imports a name}{imports!name})
+if the name is in the library's imported namespace.
+We say that a declaration \Index{is imported by a library}
+(or equivalently, that a library
+\IndexCustom{imports a declaration}{imports!declaration})
+if the declaration is in the library's imported namespace.
+
+% !!!TODO!!! ------------------------------------------------------------ BEGIN
 
 \LMHash{}%
 Let $I$ be an import directive that refers to a URI via the string $s_1$.
@@ -14179,9 +14377,14 @@ The deferred prefix object has the following methods:
 \begin{itemize}
 \item \code{loadLibrary}.
 This method returns a future $f$.
-When called, the method causes an immediate import $I'$ to be executed at some future time, where $I'$ is derived from $I$ by eliding the word \DEFERRED{} and adding a \HIDE{} \code{loadLibrary} combinator clause.
+When called, the method causes
+an immediate import $I'$ to be executed at some future time,
+where $I'$ is derived from $I$ by eliding the word \DEFERRED{}
+and adding a \HIDE{} \code{loadLibrary} combinator clause.
 When $I'$ executes without error, $f$ completes successfully.
-If $I'$ executes without error, we say that the call to \code{loadLibrary} has succeeded, otherwise we say the call has failed.
+If $I'$ executes without error,
+we say that the call to \code{loadLibrary} has succeeded,
+otherwise we say the call has failed.
 \item
   For every top level function $f$ named \id{} in the imported library $B$,
   a corresponding method named \id{} with the same signature as $f$.
@@ -14204,19 +14407,28 @@ If $I'$ executes without error, we say that the call to \code{loadLibrary} has s
   Calling the method results in a dynamic error.
 \end{itemize}
 
-\rationale{
-The purpose of adding members of $B$ to $p$ is to ensure that any errors raised when using $p$ are correct, and no spurious errors are generated.
-In fact, at run time we cannot add these members until $B$ is loaded; but any such invocations will fail at run time as specified by virtue of being completely absent.
+\rationale{%
+The purpose of adding members of $B$ to $p$ is to ensure that
+any errors raised when using $p$ are correct,
+and no spurious errors are generated.
+In fact, at run time we cannot add these members until $B$ is loaded;
+but any such invocations will fail at run time
+as specified by virtue of being completely absent.%
 }
-%But this is still a lie detectable by reflection. Probably revise so the type of p has these members but p does not.
-
-The static type of the prefix object $p$ is a unique interface type that has those members whose names and signatures are listed above.
 
 \LMHash{}%
-After a call succeeds, the name $p$ is mapped to a non-deferred prefix object as described below.
-In addition, the prefix object also supports the \code{loadLibrary} method, and so it is possible to call \code{loadLibrary} again.
-If a call fails, nothing happens, and one again has the option to call \code{loadLibrary} again.
-Whether a repeated call to \code{loadLibrary} succeeds will vary as described below.
+The static type of the prefix object $p$ is a unique interface type
+that has those members whose names and signatures are listed above.
+
+\LMHash{}%
+After a call succeeds, the name $p$ is mapped to
+a non-deferred prefix object as described below.
+In addition, the prefix object also supports the \code{loadLibrary} method,
+and so it is possible to call \code{loadLibrary} again.
+If a call fails, nothing happens, and one has
+the option to call \code{loadLibrary} again.
+Whether a repeated call to \code{loadLibrary} succeeds
+will vary as described below.
 
 \LMHash{}%
 The effect of a repeated call to \code{$p$.loadLibrary} is as follows:
@@ -14395,6 +14607,8 @@ Other libraries may wish to use $L$ and may want to use members of $L$ that conf
 The above rule makes this possible, essentially canceling \code{dart:core}'s special treatment by means of yet another special rule.
 }
 
+% !!!TODO!!! ------------------------------------------------------------ END
+
 
 \subsection{Exports}
 \LMLabel{exports}
@@ -14418,7 +14632,8 @@ via \Index{export directives}, often referred to simply as \Index{exports}:
 \LMHash{}%
 An export specifies a URI $x$
 where the declaration of an exported library is to be found.
-The interpretation of URIs is described in section \ref{uris} below.
+The interpretation of URIs is described elsewhere
+(\ref{uris}).
 It is a compile-time error if the specified URI
 does not refer to a library declaration.
 
@@ -14432,8 +14647,6 @@ We say that a declaration \Index{is exported by a library}
 \IndexCustom{exports a declaration}{exports!declaration})
 if the declaration is in the library's exported namespace.
 
-%% TODO(eernst): Move this to `Imports` when that section gets update: Seems
-%% natural to define it at the first usage in terms of the page number.
 \LMHash{}%
 We define an operation for
 combining namespaces with disjoint sets of keys as follows.
@@ -14460,73 +14673,34 @@ and let \List{L}{1}{m} be libraries
 such that $E_i$ refers to $L_i$ for all $i \in 1 .. m$.
 
 \LMHash{}%
-Let \Namespace{L} be the namespace that
+In the first step we compute the namespace provided by each exported library.
+Let \NamespaceName{\metavar{local}} be the namespace that
 for each public top-level declaration $D$ with name $n$ in $L$ maps $n$ to $D$.
 For each $i \in 1 .. m$,
-let $\Namespace{\metavar{export}, i}$ be the exported namespace of $L_i$,
-and let \Namespace{i} be a namespace obtained from
-$\Namespace{\metavar{export}, i}$ by the narrowing process described below.
+let \NamespaceName{\metavar{narrowed},i} be
+the namespace obtained from applying
+the namespace combinators of $E_i$ to
+the exported namespace of $L_i$
+(\ref{namespaceCombinators}).
 
 \LMHash{}%
-The narrowing process that yields
-\Namespace{i} from $\Namespace{\metavar{export}, i}$
-consists of two steps.
-Each of them restricts the domain of the namespace to a subset
-(\commentary{%
-that is, it deletes the binding from a key to a value,
-for certain keys%
-}).
-
-{ %% Local scope: abbreviate narrowing namespaces.
-
-% The sequence of narrowed name spaces of export i.
-\def\NSNi#1{\Namespace{\metavar{narrowing},i,{#1}}}
-
-% The final narrowed name space of a given export. We don't want to
-% mention the number of hide/show clauses when the export varies.
-\def\NSN#1{\Namespace{\metavar{narrowing},{#1}}}
-
-\LMHash{}%
-Let \NSNi{0} be \Namespace{\metavar{export}, i}.
-Then, for each combinator clause $C_j$, $j \in 1 .. l$ in $E_i$
-(where \SHOW($\ldots$) and \HIDE($\ldots$) are defined in~\ref{imports}):
-
-\begin{itemize}
-\item If $C_j$ is of the form \code{\SHOW{} $\id_1, \ldots,\ \id_k$} then let
-
-$\NSNi{j} = \SHOW([\id_1, \ldots,\ \id_k], \NSNi{j-1})$.
-\item If $C_i$ is of the form \code{\HIDE{} $\id_1, \ldots,\ \id_k$}
-
-then let $\NSNi{j} = \HIDE([\id_1, \ldots,\ \id_k], \NSNi{j-1})$.
-\end{itemize}
-
-\LMHash{}%
-Let \NSN{i} be \NSNi{l}.
-
-\commentary{%
-This first step of narrowing performs the actions requested
-by \SHOW{} and \HIDE{} clauses in the export $E_i$
-and yields the result \NSN{i}.
-The second step deals with conflicts.%
-}
-
-\LMHash{}%
-The second step starts from \NSN{i}
-and obtains the final result, \Namespace{i},
+The second step starts from \NamespaceName{\metavar{narrowed},i}
+and obtains the result, \NamespaceName{\metavar{export},i},
 by eliminating each key $n$, bound to declaration $D$,
-where one of the following conditions hold:
+where one of the following conditions hold,
+where \id{} is the basename of $n$:
 
 \begin{itemize}
-\item \Namespace{L} maps $n$ to a declaration.
+\item \NamespaceName{\metavar{local}} is defined at $n'$
+  such that the basename of $n'$ is \id.
   \commentary{%
     In other words, a declaration in $L$ shadows
-    re-exported declarations with the same name.%
+    re-exported declarations with the same basename.%
   }
-\item The first case does not apply,
-  $L_i$ is a system library,
-  there exists a $j \not= i$ in $1 .. m$ such that
-  $L_j$ is not a system library,
-  and \NSN{j} maps $n$ to a declaration.
+\item The first case does not apply, $L_i$ is a system library,
+  there exists a $j \in 1 .. m$ such that $L_j$ is not a system library,
+  and \NamespaceName{\metavar{narrowed},j} is defined at $n'$
+  such that the basename of $n'$ is \id.
   \commentary{%
     So a re-exported declaration from a non-system library shadows
     re-exported declarations from system libraries.%
@@ -14537,17 +14711,22 @@ where one of the following conditions hold:
   }
 \end{itemize}
 
-\LMHash{}%
-The removal of these bindings from \NSN{i} yields the
-final, narrowed namespace \Namespace{i}.
+\commentary{%
+The removal of these bindings from
+\NamespaceName{\metavar{narrowed},i}
+yields the namespace exported from $L_i$,
+\NamespaceName{\metavar{export},i},
+and ensures that each exported namespace has a
+key set which is disjoint with that of
+\NamespaceName{\metavar{local}}.%
+}
 
 \LMHash{}%
 Assume that $i$ and $j$ are distinct numbers in $1 .. m$.
-It is a compile-time error if there exist a key $n$ such that
-\Namespace{i} maps $n$ to a declaration $D_i$,
-and \Namespace{j} maps $n$ to a declaration $D_j$,
-and $D_i$ and $D_j$ are not the same declaration.
-}
+It is a compile-time error if there exists a key $n$ such that
+\NamespaceName{\metavar{export},i} maps $n$ to a declaration $D_i$,
+and \NamespaceName{\metavar{export},j} maps $n$ to a declaration $D_j$,
+and $D_i$ and $D_j$ are not the same declaration.%
 
 \commentary{%
 It is possible for $D_i$ and $D_j$ to be the same declaration,
@@ -14556,20 +14735,27 @@ e.g., due to multiple re-exports.%
 
 \LMHash{}%
 Finally, the \Index{exported namespace} of $L$ is
-$\Namespace{L} \cup \Namespace{1} \cup \ldots \Namespace{m}$.
+$\NamespaceName{L} \cup
+\NamespaceName{\metavar{export},1} \cup
+\ldots \NamespaceName{\metavar{export},m}$.
 
 \commentary{%
-This union is well-defined because all these namespaces have
-pairwise disjoint sets of keys.%
+Unions of namespaces are defined elsewhere
+(\ref{imports}).
+This union is well-defined because all these namespaces only share
+keys where they have the same value.%
 }
 
 \LMHash{}%
 For a given $i$,
-we say that $L$ \Index{re-exports library} $L_i$,
-and also that $L$ \Index{re-exports namespace} \Namespace{i}.
+we say that $L$
+\Index{re-exports library}
+$L_i$, and also that $L$
+\Index{re-exports namespace}
+\NamespaceName{\metavar{export},i}.
 When no confusion can arise, we may simply state
 that $L$ \NoIndex{re-exports} $L_i$, or
-that $L$ \NoIndex{re-exports} \Namespace{i}.
+that $L$ \NoIndex{re-exports} \NamespaceName{\metavar{export},i}.
 
 \LMHash{}%
 It is a compile-time error to export two different libraries with the same name
@@ -15063,12 +15249,6 @@ A \Index{type alias} declares a name for a type expression.
 It is common to use the phrase ``a typedef'' for such a declaration,
 because of the prominent occurrence of the token \TYPEDEF.
 }
-
-% TODO(eernst): We include <metadata> in <typeAlias> even though it is not
-% there in Dart.g, because <libraryDefinition> in Dart.g allows metadata
-% before every <topLevelDefinition>, but that's not yet been transferred to
-% this document. So we'll need to remove the <metadata> below _when_ it is
-% made redundant by changing <libraryDefinition> to be like in Dart.g.
 
 \begin{grammar}
 <typeAlias> ::= \gnewline{}

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -14653,7 +14653,7 @@ The namespace \NamespaceName{i} will then have the following bindings:
 \item
   For every type $T$ named \id{} in
   \NamespaceName{\metavar{import}, i},
-  a compiled getter named \id{} with return type \code{Type}
+  a binding from \id{} to a compiled getter with return type \code{Type}
   that, when invoked, returns the type object for $T$.
 \end{itemize}
 

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -40,7 +40,7 @@
 % - Make lexical identifier lookups use the rules for 'Identifier Reference'
 %   consistently; that is, always look up `id` as well as `id=`, and commit
 %   to the kind of declaration found by that lookup.
-% - Clarify the section 'Imports'; includes setter/getter bundling following
+% - Clarify the section 'Imports'; includes `id`/`id=` processing following
 %   the approach in 'Lexical Lookup'.
 %
 % 2.3
@@ -14173,7 +14173,7 @@ is an import that is not deferred.
 
 \LMHash{}%
 An immediate import directive $I$ may optionally include
-a prefix clause of the form \code{\AS{} \id} used to prefix
+a \Index{prefix clause} of the form `\code{\AS{}\,\,\id}' used to prefix
 names imported by $I$.
 In this case we say that \id{} is an \Index{import prefix},
 or simply a \Index{prefix}.
@@ -14298,8 +14298,9 @@ the exported namespace of $L'_j$
 
 \LMHash{}%
 Let \NamespaceName{\metavar{narrowed},j} be the namespace which is identical to
-\NamespaceName{\metavar{exported},j} except that
-it is undefined at each name $n$ where one of the following holds:
+\NamespaceName{\metavar{exported},j} except that it is undefined at
+each name $n$ where \NamespaceName{\metavar{exported},j} is defined and
+one of the following conditions holds:
 
 \begin{itemize}
 \item There exists an $l \in 1 .. k$ and name $n'$ such that
@@ -14307,7 +14308,7 @@ it is undefined at each name $n$ where one of the following holds:
   $n$ and $n'$ have the same basename,
   \Namespace{\metavar{exported},j}{n}
   is a declaration in a system library,
-  and \Namespace{\metavar{exported},l}{n}
+  and \Namespace{\metavar{exported},l}{n'}
   is a declaration in a non-system library.
   \commentary{%
     So an imported declaration from a non-system library shadows
@@ -14392,8 +14393,9 @@ For each $i \in 1 .. m$, the
 \Index{namespace imported from}
 $L_i$, \NamespaceName{\metavar{import},i},
 is identical to \NamespaceName{\metavar{one},i},
-except that it is undefined at each name $n$
-where one of the following conditions holds:
+except that it is undefined at each name $n$ where
+\NamespaceName{\metavar{one},i} is defined
+and one of the following conditions holds:
 
 \begin{itemize}
 \item \NamespaceName{\metavar{local}} is defined at $n'$
@@ -14409,9 +14411,9 @@ where one of the following conditions holds:
   there exists a $j \in 1 .. m$ and name $n'$ such that
   \NamespaceName{\metavar{one},j} is defined at $n'$,
   $n$ and $n'$ have the same basename,
-  \Namespace{\metavar{one},j}{n}
+  \Namespace{\metavar{one},i}{n}
   is a declaration in a system library,
-  and \Namespace{\metavar{one},l}{n'}
+  and \Namespace{\metavar{one},j}{n'}
   is a declaration in a non-system library.
   \commentary{%
     So an imported declaration from a non-system library shadows
@@ -14426,8 +14428,8 @@ where one of the following conditions holds:
   are not the same declaration,
   $L_i$ and $L_j$ are not the same library,
   and either none or both of
-  \Namespace{\metavar{one},j}{n} and
-  \Namespace{\metavar{one},l}{n'}
+  \Namespace{\metavar{one},i}{n} and
+  \Namespace{\metavar{one},j}{n'}
   are declarations in a system library.
   %
   \commentary{%
@@ -14630,7 +14632,7 @@ When $I_i$ is an immediate import that refers to a URI via the string $s_i$:
 \begin{itemize}
 \item
   If the URI that is the value of $s_i$ has not yet been accessed by
-  an import or export (\ref{exports}) directive in the current isolate 
+  an import or export (\ref{exports}) directive in the current isolate
   then the contents of the URI are compiled to yield a library $L_i$.
   \commentary{%
     Because libraries may have mutually recursive imports,
@@ -14725,25 +14727,7 @@ We say that a declaration \Index{is exported by a library}
 if the declaration is in the library's exported namespace.
 
 \LMHash{}%
-We define an operation for
-combining namespaces with disjoint sets of keys as follows.
-The
-\IndexCustom{union of two namespaces}{namespace!union},
-\IndexCustom{$\Namespace{a}\cup\Namespace{b}$}{%
-  $\cup$@$\Namespace{a} \cup \Namespace{b}$},
-is the namespace that maps
-each key $n$ of \Namespace{a}
-to the corresponding value $\Namespace{a}(n)$,
-and each key $n$ of \Namespace{b}
-to $\Namespace{b}(n)$.
-
-\commentary{%
-Note that this is well-defined because the union does not exist
-in the case where the sets of keys of the two namespaces overlap.%
-}
-
-\LMHash{}%
-The exported namespace of a library is then determined as follows.
+The exported namespace of a library is then determined as follows, in two steps.
 Let $L$ be a library,
 let \List{E}{1}{m} be the export directives of $L$,
 and let \List{L}{1}{m} be libraries
@@ -14765,9 +14749,15 @@ the exported namespace of $L_i$
 (\ref{namespaceCombinators}).
 
 \LMHash{}%
-The second step starts from \NamespaceName{\metavar{one},i}
-and obtains the result, \NamespaceName{\metavar{export},i},
-by eliminating each key $n$ where one of the following conditions hold:
+In the second step we compute the
+\Index{namespace exported from}
+$L_i$, \NamespaceName{\metavar{export},i}.
+For each $i \in 1 .. m$,
+\NamespaceName{\metavar{export},i}
+is identical to \NamespaceName{\metavar{one},i},
+except that it is undefined at each name $n$ where
+\NamespaceName{\metavar{one},i} is defined
+and one of the following conditions hold:
 
 \begin{itemize}
 \item \NamespaceName{\metavar{local}} is defined at $n'$
@@ -14780,9 +14770,9 @@ by eliminating each key $n$ where one of the following conditions hold:
   there exists a $j \in 1 .. m$ and name $n'$ such that
   \NamespaceName{\metavar{one},j} is defined at $n'$,
   $n$ and $n'$ have the same basename,
-  \Namespace{\metavar{one},j}{n}
+  \Namespace{\metavar{one},i}{n}
   is a declaration in a system library,
-  and \Namespace{\metavar{one},l}{n'}
+  and \Namespace{\metavar{one},j}{n'}
   is a declaration in a non-system library.
   \commentary{%
     So a re-exported declaration from a non-system library shadows
@@ -14795,13 +14785,8 @@ by eliminating each key $n$ where one of the following conditions hold:
 \end{itemize}
 
 \commentary{%
-The removal of these bindings from
-\NamespaceName{\metavar{one},i}
-yields the namespace exported from $L_i$,
-\NamespaceName{\metavar{export},i},
-and ensures that each exported namespace has a
-key set which is disjoint with that of
-\NamespaceName{\metavar{local}}.%
+The removal of these bindings ensures that each exported namespace has a
+key set which is disjoint with that of \NamespaceName{\metavar{local}}.%
 }
 
 \LMHash{}%


### PR DESCRIPTION
[Edit: Having performed experiments, I can see that the getter/setter conflicts specified by the use of 'basename' in the new spec text are already an error with the analyzer. Breakage exists in the case where a library imports or exports a getter/setter pair from two different libraries, and only uses the getter (the analyzer currently accepts this, and with the rules proposed in this PR a `hide id` must be used to hide the setter). Note that the getter from a system library wins over a setter from a non-system library, so we probably don't want precisely the current behavior in any case.]

This PR contains a complete rewrite of the spec section `Imports`, and a revision of `Exports` (because some material in `Exports` should be reused for both im- and exports, and some corrections detected during the rewrite of imports were carried over).

It preserves the treatment where getter/setter names are bundled wherever that was already the case. It introduces an explicit bundling of getter/setter names using the word `basename` during the computation of imported and exported namespaces (so a search for `basename` in the diff shows where).

It is a total rewrite because the old text was ambiguous in a number of ways and incomplete in others, whereas the new text has a rather explicit structure.

The current text amounts to a rather strict and consistent proposal about how to handle getter/setter names and conflicts among them.

If we prefer to allow getters/setters to conflict in ways that the current text will not allow (e.g., if two distinct libraries _L1_ and _L2_ export a getter `x` respectively a setter `x=` then an import of both will eliminate both, but the old rules would let them coexist), then it will be a matter of adjusting the use of `basename` in the namespace combination rules.