### PR TITLE
Make mixin application implement the mixin's interface.

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -3481,7 +3481,7 @@ then the (implicit or explicit) superinitializer in $k$ is an error.%
 }
 
 \LMHash{}%
-The superinitializer that appears, explicitly or implicitly, 
+The superinitializer that appears, explicitly or implicitly,
 in the initializer list of a constant constructor
 must specify a constant constructor of
 the superclass of the immediately enclosing class,
@@ -4586,7 +4586,7 @@ interface members that are actually super-invoked.}
 \LMHash{}%
 The mixin application of $M$ to $S$ with name $N$ introduces a new
 class, $C$, with name $N$, superclass $S$,
-implemented interface $I_1$, \ldots{}, $I_k$
+implemented interface $M$
 and \metavar{members} as instance members.
 The class $C$ has no static members.
 If $S$ declares any generative constructors, then the application
@@ -11603,7 +11603,7 @@ and therefore must be evaluated.
   \alt \SUPER{} <unconditionalAssignableSelector>
   \alt <constructorInvocation> <assignableSelectorPart>
   \alt <identifier>
- 
+
 <assignableSelectorPart> ::= <selector>* <assignableSelector>
 
 <unconditionalAssignableSelector> ::= `[' <expression> `]'
@@ -13950,7 +13950,7 @@ if the declaration is in the library's exported namespace.
 %% natural to define it at the first usage in terms of the page number.
 \LMHash{}%
 We define an operation for
-combining namespaces with disjoint sets of keys  as follows. 
+combining namespaces with disjoint sets of keys as follows.
 The
 \IndexCustom{union of two namespaces}{namespace!union},
 \IndexCustom{$\Namespace{a}\cup\Namespace{b}$}{%


### PR DESCRIPTION
The current specification of mixin application does not say that
the mixin application class implements the mixin's interface.
Instead it implements the implemented interfaces of the mixin declaration
directly.

This is clearly wrong, since the mixin application class must implement
the mixin interface (`is MyMixin` must work!).

When we add the mixin interface to the mixin application class as an immediate
super-interface, we no longer need to have the mixin's implemented interfaces
as immediate superinterfaces.

This change will affect the max-depth of the inheritance chain of the mixin
application if an implemented interface of the mixin was currently the longest
inheritance chain leading to the mixin interface. By inserting the
mixin interface, the max-depth increases by one. This may affect some
least upper bound computations.

(The fact that LUB is affected by completely opaque class hierarchy
refactorings, and that LUB is visible to end users in type inference,
suggests that the LUB computation is fundamentally broken and should be
scrapped before it hurts us more).