### PR TITLE
Feature spec of explicit variance

### DIFF
--- a/accepted/future-releases/variance/feature-specification-use-site-variance.md
+++ b/accepted/future-releases/variance/feature-specification-use-site-variance.md
@@ -413,15 +413,17 @@ widen(M, Con<inout U>) = Con<narrow(M, U)>, if doesNarrow(M, U)
 
 // Interface type narrowing, atomic.
 
-narrow(v X: T, Cl<X>) = Cl<Never>             // v: legacy, out, or inout.
+narrow(X: T, Cl<X>) = Cl<Never>
+narrow(v X: T, Cl<X>) = Cl<T>                 // v: inout or in.
 narrow(v X: out T, Cl<X>) = Cl<Never>         // v: legacy or inout.
-narrow(v X: inout T, Cl<X>) = Cl<T>           // v: legacy or out.
+narrow(v X: inout T, Cl<X>) = Cl<T>           // v: legacy or in.
 narrow(inout X: in T, Cl<X>) = Cl<T>
 narrow(v X: *, Cl<X>) = Cl<Never>             // v: any.
 
-narrow(v X: T, Co<X>) = Co<Never>             // v: legacy, out, or inout.
+narrow(X: T, Co<X>) = Co<Never>
+narrow(v X: T, Co<X>) = Co<T>                 // v: inout or in.
 narrow(v X: out T, Co<X>) = Co<Never>         // v: legacy or inout.
-narrow(v X: inout T, Co<X>) = Co<T>           // v: legacy or out.
+narrow(v X: inout T, Co<X>) = Co<T>           // v: legacy or in.
 narrow(inout X: in T, Co<X>) = Co<T>
 narrow(v X: *, Co<X>) = Co<Never>             // v: any.
 
@@ -432,27 +434,22 @@ narrow(X: inout T, Ci<X>) = Ci<T>
 narrow(inout X: in T, Ci<X>) = Never
 narrow(v X: *, Ci<X>) = Never                 // v: any.
 
-narrow(X: T, Con<X>) = Con<T>
-narrow(inout X: T, Con<X>) = Con<T>
-narrow(in X: T, Con<X>) = Con<B>
+narrow(v X: T, Con<X>) = Con<T>               // v: legacy, out, or inout.
 narrow(v X: out T, Con<X>) = Con<T>           // v: legacy or inout.
-narrow(v X: inout T, Con<X>) = Con<T>         // v: legacy or in.
-narrow(inout X: in T, Con<X>) = Con<T>
+narrow(v X: inout T, Con<X>) = Con<T>         // v: legacy or out.
+narrow(inout X: in T, Con<X>) = Con<B>
 narrow(v X: *, Con<X>) = Con<B>               // v: any.
 
-narrow(v X: T, Ci<out X>) = Ci<Never>         // v: legacy or out.
-narrow(inout X: T, Ci<out X>) = Ci<out T>
-narrow(X: out T, Ci<out X>) = Ci<Never>
-narrow(inout X: out T, Ci<out X>) = Ci<Never>
-narrow(v X: inout T, Ci<out X>) = Ci<out T>   // v: legacy or out.
+narrow(X: T, Ci<out X>) = Ci<Never>
+narrow(v X: T, Ci<out X>) = Ci<out T>         // v: inout or in.
+narrow(v X: out T, Ci<out X>) = Ci<Never>     // v: legacy or inout.
+narrow(v X: inout T, Ci<out X>) = Ci<out T>   // v: legacy or in.
 narrow(inout X: in T, Ci<out X>) = Ci<out T>
 narrow(v X: *, Ci<out X>) = Ci<Never>         // v: any.
 
-narrow(X: T, Ci<in X>) = Ci<in Never>
-narrow(v X: T, Ci<in X>) = Ci<in T>           // v: inout or in.
-narrow(v X: out T, Ci<in X>) = Ci<in B>       // v: legacy or inout.
-narrow(X: inout T, Ci<in X>) = Ci<in T>
-narrow(in X: inout T, Ci<in X>) = Ci<in T>
+narrow(v X: T, Ci<in X>) = Ci<in T>           // v: legacy, out, or inout.
+narrow(v X: out T, Ci<in X>) = Ci<in T>       // v: legacy or inout.
+narrow(v X: inout T, Ci<in X>) = Ci<in T>     // v: legacy or out.
 narrow(inout X: in T, Ci<in X>) = Ci<in B>
 narrow(v X: *, Ci<in X>) = Ci<in B>           // v: any.
 
@@ -560,15 +557,17 @@ doesWiden(M, Con<inout U>) = doesNarrow(M, U)
 
 // Determine whether narrowing will make other changes than substitution.
 
-doesNarrow(v X: T, Cl<X>) = true                  // v: legacy, out, or inout.
+doesNarrow(X: T, Cl<X>) = true
+doesNarrow(v X: T, Cl<X>) = false                 // v: inout or in.
 doesNarrow(v X: out T, Cl<X>) = true              // v: legacy or inout.
-doesNarrow(v X: inout T, Cl<X>) = false           // v: legacy or out.
+doesNarrow(v X: inout T, Cl<X>) = false           // v: legacy or in.
 doesNarrow(inout X: in T, Cl<X>) = false
 doesNarrow(v X: *, Cl<X>) = true                  // v: any.
 
-doesNarrow(v X: T, Co<X>) = true                  // v: legacy, out, or inout.
+doesNarrow(X: T, Co<X>) = true
+doesNarrow(v X: T, Co<X>) = false                 // v: inout or in.
 doesNarrow(v X: out T, Co<X>) = true              // v: legacy or inout.
-doesNarrow(v X: inout T, Co<X>) = false           // v: legacy or out.
+doesNarrow(v X: inout T, Co<X>) = false           // v: legacy or in.
 doesNarrow(inout X: in T, Co<X>) = false
 doesNarrow(v X: *, Co<X>) = true                  // v: any.
 
@@ -579,27 +578,22 @@ doesNarrow(X: inout T, Ci<X>) = false
 doesNarrow(inout X: in T, Ci<X>) = true
 doesNarrow(v X: *, Ci<X>) = true                  // v: any.
 
-doesNarrow(X: T, Con<X>) = false
-doesNarrow(inout X: T, Con<X>) = false
-doesNarrow(in X: T, Con<X>) = true
+doesNarrow(v X: T, Con<X>) = false                // v: legacy, out, or inout.
 doesNarrow(v X: out T, Con<X>) = false            // v: legacy or inout.
-doesNarrow(v X: inout T, Con<X>) = false          // v: legacy or in.
-doesNarrow(inout X: in T, Con<X>) = false
+doesNarrow(v X: inout T, Con<X>) = false          // v: legacy or out.
+doesNarrow(inout X: in T, Con<X>) = true
 doesNarrow(v X: *, Con<X>) = true                 // v: any.
 
-doesNarrow(v X: T, Ci<out X>) = true              // v: legacy or out.
-doesNarrow(inout X: T, Ci<out X>) = false
-doesNarrow(X: out T, Ci<out X>) = true
-doesNarrow(inout X: out T, Ci<out X>) = true
-doesNarrow(v X: inout T, Ci<out X>) = false       // v: legacy or out.
+doesNarrow(X: T, Ci<out X>) = true
+doesNarrow(v X: T, Ci<out X>) = false             // v: inout or in.
+doesNarrow(v X: out T, Ci<out X>) = true          // v: lecacy or inout.
+doesNarrow(v X: inout T, Ci<out X>) = false       // v: legacy or in.
 doesNarrow(inout X: in T, Ci<out X>) = false
 doesNarrow(v X: *, Ci<out X>) = true              // v: any.
 
-doesNarrow(X: T, Ci<in X>) = true
-doesNarrow(v X: T, Ci<in X>) = false              // v: inout or in.
-doesNarrow(v X: out T, Ci<in X>) = true           // v: legacy or inout.
-doesNarrow(X: inout T, Ci<in X>) = false
-doesNarrow(in X: inout T, Ci<in X>) = false
+doesNarrow(v X: T, Ci<in X>) = false              // v: legacy, out, or inout.
+doesNarrow(v X: out T, Ci<in X>) = false          // v: legacy or inout.
+doesNarrow(v X: inout T, Ci<in X>) = false        // v: legacy or out.
 doesNarrow(inout X: in T, Ci<in X>) = true
 doesNarrow(v X: *, Ci<in X>) = true               // v: any.
 

--- a/accepted/future-releases/variance/feature-specification-use-site-variance.md
+++ b/accepted/future-releases/variance/feature-specification-use-site-variance.md
@@ -321,9 +321,9 @@ where `varianceMap` is a mapping from each type variable `Xj` to the correspondi
 
 We consider a member access where the receiver type is `C<T>` and the member signature is `s`, which corresponds to the function type `U1 Function(U2)`.
 
-We describe `widen` and the associated `narrow` function using the argument `X: T` to describe the situation where there is no use-site variance modifier, the type variable is `X`, and the actual type argument passed to `X` is `T`, and similarly for `X: out T`, `X: inout T`, and `X: in T`.
+We describe `widen` and the associated `narrow` function using the argument `X: T` to describe the situation where there is no use-site variance modifier, the type variable is `X`, which is legacy, and the actual type argument passed to `X` is `T`, and similarly for `X: out T`, `X: inout T`, and `X: in T`. Similarly, `out X: v T` indicates that the declaration-site variance of `X` is `out` and the use-site variance is `v` (which can be absent, `out`, `inout`, or `in`); and similarly for `inout X: v T` and `in X: v T` with the remaining declaration-site variances.
 
-When the map is not used to single out cases, we use `M` to stand for an arbitrary map (*e.g., it could stand for `X: inout T`*).
+When the map is not used for pattern matching, we use `M` to stand for an arbitrary map (*e.g., it could stand for `out X: inout T`*).
 
 We process the member signature as a whole as a function type. (*Again, we simplify it to take exactly one argument.*)
 

--- a/accepted/future-releases/variance/feature-specification-use-site-variance.md
+++ b/accepted/future-releases/variance/feature-specification-use-site-variance.md
@@ -236,7 +236,7 @@ class B<X> extends A<X> {
 }
 ```
 
-*Note that this is a pragmatic design choice. It would be possible to allow classes like `B` to exist, if it turns out to ease the migration of existing code to use sound variance.*
+*Note that this is a pragmatic design choice. It would be possible to allow classes like `B` to exist, if it turns out to ease migration of existing code.*
 
 *It _is_ allowed to create the opposite relationship, which is surely helpful during migration:*
 
@@ -289,8 +289,7 @@ class B<out X> extends A<X> { // or `implements`.
 
 ### Member signatures with Widening Use-site Variance
 
-
-
+!!!HERE!!!
 
 *For example:*
 

--- a/accepted/future-releases/variance/feature-specification-use-site-variance.md
+++ b/accepted/future-releases/variance/feature-specification-use-site-variance.md
@@ -395,21 +395,21 @@ widen(M, Cl<U>) = Cl<widen(M, U)>
 
 widen(M, Co<U>) = Co<widen(M, U)>
 
-widen(M, Ci<U>) = [T/X]Ci<U>, if !doesWiden(M, U)
-                = Ci<out widen(M, U)>, otherwise.
+widen(M, Ci<U>) = Ci<out widen(M, U)>, if doesWiden(M, U)
+                = [T/X]Ci<U>, otherwise.
 
-widen(M, Con<U>) = [T/X]Con<U>, if !doesNarrow(M, U)
-                 = Con<narrow(M, U)>, otherwise.
+widen(M, Con<U>) = Con<narrow(M, U)>, if doesNarrow(M, U)
+                 = [T/X]Con<U>, otherwise.
 
 widen(M, Ci<out U>) = Ci<out widen(M, U)>
 
 widen(M, Ci<in U>) = Ci<in narrow(M, U)>
 
-widen(M, Co<inout U>) = [T/X]Co<inout U>, if !doesWiden(M, U)
-                      = Co<widen(M, U)>, otherwise.
+widen(M, Co<inout U>) = Co<widen(M, U)>, if doesWiden(M, U)
+                      = [T/X]Co<inout U>, otherwise.
 
-widen(M, Con<inout U>) = [T/X]Con<inout U>, if !doesNarrow(M, U)
-                       = Con<narrow(M, U)>, otherwise.
+widen(M, Con<inout U>) = Con<narrow(M, U)>, if doesNarrow(M, U)
+                       = [T/X]Con<inout U>, otherwise.
 
 // Interface type narrowing, atomic.
 
@@ -476,20 +476,20 @@ narrow(M, Cl<U>) = Cl<narrow(M, U)>
 
 narrow(M, Co<U>) = Co<narrow(M, U)>
 
-narrow(M, Ci<U>) = Ci<U>, if !doesNarrow(M, U)
-                 = Never, otherwise.
+narrow(M, Ci<U>) = Never, if doesNarrow(M, U)
+                 = [T/X]Ci<U>, otherwise.
 
-narrow(M, Con<U>) = Con<widen(M, U)>, otherwise.
+narrow(M, Con<U>) = Con<widen(M, U)>
 
 narrow(M, Ci<out U>) = Ci<out narrow(M, U)>
 
 narrow(M, Ci<in U>) = Ci<in widen(M, U)>
 
-narrow(M, Co<inout U>) = Co<inout U>, if !doesNarrow(M, U)
-                       = Never, otherwise.
+narrow(M, Co<inout U>) = Never, if doesNarrow(M, U)
+                       = [T/X]Co<inout U>, otherwise.
 
-narrow(M, Con<inout U>) = Con<inout U>, if !doesWiden(M, U)
-                        = Never, otherwise.
+narrow(M, Con<inout U>) = Never, if doesWiden(M, U)
+                        = [T/X]Con<inout U>, otherwise.
 
 // Determine whether widening will make other changes than substitution.
 
@@ -558,7 +558,7 @@ doesWiden(M, Ci<in U>) = doesNarrow(M, U)
 doesWiden(M, Co<inout U>) = doesWiden(M, U)
 doesWiden(M, Con<inout U>) = doesNarrow(M, U)
 
-// Determine whether narrowing is a no-op.
+// Determine whether narrowing will make other changes than substitution.
 
 doesNarrow(v X: T, Cl<X>) = true                  // v: legacy, out, or inout.
 doesNarrow(v X: out T, Cl<X>) = true              // v: legacy or inout.

--- a/accepted/future-releases/variance/feature-specification-use-site-variance.md
+++ b/accepted/future-releases/variance/feature-specification-use-site-variance.md
@@ -335,6 +335,12 @@ widen(M, U1 Function(U2)) = widen(M, U1) Function(narrow(M, U2))
 
 // Interface type widening, atomic.
 
+widen(v X: T, X) = T                         // v: legacy, out, or inout.
+widen(v X: out T, X) = T                     // v: legacy or inout.
+widen(v X: inout T, X) = T                   // v: legacy or out.
+widen(inout X: in T, X) = B
+widen(v X: *, X) = B                         // v: any.
+
 widen(v X: T, Cl<X>) = Cl<T>                 // v: legacy, out, or inout.
 widen(v X: out T, Cl<X>) = Cl<T>             // v: legacy or inout.
 widen(v X: inout T, Cl<X>) = Cl<T>           // v: legacy or out.
@@ -413,6 +419,13 @@ widen(M, Con<inout U>) = Con<narrow(M, U)>, if doesNarrow(M, U)
 
 // Interface type narrowing, atomic.
 
+narrow(X: T, X) = Never
+narrow(v X: T, X) = T                         // v: inout or in.
+narrow(v X: out T, X) = Never                 // v: legacy or inout.
+narrow(v X: inout T, X) = T                   // v: legacy or in.
+narrow(inout X: in T, X) = T
+narrow(v X: *, X) = Never                     // v: any.
+
 narrow(X: T, Cl<X>) = Cl<Never>
 narrow(v X: T, Cl<X>) = Cl<T>                 // v: inout or in.
 narrow(v X: out T, Cl<X>) = Cl<Never>         // v: legacy or inout.
@@ -490,6 +503,12 @@ narrow(M, Con<inout U>) = Never, if doesWiden(M, U)
 
 // Determine whether widening will make other changes than substitution.
 
+doesWiden(v X: T, X) = false                     // v: legacy, out, or inout.
+doesWiden(v X: out T, X) = false                 // v: legacy or inout.
+doesWiden(v X: inout T, X) = false               // v: legacy or out.
+doesWiden(inout X: in T, X) = true
+doesWiden(v X: *, X) = true                      // v: any.
+
 doesWiden(v X: T, Cl<X>) = false                 // v: legacy, out, or inout.
 doesWiden(v X: out T, Cl<X>) = false             // v: legacy or inout.
 doesWiden(v X: inout T, Cl<X>) = false           // v: legacy or out.
@@ -556,6 +575,13 @@ doesWiden(M, Co<inout U>) = doesWiden(M, U)
 doesWiden(M, Con<inout U>) = doesNarrow(M, U)
 
 // Determine whether narrowing will make other changes than substitution.
+
+doesNarrow(X: T, X) = true
+doesNarrow(v X: T, X) = false                     // v: inout or in.
+doesNarrow(v X: out T, X) = true                  // v: legacy or inout.
+doesNarrow(v X: inout T, X) = false               // v: legacy or in.
+doesNarrow(inout X: in T, X) = false
+doesNarrow(v X: *, X) = true                      // v: any.
 
 doesNarrow(X: T, Cl<X>) = true
 doesNarrow(v X: T, Cl<X>) = false                 // v: inout or in.

--- a/accepted/future-releases/variance/feature-specification-use-site-variance.md
+++ b/accepted/future-releases/variance/feature-specification-use-site-variance.md
@@ -1,0 +1,429 @@
+# Sound and Explicit Variance
+
+Author: eernst@google.com
+
+Status: Draft
+
+
+## CHANGELOG
+
+2019.08.30:
+- Initial version uploaded.
+
+
+## Summary
+
+This document proposes a specification for sound and explicit management of [variance](https://github.com/dart-lang/language/issues/213) in Dart.
+
+Issues on topics related to this proposal can be found [here](https://github.com/dart-lang/language/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3Avariance+).
+
+Currently, a parameterized class type is covariant in every type parameter. For example, `List<int>` is a subtype of `List<num>` because `int` is a subtype of `num` (so the list type and its type argument "co-vary").
+
+This is sound for all covariant occurrences of such type parameters in the class body (for instance, the getter `first` of a list has return type `E`, which is sound). It is also sound for contravariant occurrences when a sufficiently exact receiver type is known (e.g., for a literal like `<num>[].add(4.2)`, or for a generative constructor `SomeClass<num>.foo(4.2)`).
+
+However, in general, every member access where a covariant type parameter occurs in a non-covariant position may cause a dynamic type error, because the actual type annotation at run time&mdash;say, the type of a parameter of a method&mdash;is a subtype of the one which occurs in the static type.
+
+This proposal introduces explicit variance modifiers for type parameters, as well as invariance modifiers for actual type arguments. It includes compile-time restrictions on type declarations and on the use of objects whose static type includes these modifiers, ensuring that the above-mentioned dynamic type errors cannot occur.
+
+In order to ease the transition where types with explicit variance are created and used, this proposal allows for certain subtype relationships where dynamic type checks are still needed when using legacy types (where type parameters are _implicitly_ covariant) to access an object, even in the case where the object has a type with explicit variance. For example, it is allowed to declare `class MyList<out E> implements List<E> {...}`, even though this means that `MyList` has members such as `add` that require dynamic checks and may incur a dynamic type error.
+
+
+## Syntax
+
+The grammar is adjusted as follows:
+
+```
+<typeParameter> ::= // Modified.
+    <metadata> <typeParameterVariance>? <typeIdentifier>
+    ('extends' <typeNotVoid>)?
+
+<typeParameterVariance> ::= // New.
+    'out' | 'inout' | 'in'
+
+<typeArguments> ::= // Modified.
+    '<' <typeArgumentList> '>'
+
+<typeArgumentList> ::= // New.
+    <typeArgument> (',' <typeArgument>)*
+
+<typeArgument> ::= // New.
+    'exactly'? <type>
+```
+
+Moreover, `'exactly'` is added to the set of built-in identifiers.
+
+
+## Static Analysis
+
+This feature allows type parameters to be declared with a _variance modifier_ which is one of `out`, `inout`, or `in`. This implies that the use of such a type parameter is restricted, in return for improved static type safety. Moreover, the rules for other topics like subtyping and for determining the variance of a subterm in a type are adjusted.
+
+
+### Subtype Rules
+
+The [subtype rule](https://github.com/dart-lang/language/blob/e3010343a8e6f608a831078b0a04d4f1eeca46d4/specification/dartLangSpec.tex#L14845) for interface types that is concerned with the relationship among type arguments ('class covariance') is modified as follows:
+
+In order to conclude that _C&lt;S<sub>1</sub>,... S<sub>s</sub>&gt; <: C&lt;T<sub>1</sub>,... T<sub>s</sub>&gt;_ the current rule requires that _S<sub>j</sub> <: T<sub>j</sub>_ for each _j_ in 1 .. _s_. *This means that, to be a subtype, all actual type arguments must be subtypes.*
+
+The rule is updated as follows in order to take variance modifiers into account:
+
+Let _j_ in 1 .. _s_. If none of _S<sub>j</sub>_ or _T<sub>j</sub>_ have the modifier `exactly` then the following rules apply:
+
+If the corresponding type parameter _X<sub>j</sub>_ has no variance modifier, or it has the variance modifier `out`, we require _S<sub>j</sub> <: T<sub>j</sub>_.
+
+If the corresponding type parameter _X<sub>j</sub>_ has the variance modifier `inout`, we require _S<sub>j</sub> <: T<sub>j</sub>_ as well as _T<sub>j</sub> <: S<sub>j</sub>_.
+
+If the corresponding type parameter _X<sub>j</sub>_ has the variance modifier `in`, we require _T<sub>j</sub> <: S<sub>j</sub>_.
+
+If both _S<sub>j</sub>_ and _T<sub>j</sub>_ have the modifier `exactly` then let _S1<sub>j</sub>_ be _S<sub>j</sub>_ except that `exactly` has been eliminated, and similarly for _T1<sub>j</sub>_; we then require _S1<sub>j</sub> <: T1<sub>j</sub>_ as well as _T1<sub>j</sub> <: S1<sub>j</sub>_ (*whether or not the corresponding type parameter has a variance modifier, and no matter which one*).
+
+A new subtype rule for type arguments where `exactly` does not occur symmetrically is added:
+
+_C&lt;S<sub>1</sub>,... S<sub>s</sub>&gt; <: T_ whenever _C&lt;T<sub>1</sub>,... T<sub>s</sub>&gt; <: T_, where we have the relationship for each _j_ in 1 .. _s_ that either _S<sub>j</sub>_ is _T<sub>j</sub>_ or _S<sub>j</sub>_ is _exactly T<sub>j</sub>_.
+
+*For instance:*
+
+```dart
+// Not runnable code, just examples of subtype relationships:
+List<exactly num> <: List<num> <: List<Object> <: Object
+List<exactly List<num>> <: List<List<num>> <: List<Object>
+List<exactly List<exactly num>> <: List<List<exactly num>> <: List<List<num>>
+List<exactly num> <: Iterable<exactly num> <: Iterable<num>
+
+// But the subtype relation does _not_ include the following:
+List<num> <\: List<exactly num>
+List<exactly List<exactly num>> <\: List<exactly List<num>>
+```
+
+*We cannot assign an expression of type `List<num>` to a variable of type `List<exactly num>` without a dynamic type check. Similarly, we cannot assign an expression of type `List<exactly List<exactly num>>` to a variable of type `List<exactly List<num>>`. Here is an example illustrating why this is so.*
+
+```dart
+main() {
+  List<num> xs = <int>[];
+  List<exactly num> ys = xs; // This must be an error because:
+  ys.add(3.41); // Safe, based on the type of `ys`, but it should throw.
+
+  List<exactly List<exactly num>> zs = [];
+  List<exactly List<num>> ws = zs; // This must be an error because:
+  ws.add(<int>[]); // Safe, based on the type of `ws`, but it should throw.
+  zs[0][0] = 4.31; // Safe, based on the type of `zs`, but it should throw.
+}
+```
+
+*In the above example, an execution that maintains heap soundness would throw already at `ws.add(<int>[])`, because `List<int>` is not a subtype of `List<exactly num>`. Otherwise, we can proceed to `zs[0][0] = 4.31` and cause a base level type error, which illustrates that we cannot just ignore the distinction between `List<exactly num>` and `List<num>` as a type argument, neither statically nor dynamically.*
+
+Finally, the subtype rule that connects a class to its superinterfaces is updated to take `exactly` into account:
+
+Given that _C_ is a class that declares type parameters _X<sub>1</sub> .. X<sub>s</sub>_ such that
+_D&lt;T<sub>1</sub> .. T<sub>m</sub>&gt;_ is a direct superinterface of _C_, we conclude that
+_C&lt;v<sub>1</sub> S<sub>1</sub> .. v<sub>s</sub> S<sub>s</sub>&gt; <: T_
+if
+_[v<sub>1</sub> S<sub>1</sub>/X<sub>1</sub> .. v<sub>s</sub> S<sub>s</sub>/X<sub>s</sub>]D&lt;T<sub>1</sub> .. T<sub>m</sub>&gt; <: T_
+where _S<sub>j</sub>_ is a type and _v<sub>j</sub>_ is either empty or `exactly`, for all _j_ in 1 .. _s_.
+
+
+### Variance Rules
+
+The rules for determining the variance of a position are updated as follows:
+
+We say that a type _S_ occurs in a _covariant position_ in a type _T_ iff one of the following conditions is true:
+
+- _T_ is _S_.
+
+- _T_ is of the form _G&lt;S<sub>1</sub>,... S<sub>n</sub>&gt;_ where _G_ denotes a generic class or type alias and _S_ occurs in a covariant position in _S<sub>j</sub>_ for some _j_ in 1 .. _n_ where the corresponding type parameter of _G_ is covariant; or in a contravariant position where the corresponding type parameter is contravariant.
+
+- _T_ is of the form _S<sub>0</sub> Function&lt;X<sub>1</sub> extends B<sub>1</sub>, ...>(...)_ where the type parameter list may be omitted, and _S_ occurs in a covariant position in _S<sub>0</sub>_.
+
+- _T_ is of the form _S<sub>0</sub> Function&lt;X<sub>1</sub> extends B<sub>1</sub>, ...&gt;(S<sub>1</sub> x<sub>1</sub>, ... S<sub>k</sub> x<sub>k</sub>, [S<sub>k+1</sub> x<sub>k+1</sub> = d<sub>k+1</sub>, ..., S<sub>n</sub> x<sub>n</sub> = d<sub>n</sub>])_ or of the form _S<sub>0</sub> Function&lt;X<sub>1</sub> extends B<sub>1</sub>, ...&gt; (S<sub>1</sub> x<sub>1</sub>, ... S<sub>k</sub> x<sub>k</sub>, {S<sub>k+1</sub> x<sub>k+1</sub> = d<sub>k+1</sub>, ..., S<sub>n</sub> x<sub>n</sub> = d<sub>n</sub>})_ where the type parameter list and each default value may be omitted, and _S_ occurs in a contravariant position in _S<sub>j</sub>_ for some _j_ in 1 .. _n_.
+
+We say that a type _S_ occurs in a _contravariant position_ in a type _T_ iff one of the following conditions is true:
+
+- _T_ is of the form _G&lt;S<sub>1</sub>, ... S<sub>n</sub>&gt;_ where _G_ denotes a generic class or type alias and _S_ occurs in a contravariant position in _S<sub>j</sub>_ for some _j_ in 1 .. _n_ where the corresponding type parameter of _G_ is covariant; or in a covariant position where the corresponding type parameter is contravariant.
+
+- _T_ is of the form _S<sub>0</sub> Function&lt;X<sub>1</sub> extends B<sub>1</sub>, ...>(...)_ where the type parameter list may be omitted, and _S_ occurs in a contravariant position in _S<sub>0</sub>_.
+
+- _T_ is of the form _S<sub>0</sub> Function&lt;X<sub>1</sub> extends B<sub>1</sub>, ...&gt;(S<sub>1</sub> x<sub>1</sub>, ... S<sub>k</sub> x<sub>k</sub>, [S<sub>k+1</sub> x<sub>k+1</sub> = d<sub>k+1</sub>, ... S<sub>n</sub> x<sub>n</sub> = d<sub>n</sub>])_ or of the form _S<sub>0</sub> Function&lt;X<sub>1</sub> extends B<sub>1</sub>, ...&gt;(S<sub>1</sub> x<sub>1</sub>, ... S<sub>k</sub> x<sub>k</sub>, {S<sub>k+1</sub> x<sub>k+1</sub> = d<sub>k+1</sub>, ... S<sub>n</sub> x<sub>n</sub> = d<sub>n</sub>})_ where the type parameter list and each default value may be omitted, and _S_ occurs in a covariant position in _S<sub>j</sub>_ for some _j_ in 1 .. _n_.
+
+We say that a type _S_ occurs in an _invariant position_ in a type _T_ iff one of the following conditions is true:
+
+- _T_ is of the form _G&lt;S<sub>1</sub>, ... S<sub>n</sub>&gt;_ where _G_ denotes a generic class or type alias, and _S_ occurs in an invariant position in _S<sub>j</sub>_ for some _j_ in 1 .. _n_; or _S_ occurs (in any position) in _S<sub>j</sub>_, and the corresponding type parameter of _G_ is invariant.
+
+- _T_ is of the form _S<sub>0</sub> Function&lt;X<sub>1</sub> extends B<sub>1</sub>, ... X<sub>m</sub> extends B<sub>m</sub>&gt;(S<sub>1</sub> x<sub>1</sub>, ... S<sub>k</sub> x<sub>k</sub>, [S<sub<k+1</sub> x<sub>k+1</sub> = d<sub>k+1</sub>, ... S<sub>n</sub> x<sub>n</sub> = d<sub>n</sub>])_ or of the form _S<sub>0</sub> Function&lt;X<sub>1</sub> extends B<sub>1</sub>, ... X<sub>m</sub> extends B<sub>m</sub>&gt;(S<sub>1</sub> x<sub>1</sub>, ... S<sub>k</sub> x<sub>k</sub>, {S<sub>k+1</sub> x<sub>k+1</sub> = d<sub>k+1</sub>, ... S<sub>n</sub> x<sub>n</sub> = d<sub>n</sub>})_ where the type parameter list and each default value may be omitted, and _S_ occurs in an invariant position in _S<sub>j</sub>_ for some _j_ in 0 .. _n_, or _S_ occurs (in any position) in _B<sub>i</sub>_ for some _i_ in 1 .. _m_.
+
+It is a compile-time error if a type parameter declared by a static extension has a variance modifier.
+
+*Variance is not relevant to static extensions, because there is no notion of subsumption. Each usage will be a single call site, and the value of every type argument associated with an extension method invocation is statically known at the call site.*
+
+It is a compile-time error if a type parameter _X_ declared by a type alias has a variance modifier, unless it is `inout`; or unless it is `out` and the right hand side of the type alias has only covariant occurrences of _X_; or unless it is `in` and the right hand side of the type alias has only contravariant occurrences of _X_.
+
+*The variance for each type parameter of a type alias is restricted based on the body of the type alias. Explicit variance modifiers may be used to document how the type parameter is used on the right hand side, and they may be used to impose more strict constraints than those implied by the right hand side.*
+
+We say that a type parameter _X_ of a type alias _F_ _is covariant/invariant/contravariant_ if it has the variance modifier `out`/`inout`/`in`, respectively. We say that it is _covariant/contravariant_ if it has no variance modifier, and it occurs only covariantly/contravariantly, respectively, on the right hand side of `=` in the type alias (*for an old-style type alias, rewrite it to the form using `=` and then check*). Otherwise (*when _X_ has no modifier, but occurs invariantly or both covariantly and contravariantly*), we say that _X_ _is invariant_.
+
+Let _D_ be the declaration of a class or mixin, and let _X_ be a type parameter declared by _D_.
+
+We say that _X_ _is covariant_ if it has no variance modifier or it has the variance modifier `out`; that it _is invariant_ if it has the variance modifier `inout`; and that it _is contravariant_ if it has the variance modifier `in`.
+
+If _X_ has the variance modifier `out` then it is a compile-time error for _X_ to occur in a non-covariant position in a member signature in the body of _D_, except that it is not an error if it occurs in a covariant position in the type annotation of a covariant formal parameter (*note that this is a contravariant position in the member signature as a whole*). *For instance, _X_ can not be the type of a method parameter (unless covariant), and it can not be the bound of a type parameter of a generic method.*
+
+If _X_ has the variance modifier `in` then it is a compile-time error for _X_ to occur in a non-contravariant position in a member signature in the body of _D_, except that it is not an error if it occurs in a contravariant position in the type of a covariant formal parameter. *For instance, _X_ can not be the return type of a method or getter, and it can not be the bound of a type parameter of a generic method.*
+
+*If _X_ has the variance modifier `inout` then there are no variance related restrictions on the positions where it can occur.*
+
+*For superinterfaces we need slightly stronger rules than the ones that apply for types in the body of a type declaration.*
+
+Let _D_ be a class or mixin declaration, let _S_ be a direct superinterface of _D_, and let _X_ be a type parameter declared by _D_.
+
+It is a compile-time error if _X_ has no variance modifier and _X_ occurs in an actual type argument in _S_ such that the corresponding type parameter has a variance modifier. It is a compile-time error if _X_ has the modifier `out`, and _X_ occurs in a non-covariant position in _S_. It is a compile-time error if _X_ has the variance modifier `in`, and _X_ occurs in a non-contravariant position in _S_.
+
+*A type parameter with variance modifier `inout` can occur in any position in a superinterface, and other variance modifiers have constraints such that if we consider type arguments _Args1_ and _Args2_ passed to _D_ such that the former produces a subtype, then we also have _S1 <: S2_ where _S1_ and _S2_ are the corresponding instantiations of _S_.*
+
+```dart
+class A<out X, inout Y, in Z> {}
+class B<out U, inout V, in W> implements
+    A<U Function(W), V Function(V), W Function(V)> {}
+
+// B<int, String, num> <: B<num, String, int>, and hence
+// A<int Function(num), String Function(String), num Function(String)> <:
+// A<num Function(int), String Function(String), int Function(String)>.
+```
+
+*But a type parameter without a variance modifier can not be used in an actual type argument for a parameter with a variance modifier, not even when that modifier is `out`. The reason for this is that it would allow a subtype to introduce the potential for dynamic errors with a member which is in the interface of the supertype and considered safe.*
+
+```dart
+abstract class A<out X> {
+  Object foo();
+}
+
+class B<X> extends A<X> {
+  // The following declaration would be an error with `class B<out X>`,
+  // so we do not allow it in a subtype of `class A<out X>`.
+  void Function(X) foo() => (X x) {};
+}
+```
+
+*On the other hand, to ease migration, it _is_ allowed to create the opposite relationship:*
+
+```dart
+class A<X> {
+  void foo(X x) {}
+}
+
+class B<out X> extends A<X> {}
+
+main() {
+  B<num> myB = B<int>();
+  ...
+  myB.foo(42.1);
+}
+```
+
+*In this situation, the invocation `myB.foo(42.1)` is subject to a dynamic type check (and it will fail if `myB` is still a `B<int>` when that invocation takes place), but it is statically known at the call site that `foo` has this property for any subtype of `A`, so we can deal with the situation statically, e.g., via a lint.*
+
+*An upcast (like `(myB as A<num>).foo()`) could be used to silence any diagnostic messages, so a strict rule whereby a member access like `myB.foo(42.1)` is a compile-time error may not be very helpful in practice.*
+
+*Note that the class `B` _can_ be written in such a way that the potential dynamic type error is eliminated:*
+
+```dart
+class A<X> {
+  void foo(X x) {}
+}
+
+class B<out X> extends A<X> {
+  void foo(Object? o) {...}
+}
+```
+
+*In this case an invocation of `foo` on a `B` will never incur a dynamic error due to the run-time type of its argument, which might be a useful migration strategy in the case where a lot of call sites are flagged by a lint, especially when `B.foo` is genuinely able to perform its task with objects whose type is not `X`.*
+
+*However, in the more likely case where `foo` does require an argument of type `X`, we do not wish to insist that developers declare an apparently safe member signature like `void foo(Object?)`, and then throw an exception in the body of `foo`. That would just eliminate some compile-time errors at call sites which are actually justified.*
+
+*If such a method needs to be implemented, the modifier `covariant` must be used, in order to avoid the compile-time error for member signatures involving an `out` type parameter:*
+
+```dart
+class A<X> {
+  void foo(X x) {}
+}
+
+class B<out X> extends A<X> { // or `implements`.
+  void foo(covariant X x) {...}
+}
+```
+
+Finally, the occurrences of `exactly` in member signatures are restricted. Let _D_ be a class or mixin declaration and let _s_ be the member signature of an instance member declared by _D_. Assume that _s_ contains a parameterized type _T_ in a non-covariant position, and assume that _T_ has a type argument of the form _exactly U_. In this situation it is a compile-time error if _U_ contains an occurrence of a type variable that does not have the variance modifier `inout`.
+
+```dart
+class C<X, inout Y, in Z> {
+  void f(Map<exactly X, exactly Z> xs) {} // Errors.
+  void Function(List<exactly X>) get h => (_) {}; // Error.
+  void g(Map<exactly int, exactly Y> xs) {} // OK.
+}
+```
+
+*This restriction is required for soundness. The reason is that member accesses must use a static type for the member which is known to be a supertype of the actual type of that member, and these occurrences of `exactly` will make such supertypes so imprecise that they will not be very useful, e.g., `f` would have the member signature `void f(Never)` no matter which values for `X` and `Z` are known statically.*
+
+
+### Expressions
+
+It is a compile-time error for an instance creation expression or a collection literal to pass a type argument marked `exactly`. It is a compile-time error to pass an actual type argument to a generic function invocation which is marked `exactly`.
+
+```dart
+class A<X> {}
+
+main() {
+  var xs = <exactly num>[]; // Error.
+  var ys = <List<exactly num>>[]; // OK.
+  var a = A<exactly String>(); // Error.
+  A<exactly String> a2 = A(); // OK.
+
+  void f<X>(X x) => print(x);
+  f<exactly int>(42); // Error.
+}
+```
+
+*We could say that the list of "type arguments" passed to a constructor invocation or literal collection contains types, not type arguments; and only type arguments can be marked `exactly`. However, those types may themselves receive type arguments, and they can be marked `exactly` as needed.*
+
+The static type of an instance creation expression that invokes a generative constructor of a generic class `C` with type arguments `T1, ... Tk` is `C<exactly T1, ..., exactly Tk>`.
+
+The static type of a list literal receiving type argument `T` is `List<exactly T>`; the static type of a set literal receiving type argument `T` is `Set<exactly T>`; and the static type of a map literal receiving type arguments `K` and `V` is `Map<exactly K, exactly V>`.
+
+*It cannot be assumed that a similar relationship exists for regular invocations, say, of a generic function or a factory constructor, so it is an error for an actual type argument to be marked `exactly`.*
+
+```dart
+class C<X> {
+  C();
+  factory C.named() => C<Never>();
+}
+
+main() {
+  // OK, but the static and dynamic type of `c` is not `C<exactly int>`:
+  var c = C<int>.named();
+
+  // Error, because it is misleading:
+  var c2 = C<exactly int>.named();
+}
+```
+
+*Note that the use of `exactly` even for a type argument where the corresponding type parameter _X_ is marked `out` or `in` may be useful: The members declared in the type that receives this type argument must in general be sound with respect to _X_, but there may be some member signatures inherited from a supertype where some type parameters have no variance modifier, and the use of `exactly` will then provide a guarantee against dynamic type errors which does not otherwise exist:*
+
+```dart
+class A<X> {
+  void foo(X x) {}
+}
+
+class B<out X> extends A<X> {}
+
+class C<out Y> {
+  List<Y> get bar => [];
+}
+
+main() {
+  B<exactly num> b = B();
+  b.foo(17.9); // Statically safe.
+
+  C<exactly num> c = C();
+  c.bar.add(179); // Statically safe, even though `c.bar` has a legacy type.
+}
+```
+
+*Note that there is no way to make it statically safe to pass an actual argument to a covariant formal parameter of a given member `m`. Any receiver may have a dynamic type which is a proper subtype of the statically known type, and it may have an overriding declaration of `m` that makes the parameter covariant. So, by design, a modular static analysis cannot guarantee that any given invocation will not cause a dynamic error due to a dynamic type check for a covariant parameter.*
+
+
+### Member Access Typing
+
+For soundness, occurrences of the modifier `exactly` in member signatures are subject to elimination during the computation of the type of member access operations (*such as invocations of methods, getters, or setters*).
+
+Let _D_ be the declaration of a generic class or mixin named _N_ and let _X<sub>1</sub> .. X<sub>k</sub>_ be the type parameters declared by _D_. Let _T_ be a parameterized type which applies _N_ to a list of actual type arguments _S<sub>1</sub> .. S<sub>k</sub>_ in a context where the name _N_ denotes the declaration _D_, and consider the situation where a member access to a member `m` in the interface of _T_ is performed. Let _S1<sub>1</sub> .. S1<sub>k</sub>_ be the same as _S<sub>1</sub> .. S<sub>k</sub>_, except that any occurrence of `exactly` at the top level of each type argument has been removed.
+
+Let _s_ be the member signature of `m` from the interface of _D_, and _s1_ be _[S1<sub>1</sub>/X<sub>1</sub> .. S1<sub>k</sub>/X<sub>k</sub>]s_. 
+
+*This is the "raw" version of the statically known type of `m`; to obtain a sound typing we need one more step where certain occurrences of `exactly` are erased.*
+
+For each _j_ in 1 .. _k_, if _X<sub>j</sub>_ does not have the variance modifier `inout`, and _S<sub>j</sub>_ does not have the modifier `exactly`, then for each occurrence of `exactly` on a type that contains _X<sub>j</sub>_ in _s_, the corresponding occurrence of `exactly` in _s1_ is eliminated.
+
+*For example:*
+
+```dart
+class C<X> {
+  List<exactly X> get g => [];
+}
+
+main() {
+  C<exactly int> ci = C<int>();
+  C<num> cn = ci; // OK, upcast.
+  List<num> xs = cn.g; // OK, `cn.g` has type `List<num>`.
+  List<exactly num> ys = ci.g; // OK, `ci.g` has type `List<exactly int>`.
+  ys = cn.g; // Error (downcast).
+}
+```
+
+*This example also illustrates why the ability to have `exactly` in a member signature helps improving the static typing: The declaration in class `C` ensures that `g` actually returns a `List<exactly X>`. In the situation where the value of `X` is known at the call site to be a specific type `T`, this allows the returned result to be typed `List<exactly T>`, which in turn makes the usage of `add` and similar members statically safe.*
+
+
+## Dynamic Semantics
+
+Every instance of a generic class has a dynamic type where every type argument has the modifier `exactly`.
+
+*Note that this only applies at the top level in the dynamic type of the object. It may or may not have the modifier `exactly` on type arguments of type arguments.*
+
+```dart
+main() {
+  var xs = <List<num>>[]; // Dynamic type is `List<exactly List<num>>`.
+  var ys = <List<exactly num>>[]; // `List<exactly List<exactly num>>`.
+}
+```
+
+The dynamic representation of generic class types include information about whether a given actual type argument is marked `exactly` or not.
+
+*This is required for soundness.*
+
+```dart
+main() {
+  dynamic xs = <List<exactly num>>[];
+  xs.add(<int>[]); // Must throw, hence `exactly` must be known at run time.
+}
+```
+
+
+## Migration
+
+This proposal supports migration of code using dynamically checked covariance to code where some explicit variance modifiers are used, thus eliminating the potential for some dynamic type errors. There are two main scenarios.
+
+Let _legacy class_ denote a generic class that has one or more type parameters with no variance modifiers.
+
+If a new class _A_ has no superinterface relationship with any legacy class (directly or indirectly) then all non-dynamic member accesses to instances of _A_ and its subtypes will be statically safe.
+
+*In other words, if the plan is to use explicit variance only with type declarations that are not "connected to" unsoundly covariant type parameters then there is no migration.*
+
+However, there is a need for migration support in the case where an existing legacy class _B_ is modified such that an explicit variance modifier is added to one or more of its type parameters.
+
+In particular, an existing subtype _C_ of _B_ must now add variance modifiers in order to remain error free, and this may conflict with the existing member signatures of _C_:
+
+```dart
+// Before the update.
+class B<X> {}
+class C<X> implements B<X> {
+  void f(X x) {}
+}
+
+// After the update of `B`.
+class B<out X> {}
+class C<X> implements B<X> { // Error.
+  void f(X x) {} // If we just make it `C<out X>` then this is an error.
+}
+
+// Adjusting `C` to eliminate the errors.
+class B<out X> {}
+class C<out X> implements B<X> {
+  void f(covariant X x) {}
+}
+```
+
+This approach can be used in a scenario where all parts of the program are migrated to the new language level where explicit variance is supported.
+
+In the other scenario, some libraries will opt in using a suitable language level, and others will not.
+
+If a library _L1_ is at a language level where explicit variance is not supported (so it is 'opted out') then code in an 'opted in' library _L2_ is seen from _L1_ as erased, in the sense that (1) the variance modifiers `out` and `inout` are ignored, and `exactly` in types is ignored, and (2) it is a compile-time error to pass a type argument `T` to a type parameter with variance modifier `in`, unless `T` is a top type; (3) any type argument `T` passed to an `in` type parameter in opted-in code is seen in opted-out code as `Object?`.
+
+Conversely, declarations in _L1_ (opted out) is seen from _L2_ (opted in) without changes. So class type parameters declared in _L1_ are considered to be unsoundly covariant by both opted in and opted out code, and similarly for type aliases used to declare function types. Types of entities exported from _L1_ to _L2_ are seen as erased (which matters when _L1_ imports entities from some other opted-in library).
+
+Reification of `exactly` on type parameters is required for a sound semantics, but during a transitional period it could be considered as a static-only attribute, thus allowing for soundness violations of this property at run time, and only enforcing it for programs with no opted out code.

--- a/accepted/future-releases/variance/feature-specification.md
+++ b/accepted/future-releases/variance/feature-specification.md
@@ -21,7 +21,7 @@ Currently, a parameterized class type is covariant in every type parameter. For 
 
 This is sound for all covariant occurrences of such type parameters in the class body (for instance, the getter `first` of a list has return type `E`, which is sound). It is also sound for contravariant occurrences when a sufficiently exact receiver type is known (e.g., for a literal like `<num>[].add(4.2)`, or for a generative constructor `SomeClass<num>.foo(4.2)`).
 
-However, in general, every member access where a covariant type parameter occurs in a contravariant position may cause a dynamic type error, because the actual type annotation at run time&mdash;say, the type of a parameter of a method&mdash;is a subtype of the one which is known at compile-time.
+However, in general, every member access where a covariant type parameter occurs in a non-covariant position may cause a dynamic type error, because the actual type annotation at run time&mdash;say, the type of a parameter of a method&mdash;is a subtype of the one which occurs in the static type.
 
 This proposal introduces explicit variance modifiers for type parameters, as well as invariance modifiers for actual type arguments. It includes compile-time restrictions on the use of objects whose static type includes these modifiers, ensuring that the above-mentioned dynamic type errors cannot occur.
 
@@ -55,7 +55,90 @@ Moreover, `'exactly'` is added to the set of built-in identifiers.
 
 ## Static Analysis
 
-This feature allows type parameters to be declared with a _variance modifier_ which is one of `out`, `inout`, or `in`. This implies that the use of such a type parameter is restricted as follows.
+This feature allows type parameters to be declared with a _variance modifier_ which is one of `out`, `inout`, or `in`. This implies that the use of such a type parameter is restricted, in return for improved static type safety. Moreover, the rules for other topics like subtyping and for determining the variance of a subterm in a type are adjusted.
+
+
+### Subtype Rules
+
+The [subtype rule](https://github.com/dart-lang/language/blob/e3010343a8e6f608a831078b0a04d4f1eeca46d4/specification/dartLangSpec.tex#L14845) for interface types that is concerned with the relationship among type arguments ('class covariance') is modified as follows:
+
+In order to conclude that _C&lt;S<sub>1</sub>,... S<sub>s</sub>&gt; <: C&lt;T<sub>1</sub>,... T<sub>s</sub>&gt;_ the current rule requires that _S<sub>j</sub> <: T<sub>j</sub>_ for each _j_ in 1 .. _s_. *This means that, to be a subtype, all actual type arguments must be subtypes.*
+
+The rule is updated as follows in order to take variance modifiers into account:
+
+Let _j_ in 1 .. _s_. If none of _S<sub>j</sub>_ or _T<sub>j</sub>_ have the modifier `exactly` then the following rules apply:
+
+If the corresponding type parameter _X<sub>j</sub>_ has no variance modifier, or it has the variance modifier `out`, we require _S<sub>j</sub> <: T<sub>j</sub>_.
+
+If the corresponding type parameter _X<sub>j</sub>_ has the variance modifier `in`, we require _T<sub>j</sub> <: S<sub>j</sub>_.
+
+If the corresponding type parameter _X<sub>j</sub>_ has the variance modifier `inout`, we require _S<sub>j</sub> <: T<sub>j</sub>_ as well as _T<sub>j</sub> <: S<sub>j</sub>_.
+
+If both _S<sub>j</sub>_ and _T<sub>j</sub>_ have the modifier `exactly` then let _S1<sub>j</sub>_ be _S<sub>j</sub>_ except that `exactly` has been eliminated, and similarly for _T1<sub>j</sub>_; we then require _S1<sub>j</sub> <: T1<sub>j</sub>_ as well as _T1<sub>j</sub> <: S1<sub>j</sub>_ (*whether or not the corresponding type parameter has a variance modifier, and no matter which one*).
+
+A new subtype rule for type arguments where `exactly` does not occur symmetrically is added:
+
+_C&lt;S<sub>1</sub>,... S<sub>s</sub>&gt; <: T_ whenever _C&lt;T<sub>1</sub>,... T<sub>s</sub>&gt; <: T_, where we have the relationship for each _j_ in 1 .. _s_ that either _S<sub>j</sub>_ is _T<sub>j</sub>_ or _S<sub>j</sub>_ is _exactly T<sub>j</sub>_.
+
+*For instance:*
+
+```dart
+// Not runnable code, just examples of subtype relationships:
+List<exactly num> <: List<num> <: List<Object> <: Object
+List<exactly List<num>> <: List<List<num>> <: List<Object>
+List<exactly List<exactly num>> <: List<List<exactly num>> <: List<List<num>>
+List<exactly num> <: Iterable<exactly num> <: Iterable<num>
+
+// But the subtype relation does _not_ include the following:
+List<num> <\: List<exactly num>
+List<exactly List<exactly num>> <\: List<exactly List<num>>
+```
+
+*We cannot assign an expression of type `List<num>` to a variable of type `List<exactly num>` without a dynamic type check. Similarly, we cannot assign an expression of type `List<exactly List<exactly num>>` to a variable of type `List<exactly List<num>>`. Here is an example illustrating why this is so.*
+
+```dart
+main() {
+  List<num> xs = <int>[];
+  List<exactly num> ys = xs; // This must be an error because:
+  ys.add(3.41); // Safe, based on the type of `ys`, but it should throw.
+  
+  List<exactly List<exactly num>> zs = [];
+  List<exactly List<num>> ws = zs; // This must be an error because:
+  ws.add(<int>[]); // Safe, based on the type of `ws`, but it should throw.
+  zs[0][0] = 4.31; // Safe, based on the type of `zs`, but it should throw.
+}
+```
+
+*In the above example, an execution that maintains heap soundness would throw already at `ws.add(<int>[])`, because `List<int>` is not a subtype of `List<exactly num>`. Otherwise, we can proceed to `zs[0][0] = 4.31` and cause a base level type error, which illustrates that we cannot just ignore the distinction between `List<exactly num>` and `List<num>` as a type argument, neither statically nor dynamically.*
+
+
+### Variance Rules
+
+The rules for determining the variance of a position are updated as follows:
+
+We say that a type _S_ occurs in a _covariant position_ in a type _T_ iff one of the following conditions is true:
+
+- _T_ is _S_.
+
+- _T_ is of the form _G&lt;S<sub>1</sub>,... S<sub>n</sub>&gt;_ where _G_ denotes a generic class or type alias and _S_ occurs in a covariant position in _S<sub>j</sub>_ for some _j_ in 1 .. _n_ where the corresponding type parameter of _G_ is covariant; or in a contravariant position where the corresponding type parameter is contravariant.
+
+- _T_ is of the form _S<sub>0</sub> Function&lt;X<sub>1</sub> extends B<sub>1</sub>, ...>(...)_ where the type parameter list may be omitted, and _S_ occurs in a covariant position in _S<sub>0</sub>_.
+
+- _T_ is of the form _S<sub>0</sub> Function&lt;X<sub>1</sub> extends B<sub>1</sub>, ...&gt;(S<sub>1</sub> x<sub>1</sub>, ... S<sub>k</sub> x<sub>k</sub>, [S<sub>k+1</sub> x<sub>k+1</sub> = d<sub>k+1</sub>, ..., S<sub>n</sub> x<sub>n</sub> = d<sub>n</sub>])_ or of the form _S<sub>0</sub> Function&lt;X<sub>1</sub> extends B<sub>1</sub>, ...&gt; (S<sub>1</sub> x<sub>1</sub>, ... S<sub>k</sub> x<sub>k</sub>, {S<sub>k+1</sub> x<sub>k+1</sub> = d<sub>k+1</sub>, ..., S<sub>n</sub> x<sub>n</sub> = d<sub>n</sub>})_ where the type parameter list and each default value may be omitted, and _S_ occurs in a contravariant position in _S<sub>j</sub>_ for some _j_ in 1 .. _n_.
+
+We say that a type _S_ occurs in a _contravariant position_ in a type _T_ iff one of the following conditions is true:
+
+- _T_ is of the form _G&lt;S<sub>1</sub>, ... S<sub>n</sub>&gt;_ where _G_ denotes a generic class or type alias and _S_ occurs in a contravariant position in _S<sub>j</sub>_ for some _j_ in 1 .. _n_ where the corresponding type parameter of _G_ is covariant; or in a covariant position where the corresponding type parameter is contravariant.
+
+- _T_ is of the form _S<sub>0</sub> Function&lt;X<sub>1</sub> extends B<sub>1</sub>, ...>(...)_ where the type parameter list may be omitted, and _S_ occurs in a contravariant position in _S<sub>0</sub>_.
+
+- _T_ is of the form _S<sub>0</sub> Function&lt;X<sub>1</sub> extends B<sub>1</sub>, ...&gt; S<sub>1</sub> x<sub>1</sub>, ... S<sub>k</sub> x<sub>k</sub>, [S<sub>k+1</sub> x<sub>k+1</sub> = d<sub>k+1</sub>, ... S<sub>n</sub> x<sub>n</sub> = d<sub>n</sub>])_ or of the form _S<sub>0</sub> Function&lt;X<sub>1</sub> extends B<sub>1</sub>, ...&gt; S<sub>1</sub> x<sub>1</sub>, ... S<sub>k</sub> x<sub>k</sub>, {S<sub>k+1</sub> x<sub>k+1</sub> = d<sub>k+1</sub>, ... S<sub>n</sub> x<sub>n</sub> = d<sub>n</sub>})_ where the type parameter list and each default value may be omitted, and _S_ occurs in a covariant position in _S<sub>j</sub>_ for some _j_ in 1 .. _n_.
+
+We say that a type _S_ occurs in an _invariant position_ in a type _T_ iff one of the following conditions is true:
+
+- _T_ is of the form _G&lt;S<sub>1</sub>, ... S<sub>n</sub>&gt;_ where _G_ denotes a generic class or type alias, and _S_ occurs in an invariant position in _S<sub>j</sub>_ for some _j_ in 1 .. _n_; or _S_ occurs (in any position) in _S<sub>j</sub>_, and the corresponding type parameter of _G_ is invariant.
+
+- _T_ is of the form _S<sub>0</sub> Function&lt;X<sub>1</sub> extends B<sub>1</sub>, ... X<sub>m</sub> extends B<sub>m</sub>&gt;(S<sub>1</sub> x<sub>1</sub>, ... S<sub>k</sub> x<sub>k</sub>, [S<sub<k+1</sub> x<sub>k+1</sub> = d<sub>k+1</sub>, ... S<sub>n</sub> x<sub>n</sub> = d<sub>n</sub>])_ or of the form _S<sub>0</sub> Function&lt;X<sub>1</sub> extends B<sub>1</sub>, ... X<sub>m</sub> extends B<sub>m</sub>&gt;(S<sub>1</sub> x<sub>1</sub>, ... S<sub>k</sub> x<sub>k</sub>, {S<sub>k+1</sub> x<sub>k+1</sub> = d<sub>k+1</sub>, ... S<sub>n</sub> x<sub>n</sub> = d<sub>n</sub>})_ where the type parameter list and each default value may be omitted, and _S_ occurs in an invariant position in _S<sub>j</sub>_ for some _j_ in 0 .. _n_, or _S_ occurs (in any position) in _B<sub>i</sub>_ for some _i_ in 1 .. _m_.
 
 It is a compile-time error if a type parameter declared by a static extension has a variance modifier.
 
@@ -65,7 +148,11 @@ It is a compile-time error if a type parameter _X_ declared by a type alias has 
 
 *The variance for each type parameter of a type alias is restricted based on the body of the type alias. Explicit variance modifiers may be used to document how the type parameter is used on the right hand side, and they may be used to impose more strict constraints than those implied by the right hand side.*
 
+We say that a type parameter _X_ of a type alias _F_ _is covariant/invariant/contravariant_ if it has the variance modifier `out`/`inout`/`in`, respectively. We say that it is _covariant/contravariant_ if it has no variance modifier, and it occurs only covariantly/contravariantly, respectively, on the right hand side of `=` in the type alias (*for an old-style type alias, rewrite it to the form using `=` and then check*). Otherwise (*when _X_ has no modifier, but occurs invariantly or both covariantly and contravariantly*), we say that _X_ _is invariant_.
+
 Let _D_ be the declaration of a class or mixin, and let _X_ be a type parameter declared by _D_.
+
+We say that _X_ _is covariant_ if it has no variance modifier or it has the variance modifier `out`; that it _is invariant_ if it has the variance modifier `inout`; and that it _is contravariant_ if it has the variance modifier `in`.
 
 If _X_ has the variance modifier `out` then it is a compile-time error for _X_ to occur in a non-covariant position in a member signature in the body of _D_. *For instance, _X_ can not be the type of a method parameter, and it can not be the bound of a type parameter of a generic method.*
 
@@ -73,54 +160,78 @@ If _X_ has the variance modifier `in` then it is a compile-time error for _X_ to
 
 *If _X_ has the variance modifier `inout` then there are no variance related restrictions on the positions where it can occur.*
 
-The [subtype rule](https://github.com/dart-lang/language/blob/e3010343a8e6f608a831078b0a04d4f1eeca46d4/specification/dartLangSpec.tex#L14845) for interface types that is concerned with the relationship among type arguments is modified as follows:
+*For superinterfaces we need slightly stronger rules than the ones that apply for types in the body of a type declaration.*
 
-In order to conclude that _C&lt;S<sub>1</sub>,... S<sub>s</sub>  &gt; <: C&lt;T<sub>1</sub>,... T<sub>s</sub> &gt;_ the current rule requires that _S<sub>j</sub> <: T<sub>j</sub>_ for each _j_ in 1 .. _s_. *This means that, to be a subtype, all actual type arguments must be subtypes.*
+Let _D_ be a class or mixin declaration, let _S_ be a superinterface of _D_, and let _X_ be a type parameter declared by _D_.
 
-The rule is updated as follows in order to take variance modifiers into account:
+It is a compile-time error if _X_ has no variance modifier and _X_ occurs in an actual type argument in _S_ such that the corresponding type parameter has a variance modifier. It is a compile-time error of _X_ has the modifier `out`, and _X_ occurs in a non-covariant position in _S_. It is a compile-time error if _X_ has the variance modifier `in`, and _X_ occurs in a non-contravariant position in _S_.
 
-For each _j_ in 1 .. _s_ where the corresponding type parameter _X<sub>j</sub>_ has no variance modifier, or it has the variance modifier `out`, we require _S<sub>j</sub> <: T<sub>j</sub>_.
+*A type parameter with variance modifier `inout` can occur in any position in a superinterface, and other variance modifiers have constraints such that if we consider type arguments _Args1_ and _Args2_ passed to _D_ such that the former produces a subtype, then we also have _S1 <: S2_ where _S1_ and _S2_ are the corresponding instantiations of _S_.*
 
-For each _j_ in 1 .. _s_ where the corresponding type parameter _X<sub>j</sub>_ has the variance modifier `in`, we require _T<sub>j</sub> <: S<sub>j</sub>_.
+```dart
+class A<out X, inout Y, in Z> {}
+class B<out U, inout V, in W> implements
+    A<U Function(W), V Function(V), W Function(V)> {}
 
-For each _j_ in 1 .. _s_ where the corresponding type parameter _X<sub>j</sub>_ has the variance modifier `inout`, we require _S<sub>j</sub> <: T<sub>j</sub>_ as well as _T<sub>j</sub> <: S<sub>j</sub>_.
+// B<int, String, num> <: B<num, String, int>, and
+// A<int Function(num), String Function(String), num Function(String)> <:
+// A<num Function(int), String Function(String), int Function(String)> <:
+```
 
-The rules for determining the variance of an position are updated as follows:
+*But a type parameter without a variance modifier can not be used in an actual type argument for a parameter with a variance modifier, not even when that modifier is `out`. The reason for this is that it would allow a subtype to introduce the potential for dynamic errors with a member which is in the interface of the supertype and considered safe.*
 
-We say that a type _S_ occurs in a _covariant position_ in a type _T_ iff one of the following conditions is true:
+```dart
+abstract class A<out X> {
+  Object foo();
+}
 
-- _T_ is _S_.
+class B<X> extends A<X> {
+  // The following declaration would be an error with `class B<out X>`,
+  // so we do not allow it in a subtype of `class A<out X>`.
+  void Function(X) foo() => (X x) {};
+}
+```
 
-- _T_ is of the form _G&lt;S<sub>1</sub>,... S<sub>n</sub>&gt;_ where _G_ denotes a generic class and _S_ occurs in a covariant position in _S<sub>j</sub>_ for some _j_ in 1 .. _n_ where the corresponding type parameter of _G_ has no variance modifier or it has the variance modifier `out`; or in a contravariant position where the corresponding type parameter has the variance modifier `in`.
+*On the other hand, to ease migration, it _is_ allowed to create the opposite relationship:*
 
-- _T_ is of the form _S<sub>0</sub> Function&lt;X<sub>1</sub> extends B<sub>1</sub>, ...>(S<sub>1</sub> x<sub>1</sub>, ...)_ where the type parameter list may be omitted, and _S_ occurs in a covariant position in _S<sub>0</sub>_.
+```dart
+abstract class A<X> {
+  void foo(X x);
+}
 
-- _T_ is of the form _S<sub>0</sub> Function&lt;X<sub>1</sub> extends B<sub>1</sub>, ...&gt;(S<sub>1</sub> x<sub>1</sub>, ... S<sub>k</sub> x<sub>k</sub>, [S<sub>k+1</sub> x<sub>k+1</sub> = d<sub>k+1</sub>, ..., S<sub>n</sub> x<sub>n</sub> = d<sub>n</sub>])_ or of the form _S<sub>0</sub> Function&lt;X<sub>1</sub> extends B<sub>1</sub>, ...&gt; (S<sub>1</sub> x<sub>1</sub>, ... S<sub>k</sub> x<sub>k</sub>, {S<sub>k+1</sub> x<sub>k+1</sub> = d<sub>k+1</sub>, ..., S<sub>n</sub> x<sub>n</sub> = d<sub>n</sub>})_ where the type parameter list and each default value may be omitted, and _S_ occurs in a contravariant position in _S<sub>j</sub>_ for some _j_ in 1 .. _n_.
+class B<out X> extends A<X> {}
 
-- _T_ is of the form _G&lt;S<sub>1</sub>, ... S<sub>n</sub>&gt;_ where _G_ denotes a generic type alias such that _j_ in 1 .. _n_, the formal type parameter corresponding to _S<sub>j</sub>_ is covariant, and _S_ occurs in a covariant position in _S<sub>j</sub>_.
+main() {
+  B<num> myB = B<int>();
+  ...
+  myB.foo(42.1);
+}
+```
 
-- _T_ is of the form _G&lt;S<sub>1</sub>, ... S<sub>n</sub>&gt;_ where _G_ denotes a generic type alias such that _j_ in 1 .. _n_, the formal type parameter corresponding to _S<sub>j</sub>_ is contravariant, and _S_ occurs in a contravariant position in _S<sub>j</sub>_.
+*In this situation, the invocation `myB.foo(42.1)` is subject to a dynamic type check (and it will fail if `myB` is still a `B<int>` when that invocation takes place), but it is statically known at the call site that `foo` has this property for any subtype of `A`, so we can deal with the situation statically, e.g., via a lint.*
 
-We say that a type _S_ occurs in a _contravariant position_ in a type _T_ iff one of the following conditions is true:
+*An upcast (like `(myB as A<num>).foo()`) could be used to silence any diagnostic messages, so a strict rule whereby a member access like `myB.foo(42.1)` is a compile-time error may not be very helpful in practice.*
 
-- _T_ is of the form _G&lt;S<sub>1</sub>, ... S<sub>n</sub>&gt;_ where _G_ denotes a generic class and _S_ occurs in a contravariant position in _S<sub>j</sub>_ for some _j_ in 1 .. _n_ where the corresponding type parameter of _G_ has no variance modifier or it has the variance modifier `out`; or in a covariant position where the corresponding type parameter has the variance modifier `in`.
+*Note that the class `B` _can_ be written in such a way that the potential dynamic type error is eliminated:*
 
-- _T_ is of the form _S<sub>0</sub> Function&lt;X<sub>1</sub> extends B<sub>1</sub>, ...>(S<sub>1</sub> x<sub>1</sub>, ...)_ where the type parameter list may be omitted, and _S_ occurs in a contravariant position in _S<sub>0</sub>_.
+```dart
+// Same A.
 
-- _T_ is of the form _S<sub>0</sub> Function&lt;X<sub>1</sub> extends B<sub>1</sub>, ...&gt; S<sub>1</sub> x<sub>1</sub>, ... S<sub>k</sub> x<sub>k</sub>, [S<sub>k+1</sub> x<sub>k+1</sub> = d<sub>k+1</sub>, ... S<sub>n</sub> x<sub>n</sub> = d<sub>n</sub>])_ or of the form _S<sub>0</sub> Function&lt;X<sub>1</sub> extends B<sub>1</sub>, ...&gt; S<sub>1</sub> x<sub>1</sub>, ... S<sub>k</sub> x<sub>k</sub>, {S<sub>k+1</sub> x<sub>k+1</sub> = d<sub>k+1</sub>, ... S<sub>n</sub> x<sub>n</sub> = d<sub>n</sub>})_ where the type parameter list and each default value may be omitted, and _S_ occurs in a covariant position in _S<sub>j</sub>_ for some _j_ in 1 .. _n_.
+class B<out X> extends A<X> {
+  void foo(Object? o) {...}
+}
+```
 
-- _T_ is of the form _G&lt;S<sub>1</sub>, ... S<sub>n</sub>&gt;_ where _G_ denotes a generic type alias such that _j_ in 1 .. _n_, the formal type parameter corresponding to _S<sub>j</sub>_ is covariant, and _S_ occurs in a contravariant position in _S<sub>j</sub>_.
+*In this case an invocation of `foo` on a `B` will never incur a dynamic error due to the run-time type of its argument, which might be a useful migration strategy in the case where a lot of call sites are flagged by a lint, especially when `B.foo` is genuinely able to perform its task with objects whose type is not `X`.*
 
-- _T_ is of the form _G&lt;S<sub>1</sub>, ... S<sub>n</sub>&gt;_ where _G_ denotes a generic type alias such that _j_ in 1 .. _n_, the formal type parameter corresponding to _S<sub>j</sub>_ is contravariant, and _S_ occurs in a covariant position in _S<sub>j</sub>_.
+*However, in the more likely case where `foo` does require an argument of type `X`, we do not wish to insist that developers declare an apparently safe member signature like `void foo(Object?)`, and then throw an exception in the body of `foo`. That would just eliminate some compile-time errors at call sites which are actually justified.*
 
-We say that a type _S_ occurs in an _invariant position_ in a type _T_ iff one of the following conditions is true:
+*If such a method needs to be overridden, the modifier `covariant` must be used, in order to avoid the compile-time error for member signatures involving an `out` type parameter:*
 
-- _T_ is of the form _G&lt;S<sub>1</sub>, ... S<sub>n</sub>&gt;_ where _G_ denotes a generic class or a generic type alias, and _S_ occurs in an invariant position in _S<sub>j</sub>_ for some _j_ in 1 .. _n_; or _S_ occurs (in any position) in _S<sub>j</sub>_, and the corresponding type parameter of _G_ has the variance modifier `inout`.
+```dart
+// Same A.
 
-- _T_ is of the form _S<sub>0</sub> Function&lt;X<sub>1</sub> extends B<sub>1</sub>, ... X<sub>m</sub> extends B<sub>m</sub>&gt; S<sub>1</sub> x<sub>1</sub>, ... S<sub>k</sub> x<sub>k</sub>, [S<sub<k+1</sub> x<sub>k+1</sub> = d<sub>k+1</sub>, ... S<sub>n</sub> x<sub>n</sub> = d<sub>n</sub>])_ or of the form _S<sub>0</sub> function&lt;X<sub>1</sub> extends B<sub>1</sub>, ... X<sub>m</sub> extends B<sub>m</sub>&gt;_S<sub>1</sub> x<sub>1</sub>, ... S<sub>k</sub> x<sub>k</sub>, {S<sub>k+1</sub> x<sub>k+1</sub> = d<sub>k+1</sub>, ... S<sub>n</sub> x<sub>n</sub> = d<sub>n</sub>})_ where the type parameter list and each default value may be omitted, and _S_ occurs in an invariant position in _S<sub>j</sub>_ for some _j_ in 0 .. _n_, or _S_ occurs in _B<sub>i</sub>_ for some _i_ in 1 .. _m_.
-
-- _T_ is of the form _G&lt;S<sub>1</sub>, ... S<sub>n</sub>&gt;_ where _G_ denotes a generic type alias, _j_ in 1 .. _n_, the formal type parameter corresponding to _S<sub>j</sub>_ is invariant, and _S_ occurs (in any position) in _S<sub>j</sub>_.
-
-!!!TODO!!! Constraints on the occurrence of type parameters with a variance modifier in superinterfaces. Maybe this is easy? `inout` can occur anywhere, `out` can occur in a covariant position, and `in` can occur in a contravariant position. Think about soundness!
-
-!!!TODO!!! Everything about use-site invariance.
+class B<out X> extends A<X> {
+  void foo(covariant X x) {...}
+}
+```

--- a/accepted/future-releases/variance/feature-specification.md
+++ b/accepted/future-releases/variance/feature-specification.md
@@ -1,0 +1,126 @@
+# Sound and Explicit Variance
+
+Author: eernst@google.com
+
+Status: Draft
+
+
+## CHANGELOG
+
+2019.08.30:
+- Initial version uploaded.
+
+
+## Summary
+
+This document proposes a specification for sound and explicit management of [variance](https://github.com/dart-lang/language/issues/213) in Dart.
+
+Issues on topics related to this proposal can be found [here](https://github.com/dart-lang/language/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3Avariance+).
+
+Currently, a parameterized class type is covariant in every type parameter. For example, `List<int>` is a subtype of `List<num>` because `int` is a subtype of `num` (so the list type and its type argument "co-vary").
+
+This is sound for all covariant occurrences of such type parameters in the class body (for instance, the getter `first` of a list has return type `E`, which is sound). It is also sound for contravariant occurrences when a sufficiently exact receiver type is known (e.g., for a literal like `<num>[].add(4.2)`, or for a generative constructor `SomeClass<num>.foo(4.2)`).
+
+However, in general, every member access where a covariant type parameter occurs in a contravariant position may cause a dynamic type error, because the actual type annotation at run time&mdash;say, the type of a parameter of a method&mdash;is a subtype of the one which is known at compile-time.
+
+This proposal introduces explicit variance modifiers for type parameters, as well as invariance modifiers for actual type arguments. It includes compile-time restrictions on the use of objects whose static type includes these modifiers, ensuring that the above-mentioned dynamic type errors cannot occur.
+
+In order to ease the transition where types with explicit variance are created and used, this proposal allows for certain subtype relationships where dynamic type checks are still needed when using legacy types (where type parameters are _implicitly_ covariant) to access an object, even in the case where the object has a type with explicit variance.
+
+
+## Syntax
+
+The grammar is adjusted as follows:
+
+```
+<typeParameter> ::= // Modified.
+    <metadata> <typeParameterVariance>? <typeIdentifier>
+    (('extends'|'super') <typeNotVoid>)?
+
+<typeParameterVariance> ::= // New.
+    'out' | 'inout' | 'in'
+
+<typeArguments> ::= // Modified.
+    '<' <typeArgumentList> '>'
+
+<typeArgumentList> ::= // New.
+    <typeArgument> (',' <typeArgument>)*
+
+<typeArgument> ::= // New.
+    'exactly'? <type>
+```
+
+Moreover, `'exactly'` is added to the set of built-in identifiers.
+
+
+## Static Analysis
+
+This feature allows type parameters to be declared with a _variance modifier_ which is one of `out`, `inout`, or `in`. This implies that the use of such a type parameter is restricted as follows.
+
+It is a compile-time error if a type parameter declared by a static extension has a variance modifier.
+
+*Variance is not relevant to static extensions, because there is no notion of subsumption. Each usage will be a single call site, and the value of every type argument associated with an extension method invocation is statically known at the call site.*
+
+It is a compile-time error if a type parameter _X_ declared by a type alias has a variance modifier, unless it is `inout`; or unless it is `out` and the right hand side of the type alias has only covariant occurrences of _X_; or unless it is `in` and the right hand side of the type alias has only contravariant occurrences of _X_.
+
+*The variance for each type parameter of a type alias is restricted based on the body of the type alias. Explicit variance modifiers may be used to document how the type parameter is used on the right hand side, and they may be used to impose more strict constraints than those implied by the right hand side.*
+
+Let _D_ be the declaration of a class or mixin, and let _X_ be a type parameter declared by _D_.
+
+If _X_ has the variance modifier `out` then it is a compile-time error for _X_ to occur in a non-covariant position in a member signature in the body of _D_. *For instance, _X_ can not be the type of a method parameter, and it can not be the bound of a type parameter of a generic method.*
+
+If _X_ has the variance modifier `in` then it is a compile-time error for _X_ to occur in a non-contravariant position in a member signature in the body of _D_. *For instance, _X_ can not be the return type of a method or getter, and it can not be the bound of a type parameter of a generic method.*
+
+*If _X_ has the variance modifier `inout` then there are no variance related restrictions on the positions where it can occur.*
+
+The [subtype rule](https://github.com/dart-lang/language/blob/e3010343a8e6f608a831078b0a04d4f1eeca46d4/specification/dartLangSpec.tex#L14845) for interface types that is concerned with the relationship among type arguments is modified as follows:
+
+In order to conclude that _C&lt;S<sub>1</sub>,... S<sub>s</sub>  &gt; <: C&lt;T<sub>1</sub>,... T<sub>s</sub> &gt;_ the current rule requires that _S<sub>j</sub> <: T<sub>j</sub>_ for each _j_ in 1 .. _s_. *This means that, to be a subtype, all actual type arguments must be subtypes.*
+
+The rule is updated as follows in order to take variance modifiers into account:
+
+For each _j_ in 1 .. _s_ where the corresponding type parameter _X<sub>j</sub>_ has no variance modifier, or it has the variance modifier `out`, we require _S<sub>j</sub> <: T<sub>j</sub>_.
+
+For each _j_ in 1 .. _s_ where the corresponding type parameter _X<sub>j</sub>_ has the variance modifier `in`, we require _T<sub>j</sub> <: S<sub>j</sub>_.
+
+For each _j_ in 1 .. _s_ where the corresponding type parameter _X<sub>j</sub>_ has the variance modifier `inout`, we require _S<sub>j</sub> <: T<sub>j</sub>_ as well as _T<sub>j</sub> <: S<sub>j</sub>_.
+
+The rules for determining the variance of an position are updated as follows:
+
+We say that a type _S_ occurs in a _covariant position_ in a type _T_ iff one of the following conditions is true:
+
+- _T_ is _S_.
+
+- _T_ is of the form _G&lt;S<sub>1</sub>,... S<sub>n</sub>&gt;_ where _G_ denotes a generic class and _S_ occurs in a covariant position in _S<sub>j</sub>_ for some _j_ in 1 .. _n_ where the corresponding type parameter of _G_ has no variance modifier or it has the variance modifier `out`; or in a contravariant position where the corresponding type parameter has the variance modifier `in`.
+
+- _T_ is of the form _S<sub>0</sub> Function&lt;X<sub>1</sub> extends B<sub>1</sub>, ...>(S<sub>1</sub> x<sub>1</sub>, ...)_ where the type parameter list may be omitted, and _S_ occurs in a covariant position in _S<sub>0</sub>_.
+
+- _T_ is of the form _S<sub>0</sub> Function&lt;X<sub>1</sub> extends B<sub>1</sub>, ...&gt;(S<sub>1</sub> x<sub>1</sub>, ... S<sub>k</sub> x<sub>k</sub>, [S<sub>k+1</sub> x<sub>k+1</sub> = d<sub>k+1</sub>, ..., S<sub>n</sub> x<sub>n</sub> = d<sub>n</sub>])_ or of the form _S<sub>0</sub> Function&lt;X<sub>1</sub> extends B<sub>1</sub>, ...&gt; (S<sub>1</sub> x<sub>1</sub>, ... S<sub>k</sub> x<sub>k</sub>, {S<sub>k+1</sub> x<sub>k+1</sub> = d<sub>k+1</sub>, ..., S<sub>n</sub> x<sub>n</sub> = d<sub>n</sub>})_ where the type parameter list and each default value may be omitted, and _S_ occurs in a contravariant position in _S<sub>j</sub>_ for some _j_ in 1 .. _n_.
+
+- _T_ is of the form _G&lt;S<sub>1</sub>, ... S<sub>n</sub>&gt;_ where _G_ denotes a generic type alias such that _j_ in 1 .. _n_, the formal type parameter corresponding to _S<sub>j</sub>_ is covariant, and _S_ occurs in a covariant position in _S<sub>j</sub>_.
+
+- _T_ is of the form _G&lt;S<sub>1</sub>, ... S<sub>n</sub>&gt;_ where _G_ denotes a generic type alias such that _j_ in 1 .. _n_, the formal type parameter corresponding to _S<sub>j</sub>_ is contravariant, and _S_ occurs in a contravariant position in _S<sub>j</sub>_.
+
+We say that a type _S_ occurs in a _contravariant position_ in a type _T_ iff one of the following conditions is true:
+
+- _T_ is of the form _G&lt;S<sub>1</sub>, ... S<sub>n</sub>&gt;_ where _G_ denotes a generic class and _S_ occurs in a contravariant position in _S<sub>j</sub>_ for some _j_ in 1 .. _n_ where the corresponding type parameter of _G_ has no variance modifier or it has the variance modifier `out`; or in a covariant position where the corresponding type parameter has the variance modifier `in`.
+
+- _T_ is of the form _S<sub>0</sub> Function&lt;X<sub>1</sub> extends B<sub>1</sub>, ...>(S<sub>1</sub> x<sub>1</sub>, ...)_ where the type parameter list may be omitted, and _S_ occurs in a contravariant position in _S<sub>0</sub>_.
+
+- _T_ is of the form _S<sub>0</sub> Function&lt;X<sub>1</sub> extends B<sub>1</sub>, ...&gt; S<sub>1</sub> x<sub>1</sub>, ... S<sub>k</sub> x<sub>k</sub>, [S<sub>k+1</sub> x<sub>k+1</sub> = d<sub>k+1</sub>, ... S<sub>n</sub> x<sub>n</sub> = d<sub>n</sub>])_ or of the form _S<sub>0</sub> Function&lt;X<sub>1</sub> extends B<sub>1</sub>, ...&gt; S<sub>1</sub> x<sub>1</sub>, ... S<sub>k</sub> x<sub>k</sub>, {S<sub>k+1</sub> x<sub>k+1</sub> = d<sub>k+1</sub>, ... S<sub>n</sub> x<sub>n</sub> = d<sub>n</sub>})_ where the type parameter list and each default value may be omitted, and _S_ occurs in a covariant position in _S<sub>j</sub>_ for some _j_ in 1 .. _n_.
+
+- _T_ is of the form _G&lt;S<sub>1</sub>, ... S<sub>n</sub>&gt;_ where _G_ denotes a generic type alias such that _j_ in 1 .. _n_, the formal type parameter corresponding to _S<sub>j</sub>_ is covariant, and _S_ occurs in a contravariant position in _S<sub>j</sub>_.
+
+- _T_ is of the form _G&lt;S<sub>1</sub>, ... S<sub>n</sub>&gt;_ where _G_ denotes a generic type alias such that _j_ in 1 .. _n_, the formal type parameter corresponding to _S<sub>j</sub>_ is contravariant, and _S_ occurs in a covariant position in _S<sub>j</sub>_.
+
+We say that a type _S_ occurs in an _invariant position_ in a type _T_ iff one of the following conditions is true:
+
+- _T_ is of the form _G&lt;S<sub>1</sub>, ... S<sub>n</sub>&gt;_ where _G_ denotes a generic class or a generic type alias, and _S_ occurs in an invariant position in _S<sub>j</sub>_ for some _j_ in 1 .. _n_; or _S_ occurs (in any position) in _S<sub>j</sub>_, and the corresponding type parameter of _G_ has the variance modifier `inout`.
+
+- _T_ is of the form _S<sub>0</sub> Function&lt;X<sub>1</sub> extends B<sub>1</sub>, ... X<sub>m</sub> extends B<sub>m</sub>&gt; S<sub>1</sub> x<sub>1</sub>, ... S<sub>k</sub> x<sub>k</sub>, [S<sub<k+1</sub> x<sub>k+1</sub> = d<sub>k+1</sub>, ... S<sub>n</sub> x<sub>n</sub> = d<sub>n</sub>])_ or of the form _S<sub>0</sub> function&lt;X<sub>1</sub> extends B<sub>1</sub>, ... X<sub>m</sub> extends B<sub>m</sub>&gt;_S<sub>1</sub> x<sub>1</sub>, ... S<sub>k</sub> x<sub>k</sub>, {S<sub>k+1</sub> x<sub>k+1</sub> = d<sub>k+1</sub>, ... S<sub>n</sub> x<sub>n</sub> = d<sub>n</sub>})_ where the type parameter list and each default value may be omitted, and _S_ occurs in an invariant position in _S<sub>j</sub>_ for some _j_ in 0 .. _n_, or _S_ occurs in _B<sub>i</sub>_ for some _i_ in 1 .. _m_.
+
+- _T_ is of the form _G&lt;S<sub>1</sub>, ... S<sub>n</sub>&gt;_ where _G_ denotes a generic type alias, _j_ in 1 .. _n_, the formal type parameter corresponding to _S<sub>j</sub>_ is invariant, and _S_ occurs (in any position) in _S<sub>j</sub>_.
+
+!!!TODO!!! Constraints on the occurrence of type parameters with a variance modifier in superinterfaces. Maybe this is easy? `inout` can occur anywhere, `out` can occur in a covariant position, and `in` can occur in a contravariant position. Think about soundness!
+
+!!!TODO!!! Everything about use-site invariance.

--- a/accepted/future-releases/variance/feature-specification.md
+++ b/accepted/future-releases/variance/feature-specification.md
@@ -307,6 +307,17 @@ main() {
 *Note that there is no way to make it statically safe to pass an actual argument to a covariant formal parameter of a given member `m`. Any receiver may have a dynamic type which is a proper subtype of the statically known type, and it may have an overriding declaration of `m` that makes the parameter covariant. So, by design, a modular static analysis cannot guarantee that any given invocation will not cause a dynamic error due to a dynamic type check for a covariant parameter.*
 
 
+### Member Access Typing
+
+For soundness, occurrences of the modifier `exactly` in member signatures are subject to elimination during the computation of the type of member access operations (*such as invocations of methods, getters, or setters*).
+
+Let _D_ be the declaration of a generic class or mixin named _N_ and let _X<sub>1</sub> .. X<sub>k</sub>_ be the type parameters declared by _D_. Let _T_ be a parameterized type which applies _N_ to a list of actual type arguments _S<sub>1</sub> .. S<sub>k</sub>_ in a context where the name _N_ denotes the declaration _D_, and consider the situation where a member access to a member `m` in the interface of _T_ is performed. Let _S1<sub>1</sub> .. S1<sub>k</sub>_ be the same as _S<sub>1</sub> .. S<sub>k</sub>_, except that any occurrence of `exactly` at the top level of each type argument has been removed.
+
+Let _s_ be the member signature of `m` from the interface of _D_, and _s1_ be _[S1<sub>1</sub>/X<sub>1</sub> .. S1<sub>k</sub>/X<sub>k</sub>]s_ (*this is the "raw" version of the statically known type of `m`*).
+
+For each _j_ in 1 .. _k_, if _X<sub>j</sub>_ does not have the variance modifier `inout`, and _S<sub>j</sub>_ does not have the modifier `exactly`, then for each occurrence of _exactly X<sub>j</sub>_ in _s_, the corresponding occurrence of `exactly` in _s1_ is eliminated, and so is every occurrence of `exactly` on each enclosing type, as long as they are parameterized types.
+
+
 ## Dynamic Semantics
 
 Every instance of a generic class has a dynamic type where every type argument has the modifier `exactly`.

--- a/accepted/future-releases/variance/feature-specification.md
+++ b/accepted/future-releases/variance/feature-specification.md
@@ -111,6 +111,15 @@ main() {
 
 *In the above example, an execution that maintains heap soundness would throw already at `ws.add(<int>[])`, because `List<int>` is not a subtype of `List<exactly num>`. Otherwise, we can proceed to `zs[0][0] = 4.31` and cause a base level type error, which illustrates that we cannot just ignore the distinction between `List<exactly num>` and `List<num>` as a type argument, neither statically nor dynamically.*
 
+Finally, the subtype rule that connects a class to its superinterfaces is updated to take `exactly` into account:
+
+Given that _C_ is a class that declares type parameters _X<sub>1</sub> .. X<sub>s</sub>_ such that
+_D&lt;T<sub>1</sub> .. T<sub>m</sub>&gt;_ is a direct superinterface of _C_, we conclude that
+_C&lt;v<sub>1</sub> S<sub>1</sub> .. v<sub>s</sub> S<sub>s</sub>&gt; <: T_
+if
+_[v<sub>1</sub> S<sub>1</sub>/X<sub>1</sub> .. v<sub>s</sub> S<sub>s</sub>/X<sub>s</sub>]D&lt;T<sub>1</sub> .. T<sub>m</sub>&gt; <: T_
+where _S<sub>j</sub>_ is a type and _v<sub>j</sub>_ is either empty or `exactly`, for all _j_ in 1 .. _s_.
+
 
 ### Variance Rules
 

--- a/accepted/future-releases/variance/feature-specification.md
+++ b/accepted/future-releases/variance/feature-specification.md
@@ -23,9 +23,9 @@ This is sound for all covariant occurrences of such type parameters in the class
 
 However, in general, every member access where a covariant type parameter occurs in a non-covariant position may cause a dynamic type error, because the actual type annotation at run time&mdash;say, the type of a parameter of a method&mdash;is a subtype of the one which occurs in the static type.
 
-This proposal introduces explicit variance modifiers for type parameters, as well as invariance modifiers for actual type arguments. It includes compile-time restrictions on the use of objects whose static type includes these modifiers, ensuring that the above-mentioned dynamic type errors cannot occur.
+This proposal introduces explicit variance modifiers for type parameters, as well as invariance modifiers for actual type arguments. It includes compile-time restrictions on type declarations and on the use of objects whose static type includes these modifiers, ensuring that the above-mentioned dynamic type errors cannot occur.
 
-In order to ease the transition where types with explicit variance are created and used, this proposal allows for certain subtype relationships where dynamic type checks are still needed when using legacy types (where type parameters are _implicitly_ covariant) to access an object, even in the case where the object has a type with explicit variance.
+In order to ease the transition where types with explicit variance are created and used, this proposal allows for certain subtype relationships where dynamic type checks are still needed when using legacy types (where type parameters are _implicitly_ covariant) to access an object, even in the case where the object has a type with explicit variance. For example, it is allowed to declare `class MyList<out E> implements List<E> {...}`, even though this means that `MyList` has members such as `add` that require dynamic checks and may incur a dynamic type error.
 
 
 ## Syntax
@@ -70,9 +70,9 @@ Let _j_ in 1 .. _s_. If none of _S<sub>j</sub>_ or _T<sub>j</sub>_ have the modi
 
 If the corresponding type parameter _X<sub>j</sub>_ has no variance modifier, or it has the variance modifier `out`, we require _S<sub>j</sub> <: T<sub>j</sub>_.
 
-If the corresponding type parameter _X<sub>j</sub>_ has the variance modifier `in`, we require _T<sub>j</sub> <: S<sub>j</sub>_.
-
 If the corresponding type parameter _X<sub>j</sub>_ has the variance modifier `inout`, we require _S<sub>j</sub> <: T<sub>j</sub>_ as well as _T<sub>j</sub> <: S<sub>j</sub>_.
+
+If the corresponding type parameter _X<sub>j</sub>_ has the variance modifier `in`, we require _T<sub>j</sub> <: S<sub>j</sub>_.
 
 If both _S<sub>j</sub>_ and _T<sub>j</sub>_ have the modifier `exactly` then let _S1<sub>j</sub>_ be _S<sub>j</sub>_ except that `exactly` has been eliminated, and similarly for _T1<sub>j</sub>_; we then require _S1<sub>j</sub> <: T1<sub>j</sub>_ as well as _T1<sub>j</sub> <: S1<sub>j</sub>_ (*whether or not the corresponding type parameter has a variance modifier, and no matter which one*).
 
@@ -132,7 +132,7 @@ We say that a type _S_ occurs in a _contravariant position_ in a type _T_ iff on
 
 - _T_ is of the form _S<sub>0</sub> Function&lt;X<sub>1</sub> extends B<sub>1</sub>, ...>(...)_ where the type parameter list may be omitted, and _S_ occurs in a contravariant position in _S<sub>0</sub>_.
 
-- _T_ is of the form _S<sub>0</sub> Function&lt;X<sub>1</sub> extends B<sub>1</sub>, ...&gt; S<sub>1</sub> x<sub>1</sub>, ... S<sub>k</sub> x<sub>k</sub>, [S<sub>k+1</sub> x<sub>k+1</sub> = d<sub>k+1</sub>, ... S<sub>n</sub> x<sub>n</sub> = d<sub>n</sub>])_ or of the form _S<sub>0</sub> Function&lt;X<sub>1</sub> extends B<sub>1</sub>, ...&gt; S<sub>1</sub> x<sub>1</sub>, ... S<sub>k</sub> x<sub>k</sub>, {S<sub>k+1</sub> x<sub>k+1</sub> = d<sub>k+1</sub>, ... S<sub>n</sub> x<sub>n</sub> = d<sub>n</sub>})_ where the type parameter list and each default value may be omitted, and _S_ occurs in a covariant position in _S<sub>j</sub>_ for some _j_ in 1 .. _n_.
+- _T_ is of the form _S<sub>0</sub> Function&lt;X<sub>1</sub> extends B<sub>1</sub>, ...&gt;(S<sub>1</sub> x<sub>1</sub>, ... S<sub>k</sub> x<sub>k</sub>, [S<sub>k+1</sub> x<sub>k+1</sub> = d<sub>k+1</sub>, ... S<sub>n</sub> x<sub>n</sub> = d<sub>n</sub>])_ or of the form _S<sub>0</sub> Function&lt;X<sub>1</sub> extends B<sub>1</sub>, ...&gt;(S<sub>1</sub> x<sub>1</sub>, ... S<sub>k</sub> x<sub>k</sub>, {S<sub>k+1</sub> x<sub>k+1</sub> = d<sub>k+1</sub>, ... S<sub>n</sub> x<sub>n</sub> = d<sub>n</sub>})_ where the type parameter list and each default value may be omitted, and _S_ occurs in a covariant position in _S<sub>j</sub>_ for some _j_ in 1 .. _n_.
 
 We say that a type _S_ occurs in an _invariant position_ in a type _T_ iff one of the following conditions is true:
 
@@ -154,9 +154,9 @@ Let _D_ be the declaration of a class or mixin, and let _X_ be a type parameter 
 
 We say that _X_ _is covariant_ if it has no variance modifier or it has the variance modifier `out`; that it _is invariant_ if it has the variance modifier `inout`; and that it _is contravariant_ if it has the variance modifier `in`.
 
-If _X_ has the variance modifier `out` then it is a compile-time error for _X_ to occur in a non-covariant position in a member signature in the body of _D_. *For instance, _X_ can not be the type of a method parameter, and it can not be the bound of a type parameter of a generic method.*
+If _X_ has the variance modifier `out` then it is a compile-time error for _X_ to occur in a non-covariant position in a member signature in the body of _D_, except that it is not an error if it occurs in a covariant position in the type annotation of a covariant formal parameter (*note that this is a contravariant position in the member signature as a whole*). *For instance, _X_ can not be the type of a method parameter (unless covariant), and it can not be the bound of a type parameter of a generic method.*
 
-If _X_ has the variance modifier `in` then it is a compile-time error for _X_ to occur in a non-contravariant position in a member signature in the body of _D_. *For instance, _X_ can not be the return type of a method or getter, and it can not be the bound of a type parameter of a generic method.*
+If _X_ has the variance modifier `in` then it is a compile-time error for _X_ to occur in a non-contravariant position in a member signature in the body of _D_, except that it is not an error if it occurs in a contravariant position in the type of a covariant formal parameter. *For instance, _X_ can not be the return type of a method or getter, and it can not be the bound of a type parameter of a generic method.*
 
 *If _X_ has the variance modifier `inout` then there are no variance related restrictions on the positions where it can occur.*
 
@@ -164,7 +164,7 @@ If _X_ has the variance modifier `in` then it is a compile-time error for _X_ to
 
 Let _D_ be a class or mixin declaration, let _S_ be a superinterface of _D_, and let _X_ be a type parameter declared by _D_.
 
-It is a compile-time error if _X_ has no variance modifier and _X_ occurs in an actual type argument in _S_ such that the corresponding type parameter has a variance modifier. It is a compile-time error of _X_ has the modifier `out`, and _X_ occurs in a non-covariant position in _S_. It is a compile-time error if _X_ has the variance modifier `in`, and _X_ occurs in a non-contravariant position in _S_.
+It is a compile-time error if _X_ has no variance modifier and _X_ occurs in an actual type argument in _S_ such that the corresponding type parameter has a variance modifier. It is a compile-time error if _X_ has the modifier `out`, and _X_ occurs in a non-covariant position in _S_. It is a compile-time error if _X_ has the variance modifier `in`, and _X_ occurs in a non-contravariant position in _S_.
 
 *A type parameter with variance modifier `inout` can occur in any position in a superinterface, and other variance modifiers have constraints such that if we consider type arguments _Args1_ and _Args2_ passed to _D_ such that the former produces a subtype, then we also have _S1 <: S2_ where _S1_ and _S2_ are the corresponding instantiations of _S_.*
 
@@ -173,9 +173,9 @@ class A<out X, inout Y, in Z> {}
 class B<out U, inout V, in W> implements
     A<U Function(W), V Function(V), W Function(V)> {}
 
-// B<int, String, num> <: B<num, String, int>, and
+// B<int, String, num> <: B<num, String, int>, and hence
 // A<int Function(num), String Function(String), num Function(String)> <:
-// A<num Function(int), String Function(String), int Function(String)> <:
+// A<num Function(int), String Function(String), int Function(String)>.
 ```
 
 *But a type parameter without a variance modifier can not be used in an actual type argument for a parameter with a variance modifier, not even when that modifier is `out`. The reason for this is that it would allow a subtype to introduce the potential for dynamic errors with a member which is in the interface of the supertype and considered safe.*
@@ -195,8 +195,8 @@ class B<X> extends A<X> {
 *On the other hand, to ease migration, it _is_ allowed to create the opposite relationship:*
 
 ```dart
-abstract class A<X> {
-  void foo(X x);
+class A<X> {
+  void foo(X x) {}
 }
 
 class B<out X> extends A<X> {}
@@ -215,7 +215,9 @@ main() {
 *Note that the class `B` _can_ be written in such a way that the potential dynamic type error is eliminated:*
 
 ```dart
-// Same A.
+class A<X> {
+  void foo(X x) {}
+}
 
 class B<out X> extends A<X> {
   void foo(Object? o) {...}
@@ -226,12 +228,14 @@ class B<out X> extends A<X> {
 
 *However, in the more likely case where `foo` does require an argument of type `X`, we do not wish to insist that developers declare an apparently safe member signature like `void foo(Object?)`, and then throw an exception in the body of `foo`. That would just eliminate some compile-time errors at call sites which are actually justified.*
 
-*If such a method needs to be overridden, the modifier `covariant` must be used, in order to avoid the compile-time error for member signatures involving an `out` type parameter:*
+*If such a method needs to be implemented, the modifier `covariant` must be used, in order to avoid the compile-time error for member signatures involving an `out` type parameter:*
 
 ```dart
-// Same A.
+class A<X> {
+  void foo(X x) {}
+}
 
-class B<out X> extends A<X> {
+class B<out X> extends A<X> { // or `implements`.
   void foo(covariant X x) {...}
 }
 ```
@@ -261,7 +265,7 @@ The static type of an instance creation expression that invokes a generative con
 
 The static type of a list literal receiving type argument `T` is `List<exactly T>`; the static type of a set literal receiving type argument `T` is `Set<exactly T>`; and the static type of a map literal receiving type arguments `K` and `V` is `Map<exactly K, exactly V>`.
 
-*It cannot be assumed that a similar relationship exists for regular invocations, say, of a static method or a factory constructor, so they couldn't allow for actual type arguments marked `exactly`.*
+*It cannot be assumed that a similar relationship exists for regular invocations, say, of a generic function or a factory constructor, so it is an error for an actual type argument to be marked `exactly`.*
 
 ```dart
 class C<X> {
@@ -269,12 +273,43 @@ class C<X> {
   factory C.named() => C<Never>();
 }
 
-main() => C<int>.named(); // Does not have type `C<exactly int>`.
+main() {
+  // OK, but the static and dynamic type of `c` is not `C<exactly int>`:
+  var c = C<int>.named();
+
+  // Error, because it is misleading:
+  var c2 = C<exactly int>.named();
+}
 ```
+
+*Note that the use of `exactly` even for a type argument where the corresponding type parameter _X_ is marked `out` or `in` may be useful: The members declared in the type that receives this type argument must in general be sound with respect to _X_, but there may be some member signatures inherited from a supertype where some type parameters have no variance modifier, and the use of `exactly` will then provide a guarantee against dynamic type errors which does not otherwise exist:*
+
+```dart
+class A<X> {
+  void foo(X x) {}
+}
+
+class B<out X> extends A<X> {}
+
+class C<out Y> {
+  List<Y> get bar => [];
+}
+
+main() {
+  B<exactly num> b = B();
+  b.foo(17.9); // Statically safe.
+
+  C<exactly num> c = C();
+  c.bar.add(179); // Statically safe, even though `c.bar` has a legacy type.
+}
+```
+
+*Note that there is no way to make it statically safe to pass an actual argument to a covariant formal parameter of a given member `m`. Any receiver may have a dynamic type which is a proper subtype of the statically known type, and it may have an overriding declaration of `m` that makes the parameter covariant. So, by design, a modular static analysis cannot guarantee that any given invocation will not cause a dynamic error due to a dynamic type check for a covariant parameter.*
+
 
 ## Dynamic Semantics
 
-Every instance of a generic class has a type where every type argument has the modifier `exactly`.
+Every instance of a generic class has a dynamic type where every type argument has the modifier `exactly`.
 
 *Note that this only applies at the top level in the type of the object. It may or may not have the modifier `exactly` on type arguments of type arguments.*
 
@@ -292,7 +327,7 @@ The dynamic representation of generic class types include information about whet
 ```dart
 main() {
   dynamic xs = <List<exactly num>>[];
-  xs.add(<int>[]); // Must throw.
+  xs.add(<int>[]); // Must throw, hence `exactly` must be known at run time.
 }
 ```
 
@@ -307,7 +342,7 @@ If a new class _A_ has no superinterface relationship with any legacy class (dir
 
 *In other words, if the plan is to use explicit variance only with type declarations that are not "connected to" unsoundly covariant type parameters then there is no migration.*
 
-However, there is a need for migration support in the case where an existing legacy class _B_ is modified such that one or more of its type parameters have an explicit variance modifier.
+However, there is a need for migration support in the case where an existing legacy class _B_ is modified such that an explicit variance modifier is added to one or more of its type parameters.
 
 In particular, an existing subtype _C_ of _B_ must now add variance modifiers in order to remain error free, and this may conflict with the existing member signatures of _C_:
 
@@ -335,7 +370,7 @@ This approach can be used in a scenario where all parts of the program are migra
 
 In the other scenario, some libraries will opt in using a suitable language level, and others will not.
 
-If a library _L1_ is at a language level where explicit variance is not supported (so it is 'opted out') then code in an 'opted in' library _L2_ is seen from _L1_ as erased, in the sense that (1) the variance modifiers `out` and `inout` are ignored, and `exactly` in types is ignored, and (2) it is a compile-time error to pass a type argument `T` to a type parameter with variance modifier `in`, unless `T` is a top type.
+If a library _L1_ is at a language level where explicit variance is not supported (so it is 'opted out') then code in an 'opted in' library _L2_ is seen from _L1_ as erased, in the sense that (1) the variance modifiers `out` and `inout` are ignored, and `exactly` in types is ignored, and (2) it is a compile-time error to pass a type argument `T` to a type parameter with variance modifier `in`, unless `T` is a top type; (3) any type argument `T` passed to an `in` type parameter in opted-in code is seen in opted-out code as `Object?`.
 
 Conversely, declarations in _L1_ (opted out) is seen from _L2_ (opted in) without changes. So class type parameters declared in _L1_ are considered to be unsoundly covariant by both opted in and opted out code, and similarly for type aliases used to declare function types. Types of entities exported from _L1_ to _L2_ are seen as erased (which matters when _L1_ imports entities from some other opted-in library).
 

--- a/accepted/future-releases/variance/feature-specification.md
+++ b/accepted/future-releases/variance/feature-specification.md
@@ -35,7 +35,7 @@ The grammar is adjusted as follows:
 ```
 <typeParameter> ::= // Modified.
     <metadata> <typeParameterVariance>? <typeIdentifier>
-    (('extends'|'super') <typeNotVoid>)?
+    ('extends' <typeNotVoid>)?
 
 <typeParameterVariance> ::= // New.
     'out' | 'inout' | 'in'
@@ -171,7 +171,7 @@ If _X_ has the variance modifier `in` then it is a compile-time error for _X_ to
 
 *For superinterfaces we need slightly stronger rules than the ones that apply for types in the body of a type declaration.*
 
-Let _D_ be a class or mixin declaration, let _S_ be a superinterface of _D_, and let _X_ be a type parameter declared by _D_.
+Let _D_ be a class or mixin declaration, let _S_ be a direct superinterface of _D_, and let _X_ be a type parameter declared by _D_.
 
 It is a compile-time error if _X_ has no variance modifier and _X_ occurs in an actual type argument in _S_ such that the corresponding type parameter has a variance modifier. It is a compile-time error if _X_ has the modifier `out`, and _X_ occurs in a non-covariant position in _S_. It is a compile-time error if _X_ has the variance modifier `in`, and _X_ occurs in a non-contravariant position in _S_.
 
@@ -355,6 +355,8 @@ main() {
   ys = cn.g; // Error (downcast).
 }
 ```
+
+*This example also illustrates why the ability to have `exactly` in a member signature helps improving the static typing: The declaration in class `C` ensures that `g` actually returns a `List<exactly X>`. In the situation where the value of `X` is known at the call site to be a specific type `T`, this allows the returned result to be typed `List<exactly T>`, which in turn makes the usage of `add` and similar members statically safe.*
 
 
 ## Dynamic Semantics

--- a/accepted/future-releases/variance/feature-specification.md
+++ b/accepted/future-releases/variance/feature-specification.md
@@ -249,7 +249,7 @@ class B<out X> extends A<X> { // or `implements`.
 }
 ```
 
-Finally, the occurrences of `exactly` in member signatures are restricted. Let _D_ be a class or mixin declaration and let _s_ be the member signature of an instance member declared by _D_. It is a compile-time error if _s_ contains a type argument of the form _exactly T_ in a non-covariant position where _T_ contains an occurrence of a type variable that does not have the variance modifier `inout`.
+Finally, the occurrences of `exactly` in member signatures are restricted. Let _D_ be a class or mixin declaration and let _s_ be the member signature of an instance member declared by _D_. Assume that _s_ contains a parameterized type _T_ in a non-covariant position, and assume that _T_ has a type argument of the form _exactly U_. In this situation it is a compile-time error if _U_ contains an occurrence of a type variable that does not have the variance modifier `inout`.
 
 ```dart
 class C<X, inout Y, in Z> {


### PR DESCRIPTION
This is a first draft version of the feature specification of explicit variance support in Dart: (1) Explicit variance modifiers `out`/`inout`/`in` that generic type declarations can use on their type parameters, and (2) an explicit invariance modifier `exactly` on type arguments that client code can use in order to obtain statically safe use of legacy classes (using the current kind of covariance which requires dynamic checks).

It is rather permissive, in the sense that it allows for things like `class B<out X> extends A<X> {}` where `A` is a legacy class (say, `class A<X> { foo(X x) {}}`), which means that we _can_ have a variable `b` of type `B<num>`, and we can call `b.foo(1.23)`, and it will throw at run-time.

We could also say that the method `foo` is inaccessible in `B` (just like Java wildcards: we could "filter" out the part of the API whose member signatures violate the given variance). But I suspect that it will work better in practice to catch such cases with a lint.

Member declarations involving type parameters that have explicit variance modifiers are checked strictly (so `class B<out X> { void foo(X x) {...}}` is a compile-time error), but it is of course always possible to check such properties in the body and throw (`void foo(Object? o) { X x = o as X; ...}`), and, with that, I saw no reason to prohibit `covariant` parameters.
