### PR TITLE
Changed invocation of non-function objects to use a `call` getter

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -9081,16 +9081,17 @@ the returned result is then the result of evaluating $i$.
 
 \LMHash{}%
 Otherwise $o$ is not a function object.
-If $o$ has a method named \CALL{}
-the following ordinary method invocation is evaluated,
-and its result is then the result of evaluating $i$:
+If $o$ has a member named \CALL{}
+the following expression is evaluated to an object $r$,
+and the result of evaluating $i$ is then $r$:
 
 \noindent
 \code{$f$.call<$A_1, \ldots,\ A_r$>($a_1, \ldots,\ a_n,\ x_{n+1}$: $a_{n+1}, \ldots,\ x_{n+k}$: $a_{n+k}$)}.
 
 \LMHash{}%
-Otherwise $o$ has no method named \CALL{}.
-A new instance $im$ of the predefined class \code{Invocation} is created, such that:
+Otherwise $o$ has no member named \CALL{}.
+A new instance $im$ of the predefined class \code{Invocation} is created,
+such that:
 \begin{itemize}
 \item \code{$im$.isMethod} evaluates to \code{\TRUE{}}.
 \item \code{$im$.memberName} evaluates to the symbol \code{\#call}.
@@ -9114,8 +9115,9 @@ and its result is then the result of evaluating $i$.
 The situation where \code{noSuchMethod} is invoked can only arise
 when the static type of $e_f$ is \DYNAMIC{}.
 The run-time semantics ensures that
-a function invocation may amount to an invocation of the instance method \CALL{}.
-However, an interface type with a method named \CALL{}
+a function invocation may amount to
+an invocation of the instance member \CALL{}.
+However, an interface type with a member named \CALL{}
 is not itself a subtype of any function type
 (\ref{subtypeRules}).
 }
@@ -9562,14 +9564,18 @@ instance member named $m$, unless either:
 \item $T$ is \DYNAMIC{}.
 Or
 \item $T$ is \FUNCTION{} and $m$ is \CALL.
-\rationale{
-This means that for invocations of an instance method named \CALL,
+\rationale{%
+This means that for invocations of an instance member named \CALL,
 a receiver of type \FUNCTION{} is treated like a receiver of type \DYNAMIC{}.
-The expectation is that any concrete subclass of \FUNCTION{} will implement \CALL,
+The expectation is that
+any concrete subclass of \FUNCTION{} will implement \CALL,
 but there is no method signature which can be assumed for \CALL{} in \FUNCTION{}
-because every signature will conflict with some potential overriding declarations.
-Note that any use of \CALL{} on a subclass of \FUNCTION{} that fails to implement \CALL{} will provoke a compile-time error,
-as this exemption is limited to type \FUNCTION{}, and does not apply to its subtypes.
+because every signature will conflict with
+some potential overriding declarations.
+Note that any use of \CALL{} on a subclass of \FUNCTION{} that fails
+to implement \CALL{} will provoke a compile-time error,
+as this exemption is limited to type \FUNCTION{},
+and does not apply to its subtypes.%
 }
 \end{itemize}
 
@@ -16026,7 +16032,8 @@ whenever doing so is sound.
   }
 
 \item
-  Let $e$ be an expression which is of the form \code{$d$.\id(\metavar{arguments})}
+  Let $e$ be an expression which is of the form
+  \code{$d$.\id(\metavar{arguments})}
   or the form \code{$d$.\id<\metavar{typeArguments}>(\metavar{arguments})},
   where the static type of $d$ is \DYNAMIC,
   \id{} is the name of a getter declared in \code{Object} with return type $F$,
@@ -16040,8 +16047,8 @@ whenever doing so is sound.
   because it is checked as a
   function expression invocation where an entity of static type \code{Type} is
   invoked. Note that it could actually succeed: An overriding implementation
-  of \code{runtimeType} could return an instance whose dynamic type is a subtype
-  of \code{Type} that has a \CALL{} method.
+  of \code{runtimeType} could return an instance whose dynamic type is
+  a subtype of \code{Type} that has a member named \CALL.
   We decided to make it an error because it is likely to be a mistake,
   especially in cases like \code{$d$.hashCode()}
   where a developer might have forgotten that \code{hashCode} is a getter.


### PR DESCRIPTION
Cf. issue https://github.com/dart-lang/sdk/issues/36420: All implementations except DDC will invoke a getter named `call` or a method named `call` in the case where a function expression invocation (dynamic or statically checked) is performed where the target is not a function object.

The language specification currently specifies that only a method named `call` can be invoked in this manner (so if a getter is found it is an error, dynamic or static).

This PR makes the necessary changes to the specification to allow using a getter (to obtain a function object which is then invoked).