### PR TITLE
Add subtyping for function types with required named parameters

### DIFF
--- a/resources/type-system/subtyping.md
+++ b/resources/type-system/subtyping.md
@@ -239,8 +239,8 @@ promoted type variables `X0 & S0` and `T1` is `X0 & S1` then:
   - and `{yn+1, ... , yq}` subsetof `{xn+1, ... , xm}`
   - and `Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk]` for `i` in `0...n`
   - and `Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk]` for `i` in `n+1...q`, `yj = xi`
-  - and if `r0j` is `required` for some `j` in `n+1...m` then
-    there exists an `i` in `n+1...q` such that `xj = yi`, and `r1i` is `required`
+  - and for each `j` such that `r0j` is `required`, then there exists an
+    `i` in `n+1...q` such that `xj = yi`, and `r1i` is `required`
   - and `U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]`
   - and `B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk]` for `i` in `0...k`
   - where the `Zi` are fresh type variables with bounds `B0i[Z0/X0, ..., Zk/Xk]`

--- a/resources/type-system/subtyping.md
+++ b/resources/type-system/subtyping.md
@@ -231,12 +231,16 @@ promoted type variables `X0 & S0` and `T1` is `X0 & S1` then:
   - where the `Zi` are fresh type variables with bounds `B0i[Z0/X0, ..., Zk/Xk]`
 
 - **Named Function Types**: `T0` is
-  `U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn, {Vn+1 xn+1, ..., Vm xm})`
+  `U0 Function<X0 extends B00, ..., Xk extends B0k>(V0 x0, ..., Vn xn, {r0n+1 Vn+1 xn+1, ..., r0m Vm xm})`
+  where `r0j` is empty or `required` for `j` in `n+1...m`
   - and `T1` is
-    `U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn, {Sn+1 yn+1, ..., Sq yq})`
+    `U1 Function<Y0 extends B10, ..., Yk extends B1k>(S0 y0, ..., Sn yn, {r1n+1 Sn+1 yn+1, ..., r1q Sq yq})`
+    where `r1j` is empty or `required` for `j` in `n+1...q`
   - and `{yn+1, ... , yq}` subsetof `{xn+1, ... , xm}`
   - and `Si[Z0/Y0, ..., Zk/Yk] <: Vi[Z0/X0, ..., Zk/Xk]` for `i` in `0...n`
   - and `Si[Z0/Y0, ..., Zk/Yk] <: Tj[Z0/X0, ..., Zk/Xk]` for `i` in `n+1...q`, `yj = xi`
+  - and if `r0j` is `required` for some `j` in `n+1...m` then
+    there exists an `i` in `n+1...q` such that `xj = yi`, and `r1i` is `required`
   - and `U0[Z0/X0, ..., Zk/Xk] <: U1[Z0/Y0, ..., Zk/Yk]`
   - and `B0i[Z0/X0, ..., Zk/Xk] === B1i[Z0/Y0, ..., Zk/Yk]` for `i` in `0...k`
   - where the `Zi` are fresh type variables with bounds `B0i[Z0/X0, ..., Zk/Xk]`


### PR DESCRIPTION
Add syntax for `required` parameters in rule 'Named Function Types' of subtyping.md, and add the constraint that such parameters and their requiredness cannot be forgotten by subsumption.