### PR TITLE
Integrate UI-as-code features into the language specification

### DIFF
--- a/specification/dart.sty
+++ b/specification/dart.sty
@@ -322,6 +322,11 @@
 % also used when specifying lookups and scope rules.
 \newcommand{\Namespace}[1]{\ensuremath{\metavar{NS}_{#1}}}
 
+% Context types: Avoid the `?` because that is also concrete type
+% syntax.
+%% TODO(eernst): Find a suitable symbol for this, e.g., a curly questionmark.
+\newcommand{\FreeContext}{\ensuremath{\square}}
+
 % ----------------------------------------------------------------------
 % Support for hash valued Location Markers
 

--- a/specification/dart.sty
+++ b/specification/dart.sty
@@ -331,6 +331,7 @@
 % a specification concept, may or may not have an actual underlying
 % data structure at run time.
 \newcommand{\LiteralSequence}[1]{\ensuremath{[\![{#1}]\!]}}
+\newcommand{\EvaluateElement}[1]{\ensuremath{\metavar{evaluateElement}({#1})}}
 
 % ----------------------------------------------------------------------
 % Support for hash valued Location Markers

--- a/specification/dart.sty
+++ b/specification/dart.sty
@@ -335,7 +335,8 @@
 % Context types: Avoid the `?` because that is also concrete type
 % syntax.
 %% TODO(eernst): Find a suitable symbol for this, e.g., a curly questionmark.
-\newcommand{\FreeContext}{\ensuremath{\square}}
+\newcommand{\FreeContext}{\ensuremath{\raisebox{0.25ex}{%
+      \makebox[0pt][c]{\hspace{0.8em}\scriptsize?}}\square}}
 
 % Sequences of objects used during collection literal evaluation: Just
 % a specification concept, may or may not have an actual underlying

--- a/specification/dart.sty
+++ b/specification/dart.sty
@@ -327,6 +327,11 @@
 %% TODO(eernst): Find a suitable symbol for this, e.g., a curly questionmark.
 \newcommand{\FreeContext}{\ensuremath{\square}}
 
+% Sequences of objects used during collection literal evaluation: Just
+% a specification concept, may or may not have an actual underlying
+% data structure at run time.
+\newcommand{\LiteralSequence}[1]{\ensuremath{[\![{#1}]\!]}}
+
 % ----------------------------------------------------------------------
 % Support for hash valued Location Markers
 

--- a/specification/dart.sty
+++ b/specification/dart.sty
@@ -158,6 +158,11 @@
 \newcommand{\PairList}[4]{\ensuremath{%
   {#1}_{#3}\ {#2}_{#3},\,\ldots,\ {#1}_{#4}\ {#2}_{#4}}}
 
+% Used to specify a list of tuples of the form $(K_j, V_j)$ which are
+% used with collection literals.
+\newcommand{\KeyValueTypeList}[4]{\ensuremath{%
+  ({#1}_{#3},\,{#2}_{#3}),\,\ldots,\ ({#1}_{#4},\,{#2}_{#4})}}
+
 % Used to specify comma separated lists of triples of similar symbols,
 % as needed, e.g., for declarations of formal parameters with defaults.
 % Parameters: Name of first part of triple, name of second part,
@@ -331,7 +336,8 @@
 % a specification concept, may or may not have an actual underlying
 % data structure at run time.
 \newcommand{\LiteralSequence}[1]{\ensuremath{[\![{#1}]\!]}}
-\newcommand{\EvaluateElement}[1]{\ensuremath{\metavar{evaluateElement}({#1})}}
+\newcommand{\EvaluateElementName}{\metavar{evaluateElement}}
+\newcommand{\EvaluateElement}[1]{\ensuremath{\EvaluateElementName({#1})}}
 
 % ----------------------------------------------------------------------
 % Support for hash valued Location Markers

--- a/specification/dart.sty
+++ b/specification/dart.sty
@@ -163,6 +163,11 @@
 \newcommand{\KeyValueTypeList}[4]{\ensuremath{%
   ({#1}_{#3},\,{#2}_{#3}),\,\ldots,\ ({#1}_{#4},\,{#2}_{#4})}}
 
+% Used to specify a list of key/value pairs of the form $k_j: v_j$ which are
+% used for the semantics of collection literals.
+\newcommand{\KeyValueList}[4]{\ensuremath{%
+  {#1}_{#3}:\,{#2}_{#3},\,\ldots,\ {#1}_{#4}:\,{#2}_{#4}}}
+
 % Used to specify comma separated lists of triples of similar symbols,
 % as needed, e.g., for declarations of formal parameters with defaults.
 % Parameters: Name of first part of triple, name of second part,

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -7027,7 +7027,7 @@ This section specifies several literal expressions denoting collections.
 Some syntactic forms may denote more than one kind of collection,
 in which case a disambiguation step is performed
 in order to determine the kind
-(\ref{collectionLiteralDisambiguation}).
+(\ref{setAndMapLiteralDisambigutation}).
 
 \begin{grammar}
 <listLiteral> ::= \CONST{}? <typeArguments>? `[' <elements>? `]'
@@ -7063,7 +7063,8 @@ Each element may be a declarative specification of a single entity,
 such as an \synt{expressionElement} or a \synt{mapElement},
 it may specify a collection which is to be included,
 of the form \synt{spreadElement},
-or it may be a computational element specifying zero or more entities,
+or it may be a computational element specifying
+how to obtain zero or more entities,
 of the form \synt{ifElement} or \synt{forElement}.
 
 \LMHash{}%
@@ -7088,16 +7089,547 @@ It is a compile-time error if the leaf elements of a \synt{listLiteral}
 contains a \synt{mapElement}.
 
 
-\subsubsection{Lists}
-\LMLabel{lists}
+\subsubsection{Type Promotion}
+\LMLabel{collectionLiteralTypePromotion}
+
+\LMHash{}%
+An \synt{ifElement} interacts with type promotion
+in the same way that \IF{} statements do.
+Assume that $\ell$ is an \synt{ifElement} of the form
+\code{\IF{} ($b$) $\ell_1$} or
+\code{\IF{} ($b$) $\ell_1$ \ELSE{} $\ell_2$}.
+If $b$ shows that a local variable $v$ has type $T$, then
+the type of $v$ is known to be $T$ in $\ell_1$,
+unless any of the following are true:
+
+\begin{itemize}
+\item $v$ is potentially mutated in $\ell_1$,
+\item $v$ is potentially mutated within a function
+  other than the one where $v$ is declared, or
+\item $v$ is accessed by a function defined in $\ell_1$ and
+  $v$ is potentially mutated anywhere in the scope of $v$.
+\end{itemize}
+
+%% TODO(eernst): Come nnbd, update this.
+\commentary{%
+Type promotion will likely get more sophisticated in a future version of Dart.
+When that happens,
+\synt{ifElements} will continue to match \IF{} statements
+(\ref{if}).%
+}
+
+
+\subsubsection{Collection Literal Element Evaluation}
+\LMLabel{collectionLiteralElementEvaluation}
+
+\LMHash{}%
+The evaluation of a syntactic sequence of collection literal elements
+(\ref{collectionLiterals})
+yields a
+\IndexCustom{collection literal object sequence}{collection literal!object sequence},
+also called an \NoIndex{object sequence} when no ambiguity can arise.
+We use the notation
+\IndexCustom{\LiteralSequence{\ldots}}{[[...]]@\LiteralSequence{\ldots}}
+to denote an object sequence of specific elements.
+Each element in the sequence is an object $o$ or a pair $o_1: o_2$.
+It is left unspecified how an object sequence is implemented,
+it is only required that it contains specific objects or pairs,
+in a specific order.
+For each kind of collection the sequence is used in the given order
+to populate the collection,
+in a manner which is specific to the kind,
+and which is specified separately
+(\ref{lists}, \ref{maps}, \ref{sets}).
+
+\commentary{%
+There may be an actual data structure representing the sequence at run time,
+but it could also be eliminated
+because each element is inserted directly into the target collection
+as soon as it has been computed,
+or because the collection is a constant.
+Note that each object sequence will exclusively contain objects,
+or it will exclusively contain pairs,
+because any mixed sequence would cause
+an error at compile time or at run time.%
+}
+
+\LMHash{}%
+Assume that a target collection \metavar{target} is given,
+and the object sequence obtained as described below will be received
+by \metavar{target} for insertion.
+Let $T_{\metavar{target}}$ denote the dynamic type of \metavar{target}.
+
+\commentary{%
+Access to \metavar{target} and its type is needed in order to
+be able to raise dynamic errors at specific points during
+the evaluation of an object sequence.%
+}
+
+\LMHash{}%
+Assume that a code location and a dynamic context is given, that is,
+a binding of names declared by the current library exists,
+the current instance of the enclosing class is accessible as \THIS{}
+if the given location is in the instance scope of a class, etc.
+In such a context it is possible to evaluate
+a sequence of collection literal elements as follows.
+
+\LMHash{}%
+Let $s_{\metavar{syntax}}$ of the form \List{\ell}{1}{k} be
+a sequence of collection literal elements.
+The sequence of objects $s_{\metavar{object}}$
+obtained by evaluating $s_{\metavar{syntax}}$
+is the concatenation of the sequences of objects $s_{\metavar{object},j}$
+obtained by evaluating each element $\ell_j$, $j \in 1 .. k$:
+$s_{\metavar{object}} = s_{\metavar{object},1}+\ldots+s_{\metavar{object},k}$.
+
+\LMHash{}%
+A single collection literal element $\ell$ evaluates to
+an object sequence $s$ as follows:
+
+\LMHash{}%
+\Case{Expression elements}
+When $\ell$ is an \synt{expressionElement} of the form $e$,
+$e$ is evaluated to an object $o$,
+and the result $s$ is \LiteralSequence{o}.
+\EndCase
+
+\LMHash{}%
+\Case{Map elements}
+When $\ell$ is a \synt{mapElement} of the form
+\code{$e_1$:\,\,$e_2$},
+$e_1$ is evaluated to an object $o_1$,
+then $e_2$ is evaluated to an object $o_2$,
+and the result $s$ is \LiteralSequence{o_1:\,o_2}.
+\EndCase
+
+\begin{figure}[t]
+\begin{normativeDartCode}
+\VAR{} iterator = spread.entries.iterator;
+\WHILE{} (iterator.moveNext()) \{
+  \VAR{} entry = iterator.current;
+  Key key = entry.key;
+  Value value = entry.value;
+  $\ldots$ // \comment{Append the pair} key:\,value \comment{to the result $s$.}
+\}
+\end{normativeDartCode}
+\vspace{-3mm}
+  \caption{Evaluation of a map spread}
+  \label{fig:evaluationOfAMapSpread}
+\end{figure}
+
+\begin{figure}[t]
+\begin{normativeDartCode}
+\VAR{} iterator = spread.iterator;
+\WHILE{} (iterator.moveNext()) \{
+  Value value = iterator.current;
+  $\ldots$ // \comment{Append} value \comment{to the result $s$.}
+\}
+\end{normativeDartCode}
+\vspace{-3mm}
+  \caption{Evaluation of a list or set spread}
+  \label{fig:evaluationOfAnIterableSpread}
+\end{figure}
+
+\LMHash{}%
+\Case{Spread elements}
+\begin{enumerate}
+\item
+  When $\ell$ is a \synt{spreadElement} of the form
+  `\code{...?$e$}', $e$ is evaluated to an object $o$.
+  If $o$ is the null object then the result $s$ is the empty sequence
+  \LiteralSequence{}.
+  Otherwise evaluation proceeds with step 2.
+
+  When $\ell$ is a \synt{spreadElement} of the form
+  `\code{...$e$}', $e$ is evaluated to an object $o$.
+  %% TODO(eernst): Come NNBD, this error cannot occur any more: delete.
+  If $o$ is the null object then a dynamic error occurs.
+  Otherwise evaluation proceeds with step 2.
+\item
+  Let $T$ be the dynamic type of $o$.
+  \begin{itemize}
+  \item
+    %% TODO(eernst): Come NNBD, change to `Object?`.
+    When both $T$ and $T_{\metavar{target}}$ is a subtype of
+    \code{Map<Object, Object>},
+    the code in Fig.~\ref{fig:evaluationOfAMapSpread} is executed,
+    where \code{spread} is a fresh variable bound to $o$
+    whose type is the static type of $e$,
+    and \code{Key} and \code{Value} are fresh type variables
+    bound to the type variables of $T_{\metavar{target}}$ at \code{Map}.
+
+    \commentary{%
+      The code for appending the pair \code{key:value} is omitted,
+      because the representation of $s$ is implementation specific.%
+    }
+
+    % Will not change with nnbd: `spread` type arguments could be \DYNAMIC{}.
+    It is allowed for an implementation to delay the dynamic errors
+    that occur if the given \code{key} does not have the type \code{Key},
+    or the given \code{value} does not have the type \code{Value},
+    except that if an error occurs
+    then it must preempt appending the pair to $s$.
+  \item
+    %% TODO(eernst): Come NNBD, change to `Object?`.
+    When both $T$ and $T_{\metavar{target}}$ is a subtype of
+    \code{Iterable<Object>},
+    the code in Fig.~\ref{fig:evaluationOfAnIterableSpread} is executed,
+    where \code{spread} is a fresh variable bound to $o$
+    whose type is the static type of $e$,
+    and \code{Value} is a fresh type variable
+    bound to the type variable of $T_{\metavar{target}}$ at \code{Iterable}.
+
+    \commentary{%
+      The code for appending the \code{value} is again omitted,
+      because it is implementation specific.%
+    }
+  \item
+    Otherwise, a dynamic error occurs.
+
+    \commentary{%
+      This occurs when the target is a map respectively iterable,
+      and the spread is not.%
+    }
+  \end{itemize}
+\end{enumerate}
+
+\commentary{%
+This may not be the most efficient way to traverse the items in a collection.
+In order to give implementations more room to optimize,
+we allow the following deviations.%
+}
+
+\LMHash{}%
+If $o$ is an object whose class implements
+\code{List}, \code{Queue}, or \code{Set},
+an implementation may choose to call \code{length} on the object.
+
+\commentary{%
+This may let it allocate space for the resulting collection more efficiently.
+Classes that implement these are expected to have an efficient,
+side-effect free implementation of \code{length}.%
+}
+
+\LMHash{}%
+If $o$ is an object whose class implements \code{List},
+an implementation may choose to call operator \lit{[]}
+in order to access elements from the list.
+If it does so, it will only pass indices
+that are non-negative and less than the value returned by \code{length}.
+
+\LMHash{}%
+A Dart implementation may detect whether these options apply
+at compile time based on the static type of $e$,
+or at runtime based on the actual value.
+\EndCase
 
 !!!HERE!!!
+
+\LMHash{}%
+\Case{Elements}
+
+\EndCase
+
+\LMHash{}%
+\Case{Elements}
+
+\EndCase
+
+\LMHash{}%
+\Case{Elements}
+
+\EndCase
+
+\LMHash{}%
+\Case{Elements}
+
+\EndCase
+
+\LMHash{}%
+\Case{Elements}
+
+\EndCase
+
+\begin{enumerate}
+\item
+  Else, if $\ell$ is an \synt{ifElement}:
+  \begin{enumerate}
+  \item
+    Evaluate the condition expression to a value \metavar{condition}.
+    \begin{enumerate}
+    \item If \metavar{condition} is \TRUE:
+      \begin{enumerate}
+      \item Evaluate the "then" element using this procedure.
+      \end{enumerate}
+    \item Else, if \metavar{condition} is \FALSE:
+      \begin{enumerate}
+      \item If there is an "else" element of the \IF:
+        %% \begin{enumerate}
+        %% \item Evaluate the "else" element using this procedure.
+        %% \end{enumerate}
+      \end{enumerate}
+    \item Else, throw a dynamic error.
+    \end{enumerate}
+  \end{enumerate}
+\item
+  Else, if $\ell$ is a synchronous \synt{forElement} for a for-in loop:
+
+  \begin{enumerate}
+  \item Evaluate the iterator expression to a value \metavar{sequence}.
+  \item If \metavar{sequence} is not an instance of
+    a class that implements \code{Iterable},
+    throw a dynamic exception.
+  \item
+    Evaluate \code{sequence.iterator} to a value \metavar{iterator}.
+    \begin{enumerate}
+    \item Loop:
+      \begin{enumerate}
+      \item
+        Evaluate \code{iterator.moveNext()} to a value \metavar{hasValue}.
+      \item
+        If \metavar{hasValue} is \TRUE:
+        %% \begin{enumerate}
+        %% \item
+        %%   If the for-in element declares a variable,
+        %%   create a new namespace and a fresh \code{variable} for it.
+        %%   Otherwise, use the existing \code{variable} it refers to.
+        %% \item
+        %%   Bind \code{variable} to
+        %%   the result of evaluating \code{iterator.current}.
+        %% \item
+        %%   Evaluate the body element using this procedure
+        %%   in the scope of \code{variable}.
+        %% \end{enumerate}
+      \item
+        Else, if \metavar{hasValue} is \FALSE, exit the loop.
+      \item
+        Else, throw a dynamic error.
+      \end{enumerate}
+    \end{enumerate}
+  \end{enumerate}
+\item
+  Else, if $\ell$ is an asynchronous \AWAIT{} for-in element:
+  \begin{enumerate}
+  \item
+    Evaluate the stream expression to a value \metavar{stream}.
+  \item
+    If \metavar{stream} is not an instance of
+    a class that implements \code{Stream},
+    throw a dynamic error.
+  \item
+    Pause the subscription of any surrounding \AWAIT{} \FOR{} loop
+    in the current method.
+  \item
+    Let \metavar{streamDone} be a value implementing \code{Future<Null>}.
+  \item
+    Listen on \metavar{stream} and take the following actions on events:
+
+    \begin{itemize}
+    \item On a data event with value \metavar{value}:
+      \begin{enumerate}
+      \item
+        If the for-in element declares a variable,
+        create a new namespace and a fresh \code{variable} for it.
+        Otherwise, use the existing `variable` it refers to.
+      \item
+        Bind \code{variable} to \metavar{value}.
+      \item
+        Evaluate the body element using this procedure.
+      \item
+        If evaluation of the body throws an
+        error \metavar{error} and stack trace \metavar{stack}, then:
+        %% \begin{enumerate}
+        %% \item
+        %%   Stop listening on the stream by calling the \code{cancel()}
+        %%   method of the corresponding stream subscription, which
+        %%   returns a future $f$.
+        %% \item
+        %%   Wait for $f$ to complete.
+        %%   If $f$ completes with
+        %%   an error \metavar{error2} and stack trace \metavar{stack2},
+        %%   then complete \metavar{streamDone}
+        %%   with error \metavar{error2} and stack trace \metavar{stack2}.
+        %%   Otherwise complete \metavar{streamDone}
+        %%   with error \metavar{error} and stack trace \metavar{stack}.
+        %% \end{enumerate}
+      \item
+        Else, evaluation of the body element completes successfully.
+        %% \begin{enumerate}
+        %% \item Resume the stream subscription if it has been paused.
+        %% \end{enumerate}
+      \item
+        On an error event
+        with error \metavar{error} and stack trace \metavar{stack}:
+        %% \begin{enumerate}
+        %% \item
+        %%   Stop listening on the stream by calling the \code{cancel()} method of
+        %%   the corresponding stream subscription,
+        %%   which returns a future $f$.
+        %% \item
+        %%   Wait for $f$ to complete.
+        %%   If `f` completes
+        %%   with an error \metavar{error2} and stack trace \metavar{stack2},
+        %%   then complete \metavar{streamDone}
+        %%   with error \metavar{error2} and stack trace \metavar{stack2}.
+        %%   Otherwise complete \metavar{streamDone}
+        %%   with error \metavar{error} and stack trace \metavar{stack}.
+        %% \end{enumerate}
+      \item
+        On a done event, complete `streamDone` with the value `null`.
+      \end{enumerate}
+    \end{itemize}
+  \item
+    Evaluation of the for-in element completes
+    when \metavar{streamDone} completes.
+    If \metavar{streamDone} completes
+    with an error \metavar{error} and stack trace \metavar{stack},
+    then evaluation of the element
+    throws \metavar{error} with stack trace \metavar{stack},
+    otherwise the evaluation completes successfully.
+  \end{enumerate}
+\item
+  Else, $\ell$ is a C-style \synt{forElement}:
+  \begin{enumerate}
+  \item
+    Evaluate the initializer clause of the element, if there is one.
+  \item
+    Loop:
+    \begin{enumerate}
+    \item
+      If the initializer clause declares a variable,
+      create a new namespace and bind that variable in that namespace.
+    \item
+      Evaluate the condition expression to a value \metavar{condition}.
+      If there is no condition expression, use \TRUE.
+    \item
+      If \metavar{condition} is \TRUE:
+      \begin{enumerate}
+      \item
+        Evaluate the body element using this procedure in the namespace
+        of the variable declared by the initializer clause
+        if there is one.
+      \item
+        If there is an increment clause, execute it.
+      \end{enumerate}
+    \item
+      Else, if \metavar{condition} is \FALSE, exit the loop.
+    \item
+      Else, throw a dynamic error.
+    \end{enumerate}
+  \end{enumerate}
+\end{enumerate}
+
+\LMHash{}%
+The procedure theoretically supports a mixture of expressions and map entries,
+but the static semantics prohibit an actual literal containing that.
+
+\LMHash{}%
+Once the \metavar{result} series of values or entries is produced
+from the tree of elements,
+the final object is produced from that based on what kind of literal it is:
+
+
+\subsubsection{List}
+\LMLabel{uiAsCodeList}
+
+!!!HERE!!!
+
+\LMHash{}%
+The result of the literal expression is a fresh instance of
+a class that implements \code{List<$E$>} where $E$ is
+the element type of the literal.
+It contains the values in \metavar{result}, in order.
+If the literal is constant,
+the list is canonicalized and immutable,
+otherwise it is not.
+
+
+\subsubsection{Set}
+\LMLabel{uiAsCodeSet}
+
+!!!HERE!!!
+
+\LMHash{}%
+Create a fresh instance \metavar{set} of
+a class that implements \code{Set<$E$>} where $E$
+is the set element type of the literal.
+
+\LMHash{}%
+For each \metavar{value} in \metavar{result}:
+
+\begin{enumerate}
+\item
+  If \metavar{set} contains
+  a value \metavar{existing} that is equal to \metavar{value}
+  according to \metavar{existing}'s operator \lit{==}:
+\item
+  If the literal is constant, it is a compile-time error.
+\item
+  Else, do nothing.
+  \commentary{Duplicates are discarded and the first one wins.}
+\item
+  Else, add \metavar{value} to \metavar{set}.
+\end{enumerate}
+
+\LMHash{}%
+The result of the literal expression is \metavar{set}.
+If the literal is constant,
+canonicalize it make the set immutable.
+
+
+\subsubsection{Map}
+\LMLabel{uiAsCodeMap}
+
+!!!HERE!!!
+
+\LMHash{}%
+Allocate a fresh instance \metavar{map} of
+a class that implements \code{LinkedHashMap<$K$, $V$>} where $K$ is
+the key type of the literal and $V$ is
+the value type.
+
+\LMHash{}%
+For each entry \code{\metavar{key}: \metavar{value}} in \metavar{result}:
+
+\begin{enumerate}
+\item
+  If \metavar{map} contains an entry \metavar{existing}
+  whose key \metavar{existingKey} is equal to \metavar{key}
+  according to \metavar{existingKeys}'s operator \lit{==}:
+  \begin{enumerate}
+  \item
+    If the literal is constant, it is a compile-time error.
+  \item
+    Else, replace the value in \metavar{existing} with \metavar{value},
+    while keeping its position in the sequence of entries
+    and \metavar{existingKey} the same.
+  \end{enumerate}
+\item
+  Else add entry \code{\metavar{key}: \metavar{value}} to \metavar{map}.
+\end{enumerate}
+
+\LMHash{}%
+The result of the map literal expression is \metavar{map}.
+If the literal is constant,
+canonicalize it and make the map immutable.
+
+
+\subsubsection{Lists}
+\LMLabel{lists}
 
 \LMHash{}%
 A \IndexCustom{list literal}{literal!list}
 denotes a list, which is an integer indexed collection of objects.
 The grammar rule for \synt{listLiteral} is specified elsewhere
 (\ref{collectionLiterals}).
+
+\LMHash{}%
+When a given list literal $e$ has no type arguments,
+the type argument $T$ is selected as specified below
+(\ref{listLiteralInference}),
+and $e$ is henceforth treated as
+(\ref{notation})
+\code{<$T$>$e$}.
 
 \LMHash{}%
 A list may contain zero or more objects.
@@ -7107,6 +7639,11 @@ An empty list has an empty set of indices.
 A non-empty list has the index set $\{0, \ldots, n - 1\}$ where $n$ is the size of the list.
 It is a dynamic error to attempt to access a list
 using an index that is not a member of its set of indices.
+
+\LMHash{}%
+The sequence of elements of a given list literal
+is determined as described below
+(\ref{listEvaluation}).
 
 \LMHash{}%
 If a list literal $\ell$ begins with the reserved word \CONST{}
@@ -7122,13 +7659,13 @@ Otherwise, it is a
 and it is evaluated at run time.
 Only run-time list literals can be mutated
 after they are created.
-% This error can occur because being constant is a dynamic property, here.
+% This error can occur because being constant is a dynamic property.
 Attempting to mutate a constant list literal will result in a dynamic error.
 
 \commentary{%
 % The following is true either directly or indirectly: There is a \CONST{}
-% modifier on the literal list, or we use the "immediate subexpression" rule
-% about constant contexts.
+% modifier on the list literal, or the list literal as a whole occurs
+% in a constant context.
 Note that the element expressions of a constant list literal
 occur in a constant context
 (\ref{constantContexts}),
@@ -7244,6 +7781,139 @@ or the form
 \code{[$e_1, \ldots, e_n$]}
 is \code{List<\DYNAMIC>}.
 
+
+\subsubsection{List Literal Inference}
+\LMLabel{listLiteralInference}
+
+!!!HERE!!!
+
+\LMHash{}%
+Inference for list literals mostly follows that of set literals
+without the complexity around disambiguation with maps and
+using \code{List} or \code{Iterable} in a few places instead of \code{Set}.
+
+\LMHash{}%
+Inside a \synt{listLiteral} \metavar{listLiteral},
+the inferred type of an element $\ell$ is a list element type $T$.
+It is computed relative to a downwards element context type $P$,
+where $P$ is $T$
+if downwards inference constrains the type of \metavar{listLiteral}
+to \code{Iterable<$T$>} for some $T$.
+Otherwise, $P$ is \lit{?}.
+
+\begin{itemize}
+\item
+  If $\ell$ is an \synt{expressionElement} with expression $e1$:
+  \begin{itemize}
+  \item
+    The inferred list element type of $\ell$ is
+    the inferred type of the expression $e1$ in context $P$.
+  \end{itemize}
+\item
+  If $\ell$ is a \synt{spreadElement} with expression $e1$:
+
+  \begin{itemize}
+  \item
+    If $P$ is \lit{?} then let $S$ be
+    the inferred type of $e1$ in context \lit{?}:
+
+    \begin{itemize}
+    \item
+      If $S$ is a non-\code{Null} subtype of \code{Iterable<Object>}, then
+      the inferred list element type of $\ell$ is $T$ where $T$ is
+      the type such that \code{Iterable<$T$>} is
+      a superinterface of $S$
+      (\commentary{%
+        the result of constraint matching for $X$ using
+        the constraint \code{$S$ <: Iterable<$X$>}}).
+
+      \begin{itemize}
+      \item
+        If $S$ is \DYNAMIC{}, then
+        the inferred list element type of $\ell$ is \DYNAMIC{}.
+      \item
+        If $S$ is \code{Null} and the spread operator is \lit{...?}, then
+        the list element type is \code{Null}.
+      \item
+        Otherwise it is an error
+        (\commentary{%
+          because it is a spread of a non-spreadable type like Object%
+        }).
+      \end{itemize}
+    \item
+      Else, let $S$ be
+      the inferred type of $e1$ in context \code{Iterable<$P$>}:
+
+      \begin{itemize}
+      \item
+        If $S$ is a non-\code{Null} subtype of \code{Iterable<Object>}, then
+        the inferred list element type of $\ell$ is $T$ where $T$ is
+        the type such that \code{Iterable<$T$>} is
+        a superinterface of $S$
+        (\commentary{%
+          the result of constraint matching for $X$ using
+          the constraint \code{$S$ <: Iterable<$X$>}%
+        }).
+      \item
+        If $S$ is \DYNAMIC{}, then
+        the inferred list element type of $\ell$ is \DYNAMIC{}.
+      \item
+        Otherwise it is an error.
+      \end{itemize}
+    \end{itemize}
+  \item
+    If $\ell$ is an \synt{ifElement} with one $\ell$, $p1$,
+    and no "else" element:
+    The condition is inferred with a context type of \code{bool}.
+
+    The inferred list element type of $\ell$ is
+    the inferred list element type of $p1$ with element context type $P$.
+  \item
+    If $\ell$ is a \synt{ifElement} with two $\ell$s, $p1$ and $p2$:
+    The condition is inferred with a context type of \code{bool}.
+
+    The inferred list element type of $\ell$ is
+    the least upper bound of $S1$ and $S2$ where $S1$ is
+    the inferred list element type of $p1$ and $S2$ is
+    the inferred list element type of $p2$,
+    both with element context type $P$.
+
+  \item
+    If $\ell$ is a \synt{forElement} with $\ell$ $p1$ then:
+
+    Inference for the iterated expression and the controlling variable
+    is done as for the corresponding \FOR{} or \AWAIT{} \FOR{} statement.
+
+    The inferred list element type of $\ell$ is the inferred list element
+    type of $p1$ with element context type $P$.
+  \end{itemize}
+\end{itemize}
+
+\commentary{%
+Note: $\ell$ cannot be a \synt{mapElement} as
+those are not allowed inside list literals.%
+}
+
+\LMHash{}%
+Finally, we define inference on a \synt{listLiteral} \metavar{collection}
+as follows:
+
+\begin{itemize}
+\item
+  If $P$ is \lit{?} then
+  the static type of \metavar{collection} is \code{List<$T$>} where $T$ is
+  the least upper bound of the inferred list element types of the elements.
+\item
+  Otherwise,
+  the static type of \metavar{collection} is \code{List<$T$>} where $T$ is
+  determined by downwards inference.
+\end{itemize}
+
+
+\subsubsection{List Literal Evaluation}
+\LMLabel{listLiteralEvaluation}
+
+!!!HERE!!!
 
 \subsubsection{Maps}
 \LMLabel{maps}
@@ -7552,8 +8222,8 @@ or the form
 is \code{Set<\DYNAMIC>}.
 
 
-\subsubsection{Collection Literal Disambiguation}
-\LMLabel{collectionLiteralDisambiguation}
+\subsubsection{Set and Map Literal Disambiguation}
+\LMLabel{setAndMapLiteralDisambigutation}
 
 \LMHash{}%
 Some syntactic forms like \code{\{\}} and \code{\{...\id\}} are ambiguous:
@@ -7564,7 +8234,7 @@ The first step uses only the syntax and context type,
 %% (\ref{contextType})
 and is described in this section.
 The second step uses expression types and is described next
-(\ref{collectionLiteralInference}).
+(\ref{setAndMapLiteralInference}).
 
 \LMHash{}%
 Let $e$ be a \synt{setOrMapLiteral}
@@ -7598,29 +8268,29 @@ The disambiguation step of this section is
 the first applicable entry in the following list:
 
 \begin{itemize}
-\item $e$ has \synt{typeArguments}:
-  With exactly one type argument $T$,
-  $e$ is a set literal with static type \code{Set<$T$>}.
-  With exactly two type arguments $K$ and $V$,
-  $e$ is a map literal with static type \code{Map<$K$, $V$>}.
-  With any other number of type arguments a compile-time error occurs.
+\item When $e$ has type arguments \List{T}{1}{k}:
+  If $k = 1$ then $e$ is a set literal with static type
+  \code{Set<$T_1$>}.
+  If $k = 2$ then $e$ is a map literal with static type
+  \code{Map<$T_1$, $T_2$>}.
+  If $k > 2$ a compile-time error occurs.
 \item
   %% TODO(eernst): Come nnbd: `Object?`.
-  $S <: \code{Iterable<Object>} \wedge S \not<: \code{Map<Object, Object>}$:
+  When $S <: \code{Iterable<Object>} \wedge S \not<: \code{Map<Object, Object>}$:
   $e$ is a set literal.
 \item
   %% TODO(eernst): Come nnbd: `Object?`.
-  $S <: \code{Map<Object, Object>} \wedge S \not<: \code{Iterable<Object>}$:
+  When $S <: \code{Map<Object, Object>} \wedge S \not<: \code{Iterable<Object>}$:
   $e$ is a map literal.
 \item
-  ${\cal L} \not= \emptyset$ (\commentary{$e$ has leaf elements}):
-  When $\cal L$ contains both a \synt{mapElement} and an \synt{expressionElement},
+  When ${\cal L} \not= \emptyset$ (\commentary{$e$ has leaf elements}):
+  If $\cal L$ contains both a \synt{mapElement} and an \synt{expressionElement},
   a compile-time error occurs.
-  Otherwise, when $\cal L$ contains an \synt{expressionElement}
+  Otherwise, if $\cal L$ contains an \synt{expressionElement}
   $e$ is a set literal.
   Otherwise $\cal L$ contains a \synt{mapElement}, and $e$ is a map literal.
 \item
-  $e$ has no \synt{typeArguments}, no elements, and $S$ is undefined:
+  When $e$ has no \synt{typeArguments}, no elements, and $S$ is undefined:
   $e$ is a map literal.
   \commentary{%
     In other words, an empty \code{\{\}} is a map by default.%
@@ -7631,32 +8301,29 @@ the first applicable entry in the following list:
     In this case $e$ is non-empty but contains only spreads,
     wrapped zero or more times in \synt{ifElement}s or \synt{forElement}s.
     Disambiguation will occur during inference
-    (\ref{collectionLiteralInference}).%
+    (\ref{setAndMapLiteralInference}).%
   }
 \end{itemize}
 
 \commentary{%
 When this step does not determine a static type,
 it will be determined by type inference
-(\ref{collectionLiteralInference}).%
+(\ref{setAndMapLiteralInference}).%
 }
 
 \LMHash{}%
 If this process successfully disambiguates the literal
 then we say that $e$ is
-\IndexCustom{unambiguously a map}{map!unambiguously}
-or
 \IndexCustom{unambiguously a set}{set!unambiguously},
+or
+\IndexCustom{unambiguously a map}{map!unambiguously}
 as appropriate.
 
 
-\subsubsection{Collection Literal Inference}
-\LMLabel{collectionLiteralInference}
+\subsubsection{Set and Map Literal Inference}
+\LMLabel{setAndMapLiteralInference}
 
 !!!HERE!!!
-
-\paragraph{Maps and sets}
-\LMLabel{uiAsCodeMapsAndSets}
 
 \LMHash{}%
 We perform inference on the literal,
@@ -8027,166 +8694,6 @@ Or, if there is nothing indicates that it is \emph{either} a map or set:%
 \DYNAMIC{} dyn;
 \VAR{} ambiguous = \{...dyn\};
 \end{dartCode}
-
-
-\paragraph{Lists}
-
-\LMHash{}%
-Inference for list literals mostly follows that of set literals
-without the complexity around disambiguation with maps and
-using \code{List} or \code{Iterable} in a few places instead of \code{Set}.
-
-\LMHash{}%
-Inside a \synt{listLiteral} \metavar{listLiteral},
-the inferred type of an element $\ell$ is a list element type $T$.
-It is computed relative to a downwards element context type $P$,
-where $P$ is $T$
-if downwards inference constrains the type of \metavar{listLiteral}
-to \code{Iterable<$T$>} for some $T$.
-Otherwise, $P$ is \lit{?}.
-
-\begin{itemize}
-\item
-  If $\ell$ is an \synt{expressionElement} with expression $e1$:
-  \begin{itemize}
-  \item
-    The inferred list element type of $\ell$ is
-    the inferred type of the expression $e1$ in context $P$.
-  \end{itemize}
-\item
-  If $\ell$ is a \synt{spreadElement} with expression $e1$:
-
-  \begin{itemize}
-  \item
-    If $P$ is \lit{?} then let $S$ be
-    the inferred type of $e1$ in context \lit{?}:
-
-    \begin{itemize}
-    \item
-      If $S$ is a non-\code{Null} subtype of \code{Iterable<Object>}, then
-      the inferred list element type of $\ell$ is $T$ where $T$ is
-      the type such that \code{Iterable<$T$>} is
-      a superinterface of $S$
-      (\commentary{%
-        the result of constraint matching for $X$ using
-        the constraint \code{$S$ <: Iterable<$X$>}}).
-
-      \begin{itemize}
-      \item
-        If $S$ is \DYNAMIC{}, then
-        the inferred list element type of $\ell$ is \DYNAMIC{}.
-      \item
-        If $S$ is \code{Null} and the spread operator is \lit{...?}, then
-        the list element type is \code{Null}.
-      \item
-        Otherwise it is an error
-        (\commentary{%
-          because it is a spread of a non-spreadable type like Object%
-        }).
-      \end{itemize}
-    \item
-      Else, let $S$ be
-      the inferred type of $e1$ in context \code{Iterable<$P$>}:
-
-      \begin{itemize}
-      \item
-        If $S$ is a non-\code{Null} subtype of \code{Iterable<Object>}, then
-        the inferred list element type of $\ell$ is $T$ where $T$ is
-        the type such that \code{Iterable<$T$>} is
-        a superinterface of $S$
-        (\commentary{%
-          the result of constraint matching for $X$ using
-          the constraint \code{$S$ <: Iterable<$X$>}%
-        }).
-      \item
-        If $S$ is \DYNAMIC{}, then
-        the inferred list element type of $\ell$ is \DYNAMIC{}.
-      \item
-        Otherwise it is an error.
-      \end{itemize}
-    \end{itemize}
-  \item
-    If $\ell$ is an \synt{ifElement} with one $\ell$, $p1$,
-    and no "else" element:
-    The condition is inferred with a context type of \code{bool}.
-
-    The inferred list element type of $\ell$ is
-    the inferred list element type of $p1$ with element context type $P$.
-  \item
-    If $\ell$ is a \synt{ifElement} with two $\ell$s, $p1$ and $p2$:
-    The condition is inferred with a context type of \code{bool}.
-
-    The inferred list element type of $\ell$ is
-    the least upper bound of $S1$ and $S2$ where $S1$ is
-    the inferred list element type of $p1$ and $S2$ is
-    the inferred list element type of $p2$,
-    both with element context type $P$.
-
-  \item
-    If $\ell$ is a \synt{forElement} with $\ell$ $p1$ then:
-
-    Inference for the iterated expression and the controlling variable
-    is done as for the corresponding \FOR{} or \AWAIT{} \FOR{} statement.
-
-    The inferred list element type of $\ell$ is the inferred list element
-    type of $p1$ with element context type $P$.
-  \end{itemize}
-\end{itemize}
-
-\commentary{%
-Note: $\ell$ cannot be a \synt{mapElement} as
-those are not allowed inside list literals.%
-}
-
-\LMHash{}%
-Finally, we define inference on a \synt{listLiteral} \metavar{collection}
-as follows:
-
-\begin{itemize}
-\item
-  If $P$ is \lit{?} then
-  the static type of \metavar{collection} is \code{List<$T$>} where $T$ is
-  the least upper bound of the inferred list element types of the elements.
-\item
-  Otherwise,
-  the static type of \metavar{collection} is \code{List<$T$>} where $T$ is
-  determined by downwards inference.
-\end{itemize}
-
-
-\subsubsection{Type promotion}
-\LMLabel{uiAsCodeTypePromotion}
-
-\LMHash{}%
-An \synt{ifElement} interacts with type promotion in
-the same way that \IF{} statements do.
-Given an \synt{ifElement} with condition \metavar{condition},
-then element \metavar{thenElement} and
-optional else element \metavar{elseElement}:
-
-\begin{itemize}
-\item
-  If \metavar{condition} shows that a local variable $v$ has type $T$, then
-  the type of $v$ is known to be $T$ in \metavar{thenElement},
-  unless any of the following are true:
-
-  \begin{itemize}
-  \item $v$ is potentially mutated in \metavar{thenElement},
-  \item $v$ is potentially mutated within a function
-    other than the one where $v$ is declared, or
-    \begin{itemize}
-    \item $v$ is accessed by a function defined in \metavar{thenElement}, and
-    \item $v$ is potentially mutated anywhere in the scope of $v$.
-    \end{itemize}
-  \end{itemize}
-\end{itemize}
-
-\commentary{%
-Note: The type promotion rules for \IF{} will likely get more sophisticated
-in a future version of Dart because of non-nullable types.
-When that happens,
-\synt{ifElements} should continue to match \IF{} statements.%
-}
 
 
 \subsubsection{Compile-time errors}
@@ -17926,7 +18433,7 @@ Also:
   \item and contains the same (identical) elements or key/value entries
     in the same order,
   \end{itemize}
-  
+
   then the current literal evaluates to the value of that previous literal.
 
   \commentary{%
@@ -17935,414 +18442,6 @@ Also:
     they contain the same keys or elements \emph{in the same order}.%
     }
 \end{itemize}
-
-\subsection{Dynamic Semantics}
-\LMLabel{uiAsCodeDynamicSemantics}
-
-\LMHash{}%
-Spread, \IF{}, and \FOR{} behave similarly across all collection types.
-To simplify the spec, there is a single procedure used for
-all kinds of collections.
-
-\LMHash{}%
-This recursive procedure builds up either a \metavar{result} sequence of
-values or key-value pair map entries.
-Then a final step handles those appropriately for the given collection type.
-
-\subsubsection{To evaluate a collection element}
-\LMLabel{uiAsCodeToEvaluateACollectionElement}
-
-%% TODO(eernst): Reshape the lists below to avoid 'too deeply nested'.
-
-\begin{enumerate}
-\item
-  If $\ell$ is an expression element:
-  \begin{enumerate}
-  \item Evaluate the element's expression and append it to \metavar{result}.
-  \end{enumerate}
-\item
-  Else, $\ell$ is a \synt{mapElement}
-  \code{\metavar{keyExpression}: \metavar{valueExpression}}:
-  \begin{enumerate}
-  \item Evaluate \metavar{keyExpression} to a value \metavar{key}.
-  \item Evaluate \metavar{valueExpression} to a value \metavar{value}.
-  \item Append an entry \code{\metavar{key}: \metavar{value}}
-    to \metavar{result}.
-  \end{enumerate}
-\item
-  Else, if $\ell$ is a spread element:
-  \begin{enumerate}
-  \item
-    Evaluate the spread expression to a value \metavar{spread}.
-    \begin{enumerate}
-    \item
-      If $\ell$ is not null-aware and \metavar{spread} is \NULL,
-      throw a dynamic exception.
-    \item
-      Else, if $\ell$ is null-aware and \metavar{spread} is \NULL,
-      do nothing.
-    \item
-      Else, if the collection is a map:
-      \begin{enumerate}
-      \item
-        If \metavar{spread} is not an instance
-        of a class that implements \code{Map},
-        throw a dynamic exception.
-      \item
-        Evaluate \code{spread.entries.iterator} to a value \metavar{iterator}.
-        %% \begin{enumerate}
-        %% \item Loop:
-        %%   \begin{enumerate}
-        %%   \item
-        %%     Evaluate \code{iterator.moveNext()} to a value \metavar{hasValue}.
-        %%   \item
-        %%     If \metavar{hasValue} is \TRUE:
-        %%     \begin{enumerate}
-        %%     \item Evaluate \code{iterator.current} to a value \metavar{entry}.
-        %%     \item Evaluate \code{entry.key} to a value \metavar{key}.
-        %%     \item Evaluate \code{entry.value} to a value \metavar{value}.
-        %%       \begin{enumerate}
-        %%       \item If \metavar{key} is not a subtype of the map's key type,
-        %%         throw a dynamic error.
-        %%       \item If \metavar{value} is not a subtype of the map's value type,
-        %%         throw a dynamic error.
-        %%       \end{enumerate}
-
-        %%       An implementation is free to execute
-        %%       the previous four operations in any order,
-        %%       except that obviously the key must be evaluated
-        %%       before its type is checked,
-        %%       and likewise for the value.
-              
-        %%     \item Append an entry \code{\metavar{key}: \metavar{value}}
-        %%       to \metavar{result}.
-        %%     \end{enumerate}
-        %%   \item
-        %%     Else, if \metavar{hasValue} is \FALSE, exit the loop.
-        %%   \item
-        %%     Else, throw a dynamic error.
-        %%   \end{enumerate}
-        %% \end{enumerate}
-      \end{enumerate}
-    \end{enumerate}
-  \item
-    Else, the collection is a list or set:
-
-    \begin{enumerate}
-    \item
-      If \metavar{spread} is not an instance of
-      a class that implements \code{Iterable},
-      throw a dynamic exception.
-    \item
-      Evaluate \code{spread.iterator} to \metavar{iterator}.
-    \item
-      Loop:
-      \begin{enumerate}
-      \item
-        Evaluate \code{iterator.moveNext()} to a value \metavar{hasValue}.
-      \item
-        If \metavar{hasValue} is \TRUE:
-        %% \begin{enumerate}
-        %% \item
-        %%   Evaluate \code{iterator.current} to a value \metavar{value}.
-        %% \item
-        %%   If \metavar{value} is not a subtype of the collection's element type,
-        %%   throw a dynamic error.
-        %% \item
-        %%   Append \metavar{value} to \metavar{result}.
-        %% \end{enumerate}
-      \item
-        Else, if \metavar{hasValue} is \FALSE, exit the loop.
-      \item
-        Else, throw a dynamic error.
-      \end{enumerate}
-
-      \commentary{%
-        The \code{iterator} API may not be
-        the most efficient way to traverse the items in a collection.
-        In order to give implementations more room to optimize,
-        we loosen the semantics:%
-      }
-      \begin{itemize}
-      \item
-        If \metavar{spread} is an object
-        whose class implements \code{List}, \code{Queue}, or \code{Set}
-        (\commentary{all from \code{dart:core}}),
-        an implementation may choose to call \code{length} on the object.
-        This may let it allocate space for the resulting collection
-        more efficiently.
-        Classes that implement these are expected to have an efficient,
-        side-effect free implementation of \code{length}.
-      \item
-        If \metavar{spread} is an object
-        whose class implements List from \code{dart:core},
-        an implementation may choose to call \lit{[]}
-        to access elements from the list.
-        If it does so, it will only pass indexes
-        \code{>= 0} and \code{<} the value returned by \code{length}.
-      \end{itemize}
-    \end{enumerate}
-
-    A Dart implementation may detect whether these options apply
-    at compile time based on the static type of \metavar{spread} or
-    at runtime based on the actual value.
-  \end{enumerate}
-\item
-  Else, if $\ell$ is an \synt{ifElement}:
-  \begin{enumerate}
-  \item
-    Evaluate the condition expression to a value \metavar{condition}.
-    \begin{enumerate}
-    \item If \metavar{condition} is \TRUE:
-      \begin{enumerate}
-      \item Evaluate the "then" element using this procedure.
-      \end{enumerate}
-    \item Else, if \metavar{condition} is \FALSE:
-      \begin{enumerate}
-      \item If there is an "else" element of the \IF:
-        %% \begin{enumerate}
-        %% \item Evaluate the "else" element using this procedure.
-        %% \end{enumerate}
-      \end{enumerate}
-    \item Else, throw a dynamic error.
-    \end{enumerate}
-  \end{enumerate}
-\item
-  Else, if $\ell$ is a synchronous \synt{forElement} for a for-in loop:
-
-  \begin{enumerate}
-  \item Evaluate the iterator expression to a value \metavar{sequence}.
-  \item If \metavar{sequence} is not an instance of
-    a class that implements \code{Iterable},
-    throw a dynamic exception.
-  \item
-    Evaluate \code{sequence.iterator} to a value \metavar{iterator}.
-    \begin{enumerate}
-    \item Loop:
-      \begin{enumerate}
-      \item
-        Evaluate \code{iterator.moveNext()} to a value \metavar{hasValue}.
-      \item
-        If \metavar{hasValue} is \TRUE:
-        %% \begin{enumerate}
-        %% \item
-        %%   If the for-in element declares a variable,
-        %%   create a new namespace and a fresh \code{variable} for it.
-        %%   Otherwise, use the existing \code{variable} it refers to.
-        %% \item
-        %%   Bind \code{variable} to
-        %%   the result of evaluating \code{iterator.current}.
-        %% \item
-        %%   Evaluate the body element using this procedure
-        %%   in the scope of \code{variable}.
-        %% \end{enumerate}
-      \item
-        Else, if \metavar{hasValue} is \FALSE, exit the loop.
-      \item
-        Else, throw a dynamic error.
-      \end{enumerate}
-    \end{enumerate}
-  \end{enumerate}
-\item
-  Else, if $\ell$ is an asynchronous \AWAIT{} for-in element:
-  \begin{enumerate}
-  \item
-    Evaluate the stream expression to a value \metavar{stream}.
-  \item
-    If \metavar{stream} is not an instance of
-    a class that implements \code{Stream},
-    throw a dynamic error.
-  \item
-    Pause the subscription of any surrounding \AWAIT{} \FOR{} loop
-    in the current method.
-  \item
-    Let \metavar{streamDone} be a value implementing \code{Future<Null>}.
-  \item
-    Listen on \metavar{stream} and take the following actions on events:
-
-    \begin{itemize}
-    \item On a data event with value \metavar{value}:
-      \begin{enumerate}
-      \item
-        If the for-in element declares a variable,
-        create a new namespace and a fresh \code{variable} for it.
-        Otherwise, use the existing `variable` it refers to.
-      \item
-        Bind \code{variable} to \metavar{value}.
-      \item
-        Evaluate the body element using this procedure.
-      \item
-        If evaluation of the body throws an
-        error \metavar{error} and stack trace \metavar{stack}, then:
-        %% \begin{enumerate}
-        %% \item
-        %%   Stop listening on the stream by calling the \code{cancel()}
-        %%   method of the corresponding stream subscription, which
-        %%   returns a future $f$.
-        %% \item
-        %%   Wait for $f$ to complete.
-        %%   If $f$ completes with
-        %%   an error \metavar{error2} and stack trace \metavar{stack2},
-        %%   then complete \metavar{streamDone}
-        %%   with error \metavar{error2} and stack trace \metavar{stack2}.
-        %%   Otherwise complete \metavar{streamDone}
-        %%   with error \metavar{error} and stack trace \metavar{stack}.
-        %% \end{enumerate}
-      \item
-        Else, evaluation of the body element completes successfully.
-        %% \begin{enumerate}
-        %% \item Resume the stream subscription if it has been paused.
-        %% \end{enumerate}
-      \item
-        On an error event
-        with error \metavar{error} and stack trace \metavar{stack}:
-        %% \begin{enumerate}
-        %% \item
-        %%   Stop listening on the stream by calling the \code{cancel()} method of
-        %%   the corresponding stream subscription,
-        %%   which returns a future $f$.
-        %% \item
-        %%   Wait for $f$ to complete.
-        %%   If `f` completes
-        %%   with an error \metavar{error2} and stack trace \metavar{stack2},
-        %%   then complete \metavar{streamDone}
-        %%   with error \metavar{error2} and stack trace \metavar{stack2}.
-        %%   Otherwise complete \metavar{streamDone}
-        %%   with error \metavar{error} and stack trace \metavar{stack}.
-        %% \end{enumerate}
-      \item
-        On a done event, complete `streamDone` with the value `null`.
-      \end{enumerate}
-    \end{itemize}
-  \item
-    Evaluation of the for-in element completes
-    when \metavar{streamDone} completes.
-    If \metavar{streamDone} completes
-    with an error \metavar{error} and stack trace \metavar{stack},
-    then evaluation of the element
-    throws \metavar{error} with stack trace \metavar{stack},
-    otherwise the evaluation completes successfully.
-  \end{enumerate}
-\item
-  Else, $\ell$ is a C-style \synt{forElement}:
-  \begin{enumerate}
-  \item
-    Evaluate the initializer clause of the element, if there is one.
-  \item
-    Loop:
-    \begin{enumerate}
-    \item
-      If the initializer clause declares a variable,
-      create a new namespace and bind that variable in that namespace.
-    \item
-      Evaluate the condition expression to a value \metavar{condition}.
-      If there is no condition expression, use \TRUE.
-    \item
-      If \metavar{condition} is \TRUE:
-      \begin{enumerate}
-      \item
-        Evaluate the body element using this procedure in the namespace
-        of the variable declared by the initializer clause
-        if there is one.
-      \item
-        If there is an increment clause, execute it.
-      \end{enumerate}
-    \item
-      Else, if \metavar{condition} is \FALSE, exit the loop.
-    \item
-      Else, throw a dynamic error.
-    \end{enumerate}
-  \end{enumerate}
-\end{enumerate}
-
-\LMHash{}%
-The procedure theoretically supports a mixture of expressions and map entries,
-but the static semantics prohibit an actual literal containing that.
-
-\LMHash{}%
-Once the \metavar{result} series of values or entries is produced
-from the tree of elements,
-the final object is produced from that based on what kind of literal it is:
-
-
-\subsubsection{List}
-\LMLabel{uiAsCodeList}
-
-\LMHash{}%
-The result of the literal expression is a fresh instance of
-a class that implements \code{List<$E$>} where $E$ is
-the element type of the literal.
-It contains the values in \metavar{result}, in order.
-If the literal is constant,
-the list is canonicalized and immutable,
-otherwise it is not.
-
-
-\subsubsection{Set}
-\LMLabel{uiAsCodeSet}
-
-\LMHash{}%
-Create a fresh instance \metavar{set} of
-a class that implements \code{Set<$E$>} where $E$
-is the set element type of the literal.
-
-\LMHash{}%
-For each \metavar{value} in \metavar{result}:
-
-\begin{enumerate}
-\item
-  If \metavar{set} contains
-  a value \metavar{existing} that is equal to \metavar{value}
-  according to \metavar{existing}'s operator \lit{==}:
-\item
-  If the literal is constant, it is a compile-time error.
-\item
-  Else, do nothing.
-  \commentary{Duplicates are discarded and the first one wins.}
-\item
-  Else, add \metavar{value} to \metavar{set}.
-\end{enumerate}
-
-\LMHash{}%
-The result of the literal expression is \metavar{set}.
-If the literal is constant,
-canonicalize it make the set immutable.
-
-
-\subsubsection{Map}
-\LMLabel{uiAsCodeMap}
-
-\LMHash{}%
-Allocate a fresh instance \metavar{map} of
-a class that implements \code{LinkedHashMap<$K$, $V$>} where $K$ is
-the key type of the literal and $V$ is
-the value type.
-
-\LMHash{}%
-For each entry \code{\metavar{key}: \metavar{value}} in \metavar{result}:
-
-\begin{enumerate}
-\item
-  If \metavar{map} contains an entry \metavar{existing}
-  whose key \metavar{existingKey} is equal to \metavar{key}
-  according to \metavar{existingKeys}'s operator \lit{==}:
-  \begin{enumerate}
-  \item
-    If the literal is constant, it is a compile-time error.
-  \item
-    Else, replace the value in \metavar{existing} with \metavar{value},
-    while keeping its position in the sequence of entries
-    and \metavar{existingKey} the same.
-  \end{enumerate}
-\item
-  Else add entry \code{\metavar{key}: \metavar{value}} to \metavar{map}.
-\end{enumerate}
-
-\LMHash{}%
-The result of the map literal expression is \metavar{map}.
-If the literal is constant,
-canonicalize it and make the map immutable.
-
 
 \printindex
 

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -7605,19 +7605,20 @@ the first applicable entry in the following list:
   $e$ is a map literal with static type \code{Map<$K$, $V$>}.
   With any other number of type arguments a compile-time error occurs.
 \item
+  %% TODO(eernst): Come nnbd: `Object?`.
   $S <: \code{Iterable<Object>} \wedge S \not<: \code{Map<Object, Object>}$:
   $e$ is a set literal.
 \item
+  %% TODO(eernst): Come nnbd: `Object?`.
   $S <: \code{Map<Object, Object>} \wedge S \not<: \code{Iterable<Object>}$:
   $e$ is a map literal.
 \item
   ${\cal L} \not= \emptyset$ (\commentary{$e$ has leaf elements}):
-  When $\cal L$ contains an \synt{expressionElement} but no \synt{mapElement},
-  $e$ is a set literal.
-  When $\cal L$ contains a \synt{mapElement} but no \synt{expressionElement},
-  $e$ is a map literal.
   When $\cal L$ contains both a \synt{mapElement} and an \synt{expressionElement},
   a compile-time error occurs.
+  Otherwise, when $\cal L$ contains an \synt{expressionElement}
+  $e$ is a set literal.
+  Otherwise $\cal L$ contains a \synt{mapElement}, and $e$ is a map literal.
 \item
   $e$ has no \synt{typeArguments}, no elements, and $S$ is undefined:
   $e$ is a map literal.
@@ -7629,7 +7630,7 @@ the first applicable entry in the following list:
   \commentary{%
     In this case $e$ is non-empty but contains only spreads,
     wrapped zero or more times in \synt{ifElement}s or \synt{forElement}s.
-    Disambiguation will occur during type inference
+    Disambiguation will occur during inference
     (\ref{collectionLiteralInference}).%
   }
 \end{itemize}
@@ -7651,6 +7652,8 @@ as appropriate.
 
 \subsubsection{Collection Literal Inference}
 \LMLabel{collectionLiteralInference}
+
+!!!HERE!!!
 
 \paragraph{Maps and sets}
 \LMLabel{uiAsCodeMapsAndSets}

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -7074,6 +7074,20 @@ in which case a disambiguation step is performed
 in order to determine the kind
 (\ref{setAndMapLiteralDisambiguation}).
 
+\LMHash{}%
+The subsections of this section are concerned with mechanisms that are
+common to all kinds of collection literals
+(\ref{collectionLiteralTypePromotion}, \ref{collectionLiteralElementEvaluation}),
+followed by a specification of list literals
+(\ref{listLiteralInference}, \ref{lists}),
+followed by a specification of how to disambiguate and infer types
+for sets and maps
+(\ref{setAndMapLiteralDisambiguation}, \ref{setAndMapLiteralInference}),
+and finally a specification of sets
+(\ref{sets})
+and maps
+(\ref{maps}).
+
 \begin{grammar}
 <listLiteral> ::= \CONST{}? <typeArguments>? `[' <elements>? `]'
 
@@ -7133,22 +7147,30 @@ a set of expression elements and/or map elements.%
 \LMHash{}%
 In order to allow collection literals to occur as constant expressions,
 we specify what it means for an element $\ell$
-to be constant or potentially constant:
+to be
+\IndexCustom{constant}{collection literal element!constant}
+or
+\IndexCustom{potentially constant}{%
+  collection literal element!potentially constant}:
 
 \begin{itemize}
 \item
-  $\ell$ is a potentially constant respectively constant element
-  if it is derived from \synt{expressionElement},
-  of the form $e$,
-  and $e$ is a potentially constant respectively constant expression.
+  Assume that $\ell$ is an \synt{expressionElement},
+  and that it is the expression $e$.
+
+  $\ell$ is a potentially constant element
+  if $e$ is a potentially constant expression,
+  and $\ell$ is a constant element
+  if $e$ is a constant expression.
 \item
-  $\ell$ is a potentially constant respectively constant element
-  if it is derived from \synt{mapElement},
-  of the form \code{$e_1$:\,$e_2$},
-  and both $e_1$ and $e_2$ are
-  potentially constant respectively constant expressions.
+  Assume that $\ell$ is a \synt{mapElement}
+  of the form \code{$e_1$:\,$e_2$}.
+
+  $\ell$ is a potentially constant element
+  if both $e_1$ and $e_2$ are potentially constant expressions,
+  and it is a constant element if they are constant expressions.
 \item
-  Assume that $\ell$ is derived from \synt{spreadElement},
+  Assume that $\ell$ is a \synt{spreadElement}
   of the form `\code{...$e$}' or `\code{...?$e$}'.
 
   $\ell$ is a potentially constant element
@@ -7163,183 +7185,115 @@ to be constant or potentially constant:
   where $e$ is a constant expression that evaluates
   to the null object.
 \item
-  Assume that $\ell$ is derived from \synt{ifElement},
+  Assume that $\ell$ is an \synt{ifElement}
   of the form
   \code{\IF\,\,($b$)\,\,$\ell_1$}
-  or the form
+  or of the form
   \code{\IF\,\,($b$)\,\,$\ell_1$\,\,\ELSE\,\,$\ell_2$}.
 
   $\ell$ is a potentially constant element
-  if $b$ is a potentially constant expression
+  if $b$ is a potentially constant expression,
   and $\ell_1$ as well as $\ell_2$, if present,
   are potentially constant.
 
-  Assume that $\ell$ is \code{\IF\,\,($b$)\,\,$\ell_1$}.
-  Then $\ell$ is a constant element
-  if $b$ is a constant expression that evaluates to \TRUE{}
-  and $\ell_1$ is constant;
-  and it is a constant element
-  if $b$ is a constant expression that evaluates to \FALSE{}
-  and $\ell_1$ is potentially constant.
+  $\ell$ is a constant element if $b$ is a constant expression
+  and:
 
-  Otherwise, $\ell$ is
-  \code{\IF\,\,($b$)\,\,$\ell_1$\,\,\ELSE\,\,$\ell_2$}.
-  Then $\ell$ is a constant element
-  if $b$ is a constant expression that evaluates to \TRUE,
-  $\ell_1$ is constant,
-  and $\ell_2$ is potentially constant;
-  and it is a constant element
-  if $b$ is a constant expression that evaluates to \FALSE,
-  $\ell_1$ is potentially constant,
-  and $\ell_2$ is constant.
+  \begin{itemize}
+  \item
+    $\ell$ is \code{\IF\,\,($b$)\,\,$\ell_1$} and
+    either $b$ evaluates to \TRUE{} and $\ell_1$ is constant,
+    or $b$ evaluates to \FALSE{} and $\ell_1$ is potentially constant.
+  \item
+    $\ell$ is \code{\IF\,\,($b$)\,\,$\ell_1$\,\,\ELSE\,\,$\ell_2$} and
+    either $b$ evaluates to \TRUE,
+    $\ell_1$ is constant,
+    and $\ell_2$ is potentially constant;
+    or $b$ evaluates to \FALSE,
+    $\ell_1$ is potentially constant,
+    and $\ell_2$ is constant.
+  \end{itemize}
 \end{itemize}
 
 \commentary{%
 A \synt{forElement} can never occur in a constant collection literal.%
 }
 
-
-\subsubsection{Compile-time errors}
-\LMLabel{uiAsCodeCompileTimeErrors}
-
-!!!HERE!!! Integrate this into other sections.
-
-\LMHash{}%
-After type inference and disambiguation,
-the collection is checked for other compile-time errors.
-It is a compile-time error if:
-
-%% TODO(eernst): Find a way to show Dart code examples inside itemize below.
-
-\begin{itemize}
-\item
-  The collection is a map literal and leaf elements contains any
-  \synt{expressionElement} elements.
-
-  \begin{dartCode}
-    <String, int>\{"not entry"\} // Error.
-  \end{dartCode}
-\item
-  The collection is a set literal and
-  leaf elements contains any \synt{mapElement} elements.
-
-  \begin{dartCode}
-    ["not": "expression"] // Error.
-    <String>\{"not": "expression"\} // Error.
-  \end{dartCode}
-
-  \commentary{%
-    We prohibit map entries in list literals syntactically,
-    earlier in the proposal.%
-  }
-\item
-  The collection is a list and the type of any of the leaf elements
-  may not be assigned to the list's element type.
-
-  \begin{dartCode}
-    <int>[if (true) "not int"] // Error.
-  \end{dartCode}
-\item
-  The collection is a map and the key type of any of the leaf elements
-  may not be assigned to the map's key type.
-
-  \begin{dartCode}
-    <int, int>{if (true) "not int": 1} // Error.
-  \end{dartCode}
-\item
-  The collection is a map and the value type of any of the leaf elements
-  may not be assigned to the map's value type.
-
-  \begin{dartCode}
-    <int, int>{if (true) 1: "not int"} // Error.
-  \end{dartCode}
-\item
-  A non-null-aware spread element has static type \code{Null}.
-\item
-  A spread element in a list or set literal has a static type that is
-  not \DYNAMIC{} and not a subtype of \code{Iterable<Object>}.
-\item
-  A spread element in a list or set has a static type that
-  implements \code{Iterable<$T$>} for some $T$ and
-  $T$ is not assignable to the element type of the list.
-\item
-  A spread element in a map literal has a static type that is
-  not \DYNAMIC{} and not a subtype of \code{Map<Object, Object>}.
-\item
-  If a map spread element's static type
-  implements \code{Map<$K$, $V$>} for some $K$ and $V$ and
-  $K$ is not assignable to the key type of the map or
-  $V$ is not assignable to the value type of the map.
-\item
-  The variable in a \synt{forElement}
-  (\commentary{either a for-in element or C-style})
-  is declared outside of the element to be final or to not have a setter.
-
-  \begin{dartCode}
-    \FINAL{} i = 0;
-    [for (i in [1]) i] // Error.
-  \end{dartCode}
-\item
-  The type of the iterator expression in a synchronous for-in element
-  may not be assigned to \code{Iterable<$T$>} for any type $T$.
-  Otherwise, the \Index{iterable type} of the iterator is $T$.
-
-  \begin{dartCode}
-    [for (var i in "not iterable") i] // Error.
-  \end{dartCode}
-\item
-  The iterable type of the iterator in a synchronous for-in element
-  may not be assigned to the for-in variable's type.
-
-  \begin{dartCode}
-    [for (int i in ["not", "int"]) i] // Error.
-  \end{dartCode}
-\item
-  The type of the stream expression in an asynchronous \AWAIT{} for-in element
-  may not be assigned to \code{Stream<$T$>} for any type $T$.
-  Otherwise, the \Index{stream type} of the stream is $T$.
-
-  \begin{dartCode}
-    [await for (var i in "not stream") i] // Error.
-  \end{dartCode}
-\item
-  The stream type of the iterator in an asynchronous \AWAIT{} for-in element
-  may not be assigned to the for-in variable's type.
-
-  \begin{dartCode}
-    [await for (int i in Stream.fromIterable(["not", "int"])) i] // Error.
-  \end{dartCode}
-
-\item
-  \AWAIT{} \FOR{} is used when
-  the function immediately enclosing the collection literal
-  is not asynchronous.
-
-  \begin{dartCode}
-    main() {
-      [await for (_ in stream)]; // Error.
-    }
-  \end{dartCode}
-\item
-  \AWAIT{} is used before a C-style \synt{forElement}.
-  \AWAIT{} can only be used with for-in loops.
-
-  \begin{dartCode}
-    main() {
-      [await for (;;)]; // Error.
-    }
-  \end{dartCode}
-
-\item
-  The type of the condition expression
-  (\commentary{the second clause})
-  in a C-style \FOR{} element
-  may not be assigned to \code{bool}.
-
-  \begin{dartCode}
-    [for (; "not bool";) 1] // Error.
-  \end{dartCode}
-\end{itemize}
+%% TODO(eernst): We may change this text to commentary or delete it,
+%% it consists of descriptions of errors, but they are already covered
+%% elsewhere.
+%%
+%% Compile-time errors.
+%%
+%% The following compile-time errors are specified in the feature
+%% specification, but they are already implied by the errors specified
+%% elsewhere.
+%%
+%% - "A non-null-aware spread element has static type \code{Null}".
+%%   For a list literal: listLiteralInference makes this an error by case
+%%   analysis on 'Spread element'.
+%%   Set/map literal: setAndMapLiteralInference, ditto.
+%%
+%% - "A spread element in a list or set literal has a static type that is
+%%   not \DYNAMIC{} and not a subtype of \code{Iterable<Object>}".
+%%   List literal: case analysis on 'Spread element'.
+%%   Set literal: case analysis on 'Spread element': only succeeds if 
+%%   $S$ implements `Map` (and not `Iterable`), so it has a key/value
+%%   type and no element type, which is an error (\ref{sets}).
+%%
+%% - "A spread element in a list or set has a static type that
+%%   implements \code{Iterable<$T$>} for some $T$ and
+%%   $T$ is not assignable to the element type of the list."
+%%   List literal: cf. 'Spread element' this implies that the spread element
+%%   has element type $T$, and non-assignability is an error, \ref{lists}.
+%%   Set literal: cf. 'Spread element' for sets/maps: ditto.
+%%
+%% - "A spread element in a map literal has a static type that is
+%%   not \DYNAMIC{} and not a subtype of \code{Map<Object, Object>}".
+%%   Set/map 'Spread element' case analysis then implies that it implements
+%%   `Iterable` and not `Map`, in which case it has no key/value type pair,
+%%   which is an error, \ref{maps}.
+%%
+%% - "If a map spread element's static type implements \code{Map<$K$, $V$>}
+%%   for some $K$ and $V$ and $K$ is not assignable to the key type of the
+%%   map or $V$ is not assignable to the value type of the map".
+%%   This is an error, \ref{maps}.
+%%
+%% - "The variable in a \synt{forElement} (\commentary{either a for-in
+%%   element or C-style}) is declared outside of the element to be final or
+%%   to not have a setter".
+%%   This error is specified in \ref{listLiteralInference} and
+%%   \ref{setAndMapLiteralInference}.
+%%
+%% - "The type of the iterator expression in a synchronous for-in element
+%%   may not be assigned to \code{Iterable<$T$>} for any type $T$.
+%%   Otherwise, the \Index{iterable type} of the iterator is $T$".
+%%   Covered by the same text as the previous error.
+%%
+%% - "The iterable type of the iterator in a synchronous for-in element
+%%   may not be assigned to the for-in variable's type."
+%%   Covered by the same text again.
+%%
+%% - "The type of the stream expression in an asynchronous \AWAIT{} for-in element
+%%   may not be assigned to \code{Stream<$T$>} for any type $T$.
+%%   Otherwise, the \Index{stream type} of the stream is $T$".
+%%   Same text again (the `forElement` text includes both await for and for).
+%%
+%% - "The stream type of the iterator in an asynchronous \AWAIT{} for-in element
+%%   may not be assigned to the for-in variable's type".
+%%   Same text again.
+%%
+%% - "\AWAIT{} \FOR{} is used when the function immediately enclosing the
+%%   collection literal is not asynchronous".
+%%   Same text again.
+%%
+%% - "\AWAIT{} is used before a C-style \synt{forElement}.
+%%   \AWAIT{} can only be used with for-in loops".
+%%   Same text again.
+%%
+%% - "The type of the condition expression (\commentary{the second clause})
+%%   in a C-style \FOR{} element may not be assigned to \code{bool}".
+%%   Same text again.
 
 
 \subsubsection{Type Promotion}
@@ -7443,7 +7397,7 @@ $T_{\metavar{target}}$.%
 Assume that a location in code and a dynamic context is given,
 such that ordinary expression evaluation is possible.
 \IndexCustom{Evaluation of a collection literal element sequence}{%
-  collection literal element sequence!evaluation}
+  collection literal element!evaluation of sequence}
 at that location and in that context is specified as follows:
 
 \LMHash{}%
@@ -7595,7 +7549,7 @@ $\EvaluateElement{\ell} := s$;
   \end{itemize}
 \end{enumerate}
 
-\commentary{%
+\rationale{%
 This may not be the most efficient way to traverse the items in a collection,
 and implementations may of course use any other approach
 with the same observable behavior.
@@ -7609,7 +7563,7 @@ If $o_{\metavar{spread}}$ is an object whose dynamic type implements
 \code{List}, \code{Queue}, or \code{Set},
 an implementation may choose to call \code{length} on the object.
 
-\commentary{%
+\rationale{%
 This may let it allocate space for the resulting collection more efficiently.
 The given class is expected to have an efficient and
 side-effect free implementation of \code{length}.%
@@ -7684,13 +7638,14 @@ for each element of \metavar{list} is
 obtained from the context type of \metavar{list}.
 If downwards inference constrains the type of \metavar{list}
 to \code{Iterable<$P_e$>} for some $P_e$ then $P$ is $P_e$.
-Otherwise, $P$ is \FreeContext{}.
+Otherwise, $P$ is \FreeContext{}
+(\ref{setAndMapLiteralDisambiguation}).
 
 \LMHash{}%
 Let $\ell$ be a term derived from \synt{element}.
 Inference of the element type of $\ell$ with context type $P$
 proceeds as follows,
-where the context type for an element type is always $P$
+where the context type for inference of an element type is always $P$,
 unless anything is said to the contrary:
 
 \LMHash{}%
@@ -7766,6 +7721,19 @@ In this case $\ell$ is of the form
 where $P$ is derived from \synt{forLoopParts} and
 `\AWAIT?' indicates that \AWAIT{} may be present or absent.
 
+The same compile-time errors occur for $\ell$ as
+the errors that would occur with the corresponding \FOR{} statement
+\code{\AWAIT?\,\,\FOR\,\,($P$)\,\,\{\}},
+located in the same scope as $\ell$.
+Moreover, the errors and type analysis of $\ell$ is performed
+as if it occurred in the body scope of said \FOR{} statement.
+
+\commentary{%
+For instance, if $P$ is of the form
+\code{\VAR\,\,v\,\,\IN\,\,$e_1$}
+then the variable \code{v} is in scope for $\ell$.%
+}
+
 Inference for the parts
 (\commentary{%
   such as the iterable expression of a for-in,
@@ -7809,7 +7777,7 @@ and the context type for \metavar{list} is $P$.
 
 \LMHash{}%
 A \IndexCustom{list literal}{literal!list}
-denotes a list, which is an integer indexed collection of objects.
+denotes a list object, which is an integer indexed collection of objects.
 The grammar rule for \synt{listLiteral} is specified elsewhere
 (\ref{collectionLiterals}).
 
@@ -7828,6 +7796,15 @@ is \code{List<$T$>}
 }
 
 \LMHash{}%
+Let $e$ be a list literal of the form
+\code{<$T$>[\List{\ell}{1}{m}]}.
+It is a compile-time error if a leaf element of $e$ is a
+\synt{mapElement}.
+It is a compile-time error if, for some $j \in 1 .. m$,
+$\ell_j$ does not have an element type,
+or the element type of $\ell_j$ may not be assigned to $T$.
+
+\LMHash{}%
 A list may contain zero or more objects.
 The number of objects in a list is its size.
 A list has an associated set of indices.
@@ -7836,10 +7813,12 @@ A non-empty list has the index set $\{0, \ldots, n - 1\}$ where $n$ is the size 
 It is a dynamic error to attempt to access a list
 using an index that is not a member of its set of indices.
 
-\LMHash{}%
-The objects in a given list literal
-is determined by evaluation of its collection literal elements
-(\ref{collectionLiteralElementEvaluation}).
+\commentary{%
+The system libraries support many operations on an instance
+whose type implements \code{List},
+but we specify only the minimal set of features
+which are used by the language itself.%
+}
 
 \LMHash{}%
 If a list literal $e$ begins with the reserved word \CONST{}
@@ -7869,15 +7848,17 @@ which means that \CONST{} modifiers need not be specified explicitly.%
 }
 
 \LMHash{}%
-It is a compile-time error if an element of a constant list literal
-is not constant.
+It is a compile-time error
+if an element of a constant list literal is not constant.
 It is a compile-time error if the type argument of a constant list literal
 (\commentary{no matter whether it is explicit or inferred})
-is not a constant type expression.
+is not a constant type expression
+(\ref{constants}).
 
 \rationale{%
-The binding of a formal type parameter is not known at compile time,
-so we cannot use type parameters inside constant expressions.%
+The binding of a formal type parameter of an enclosing class or function
+is not known at compile time,
+so we cannot use such type parameters inside constant expressions.%
 }
 
 \LMHash{}%
@@ -7907,13 +7888,13 @@ In other words, constant list literals are canonicalized.%
 
 \LMHash{}%
 A run-time list literal
-\code{<$E$>[$\ell_1, \ldots, \ell_m$]}
+\code{<$E$>[\List{\ell}{1}{m}]}
 is evaluated as follows:
 \begin{itemize}
 \item
-  The elements $\ell_1, \ldots, \ell_m$ are evaluated
+  The elements \List{\ell}{1}{m} are evaluated
   (\ref{collectionLiteralElementEvaluation}),
-  producing objects $o_1, \ldots, o_n$.
+  to an object sequence \LiteralSequence{\List{o}{1}{n}}.
 \item
   A fresh instance (\ref{generativeConstructors}) $a$, of size $n$,
   whose class implements the built-in class \code{List<$E$>}
@@ -8088,10 +8069,10 @@ Iterable l = [];
 Map m = \{\};
 \\
 \VOID{} main() \{
-  \{...x\}       // \comment{Compile-time error: ambiguous}
-  \{...x, ...l\} // \comment{A set, dynamic error when `x` is evaluated}
-  \{...x, ...m\} // \comment{A map, no dynamic errors}
-  \{...l, ...m\} // \comment{Compile-time error: must be both a set and a map}
+  \VAR v1 = \{...x\};       // \comment{Compile-time error: ambiguous}
+  \VAR v2 = \{...x, ...l\}; // \comment{A set, dynamic error when `x` is evaluated}
+  \VAR v3 = \{...x, ...m\}; // \comment{A map, no dynamic errors}
+  \VAR v4 = \{...l, ...m\}; // \comment{Compile-time error: must be set and map}
 \}
 \end{dartCode}
 
@@ -8147,17 +8128,17 @@ which is determined as follows:
 \end{itemize}
 
 \LMHash{}%
-We say that an element
-\IndexCustom{can be a set}{element!can be a set}
-if it has an element type.
-Likewise, an element
-\IndexCustom{can be a map}{element!can be a map}
-if it has a key and value type pair.
-We say that an element
-\IndexCustom{must be a set}{element!must be a set}
-if it can be a set and has and no key and value type pair.
-We say that an element
-\IndexCustom{must be a map}{element!must be a map}
+We say that a collection literal element
+\IndexCustom{can be a set}{collection literal element!can be a set}
+if it has an element type;
+it
+\IndexCustom{can be a map}{collection literal element!can be a map}
+if it has a key and value type pair;
+it
+\IndexCustom{must be a set}{collection literal element!must be a set}
+if it can be a set and has and no key and value type pair;
+and it
+\IndexCustom{must be a map}{collection literal element!must be a map}
 if can be a map and has no element type.
 
 \LMHash{}%
@@ -8360,6 +8341,19 @@ In this case $\ell$ is of the form
 where $P$ is derived from \synt{forLoopParts} and
 `\AWAIT?' indicates that \AWAIT{} may be present or absent.
 
+The same compile-time errors occur for $\ell$ as
+the errors that would occur with the corresponding \FOR{} statement
+\code{\AWAIT?\,\,\FOR\,\,($P$)\,\,\{\}},
+located in the same scope as $\ell$.
+Moreover, the errors and type analysis of $\ell$ is performed
+as if it occurred in the body scope of said \FOR{} statement.
+
+\commentary{%
+For instance, if $P$ is of the form
+\code{\VAR\,\,v\,\,\IN\,\,$e_1$}
+then the variable \code{v} is in scope for $\ell$.%
+}
+
 Inference for the parts
 (\commentary{%
   such as the iterable expression of a for-in,
@@ -8385,7 +8379,7 @@ In other words, inference flows upwards from the body element.%
 
 \LMHash{}%
 Finally, we define
-\Index{type inference on a set or map literal}{%
+\IndexCustom{type inference on a set or map literal}{%
   type inference!set or map literal}
 as a whole.
 Assume that \metavar{collection} is derived from \synt{setOrMapLiteral},
@@ -8411,6 +8405,8 @@ and the context type for \metavar{collection} is $P$.
       with the given context type.%
     }
   \end{itemize}
+
+  The static type of \metavar{collection} is then \code{Set<$T$>}.
 \item
   If \metavar{collection} is unambiguously a map
   where $P$ is \code{Map<$P_k$, $P_v$>}
@@ -8428,8 +8424,9 @@ and the context type for \metavar{collection} is $P$.
   where $V$ is the least upper bound of \List{V}{1}{n}.
   Otherwise the static value type of \metavar{collection} is $V$
   where $V$ is determined by downwards inference.
+
   \commentary{%
-    Note that the element inference will never produce a element type here
+    Note that inference will never produce a element type here
     given this downwards context.%
   }
 
@@ -8460,7 +8457,7 @@ and the context type for \metavar{collection} is $P$.
 \end{itemize}
 
 \commentary{%
-This last case can occur if the literal \emph{must} be both a set and a map.
+This last error can occur if the literal \emph{must} be both a set and a map.
 Here is an example:%
 }
 
@@ -8481,63 +8478,77 @@ Or, if there is nothing indicates that it is \emph{either} a set or a map:%
 \end{dartCode}
 
 
-\subsubsection{Set}
-\LMLabel{uiAsCodeSet}
-
-!!!HERE!!! This should be moved into \ref{sets}.
-
-\LMHash{}%
-Create a fresh instance \metavar{set} of
-a class that implements \code{Set<$E$>} where $E$
-is the element type of the literal.
-
-\LMHash{}%
-For each \metavar{value} in \metavar{result}:
-
-\begin{enumerate}
-\item
-  If \metavar{set} contains
-  a value \metavar{existing} that is equal to \metavar{value}
-  according to \metavar{existing}'s operator \lit{==}:
-\item
-  If the literal is constant, it is a compile-time error.
-\item
-  Else, do nothing.
-  \commentary{Duplicates are discarded and the first one wins.}
-\item
-  Else, add \metavar{value} to \metavar{set}.
-\end{enumerate}
-
-\LMHash{}%
-The result of the literal expression is \metavar{set}.
-If the literal is constant,
-canonicalize it make the set immutable.
-
-
 \subsubsection{Sets}
 \LMLabel{sets}
-
-!!!HERE!!! Revise.
 
 \LMHash{}%
 A \IndexCustom{set literal}{literal!set} denotes a set object.
 The grammar rule for \synt{setOrMapLiteral} which covers
 set literals as well as map literals occurs elsewhere
 (\ref{collectionLiterals}).
+A set literal consists of zero or more collection literal elements
+(\ref{collectionLiterals}).
+A term derived from \synt{setOrMapLiteral}
+may be a set literal or a map literal,
+and it is determined via a disambiguation step
+whether it is a set literal or a map literal
+(\ref{setAndMapLiteralDisambiguation}, \ref{setAndMapLiteralInference}).
 
 \LMHash{}%
-A set literal consists of zero or more element expressions.
-It is a compile-time error if a set literal has more than one type argument.
+When a given set literal $e$ has no type arguments,
+the type argument $T$ is selected as specified elsewhere
+(\ref{setAndMapLiteralInference}),
+and $e$ is henceforth treated as
+(\ref{notation})
+\code{<$T$>$e$}.
 
-\rationale{%
-A set literal with no type argument is always converted to a literal
-with a type argument by type inference (\ref{overview}), so the following
-section only address the behavior of literals with type arguments.%
+\commentary{%
+The static type of a set literal of the form \code{<$T$>$e$}
+is \code{Set<$T$>}
+(\ref{setAndMapLiteralInference}).%
 }
 
 \LMHash{}%
-If a set literal $\ell$ begins with the reserved word \CONST{}
-or $\ell$ occurs in a constant context
+Let $e$ be a set literal of the form
+\code{<$T$>\{\List{\ell}{1}{m}\}}.
+It is a compile-time error if a leaf element of $e$ is a
+\synt{mapElement}.
+It is a compile-time error if, for some $j \in 1 .. m$,
+$\ell_j$ does not have an element type,
+or the element type of $\ell_j$ may not be assigned to $T$.
+
+\LMHash{}%
+A set may contain zero or more objects.
+Sets have a method which can be used to insert objects;
+this will incur a dynamic error if the set is not modifiable.
+Otherwise, when inserting an object $o_{\metavar{new}}$ into a set $s$,
+if an object $o_{\metavar{old}}$ exists in $s$ such that
+\code{$o_{\metavar{old}}$ == $o_{\metavar{new}}$} evaluates to \TRUE{}
+then the insertion makes no changes to $s$;
+if no such object exists,
+$o_{\metavar{new}}$ is added to $s$;
+in both cases the insertion completes successfully.
+
+\LMHash{}%
+A set is ordered: iteration over the elements of a set
+occurs in the order the elements were added to the set.
+
+\commentary{%
+The system libraries support many operations on an instance
+whose type implements \code{Set},
+but we specify only the minimal set of features
+which are used by the language itself.
+
+Note that an implementation may require consistent definitions of several members
+of a class implementing \code{Set} in order to work correctly.
+For instance, there may be a getter \code{hashCode} which is required
+to have a behavior which is in some sense consistent with operator \lit{==}.
+Such constraints are documented in the system libraries.%
+}
+
+\LMHash{}%
+If a set literal $e$ begins with the reserved word \CONST{}
+or $e$ occurs in a constant context
 (\ref{constantContexts}),
 it is a
 \IndexCustom{constant set literal}{literal!set!constant}
@@ -8562,44 +8573,45 @@ which means that \CONST{} modifiers need not be specified explicitly.%
 }
 
 \LMHash{}%
-It is a compile-time error if an element expression in a constant set literal
+It is a compile-time error if a collection literal element in a constant set literal
 is not a constant expression.
 It is a compile-time error if
 the operator \lit{==} of an element expression in a constant map literal
 is not primitive
 (\ref{theOperatorEqualsEquals}).
-It is a compile-time error if the type argument of a constant set literal
-is not a constant type expression
-(\ref{constants}).
 It is a compile-time error if two elements of a constant set literal are equal
 according to their \lit{==} operator
 (\ref{equality}).
+It is a compile-time error if the type argument of a constant set literal
+(\commentary{no matter whether it is explicit or inferred})
+is not a constant type expression
+(\ref{constants}).
+
+\rationale{%
+The binding of a formal type parameter of an enclosing class or function
+is not known at compile time,
+so we cannot use such type parameters inside constant expressions.%
+}
 
 \LMHash{}%
-The value of a constant set literal
-\code{\CONST?\,\,<$E$>\{$e_1, \ldots, e_n$\}}
+The value of a constant set literal $e$ of the form
+\code{\CONST?\,\,<$E$>\{\List{\ell}{1}{m}\}}
 is an object $s$ whose class implements the built-in class
-\code{Set<$E$>}.
-The elements of $m$ are $v_i, i \in 1 .. n$,
-where $v_i$ is the value of the constant expression $e_i$.
-%
-%% TODO(eernst): If inference is specified to provide all type arguments,
-%% we should delete the following.
-The value of a constant set literal
-\code{\CONST?\,\,\{$e_1, \ldots, e_n$\}}
-is defined as the value of the constant set literal
-% For a constant set literal, it is never an error to have the \CONST, even if
-% it was omitted above. So we remove the `?`, making the next line well-defined.
-\code{\CONST\,\,<\DYNAMIC>\{$e_1, \ldots, e_n$\}}.
+\code{Set<$E$>},
+and whose contents is the set of objects in
+the object sequence \List{o}{1}{n} obtained by
+evaluation of \List{\ell}{1}{m}
+(\ref{collectionLiteralElementEvaluation}).
+The elements of $e$ occur in the same order as
+the objects in said object sequence
+(\commentary{which can be observed by iteration}).
 
 \LMHash{}%
 Let $set_1$ be a constant set literal with type argument $E$
-and element expressions, in source order, $e_{11}, \ldots, e_{1n}$ evaluating
-to objects $v_{11}, \ldots, v_{1n}$.
+containing, in that order, the objects $o_{11}, \ldots, o_{1n}$.
 Let $set_2$ be a constant set literal with type argument $F$
-and element expressions, in source order, $e_{21}, \ldots, e_{2n}$ evaluating
-to objects $v_{21}, \ldots, v_{2n}$.
-If{}f \code{identical($v_{1i}$, $v_{2i}$)}
+containing, in that order, the objects $o_{21}, \ldots, o_{2n}$.
+If{}f \code{identical($o_{1i}$, $o_{2i}$)}
 for $i \in 1 .. n$, and $E$ and $F$ is the same type,
 then \code{identical($set_1$, $set_2$)}.
 
@@ -8611,116 +8623,110 @@ if they have a different number of elements.%
 }
 
 \LMHash{}%
-A run-time set literal with element expressions $e_1, \ldots, e_n$
-(in source order) and with type argument $E$
+A run-time set literal \code{<$E$>\{\List{\ell}{1}{n}\}}
 is evaluated as follows:
 \begin{itemize}
 \item
-For each $i \in 1 .. n$ in numeric order,
-the expression $e_i$ is evaluated producing object $v_i$.
-\item A fresh object (\ref{generativeConstructors}) $s$
-implementing the built-in class \code{Set<$E$>}, is created.
-\item The set $s$ is made to have the objects $v_1, \ldots{} , v_n$ as elements,
-iterated in numerical order.
+  The elements \List{\ell}{1}{m} are evaluated
+  (\ref{collectionLiteralElementEvaluation}),
+  to an object sequence \LiteralSequence{\List{o}{1}{n}}.
 \item
-The result of the evaluation is $s$.
+  A fresh object (\ref{generativeConstructors}) $s$
+  implementing the built-in class \code{Set<$E$>}, is created.
+\item
+  For each object $o_j$ in \List{o}{1}{n}, in order,
+  $o_j$ is inserted into $s$.
+  \commentary{%
+    Note that this leaves $s$ unchanged when $s$ already contains
+    and object $o$ which is equal to $o_j$ according to operator \lit{==}.%
+  }
+\item
+  The result of the evaluation is $s$.
 \end{itemize}
 
 \LMHash{}%
 The objects created by set literals do not override
 the \lit{==} operator inherited from the \code{Object} class.
 
-\LMHash{}%
-A set literal is ordered: iterating over the elements of the sets
-always happens in the order the elements first appeared in the source code.
-
-\commentary{
-If a value repeats, the order is defined by first occurrence, but the value is defined by the last.
-}
-
-\LMHash{}%
-%% TODO(eernst): If inference is specified to provide all type arguments,
-%% we should delete the following.
-A run-time set literal
-\code{\{$e_1, \ldots, e_n$\}}
-is evaluated as
-\code{<\DYNAMIC>\{$e_1, \ldots, e_n$\}}.
-
-\LMHash{}%
-The static type of a set literal of the form
-\code{\CONST\,\,<$E$>\{$e_1, \ldots, e_n$\}}
-or the form
-\code{<$E$>\{$e_1, \ldots, e_n$\}}
-is
-\code{Set<$E$>}.
-%
-%% TODO(eernst): If inference is specified to provide all type arguments,
-%% we should delete the following.
-The static type of a list literal of the form
-\code{\CONST\,\,\{$e_1, \ldots, e_n$\}}
-or the form
-\code{\{$e_1, \ldots, e_n$\}}
-is \code{Set<\DYNAMIC>}.
-
-
-\subsubsection{Map}
-\LMLabel{uiAsCodeMap}
-
-!!!HERE!!! This should be moved into \ref{maps}.
-
-\LMHash{}%
-Allocate a fresh instance \metavar{map} of
-a class that implements \code{LinkedHashMap<$K$, $V$>} where $K$ is
-the key type of the literal and $V$ is
-the value type.
-
-\LMHash{}%
-For each entry \code{\metavar{key}: \metavar{value}} in \metavar{result}:
-
-\begin{enumerate}
-\item
-  If \metavar{map} contains an entry \metavar{existing}
-  whose key \metavar{existingKey} is equal to \metavar{key}
-  according to \metavar{existingKeys}'s operator \lit{==}:
-  \begin{enumerate}
-  \item
-    If the literal is constant, it is a compile-time error.
-  \item
-    Else, replace the value in \metavar{existing} with \metavar{value},
-    while keeping its position in the sequence of entries
-    and \metavar{existingKey} the same.
-  \end{enumerate}
-\item
-  Else add entry \code{\metavar{key}: \metavar{value}} to \metavar{map}.
-\end{enumerate}
-
-\LMHash{}%
-The result of the map literal expression is \metavar{map}.
-If the literal is constant,
-canonicalize it and make the map immutable.
-
 
 \subsubsection{Maps}
 \LMLabel{maps}
-
-!!!HERE!!! Revise.
 
 \LMHash{}%
 A \IndexCustom{map literal}{literal!map} denotes a map object.
 The grammar rule for \synt{setOrMapLiteral} which covers both
 map literals and set literals occurs elsewhere
 (\ref{collectionLiterals}).
+A map literal consists of zero or more collection literal elements
+(\ref{collectionLiterals}).
+A term derived from \synt{setOrMapLiteral}
+may be a set literal or a map literal,
+and it is determined via a disambiguation step
+whether it is a set literal or a map literal
+(\ref{setAndMapLiteralDisambiguation}, \ref{setAndMapLiteralInference}).
 
 \LMHash{}%
-A map literal consists of zero or more entries.
+When a given map literal $e$ has no type arguments,
+the type arguments $K$ and $V$ are selected as specified elsewhere
+(\ref{setAndMapLiteralInference}),
+and $e$ is henceforth treated as
+(\ref{notation})
+\code{<$K$,\,$V$>$e$}.
+
+\commentary{%
+The static type of a map literal of the form \code{<$K$,\,$V$>$e$}
+is \code{Map<$K$,\,$V$>}
+(\ref{setAndMapLiteralInference}).%
+}
+
+\LMHash{}%
+Let $e$ be a map literal of the form
+\code{<$K$,\,$V$>\{\List{\ell}{1}{m}\}}.
+It is a compile-time error if a leaf element of $e$ is an
+\synt{expressionElement}.
+It is a compile-time error if, for some $j \in 1 .. m$,
+$\ell_j$ does not have a key and value type pair;
+or the key and value type pair of $\ell_j$ is $(K_j, V_j)$,
+and $K_j$ may not be assigned to $K$ or
+$V_j$ may not be assigned to $V$.
+
+\LMHash{}%
+A map object consists of zero or more map entries.
 Each entry has a \Index{key} and a \Index{value}.
-Each key and each value is denoted by an expression.
-It is a compile-time error if a map literal has one type argument,
-or more than two type arguments.
+A key and value pair is
+added to a map using operator \lit{[]=},
+and the value for a given key is retrieved from a map using operator \lit{[]}.
+The keys of a map are treated similarly to a set
+(\ref{sets}):
+When binding a key $k_{\metavar{new}}$ to a value $v$ in a map $m$
+(\commentary{as in \code{$m$[$k_{\metavar{new}}$]\,=\,$v$}}),
+if $m$ already has a key $k_{\metavar{old}}$ such that
+\code{$k_{\metavar{old}}$ == $k_{\metavar{new}}$} evaluates to \TRUE,
+$m$ will bind $k_{\metavar{old}}$ to $v$;
+otherwise
+(\commentary{when no such key $k_{\metavar{old}}$ exists}),
+a binding from $k_{\metavar{new}}$ to $v$ is added to $m$.
 
 \LMHash{}%
-If a map literal $\ell$ begins with the reserved word \CONST{},
-or if $\ell$ occurs in a constant context
+A map is ordered: iteration over the keys, values, or key/value pairs
+occurs in the order in which the keys were added to the set.
+
+\commentary{%
+The system libraries support many operations on an instance
+whose type implements \code{Map},
+but we specify only the minimal set of features
+which are used by the language itself.
+
+Note that an implementation may require consistent definitions of several members
+of a class implementing \code{Map} in order to work correctly.
+For instance, there may be a getter \code{hashCode} which is required
+to have a behavior which is in some sense consistent with operator \lit{==}.
+Such constraints are documented in the system libraries.%
+}
+
+\LMHash{}%
+If a map literal $e$ begins with the reserved word \CONST{},
+or if $e$ occurs in a constant context
 (\ref{constantContexts}),
 it is a
 \IndexCustom{constant map literal}{literal!map!constant}
@@ -8738,54 +8744,56 @@ Attempting to mutate a constant map literal will result in a dynamic error.
 % The following is true either directly or indirectly: There is a \CONST{}
 % modifier on the literal map, or we use the "immediate subexpression" rule
 % about constant contexts.
-Note that the key and value expressions of a constant list literal
+Note that the key and value expressions of a constant map literal
 occur in a constant context
 (\ref{constantContexts}),
 which means that \CONST{} modifiers need not be specified explicitly.%
 }
 
 \LMHash{}%
+It is a compile-time error
+if a collection literal element in a constant map literal is not constant.
 It is a compile-time error if
-either a key or a value of an entry in a constant map literal
-is not a constant expression.
-It is a compile-time error if
-the operator \lit{==} of the key of an entry in a constant map literal
+the operator \lit{==} of a key in a constant map literal
 is not primitive
 (\ref{theOperatorEqualsEquals}).
+It is a compile-time error if two keys of a constant map literal are equal
+according to their \lit{==} operator
+(\ref{equality}).
 It is a compile-time error if a type argument of a constant map literal
+(\commentary{no matter whether it is explicit or inferred})
 is not a constant type expression
 (\ref{constants}).
 
+\rationale{%
+The binding of a formal type parameter of an enclosing class or function
+is not known at compile time,
+so we cannot use such type parameters inside constant expressions.%
+}
+
 \LMHash{}%
 The value of a constant map literal
-\code{\CONST?\,\,<$K, V$>\{$k_1:e_1, \ldots, k_n:e_n$\}}
+\code{\CONST?\,\,<$K, V$>\{\List{\ell}{1}{m}\}}
 is an object $m$ whose class implements the built-in class
 \code{Map<$K, V$>}.
-The entries of $m$ are $u_i:v_i, i \in 1 .. n$,
-where $u_i$ is the value of the compile-time expression $k_i$,
-and $v_i$ is the value of the compile-time expression $e_i$.
-%
-%% TODO(eernst): If inference is specified to provide all type arguments,
-%% we should delete the following.
-The value of a constant map literal
-\code{\CONST?\,\,\{$k_1:e_1, \ldots, k_n:e_n$\}}
-is defined as the value of the constant map literal
-% For a constant map literal, it is never an error to have the \CONST, even if
-% it was omitted above. So we remove the `?`, making the next line well-defined.
-\code{\CONST\,\,<\DYNAMIC, \DYNAMIC>\{$k_1:e_1, \ldots, k_n:e_n$\}}.
+The key and value pairs of $m$ is
+the pairs of the object sequence \KeyValueList{k}{v}{1}{n} obtained by
+evaluation of \List{\ell}{1}{m}
+(\ref{collectionLiteralElementEvaluation}),
+in that order.
 
 \LMHash{}%
 Let $map_1$ be a constant map literal of the form
-\code{\CONST?\,\,<$K, V$>\{$k_{11}:e_{11}, \ldots, k_{1n}:e_{1n}$\}}
+\code{\CONST?\,\,<$K, V$>\{\List{\ell}{1}{m_1}\}}
 and $map_2$ a constant map literal of the form
-\code{\CONST?\,\,<$J, U$>\{$k_{21}:e_{21}, \ldots, k_{2n}:e_{2n}$\}}.
-Let the keys of $map_1$ and $map_2$ evaluate to
-$s_{11}, \ldots, s_{1n}$ and $s_{21}, \ldots, s_{2n}$, respectively,
-and let the elements of $map_1$ and $map_2$ evaluate to
-$o_{11}, \ldots, o_{1n}$ and $o_{21}, \ldots, o_{2n}$, respectively.
+\code{\CONST?\,\,<$J, U$>\{\List{\ell}{1}{m_2}\}}.
+Assume that the key and value pairs of $map_1$ are
+\KeyValueList{k_1}{v_1}{1}{n}
+and the key and value pairs of $map_2$ are
+\KeyValueList{k_2}{v_2}{1}{n}.
 If{}f
-\code{identical($o_{1i}$, $o_{2i}$)} and
-\code{identical($s_{1i}$, $s_{2i}$)}
+\code{identical($k_{1i}$, $k_{2i}$)} and
+\code{identical($v_{1i}$, $v_{2i}$)}
 for $i \in 1 .. n$, and $K == J, V == U$, then \code{identical($map_1$, $map_2$)}.
 
 \commentary{%
@@ -8793,27 +8801,22 @@ In other words, constant map literals are canonicalized.%
 }
 
 \LMHash{}%
-It is a compile-time error if two keys of a constant map literal are equal
-according to their \lit{==} operator (\ref{equality}).
-
-\LMHash{}%
 A run-time map literal
-\code{<$K, V$>\{$k_1:e_1, \ldots, k_n:e_n$\}}
+\code{<$K, V$>\{\List{\ell}{1}{m}\}}
 is evaluated as follows:
 \begin{itemize}
 \item
-  For each $i \in 1 .. n$ in numeric order,
-  first the expression $k_i$ is evaluated producing object $u_i$,
-  and then $e_i$ is evaluated producing object $o_i$.
-  This produces all the objects $u_1, o_1, \ldots, u_n, o_n$.
+  The elements \List{\ell}{1}{m} are evaluated
+  (\ref{collectionLiteralElementEvaluation}),
+  to an object sequence \LiteralSequence{\KeyValueList{k}{v}{1}{n}}.
 \item
   A fresh instance (\ref{generativeConstructors}) $m$
   whose class implements the built-in class \code{Map<$K, V$>},
   is allocated.
 \item
   The operator \lit{[]=} is invoked on $m$
-  with first argument $u_i$ and second argument $o_i$
-  for each $i \in 1 .. n$.
+  with first argument $k_i$ and second argument $v_i$,
+  for each $i \in 1 .. n$, in that order.
 \item
   The result of the evaluation is $m$.
 \end{itemize}
@@ -8821,41 +8824,6 @@ is evaluated as follows:
 \LMHash{}%
 The objects created by map literals do not override
 the \lit{==} operator inherited from the \code{Object} class.
-
-\LMHash{}%
-%% TODO(eernst): If inference is specified to provide all type arguments,
-%% we should delete the following.
-A run-time map literal
-\code{\{$k_1:e_1, \ldots, k_n:e_n$\}}
-is evaluated as
-
-\code{<\DYNAMIC, \DYNAMIC>\{$k_1:e_1, \ldots, k_n:e_n$\}}.
-
-\LMHash{}%
-A map literal is ordered:
-iterating over the keys and/or values of the maps
-always happens in the order the keys appeared in the source code.
-
-\commentary{
-Of course, if a key repeats, the order is defined by first occurrence,
-but the value is defined by the last.
-}
-
-\LMHash{}%
-The static type of a map literal of the form
-\code{\CONST{} <$K, V$>\{$k_1:e_1, \ldots, k_n:e_n$\}}
-or the form
-\code{<$K, V$>\{$k_1:e_1, \ldots, k_n:e_n$\}}
-is
-\code{Map<$K, V$>}.
-%
-%% TODO(eernst): If inference is specified to provide all type arguments,
-%% we should delete the following.
-The static type of a map literal of the form
-\code{\CONST{} \{$k_1:e_1, \ldots, k_n:e_n$\}}
-or the form
-\code{\{$k_1:e_1, \ldots, k_n:e_n$\}} is
-\code{Map<\DYNAMIC, \DYNAMIC>}.
 
 
 \subsection{Throw}
@@ -18363,108 +18331,7 @@ operator.
 \end{itemize}
 }
 
-
-\section*{Appendix: UI as code Feature Specification}
-\LMLabel{uiAsCode}
-
-% !!!TODO!!!
-
-\subsection{Constant Semantics}
-\LMLabel{uiAsCodeConstantSemantics}
-
-\LMHash{}%
-The runtime semantics below are used to determine the compile-time value of
-a constant collection literal,
-which is defined as a \synt{listLiteral} or \synt{setOrMapLiteral}
-that occurs in a constant context or directly preceded by \CONST{}.
-
-\LMHash{}%
-Elements in a collection may be constant, potentially constant, or neither.
-All \synt{elements} directly inside in a constant collection
-must be constant elements.
-They are defined as:
-
-\begin{itemize}
-\item
-  An \synt{expressionElement} is a constant element if
-  its expression is a constant expression, and
-  a potentially constant element if
-  its expression is a potentially constant expression.
-\item
-  A \synt{mapElement} is a constant element if
-  both its key and value expression are constant expressions, and
-  a potentially constant element if
-  both are potentially constant expressions.
-\item
-  A \synt{spreadElement} starting with \lit{...} is a constant element if
-  its expression is constant and
-  it evaluates to a constant \code{List}, \code{Set} or \code{Map}
-  instance originally created by a list, set or map literal.
-  It is a potentially constant element if
-  the expression is a potentially constant expression.
-\item
-  A \synt{spreadElement} starting with \lit{...?} is a constant element if
-  its expression is constant and it evaluates to \NULL{} or
-  a constant \code{List}, \code{Set} or \code{Map} instance
-  originally created by a list, set or map literal.
-  It is a potentially constant element if
-  the expression is potentially constant expression.
-\item
-  An \synt{ifElement} is a constant element if
-  its condition is a constant expression evaluating to
-  a value of type \code{bool} and either:
-
-  \begin{itemize}
-  \item
-    The condition evaluates to \TRUE{}, the "then" element is
-    a constant expression, and the "else" element, if any, is
-    a potentially constant element.
-  \item
-    The condition evaluates to \FALSE{}, the "then" element is
-    a potentially constant element, and the "else" element, if any, is
-    a constant element.
-  \end{itemize}
-\item
-  An \synt{ifElement} is potentially constant if
-  its condition, "then" element, and "else" element, if any, are
-  potentially constant expressions.
-\item
-  \commentary{%
-    A \synt{forElement} is never a constant or potentially constant element.
-    A \synt{forElement} cannot be used in constant collection literals.%
-  }
-\end{itemize}
-
-\LMHash{}%
-Also:
-
-\begin{itemize}
-\item
-  It is a compile-time error if
-  any element in a constant set or key in a constant map
-  does not have a primitive operator \lit{==}.
-\item
-  When evaluating a const collection literal,
-  if another const collection has previously been evaluated that:
-
-  \begin{itemize}
-  \item is of the same kind (map, set, or list),
-  \item has the same type arguments,
-  \item and contains the same (identical) elements or key/value entries
-    in the same order,
-  \end{itemize}
-
-  then the current literal evaluates to the value of that previous literal.
-
-  \commentary{%
-    In other words, constants are canonicalized.
-    Note that maps and sets are only canonicalized if
-    they contain the same keys or elements \emph{in the same order}.%
-    }
-\end{itemize}
-
 \printindex
-
 \end{document}
 
 [Text after \end{document} is ignored, hence we do not need "%"]

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -48,6 +48,8 @@
 % - Clarify which constructors are covered by the section 'Constant
 %   Constructors' and removed confusing redundancy in definiton of
 %   potentially constant expressions.
+% - Integrate the feature specification of collection literal elements
+%   (aka UI-as-code).
 %
 % 2.2
 % - Specify whether the values of literal expressions override Object.==.
@@ -17014,6 +17016,991 @@ For efficiency, the \code{identical} operation uses the JavaScript \code{===}
 operator.
 \end{itemize}
 }
+
+
+\section*{Appendix: UI as code Feature Specification}
+\LMLabel{uiAsCode}
+
+# Unified Collections
+
+The Dart team is concurrently working on three proposals that affect collection
+literals:
+
+* [Set Literals][]
+* [Spread Collections][]
+* [Control Flow Collections][]
+
+[set literals]: https://github.com/dart-lang/language/blob/master/accepted/2.2/set-literals/feature-specification.md
+[spread collections]: https://github.com/dart-lang/language/blob/master/accepted/2.3/spread-collections/feature-specification.md
+[control flow collections]: https://github.com/dart-lang/language/blob/master/accepted/2.3/control-flow-collections/feature-specification.md
+
+These features interact in several ways, some of which weren't obvious at first.
+To make things easier on implementers and anyone else trying to understand the
+entire set of changes, this specification unifies and subsumes all three of
+those proposals.
+
+**This document is now the source of truth for these language changes.** The
+other three proposals are useful because they contain motivation and other
+context, but the precise syntax and semantics may be out of date in those docs.
+This is where you should be looking if you're an implementer.
+
+## Grammar
+
+Remove `setLiteral` and `mapLiteral` entirely. Then change the grammar to:
+
+```
+setOrMapLiteral   : 'const'? typeArguments? '{' elements? '}' ;
+listLiteral       : 'const'? typeArguments? '[' elements? ']' ;
+
+elements          : element ( ',' element )* ','? ;
+
+element           : expressionElement
+                  | mapEntry
+                  | spreadElement
+                  | ifElement
+                  | forElement
+                  ;
+
+expressionElement : expression ;
+mapEntry          : expression ':' expression ;
+
+spreadElement     : ( '...' | '...?' ) expression ;
+ifElement         : 'if' '(' expression ')' element ( 'else' element )? ;
+forElement        : 'await'? 'for' '(' forLoopParts ')' element ;
+```
+
+Let the *leaf elements* of *e* be the concatenation of all of the *leaf
+elements* of each `element` directly in *e* where the *leaf elements* of an
+`element` are:
+
+*   If `element` is an `ifElement`, then the *leaf elements* are the
+    concatenation of the *leaf elements* of the "then" and "else" elements of
+    `element`.
+
+*   Else, if `element` is a `forElement`, then the *leaf elements* are the *leaf
+    elements* of the body element of `element`.
+
+*   Else, if `element` is an `expressionElement` or `mapEntry`, then the *leaf
+    element* is `element` itself.
+
+*   Else, the element has no *leaf elements*. *A spread contains no leaf
+    elements.*
+
+It is a compile-time error if any *leaf elements* of a `listLiteral` are
+`mapEntry` elements. *(We could avoid this prose by duplicating the above rules
+for lists and removing `mapEntry`, but this is simpler.)*
+
+The existing rule that an expression statement cannot start with `{` now covers
+both map and set literals.
+
+## Static Semantics
+
+### Disambiguating sets and maps
+
+Because sets and maps both use curly braces as delimiters, you can create
+collection literals that are not obviously either a set or a map, like:
+
+```dart
+var a = {};
+var b = {...other};
+```
+
+Inference and set/map disambiguation are done concurrently. When possible, we
+use syntax and the surrounding context type to disambiguate between a map and
+set:
+
+Let *e* be a `setOrMapLiteral`.
+
+If *e* has a context `C`, and the base type of `C` is `Cbase` (that is, `Cbase`
+is `C` with all wrapping `FutureOr`s removed), and `Cbase` is not `?`, then let
+`S` be the greatest closure.
+
+1.  If *e* has `typeArguments` then:
+
+    *   If there is exactly one type argument `T`, then *e* is a set literal
+        with static type `Set<T>`.
+
+    *   If there are exactly two type arguments `K` and `V`, then *e* is a map
+        literal with static type `Map<K, V>`.
+
+    *   Otherwise (three or more type arguments), report a compile-time error.
+
+1.  Else, if `S` is defined and is a subtype of `Iterable<Object>` and `S` is
+    not a subtype of `Map<Object, Object>`, then *e* is a set literal.
+
+1.  Else, if `S` is defined and is a subtype of `Map<Object, Object>` and `S` is
+    not a subtype of `Iterable<Object>` then *e* is a map literal.
+
+1.  Else, if *leaf elements* is not empty, then:
+
+    *   If *leaf elements* has at least one `expressionElement` and no
+        `mapEntry` elements, then *e* is a set literal with unknown static type.
+        The static type will be filled in by type inference, defined below.
+
+    *   If *leaf elements* has at least one `mapEntry` and no
+        `expressionElement` elements, then *e* is a map literal with unknown
+        static type. The static type will be filled in by type inference,
+        defined below.
+
+    *   If *leaf elements* has at least one `mapEntry` and at least one
+        `expressionElement`, report a compile-time error.
+
+    *In other words, at least one key-value pair anywhere in the collection
+    forces it to be a map, and a bare expression forces it to be a set. Having
+    both is an error.*
+
+1.  Else, if *e* has no `typeArguments`, no useful context type, and no
+    `elements`, then *e* is treated as a map literal with unknown static type.
+    *In other words, an empty `{}` is a map unless we have a context that
+    indicates otherwise.*
+
+1.  Otherwise, *e* is still ambiguous. This can only happen when *e* is
+    non-empty but contains no *leaf elements*. In other words, it contains only
+    spreads or spreads wrapped in if and for elements. In this case, the
+    disambiguation will happen during type inference, defined below.
+
+If this process successfully disambiguates the literal, then we say that *e* is
+"unambiguously a map" or "unambiguously a set", as appropriate.
+
+### Type inference
+
+#### Maps and sets
+
+We perform inference on the literal, and collect up either a set element type
+(indicating that the literal may/must be a set), or a pair of a key type and a
+value type (indicating that the literal may/must be a map), or both. We allow
+both, because spreads of expressions of type `dynamic` do not disambiguate, and
+can be treated as either (it becomes a runtime error to spread a value into the
+wrong kind of literal).
+
+We require that at least one component unambiguously determine the literal form,
+otherwise it is a compile-time error. So, given:
+
+```dart
+dynamic x = <int, int>{};
+Iterable l = [];
+Map m = {};
+```
+
+Then:
+
+```dart
+{...x}       // Static error, because it is ambiguous.
+{...x, ...l} // Statically a set, runtime error when spreading x.
+{...x, ...m} // Statically a map, no runtime error.
+{...l, ...m} // Static error, because it must be both a set and a map.
+```
+
+In a `setOrMapLiteral` *collection*, the inferred type of an `element` is a set
+element type `T`, a pair of a key type `K` and a value type `V`, or both. It is
+computed relative to a context type `P`:
+
+*   If *collection* is unambiguously a set literal, then `P` is `Set<Pe>` where
+    `Pe` is determined by downwards inference, and may be `?` if downwards
+    inference does not constrain it.
+
+*   If *collection* is unambiguously a map literal then `P` is `Map<Pk, Pv>`
+    where `Pk` and `Pv` are determined by downwards inference, and may be `?` if
+    the downwards context does not constrain one or both.
+
+*   Otherwise, *collection* is ambiguous, and the downwards context for the
+    elements of *collection* is `?`.
+
+We say that an element *can be a set* if it has a set element type. Likewise, an
+element *can be a map* if it has a key and value type. We say that an element
+*must be a set* if it can be a set and has and no key type or value type. We say
+that an element *must be a map* if can be a map and has no set element type.
+
+To infer the type of `element`:
+
+*   If `element` is an `expressionElement` with expression `e1`:
+
+    *   If `P` is `?` then the inferred set element type of `element` is the
+        inferred type of the expression `e1` in context `?`.
+
+    *   If `P` is `Set<Ps>` then the inferred set element type of `element`
+        is the inferred type of the expression `e1` in context `Ps`.
+
+*   If `element` is a `mapEntry` `ek: ev`:
+
+    *   If `P` is `?` then the inferred key type of `element` is the inferred
+        type of `ek` in context `?` and the inferred value type of `element` is
+        the inferred type of `ev` in context `?`.
+
+    *   If `P` is `Map<Pk, Pv>` then the inferred key type of `element` is the
+        inferred type of `ek` in context `Pk` and the inferred value type of
+        `element` is the inferred type of `ev` in context `Pv`.
+
+*   If `element` is a `spreadElement` with expression `e1`:
+
+    *   If `P` is `?` then let `S` be the inferred type of `e1` in context `?`:
+
+        *   If `S` is a non-`Null` subtype of `Iterable<Object>`, then the
+            inferred set element type of `element` is `T` where `T` is the type
+            such that `Iterable<T>` is a superinterface of `S` (the result of
+            constraint matching for `X` using the constraint `S <:
+            Iterable<X>`).
+
+        *   If `S` is a non-`Null` subtype of `Map<Object, Object>`, then the
+            inferred key type of `element` is `K` and the inferred value type of
+            `element` is `V`, where `K` and `V` are the types such that `Map<K,
+            V>` is a superinterface of `S` (the result of constraint matching
+            for `X` and `Y` using the constraint `S <: Map<X, Y>`).
+
+            *Note that both this and the previous case can match on the same
+            element if `S` is a subtype of both `Iterable<Object>` and
+            `Map<Object, Object>`. In that case, we rely on other elements to
+            disambiguate.*
+
+        *   If `S` is `dynamic`, then the inferred set element type of `element`
+            is `dynamic`, the inferred key type of `element` is `dynamic`, and
+            the inferred value type of `element` is `dynamic`. *(We produce both
+            a set element type here, and a key/value pair here and rely on other
+            elements to disambiguate.)*
+
+        *   If `S` is `Null` and the spread operator is `...?` then the element
+            has set element type `Null`, map key type `Null` and map value type
+            `Null`.
+
+        *   If none of these cases match, it is an error.
+
+    *   If `P` is `Set<Ps>` then let `S` be the inferred type of `e1` in context
+        `Iterable<Ps>`:
+
+        *   If `S` is a non-`Null` subtype of `Iterable<Object>`, then the
+            inferred set element type of `element` is `T` where `T` is the type
+            such that `Iterable<T>` is a superinterface of `S` (the result of
+            constraint matching for `X` using the constraint `S <:
+            Iterable<X>`).
+
+        *   If `S` is `dynamic`, then the inferred set element type of `element`
+            is `dynamic`.
+
+        *   If `S` is `Null` and the spread operator is `...?`, then the set
+            element type is `Null`.
+
+        *   Otherwise it is an error.
+
+    *   If `P` is `Map<Pk, Pv>` then let `S` be the inferred type of `e1` in
+        context `P`:
+
+        *   If `S` is a non-`Null` subtype of `Map<Object, Object>`, then the
+            inferred key type of `element` is `K` and the inferred value type of
+            `element` is `V`, where `K` and `V` are the types such that `Map<K,
+            V>` is a superinterface of `S` (the result of constraint matching
+            for `X` and `Y` using the constraint `S <: Map<X, Y>`).
+
+        *   If `S` is `dynamic`, then the inferred key type of `element` is
+            `dynamic`, and the inferred value type of `element` is `dynamic`.
+
+        *   If `S` is `Null` and the spread operator is `...?`, then the key and
+            value element types are `Null`.
+
+        *   Otherwise it is an error.
+
+*   If `element` is an `ifElement` with one `element`, `p1`, and no "else"
+    element:
+
+    The condition is inferred with a context type of `bool`.
+
+    *   If the inferred set element type of `p1` is `S` then the inferred set
+        element type of `element` is `S`.
+
+    *   If the inferred key type of `p1` is `K` and the inferred value type of
+        `p1` is `V` then the inferred key and value types of `element` are `K`
+        and `V`.
+
+    *Note that both of the above cases can simultaneously apply because of
+    `dynamic` spreads.*
+
+*   If `element` is an `ifElement` with two `element`s, `e1` and `e2`:
+
+    The condition is inferred with a context type of `bool`.
+
+    It is a compile error if `e1` must be a set and `e2` must be a map or vice
+    versa. *In other words, you can't spread a map on one branch and a set on
+    the other. Since `dynamic` provides both set and map key/value types, a
+    `dynamic` in either branch does not run into this case.*
+
+    *   If the inferred set element type of `e1` is `S1` and the inferred set
+        element type of `e2` is `S2` then the inferred set element type of
+        `element` is the least upper bound of `S1` and `S2`.
+
+    *   If the inferred key type of `e1` is `K1` and the inferred key type of
+        `e1` is `V1` and the inferred key type of `e2` is `K2` and the inferred
+        key type of `e2` is `V2` then the inferred key type of `element` is the
+        least upper bound of `K1` and `K2` and the inferred value type is the
+        least upper bound of `V1` and `V2`.
+
+    *Note that both of the above cases can simultaneously apply because of
+    `dynamic` spreads.*
+
+*   If `element` is a `forElement` with `element` `e1` then:
+
+    Inference for the iterated expression and the controlling variable is done
+    as for the corresponding `for` or `await for` statement.
+
+    *   If the inferred set element type of `e1` is `S` then the inferred set
+        element type of `element` is `S`.
+
+    *   If the inferred key type of `e1` is `K` and the inferred key type of
+        `e1` is `V` then the inferred key and value types of `element` are `K`
+        and `V`.
+
+    *In other words, inference flows upwards from the body element. Note that
+    both of the above cases can validly apply because of `dynamic` spreads.*
+
+Finally, we define inference on a `setOrMapLiteral` *collection* as follows:
+
+*   If *collection* is unambiguously a set literal:
+
+    *   If `P` is `?` then the static type of *collection* is `Set<T>` where `T`
+        is the least upper bound of the inferred set element types of the
+        elements.
+
+    *   Otherwise, the static type of *collection* is `P`.
+
+    *Note that the element inference will never produce a key/value type here
+    given that downwards context.*
+
+*   Else, f *collection* is unambiguously a map literal where `P` is `Map<Pk,
+    Pv>`:
+
+    *   If `Pk` is `?` then the static key type of *collection* is `K` where `K`
+        is the least upper bound of the inferred key types of the elements.
+
+    *   Otherwise the static key type of *collection* is `K` where `K` is
+        determined by downwards inference.
+
+    And:
+
+    *   If `Pv` is `?` then the static value type of *collection* is `V` where
+        `V` is the least upper bound of the inferred value types of the
+        elements.
+
+    *   Otherwise the static value type of *collection* is `V` where `V` is
+        determined by downwards inference.
+
+    The static type of *collection* is `Map<K, V>`.
+
+    *Note that the element inference will never produce a set element type here
+    given this downwards context.*
+
+*   Otherwise, *collection* is still ambiguous, the downwards context for the
+    elements of *collection* is `?`, and the disambiguation is done using the
+    immediate `elements` of *collection* as follows:
+
+    *   If all elements can be a set, and at least one element must be a set,
+        then *collection* is a set literal with static type `Set<T>` where `T`
+        is the least upper bound of the set element types of the elements.
+
+    *   If all elements can be a map, and at least one element must be a map,
+        then *e* is a map literal with static type `Map<K, V>` where `K` is the
+        least upper bound of the key types of the elements and `V` is the least
+        upper bound of the value types.
+
+    *   Otherwise, the literal cannot be disambiguated and it is a compile-time
+        error. This can occur if the literal *must* be both a set and a map,
+        as in:
+
+        ```dart
+        var iterable = [1, 2];
+        var map = {1: 2};
+        var ambiguous = {...iterable, ...map};
+        ```
+
+        Or, if there is nothing indicates that it is *either* a map or set:
+
+        ```dart
+        dynamic dyn;
+        var ambiguous = {...dyn};
+        ```
+
+#### Lists
+
+Inference for list literals mostly follows that of set literals without the
+complexity around disambiguation with maps and using `List` or `Iterable` in a
+few places instead of `Set`.
+
+Inside a `listLiteral`, the inferred type of an `element` is a list element type
+`T`. It is computed relative to a downwards element context type `P`, where `P`
+is `T` if downwards inference constrains the type of `listLiteral` to
+`Iterable<T>` for some `T`. Otherwise, `P` is `?`.
+
+*   If `element` is an `expressionElement` with expression `e1`:
+
+    *   The inferred list element type of `element` is the inferred type of the
+        expression `e1` in context `P`.
+
+*   If `element` is a `spreadElement` with expression `e1`:
+
+    *   If `P` is `?` then let `S` be the inferred type of `e1` in context `?`:
+
+        *   If `S` is a non-`Null` subtype of `Iterable<Object>`, then the
+            inferred list element type of `element` is `T` where `T` is the type
+            such that `Iterable<T>` is a superinterface of `S` (the result of
+            constraint matching for `X` using the constraint `S <:
+            Iterable<X>`).
+
+        *   If `S` is `dynamic`, then the inferred list element type of
+            `element` is `dynamic`.
+
+        *   If `S` is `Null` and the spread operator is `...?`, then the list
+            element type is `Null`.
+
+        *   Otherwise it is an error (because it is a spread of a non-spreadable
+            type like Object).
+
+    *   Else, let `S` be the inferred type of `e1` in context `Iterable<P>`:
+
+        *   If `S` is a non-`Null` subtype of `Iterable<Object>`, then the
+            inferred list element type of `element` is `T` where `T` is the type
+            such that `Iterable<T>` is a superinterface of `S` (the result of
+            constraint matching for `X` using the constraint `S <:
+            Iterable<X>`).
+
+        *   If `S` is `dynamic`, then the inferred list element type of
+            `element` is `dynamic`.
+
+        *   Otherwise it is an error.
+
+*   If `element` is an `ifElement` with one `element`, `p1`, and no "else"
+    element:
+
+    The condition is inferred with a context type of `bool`.
+
+    The inferred list element type of `element` is the inferred list element
+    type of `p1` with element context type `P`.
+
+*   If `element` is a `ifElement` with two `element`s, `p1` and `p2`:
+
+    The condition is inferred with a context type of `bool`.
+
+    The inferred list element type of `element` is the least upper bound of `S1`
+    and `S2` where `S1` is the inferred list element type of `p1` and `S2` is
+    the inferred list element type of `p2`, both with element context type `P`.
+
+*   If `element` is a `forElement` with `element` `p1` then:
+
+    Inference for the iterated expression and the controlling variable is done
+    as for the corresponding `for` or `await for` statement.
+
+    The inferred list element type of `element` is the inferred list element
+    type of `p1` with element context type `P`.
+
+*Note: `element` cannot be a `mapEntry` as those are not allowed inside list
+literals.*
+
+Finally, we define inference on a `listLiteral` *collection* as follows:
+
+*   If `P` is `?` then the static type of *collection* is `List<T>` where
+    `T` is the least upper bound of the inferred list element types of the
+    elements.
+
+*   Otherwise, the static type of *collection* is `List<T>` where `T` is
+    determined by downwards inference.
+
+### Type promotion
+
+An `ifElement` interacts with type promotion in the same way that `if`
+statements do. Given an `ifElement` with condition `condition`, then element
+`thenElement` and optional else element `elseElement`:
+
+*   If `condition` shows that a local variable *v* has type `T`, then the type
+    of *v* is known to be `T` in `thenElement`, unless any of the following are
+    true:
+
+    *   *v* is potentially mutated in `thenElement`,
+    *   *v* is potentially mutated within a function other than the one where
+        *v* is declared, or
+    *   *v* is accessed by a function defined in `thenElement` and
+    *   *v* is potentially mutated anywhere in the scope of *v*.
+
+*Note: The type promotion rules for `if` will likely get more sophisticated in a
+future version of Dart because of non-nullable types. When that happens, `if`
+elements should continue to match `if` statements.*
+
+### Compile-time errors
+
+After type inference and disambiguation, the collection is checked for other
+compile-time errors. It is a compile-time error if:
+
+*   The collection is a map literal and *leaf elements* contains any
+    `expressionElement` elements.
+
+    ```dart
+    <String, int>{"not entry"} // Error.
+    ```
+
+*   The collection is a set literal and *leaf elements* contains any `mapEntry`
+    elements.
+
+    ```dart
+    ["not": "expression"] // Error.
+    <String>{"not": "expression"} // Error.
+    ```
+
+    *We prohibit map entries in list literals syntacitcally, earlier in the
+    proposal.*
+
+*   The collection is a list and the type of any of the *leaf elements* may not
+    be assigned to the list's element type.
+
+    ```dart
+    <int>[if (true) "not int"] // Error.
+    ```
+
+*   The collection is a map and the key type of any of the *leaf elements* may
+    not be assigned to the map's key type.
+
+    ```dart
+    <int, int>{if (true) "not int": 1} // Error.
+    ```
+
+*   The collection is a map and the value type of any of the *leaf elements* may
+    not be assigned to the map's value type.
+
+    ```dart
+    <int, int>{if (true) 1: "not int"} // Error.
+    ```
+
+*   A non-null-aware spread element has static type `Null`.
+
+*   A spread element in a list or set literal has a static type that is not
+    `dynamic` and not a subtype of `Iterable<Object>`.
+
+*   A spread element in a list or set has a static type that implements
+    `Iterable<T>` for some `T` and `T` is not assignable to the element type of
+    the list.
+
+*   A spread element in a map literal has a static type that is not `dynamic`
+    and not a subtype of `Map<Object, Object>`.
+
+*   If a map spread element's static type implements `Map<K, V>` for some `K`
+    and `V` and `K` is not assignable to the key type of the map or `V` is not
+    assignable to the value type of the map.
+
+*   The variable in a `for` element (either `for-in` or C-style) is declared
+    outside of the element to be `final` or to not have a setter.
+
+    ```dart
+    final i = 0;
+    [for (i in [1]) i] // Error.
+    ```
+
+*   The type of the iterator expression in a synchronous `for-in` element may
+    not be assigned to `Iterable<T>` for some type `T`. Otherwise, the *iterable
+    type* of the iterator is `T`.
+
+    ```dart
+    [for (var i in "not iterable") i] // Error.
+    ```
+
+*   The iterable type of the iterator in a synchronous `for-in` element may not
+    be assigned to the `for-in` variable's type.
+
+    ```dart
+    [for (int i in ["not", "int"]) i] // Error.
+    ```
+
+*   The type of the stream expression in an asynchronous `await for-in`
+    element may not be assigned to `Stream<T>` for some type `T`. Otherwise,
+    the *stream type* of the stream is `T`.
+
+    ```dart
+    [await for (var i in "not stream") i] // Error.
+    ```
+
+*   The stream type of the iterator in an asynchronous `await for-in` element
+    may not be assigned to the `for-in` variable's type.
+
+    ```dart
+    [await for (int i in Stream.fromIterable(["not", "int"])) i] // Error.
+    ```
+
+*   `await for` is used when the function immediately enclosing the collection
+    literal is not asynchronous.
+
+    ```dart
+    main() {
+      [await for (_ in stream)]; // Error.
+    }
+    ```
+
+*   `await` is used before a C-style `for` element. `await` can only be used
+    with `for-in` loops.
+
+    ```dart
+    main() {
+      [await for (;;)]; // Error.
+    }
+    ```
+
+*   The type of the condition expression (the second clause) in a C-style `for`
+    element may not be assigned to `bool`.
+
+    ```dart
+    [for (; "not bool";) 1] // Error.
+    ```
+
+## Constant Semantics
+
+The runtime semantics below are used to determine the compile-time value of a
+constant collection literal, which is defined as a `listLiteral` or
+`setOrMapLiteral` that occurs in a constant context or directly preceded by
+`const`.
+
+Elements in a collection may be constant, potentially constant, or neither. All
+`elements` directly inside in a constant collection must be constant elements.
+They are defined as:
+
+*   An `expressionElement` is a constant element if its expression is a constant
+    expression, and a potentially constant element if it's expression is a
+    potentially constant expression.
+
+*   A `mapEntry` is a constant element if both its key and value expression are
+    constant expressions, and a potentially constant element if both are
+    potentially constant expressions.
+
+*   A `spreadElement` starting with `...` is a constant element if its
+    expression is constant and it evaluates to a constant `List`, `Set` or `Map`
+    instance originally created by a list, set or map literal. It is a
+    potentially constant element if the expression is a potentially constant
+    expression.
+
+*   A `spreadElement` starting with `...?` is a constant element if its
+    expression is constant and it evaluates to `null` or a constant `List`,
+    `Set` or `Map` instance originally created by a list, set or map literal. It
+    is a potentially constant element if the expression is potentially constant
+    expression.
+
+*   An `ifElement` is a constant element if its condition is a constant
+    expression evaluating to a value of type `bool` and either:
+
+    *   The condition evaluates to `true`, the "then" element is a constant
+        expression, and the "else" element (if it exists) is a potentially
+        constant element.
+
+    *   The condition evaluates to `false`, the "then" element is a potentially
+        constant element, and the "else" element (if it exists) is a constant
+        element.
+
+*   An `ifElement` is potentially constant if its condition, "then" element, and
+    "else" element (if any) are potentially constant expressions.
+
+*   A `forElement` is never a constant or potentially constant element. A `for`
+    element cannot be used in constant collection literals.
+
+Also:
+
+*   It is a compile-time error if any element in a constant set or key in a
+    constant map does not have a primitive operator `==`.
+
+*   When evaluating a const collection literal, if another const collection has
+    previously been evaluated that:
+
+    *   is of the same kind (map, set, or list),
+    *   has the same type arguments,
+    *   and contains the same (identical) elements or key/value entries in the
+        same order,
+
+    then the current literal evaluates to the value of that previous literal.
+    *In other words, constants are canonicalized.* Note that maps and sets are
+    only canonicalized if they contain the same keys or elements *in the same
+    order*.
+
+## Dynamic Semantics
+
+Spread, `if`, and `for` behave similarly across all collection types. To
+simplify the spec, there is a single procedure used for all kinds of
+collections. This recursive procedure builds up either a *result* sequence of
+values or key-value pair map entries. Then a final step handles those
+appropriately for the given collection type.
+
+### To evaluate a collection `element`:
+
+1.  If `element` is an expression element:
+
+    1.  Evaluate the element's expression and append it to *result*.
+
+1.  Else, `element` is a `mapEntry` `keyExpression: valueExpression`:
+
+    1.  Evaluate `keyExpression` to a value *key*.
+
+    1.  Evaluate `valueExpression` to a value *value*.
+
+    1.  Append an entry *key*: *value* to *result*.
+
+1.  Else, if `element` is a spread element:
+
+    1.  Evaluate the spread expression to a value `spread`.
+
+    1.  If `element` is not null-aware and `spread` is `null`, throw a dynamic
+        exception.
+
+    1.  Else, if `element` is null-aware and `spread` is `null`, do nothing.
+
+    1.  Else, if the collection is a map:
+
+        1.  If `spread` is not an instance of a class that implements `Map`,
+            throw a dynamic exception.
+
+        1.  Evaluate `spread.entries.iterator` to a value `iterator`.
+
+        1.  Loop:
+
+            1.  Evaluate `iterator.moveNext()` to a value `hasValue`.
+
+            1.  If `hasValue` is `true`:
+
+                1.  Evaluate `iterator.current` to a value `entry`.
+
+                1.  Evaluate `entry.key` to a value *key*.
+
+                1.  Evaluate `entry.value` to a value *value*.
+
+                1.  If *key* is not a subtype of the map's key type, throw a
+                    dynamic error.
+
+                1.  If *value* is not a subtype of the map's value type, throw a
+                    dynamic error.
+
+                An implementation is free to execute the previous four
+                operations in any order, except that obviously the key must be
+                evaluated before its type is checked, and likewise for the
+                value.
+
+                1.  Append an entry *key*: *value* to *result*.
+
+            1.  Else, if `hasValue` is `false`, exit the loop.
+
+            1.  Else, throw a dynamic error.
+
+    1.  Else, the collection is a list or set:
+
+        1.  If `spread` is not an instance of a class that implements
+            `Iterable`, throw a dynamic exception.
+
+        1.  Evaluate `spread.iterator` to *iterator*.
+
+        1.  Loop:
+
+            1.  Evaluate `iterator.moveNext()` to a value `hasValue`.
+
+            1.  If `hasValue` is `true`:
+
+                1.  Evaluate `iterator.current` to a value *value*.
+
+                1.  If *value* is not a subtype of the collection's element
+                    type, throw a dynamic error.
+
+                1.  Append *value* to *result*.
+
+            1.  Else, if `hasValue` is `false`, exit the loop.
+
+            1.  Else, throw a dynamic error.
+
+    The `iterator` API may not be the most efficient way to traverse the items
+    in a collection. In order to give implementations more room to optimize, we
+    loosen the semantics:
+
+    *   If `spread` is an object whose class implements List, Queue, or Set (all
+        from `dart:core`), an implementation *may* choose to call `length` on
+        the object. This may let it allocate space for the resulting collection
+        more efficiently. Classes that implement these are expected to have an
+        efficient, side-effect free implementation of `length`.
+
+    *   If `spread` is an object whose class implements List from `dart:core`,
+        an implementation may choose to call `[]` to access elements from the
+        list. If it does so, it will only pass indexes `>= 0` and `<` the value
+        returned by `length`.
+
+    A Dart implementation may detect whether these options apply at compile time
+    based on the static type of `spread` or at runtime based on the actual
+    value.
+
+1.  Else, if `element` is an `ifElement`:
+
+    1.  Evaluate the condition expression to a value `condition`.
+
+    1.  If `condition` is `true`:
+
+        1.  Evaluate the "then" element using this procedure.
+
+    1.  Else, if `condition` is `false`:
+
+        1.  If there is an "else" element of the `if`:
+
+            1.  Evaluate the "else" element using this procedure.
+
+    1.  Else, throw a dynamic error.
+
+1.  Else, if `element` is a synchronous `forElement` for a `for-in` loop:
+
+    1.  Evaluate the iterator expression to a value `sequence`.
+
+    1.  If `sequence` is not an instance of a class that implements `Iterable`,
+        throw a dynamic exception.
+
+    1.  Evaluate `sequence.iterator` to a value `iterator`.
+
+    1.  Loop:
+
+        1.  Evaluate `iterator.moveNext()` to a value `hasValue`.
+
+        1.  If `hasValue` is `true`:
+
+            1.  If the `for-in` element declares a variable, create a new
+                namespace and a fresh `variable` for it. Otherwise, use the
+                existing `variable` it refers to.
+
+            1.  Bind `variable` to the result of evaluating `iterator.current`.
+
+            1.  Evaluate the body element using this procedure in the scope of
+                `variable`.
+
+        1.  Else, if `hasValue` is `false`, exit the loop.
+
+        1.  Else, throw a dynamic error.
+
+1.  Else, if `element` is an asynchronous `await for-in` element:
+
+    1.  Evaluate the stream expression to a value `stream`.
+
+    1.  If `stream` is not an instance of a class that implements `Stream`,
+        throw a dynamic error.
+
+    1.  Pause the subscription of any surrounding `await for` loop in the
+        current method.
+
+    1.  Let `streamDone` be a value implementing `Future<Null>`.
+
+    1.  Listen on `stream` and take the following actions on events:
+
+        *   On a data event with value `value`:
+
+            1.  If the `for-in` element declares a variable, create a new
+                namespace and a fresh `variable` for it. Otherwise, use the
+                existing `variable` it refers to.
+
+            1.  Bind `variable` to `value`.
+
+            1.  Evaluate the body element using this procedure.
+
+            1.  If evaluation of the body throws an error `error` and stack
+                trace `stack`, then:
+
+                1.  Stop listening on the stream by calling the `cancel()`
+                    method of the corresponding stream subscription, which
+                    returns a future `f`.
+
+                1.  Wait for `f` to complete. If `f` completes with an error
+                    `error2` and stack trace `stack2`, then complete
+                    `streamDone` with error `error2` and stack trace `stack2`.
+                    Otherwise complete `streamDone` with error `error` and stack
+                    trace `stack`.
+
+            1.  Else, evaluation of the body element completes successfully.
+
+                1.  Resume the stream subscription if it has been paused.
+
+        *   On an error event with error `error` and stack trace `stack`:
+
+            1.  Stop listening on the stream by calling the `cancel()` method of
+                the corresponding stream subscription, which returns a future
+                `f`.
+
+            1.  Wait for `f` to complete. If `f` completes with an error
+                `error2` and stack trace `stack2`, then complete `streamDone`
+                with error `error2` and stack trace `stack2`. Otherwise complete
+                `streamDone` with error `error` and stack trace `stack`.
+
+        *   On a done event, complete `streamDone` with the value `null`.
+
+    1.  Evaluation of the `for-in` element completes when `streamDone`
+        completes. If `streamDone` completes with an error `error` and stack
+        trace `stack`, then evaluation of the element throws `error` with stack
+        trace `stack`, otherwise the evaluation completes successfully.
+
+1.  Else, `element` is a C-style `for` element:
+
+    1.  Evaluate the initializer clause of the element, if there is one.
+
+    1.  Loop:
+
+        1.  If the initializer clause declares a variable, create a new
+            namespace and bind that variable in that namespace.
+
+        1.  Evaluate the condition expression to a value `condition`. If there
+            is no condition expression, use `true`.
+
+        1.  If `condition` is `true`:
+
+            1.  Evaluate the body element using this procedure in the namespace
+                of the variable declared by the initializer clause if there is
+                one.
+
+            1.  If there is an increment clause, execute it.
+
+        1.  Else, if `condition` is `false`, exit the loop.
+
+        1.  Else, throw a dynamic error.
+
+The procedure theoretically supports a mixture of expressions and map entries,
+but the static semantics prohibit an actual literal containing that.
+
+Once the *result* series of values or entries is produced from the tree of
+elements, the final object is produced from that based on what kind of literal
+it is:
+
+### List
+
+1.  The result of the literal expression is a fresh instance of a class that
+    implements `List<E>` where `E` is the element type of the literal. It
+    contains the values in *result*, in order. If the literal is constant, the
+    list is canonicalized and immutable, otherwise it is not.
+
+### Set
+
+1.  Create a fresh instance *set* of a class that implements `Set<E>` where `E`
+    is the set element type of the literal.
+
+1.  For each *value* in *result*:
+
+    1.  If *set* contains a value *existing* that is equal to *value*
+        according to *existing*'s `==` operator:
+
+        1.  If the literal is constant, it is a compile-time error.
+
+        1.  Else, do nothing. *Duplicates are discarded and the first one wins.*
+
+    1.  Else, add *value* to *set*.
+
+1.  The result of the literal expression is *set*. If the literal is constant,
+    canonicalize it make the set immutable.
+
+### Map
+
+1.  Allocate a fresh instance *map* of a class that implements `LinkedHashMap<K,
+    V>` where `K` is the key type of the literal and `V` is the value type.
+
+1.  For each entry *key*: *value* in *result*:
+
+    1.  If *map* contains an entry *existing* whose key *existingKey* is equal
+        to *key* according to *existingKeys*'s `==` operator:
+
+        1.  If the literal is constant, it is a compile-time error.
+
+        1.  Else, replace the value in *existing* with *value*, while keeping
+            its position in the sequence of entries and *existingKey* the same.
+
+    1.  Else add entry *key*: *value* to *map*.
+
+1.  The result of the map literal expression is *map*. If the literal is
+    constant, canonicalize it and make the map immutable.
+
+
+
 
 \printindex
 

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -1940,8 +1940,10 @@ and neither does any part of a declaration marked \STATIC.%
 }
 
 \LMHash{}%
-Every class has a single superclass except class \code{Object} which has no superclass.
-A class may implement a number of interfaces by declaring them in its implements clause (\ref{superinterfaces}).
+Every class has a single superclass
+except class \code{Object} which has no superclass.
+A class may implement a number of interfaces
+by declaring them in its implements clause (\ref{superinterfaces}).
 
 \LMHash{}%
 An \IndexCustom{abstract class declaration}{class declaration!abstract}
@@ -4031,8 +4033,6 @@ from one of its superinterfaces
 }
 
 \LMHash{}%
-%% TODO(eernst): 'list of interfaces' --> 'set of interfaces' if we
-%% switch to use a total order on top types for interface specificity.
 The \Index{combined interface} $I$ of a list of interfaces \List{I}{1}{k}
 is the interface that declares the set of member signatures $M$,
 where $M$ is determined as specified below.
@@ -4272,6 +4272,49 @@ An interface has a set of direct superinterfaces
 An interface $J$ is a \Index{superinterface} of an interface $I$
 if{}f either $J$ is a direct superinterface of $I$
 or $J$ is a superinterface of a direct superinterface of $I$.
+
+\LMHash{}%
+When we say that a type $S$
+\IndexCustom{implements}{type!implements a type}
+another type $T$,
+this means that $T$ is a superinterface of $S$.
+Assume that $G$ is a raw type
+(\ref{instantiationToBound})
+whose declaration declares $s$ type parameters.
+When we say that a type $S$
+\IndexCustom{implements}{type!implements a raw type}
+$G$,
+this means that there exist types \List{U}{1}{s}
+such that \code{$G$<\List{U}{1}{s}>} is a superinterface of $S$.
+
+\commentary{%
+Note that this is not the same as being a subtype.
+For instance, \code{List<int>} implements \code{Iterable<int>},
+but it does not implement \code{Iterable<num>}.
+Similarly, \code{List<int>} implements \code{Iterable}.
+Also, note that when $S$ implements $T$
+where $T$ is not a subtype of \code{Null},
+$S$ cannot be a subtype of \code{Null}.%
+}
+
+\LMHash{}%
+Assume that $S$ is a type and $G$ is a raw type such that $S$ implements $G$.
+It is then guaranteed that there exist \List{U}{1}{s} which are types such that
+\code{$G$<\List{U}{1}{s}>} is a superinterface of $S$.
+We then say that \List{U}{1}{s} are
+\IndexCustom{the type arguments of $S$ at $G$}{type arguments!of a type at a raw type},
+and we say that $U_j$ is
+\IndexCustom{the $j$th type argument of $S$ at $G$}{%
+  type arguments!of a type at a raw type, $j$th}.
+
+\commentary{%
+For instance, the type argument of \code{List<int>} at \code{Iterable}
+is \code{int}.
+This concept is particularly useful when
+the chain of direct superinterfaces from $S$ to $G$
+does not just pass all type arguments on unchanged, e.g.,
+with a declaration like \code{\CLASS\,\,C<X,\,Y>\,\,\EXTENDS\,\,B<List<Y>,\,Y,\,X> \{\}}.%
+}
 
 
 \subsubsection{Inheritance and Overriding}
@@ -7247,8 +7290,8 @@ It is a compile-time error if:
 An \synt{ifElement} interacts with type promotion
 in the same way that \IF{} statements do.
 Assume that $\ell$ is an \synt{ifElement} of the form
-\code{\IF{} ($b$) $\ell_1$} or
-\code{\IF{} ($b$) $\ell_1$ \ELSE{} $\ell_2$}.
+\code{\IF\,\,($b$)\,\,$\ell_1$} or
+\code{\IF\,\,($b$)\,\,$\ell_1$\,\,\ELSE\,\,$\ell_2$}.
 If $b$ shows that a local variable $v$ has type $T$, then
 the type of $v$ is known to be $T$ in $\ell_1$,
 unless any of the following are true:
@@ -7308,13 +7351,13 @@ and which is specified separately
 (\ref{lists}, \ref{maps}, \ref{sets}).%
 
 There may be an actual data structure
-representing object sequences at run time,
-but object sequences could also be eliminated, e.g.,
+representing the object sequence at run time,
+but the object sequence could also be eliminated, e.g.,
 because each element is inserted directly into the target collection
 as soon as it has been computed.
 Note that each object sequence will exclusively contain objects,
 or it will exclusively contain pairs,
-because any mixed sequence would cause
+because any attempt to create a mixed sequence would cause
 an error at compile time or
 (for a spread element with static type \DYNAMIC{})
 at run time.%
@@ -7354,14 +7397,25 @@ obtained by evaluating each element $\ell_j$, $j \in 1 .. k$:
 $s_{\metavar{object}}=\EvaluateElement{\ell_1}+\ldots+\EvaluateElement{\ell_k}$,
 where \EvaluateElement{\ell_j} denotes the object sequence yielded by
 evaluation of a single collection literal element $\ell_j$.
-The object sequences for elements
-must be computed in the textual order,
-because the computations may have side effects.
 
 \LMHash{}%
-We use the notation $\EvaluateElement{\ell} := s$
-at specific points where the computation is complete,
-in order to specify that the value of \EvaluateElement{\ell} is $s$.
+When a pseudo-statement of the form
+\code{$s = s + \EvaluateElement{\ell}$;}
+is used in normative code below,
+it denotes the extension of $s$ with the object sequence
+yielded by evaluation of $\ell$,
+but it also denotes the specification of actions taken to produce
+said object sequence,
+and to produce the side effects associated with this computation,
+as implied by evaluation of expressions which is specified below to be
+part of the evaluation of \EvaluateElement{\ell}.
+
+\LMHash{}%
+When a pseudo-statement of the form
+\code{$\EvaluateElement{\ell} := s$;}
+occurs in normative code below,
+at a point where the computation is complete,
+it specifies that the value of \EvaluateElement{\ell} is $s$.
 \IndexCustom{Evaluation of a collection literal element $\ell$}{%
   collection literal element!evaluation}
 in the given context
@@ -7500,6 +7554,7 @@ we also allow the following.%
 
 \LMHash{}%
 If $o$ is an object whose dynamic type implements
+(\ref{superinterfaces})
 \code{List}, \code{Queue}, or \code{Set},
 an implementation may choose to call \code{length} on the object.
 
@@ -7525,8 +7580,8 @@ or at runtime based on the actual value.
 \LMHash{}%
 \Case{If element}
 When $\ell$ is an \synt{ifElement} of the form
-\code{\IF{} ($b$) $\ell_1$} or
-\code{\IF{} ($b$) $\ell_1$ \ELSE{} $\ell_2$},
+\code{\IF\,\,($b$)\,\,$\ell_1$} or
+\code{\IF\,\,($b$)\,\,$\ell_1$\,\,\ELSE\,\,$\ell_2$},
 the condition $b$ is evaluated to a value $o_b$.
 If $o_b$ is \TRUE{} then
 $\EvaluateElement{\ell} := \EvaluateElement{\ell_1}$.
@@ -7565,7 +7620,8 @@ $\EvaluateElement{\ell} := s$;
 \vspace{-3mm}
   \caption{Evaluation of a \synt{forElement} $\ell$ of the form
     \code{\AWAIT?\,\,\FOR\,\,($P$)\,\,$\ell_1$},
-    where $P$ is derived from \synt{forLoopParts}
+    where $P$ is derived from
+    % \syntax{<forInitializerStatement> <expression>? `;' <expressionList>?}
     and \AWAIT{} is included in both the for element and the code,
     or omitted in both.}
   \label{fig:evaluationOfAForLoopElement}
@@ -7584,7 +7640,8 @@ in the static and dynamic context where $\ell$ occurs.
 
 \LMHash{}%
 \Case{For loop element}
-Let $P$ be a term derived from \synt{forLoopParts} and
+Let $P$ be a term derived from
+\syntax{<forInitializerStatement> <expression>? `;' <expressionList>?} and
 let $\ell$ be a \synt{forElement} of the form
 \code{\AWAIT?\,\,\FOR\,\,($P$)\,\,$\ell_1$},
 where `\AWAIT?' indicates that \AWAIT{} may be present or absent.
@@ -7796,23 +7853,23 @@ It is computed relative to a downwards element context type $P$,
 where $P$ is $T$
 if downwards inference constrains the type of \metavar{listLiteral}
 to \code{Iterable<$T$>} for some $T$.
-Otherwise, $P$ is \lit{?}.
+Otherwise, $P$ is \FreeContext{}.
 
 \begin{itemize}
 \item
-  If $\ell$ is an \synt{expressionElement} with expression $e1$:
+  If $\ell$ is an \synt{expressionElement} with expression $e_1$:
   \begin{itemize}
   \item
     The inferred list element type of $\ell$ is
-    the inferred type of the expression $e1$ in context $P$.
+    the inferred type of the expression $e_1$ in context $P$.
   \end{itemize}
 \item
-  If $\ell$ is a \synt{spreadElement} with expression $e1$:
+  If $\ell$ is a \synt{spreadElement} with expression $e_1$:
 
   \begin{itemize}
   \item
-    If $P$ is \lit{?} then let $S$ be
-    the inferred type of $e1$ in context \lit{?}:
+    If $P$ is \FreeContext{} then let $S$ be
+    the inferred type of $e_1$ in context \FreeContext{}:
 
     \begin{itemize}
     \item
@@ -7839,7 +7896,7 @@ Otherwise, $P$ is \lit{?}.
       \end{itemize}
     \item
       Else, let $S$ be
-      the inferred type of $e1$ in context \code{Iterable<$P$>}:
+      the inferred type of $e_1$ in context \code{Iterable<$P$>}:
 
       \begin{itemize}
       \item
@@ -7897,7 +7954,7 @@ as follows:
 
 \begin{itemize}
 \item
-  If $P$ is \lit{?} then
+  If $P$ is \FreeContext{} then
   the static type of \metavar{collection} is \code{List<$T$>} where $T$ is
   the least upper bound of the inferred list element types of the elements.
 \item
@@ -7966,9 +8023,11 @@ the first applicable entry in the following list:
   \code{Map<$T_1$, $T_2$>}.
   Otherwise a compile-time error occurs.
 \item
-  When \code{Iterable} is a superinterface of $S$ and \code{Map} is not,
+  When $S$ implements
+  (\ref{superinterfaces})
+  \code{Iterable} but not \code{Map},
   $e$ is a set literal.
-  When \code{Map} is a superinterface of $S$ and \code{Iterable} is not,
+  When $S$ implements \code{Map} but not \code{Iterable},
   $e$ is a map literal.
 \item
   When ${\cal L} \not= \emptyset$ (\commentary{that is, $e$ has leaf elements}):
@@ -7980,9 +8039,11 @@ the first applicable entry in the following list:
 \item
   When $e$ is of the form \code{\{\}} and $S$ is undefined,
   $e$ is a map literal.
-  \commentary{%
-    The fact that \code{\{\}} is a map by default limited the breakage
-    when set literals were introduced.%
+  \rationale{%
+    There is no deeper reason for this choice,
+    but the fact that \code{\{\}} is a map by default
+    was useful when set literals were introduced,
+    because it would be a breaking change to make it a set.%
   }
 \item
   Otherwise, $e$ is still ambiguous.
@@ -8003,345 +8064,397 @@ it will be determined by type inference
 \LMHash{}%
 If this process successfully disambiguates the literal
 then we say that $e$ is
-\IndexCustom{unambiguously a set}{set!unambiguously},
+\IndexCustom{unambiguously a set}{set!unambiguously}
 or
-\IndexCustom{unambiguously a map}{map!unambiguously}
+\IndexCustom{unambiguously a map}{map!unambiguously},
 as appropriate.
 
 
 \subsubsection{Set and Map Literal Inference}
 \LMLabel{setAndMapLiteralInference}
 
-!!!HERE!!!
-
 \LMHash{}%
-We perform inference on the literal,
-and collect up either a set element type
-(\commentary{indicating that the literal may/must be a set}),
-or a pair of a key type and a value type
-(\commentary{indicating that the literal may/must be a map}),
-or both.
-We allow both, because spreads of expressions of type \DYNAMIC{}
-do not disambiguate,
-and can be treated as either
-(\commentary{%
-it becomes a runtime error to spread a value into the wrong kind of literal%
-}).
+This section specifies how a \synt{setOrMapLiteral} $e$ is traversed
+and an associated
+\IndexCustom{inferred element type}{set or map literal!element type}
+and/or an associated
+\IndexCustom{inferred key and value type pair}{%
+  set or map literal!key and value type pair}
+is determined.
 
-\LMHash{}%
-We require that
-at least one component unambiguously determine the literal form,
-otherwise it is a compile-time error.
-So, given:
+\commentary{%
+If $e$ has an element type then it may be a set,
+and if it has a key and value type pair then it may be a map.
+%
+However, if the literal $e$ contains a spread element of type \DYNAMIC{},
+that element cannot be used to determine whether $e$ is a set or a map.
+The ambiguity is represented as having \emph{both}
+an element type and a key and value type pair.
+
+It is an error if the ambiguity is not resolved by some other elements,
+but if it is resolved then the dynamic spread element is required
+to evaluate to a suitable instance
+(implementing \code{Iterable} when $e$ is a set,
+and implementing \code{Map} when $e$ is a map),
+which means that it is a dynamic error if there is a mismatch.
+In other situations it is a compile-time error to have both
+an element type and a key and value type pair,
+because $e$ must then be both a set and a map.
+Here is an example:%
+}
 
 \begin{dartCode}
 \DYNAMIC{} x = <int, int>\{\};
 Iterable l = [];
-Map m = {};
+Map m = \{\};
+\\
+\VOID{} main() \{
+  \{...x\}       // \comment{Compile-time error: ambiguous}
+  \{...x, ...l\} // \comment{A set, dynamic error when `x` is evaluated}
+  \{...x, ...m\} // \comment{A map, no dynamic errors}
+  \{...l, ...m\} // \comment{Compile-time error: must be both a set and a map}
+\}
 \end{dartCode}
 
 \LMHash{}%
-Then:
-
-\begin{dartCode}
-\{...x\}       // \comment{Static error, because it is ambiguous.}
-\{...x, ...l\} // \comment{Statically a set, runtime error when spreading x.}
-\{...x, ...m\} // \comment{Statically a map, no runtime error.}
-\{...l, ...m\} // \comment{Static error, because it must be both a set and a map.}
-\end{dartCode}
-
-\LMHash{}%
-In a \synt{setOrMapLiteral} \metavar{collection},
-the inferred type of an \synt{element} is a set element type $T$,
-a pair of a key type $K$ and a value type $V$, or both.
-It is computed relative to a context type $P$:
+Let \metavar{collection} be a collection literal
+derived from \synt{setOrMapLiteral}.
+The inferred type of an \synt{element} is an element type $T$,
+a pair of a key and value type $(K, V)$, or both.
+It is computed relative to a context type $P$
+(\ref{setAndMapLiteralDisambigutation}),
+which is determined as follows:
 
 \begin{itemize}
 \item
-  If \metavar{collection} is unambiguously a set literal,
-  then $P$ is \code{Set<Pe>} where $Pe$ is determined by downwards inference,
-  and may be \lit{?} if downwards inference does not constrain it.
+  If \metavar{collection} is unambiguously a set
+  (\ref{setAndMapLiteralDisambigutation})
+  then $P$ is \code{Set<$P_e$>},
+  %% TODO(eernst): Add reference when we specify inference.
+  where $P_e$ is determined by downwards inference,
+  and may be \FreeContext{}
+  %% TODO(eernst): Correct this reference when we specify context types.
+  (\ref{setAndMapLiteralDisambigutation})
+  if downwards inference does not constrain it.
+
+  %% TODO(eernst): Remove this when we specify inference.
+  \commentary{%
+    A future version of this document will specify inference,
+    the notion of downwards inference,
+    and constraining.
+    The brief intuition is that inference selects values for
+    type parameters in generic constructs
+    where no type arguments have been provided,
+    aiming at a type which matches a given context type;
+    downwards inference does this by passing information
+    from a given expression into its subexpressions,
+    and upwards inference propagates information in the opposite direction.
+    Constraints are expressed in terms of context types;
+    being unconstrained means having \FreeContext{} as the context type.
+    Having a context type that \emph{contains}
+    one or more occurrences of \FreeContext{}
+    provides a partial constraint on the inferred type.
+  }
 \item
-  If \metavar{collection} is unambiguously a map literal
-  then $P$ is \code{Map<$Pk$, $Pv$>}
-  where $Pk$ and $Pv$ are determined by downwards inference,
-  and may be \lit{?}
+  If \metavar{collection} is unambiguously a map
+  then $P$ is \code{Map<$P_k$, $P_v$>}
+  where $P_k$ and $P_v$ are determined by downwards inference,
+  and may be \FreeContext{}
   if the downwards context does not constrain one or both.
 \item
   Otherwise, \metavar{collection} is ambiguous,
-  and the downwards context for the elements of \metavar{collection} is lit{?}.
+  and the downwards context for the elements of \metavar{collection}
+  is \FreeContext.
 \end{itemize}
 
 \LMHash{}%
 We say that an element
 \IndexCustom{can be a set}{element!can be a set}
-if it has a set element type.
+if it has an element type.
 Likewise, an element
 \IndexCustom{can be a map}{element!can be a map}
-if it has a key and value type.
+if it has a key and value type pair.
 We say that an element
 \IndexCustom{must be a set}{element!must be a set}
-if it can be a set and has and no key type or value type.
+if it can be a set and has and no key and value type pair.
 We say that an element
 \IndexCustom{must be a map}{element!must be a map}
-if can be a map and has no set element type.
+if can be a map and has no element type.
 
 \LMHash{}%
-To infer the type of $\ell$:
+Let $\ell$ be a term derived from \synt{element}.
+Inference of the type of $\ell$ then proceeds as follows:
+
+\LMHash{}%
+\Case{Expression element}
+In this case $\ell$ is an expression $e$.
+%
+If $P$ is \FreeContext,
+the inferred element type of $\ell$ is
+the inferred type of $e$ in context \FreeContext.
+%
+If $P$ is \code{Set<$P_e$>},
+the inferred element type of $\ell$ is
+the inferred type of $e$ in context $P_e$.
+\EndCase
+
+\LMHash{}%
+\Case{Map element}
+In this case $\ell$ is a pair of expressions \code{$e_k$:\,$e_v$}.
+%
+If $P$ is \FreeContext{},
+the inferred key and value type pair of $\ell$ is $(K, V)$,
+where $K$ and $V$ is
+the inferred type of $e_k$ respectively $e_v$,
+in context \FreeContext.
+%
+If $P$ is \code{Map<$P_k$, $P_v$>},
+the inferred key and value type pair of $\ell$ is $(K, V)$,
+where $K$ is
+the inferred type of $e_k$ in context $P_k$, and
+the $V$ is
+the inferred type of $e_v$ in context $P_v$.
+\EndCase
+
+\LMHash{}%
+\Case{Spread element}
+In this case $\ell$ is of the form
+`\code{...$e$}' or `\code{...?$e$}'.
+If $P$ is \FreeContext{} then let $S$ be
+the inferred type of $e_1$ in context \FreeContext.
+Then:
 
 \begin{itemize}
 \item
-  If $\ell$ is an \synt{expressionElement} with expression $e1$:
-  \begin{itemize}
-  \item
-    If $P$ is \lit{?} then the inferred set element type of $\ell$ is
-    the inferred type of the expression $e1$ in context \lit{?}.
-  \item
-    If $P$ is \code{Set<$Ps$>} then the inferred set element type of $\ell$ is
-    the inferred type of the expression $e1$ in context $Ps$.
-  \end{itemize}
-\item
-  If $\ell$ is a \synt{mapElement} \code{$ek$:\,\,$ev$}:
-  \begin{itemize}
-  \item
-    If $P$ is \lit{?} then the inferred key type of $\ell$ is
-    the inferred type of $ek$ in context \lit{?} and
-    the inferred value type of $\ell$ is
-    the inferred type of $ev$ in context \lit{?}.
-  \item
-    If $P$ is \code{Map<$Pk$, $Pv$>} then
-    the inferred key type of $\ell$ is
-    the inferred type of $ek$ in context $Pk$ and
-    the inferred value type of $\ell$ is
-    the inferred type of $ev$ in context $Pv$.
-  \end{itemize}
-\item
-  If $\ell$ is a \synt{spreadElement} with expression $e1$:
-  \begin{itemize}
-  \item
-    If $P$ is \lit{?} then let $S$ be
-    the inferred type of $e1$ in context \lit{?}:
-    \begin{itemize}
-    \item
-      If $S$ is a non-\code{Null} subtype of \code{Iterable<Object>}, then
-      the inferred set element type of $\ell$ is $T$
-      where $T$ is the type such that \code{Iterable<$T$>} is
-      a superinterface of $S$
-      (\commentary{
-        the result of constraint matching for $X$ using the constraint
-        \code{$S$ <: Iterable<$X$>}}).
-    \item
-      If $S$ is a non-\code{Null} subtype of \code{Map<Object, Object>}, then
-      the inferred key type of $\ell$ is $K$ and
-      the inferred value type of $\ell$ is $V$,
-      where $K$ and $V$ are the types such that \code{Map<$K$, $V$>} is
-      a superinterface of $S$
-      (\commentary{%
-        the result of constraint matching for $X$ and $Y$ using
-        the constraint \code{$S$ <: Map<$X$, $Y$>}%
-      }).
-
-      \commentary{%
-        Note that both this and the previous case can match on
-        the same element if $S$ is a subtype of
-        both \code{Iterable<Object>} and \code{Map<Object, Object>}.
-        In that case, we rely on other elements to disambiguate.%
-      }
-    \item
-      If $S$ is \DYNAMIC{}, then
-      the inferred set element type of $\ell$ is \DYNAMIC{},
-      the inferred key type of $\ell$ is \DYNAMIC{}, and
-      the inferred value type of $\ell$ is \DYNAMIC{}.
-
-      \commentary{%
-        We produce both a set element type here,
-        and a key/value pair here
-        and rely on other elements to disambiguate.%
-      }
-    \item
-      If $S$ is \code{Null} and the spread operator is \lit{...?} then
-      the element has set element type \code{Null},
-      map key type \code{Null} and map value type \code{Null}.
-    \item
-      If none of these cases match, it is an error.
-    \end{itemize}
-  \item
-    If $P$ is \code{Set<$Ps$>} then let $S$ be
-    the inferred type of $e1$ in context \code{Iterable<$Ps$>}:
-    \begin{itemize}
-    \item
-      If $S$ is a non-\code{Null} subtype of \code{Iterable<Object>}, then
-      the inferred set element type of $\ell$ is $T$
-      where $T$ is the type such that \code{Iterable<T>} is
-      a superinterface of $S$
-      (\commentary{%
-        the result of constraint matching for $X$ using
-        the constraint \code{$S$ <: Iterable<$X$>}}).
-    \item
-      If $S$ is \DYNAMIC{}, then
-      the inferred set element type of $\ell$ is \DYNAMIC{}.
-    \item
-      If $S$ is \code{Null} and the spread operator is \lit{...?}, then
-      the set element type is \code{Null}.
-    \item
-      Otherwise it is an error.
-    \end{itemize}
-  \item
-    If $P$ is \code{Map<$Pk$, $Pv$>} then let $S$ be
-    the inferred type of $e1$ in context $P$:
-    \begin{itemize}
-    \item
-      If $S$ is a non-\code{Null} subtype of \code{Map<Object, Object>}, then
-      the inferred key type of $\ell$ is $K$ and
-      the inferred value type of $\ell$ is $V$,
-      where $K$ and $V$ are the types such that \code{Map<$K$, $V$>} is
-      a superinterface of $S$
-      (\commentary{%
-        the result of constraint matching for $X$ and $Y$ using
-        the constraint \code{$S$ <: Map<$X$, $Y$>}}).
-    \item
-      If $S$ is \DYNAMIC{}, then
-      the inferred key type of $\ell$ is \DYNAMIC{}, and
-      the inferred value type of $\ell$ is \DYNAMIC{}.
-    \item
-      If $S$ is \code{Null} and the spread operator is \lit{...?}, then
-      the key and value element types are \code{Null}.
-    \item
-      Otherwise it is an error.
-    \end{itemize}
-  \end{itemize}
-\item
-  If $\ell$ is an \synt{ifElement} with one $\ell$, $p1$, and no "else"
-  element:
-  The condition is inferred with a context type of \code{bool}.
-  \begin{itemize}
-  \item
-    If the inferred set element type of $p1$ is $S$ then
-    the inferred set element type of $\ell$ is $S$.
-  \item
-    If the inferred key type of $p1$ is $K$ and
-    the inferred value type of $p1$ is $V$ then
-    the inferred key and value types of $\ell$ are $K$ and $V$.
-
-    \commentary{%
-      Note that both of the above cases can simultaneously apply
-      because of \DYNAMIC{} spreads.%
-    }
-  \end{itemize}
-\item
-  If $\ell$ is an \synt{ifElement} with two elements $e1$ and $e2$:
-
-  The condition is inferred with a context type of \code{bool}.
-
-  It is a compile error if $e1$ must be a set and $e2$ must be a map
-  or vice versa.
+  If $S$ implements \code{Iterable},
+  the inferred element type of $\ell$ is
+  the type argument of $S$ at \code{Iterable}.
 
   \commentary{%
-    In other words, you can't spread
-    a map on one branch and a set on the other.
-    Since \DYNAMIC{} provides both set and map key/value types,
-    a \DYNAMIC{} in either branch does not run into this case.%
+    This is the result of constraint matching for $X$
+    using the constraint $S\,\,<:\,\,\code{Iterable<$X$>}$.
+    Note that when $S$ implements a class like \code{Map} or \code{Iterable},
+    it cannot be a subtype of \code{Null}
+    (\ref{superinterfaces}).
   }
-  \begin{itemize}
-  \item
-    If the inferred set element type of $e1$ is $S1$ and
-    the inferred set element type of $e2$ is $S2$ then
-    the inferred set element type of $\ell$ is
-    the least upper bound of $S1$ and $S2$.
-  \item
-    If the inferred key type of $e1$ is $K1$ and
-    the inferred key type of $e1$ is $V1$ and
-    the inferred key type of $e2$ is $K2$ and
-    the inferred key type of $e2$ is $V2$ then
-    the inferred key type of $\ell$ is
-    the least upper bound of $K1$ and $K2$ and
-    the inferred value type is the least upper bound of $V1$ and $V2$.
-
-    \commentary{%
-      Note that both of the above cases can simultaneously apply
-      because of \DYNAMIC{} spreads.%
-    }
-  \end{itemize}
 \item
-  If $\ell$ is a \synt{forElement} with $\ell$ $e1$ then:
+  If $S$ implements \code{Map},
+  the inferred key and value type pair of $\ell$ is $(K, V)$,
+  where $K$ is the first and $V$ the second type argument
+  of $S$ at \code{Map}.
 
-  Inference for the iterated expression and the controlling variable is done
-  as for the corresponding \FOR{} or \AWAIT{} \FOR{} statement.
+  \commentary{%
+    This is the result of constraint matching for $X$ and $Y$ using
+    the constraint $S\,\,<:\,\,\code{Map<$X$, $Y$>}$.%
 
-  \begin{itemize}
-  \item
-    If the inferred set element type of $e1$ is $S$ then
-    the inferred set element type of $\ell$ is $S$.
-  \item
-    If the inferred key type of $e1$ is $K$ and
-    the inferred key type of $e1$ is $V$ then
-    the inferred key and value types of $\ell$ are $K$ and $V$.
+    Note that this case and the previous case
+    can match on the same element simultaneously
+    when $S$ implements both \code{Iterable} and \code{Map}.
+    The same situation arises several times below.
+    In such cases we rely on other elements to disambiguate.%
+  }
+\item
+  If $S$ is \DYNAMIC{} then
+  the inferred element type of $\ell$ is \DYNAMIC,
+  and the inferred key and value type pair of $\ell$ is
+  $(\DYNAMIC, \DYNAMIC)$.
 
-    \commentary{%
-      In other words, inference flows upwards from the body element.
-      Note that both of the above cases can validly apply
-      because of \DYNAMIC{} spreads.%
-    }
-  \end{itemize}
+  \commentary{%
+    We produce both an element type and a key and value type pair here,
+    and rely on other elements to disambiguate.%
+  }
+\item
+  If $S$ is \code{Null} and the spread operator is \lit{...?} then
+  the element has element type \code{Null},
+  and key and value type pair $(\code{Null}, \code{Null})$.
+\item
+  Otherwise, a compile-time error occurs.
 \end{itemize}
 
-\LMHash{}%
-Finally, we define inference on a \synt{setOrMapLiteral} \metavar{collection}
-as follows:
+\noindent
+Otherwise, if $P$ is \code{Set<$P_e$>} then let $S$ be
+the inferred type of $e_1$ in context \code{Iterable<$P_e$>}, and then:
 
 \begin{itemize}
 \item
-  If \metavar{collection} is unambiguously a set literal:
+  If $S$ implements \code{Iterable},
+  the inferred element type of $\ell$ is
+  the type argument of $S$ at \code{Iterable}.
+  \commentary{%
+    This is the result of constraint matching for $X$ using
+    the constraint $S <: \code{Iterable<$X$>}$.%
+  }
+\item
+  If $S$ is \DYNAMIC{},
+  the inferred element type of $\ell$ is \DYNAMIC{}.
+\item
+  If $S$ is \code{Null} and the spread operator is \lit{...?},
+  the inferred element type of $\ell$ is \code{Null}.
+\item
+  Otherwise, a compile-time error occurs.
+\end{itemize}
+
+\noindent
+Otherwise, if $P$ is \code{Map<$P_k$, $P_v$>} then let $S$ be
+the inferred type of $e_1$ in context $P$, and then:
+
+\begin{itemize}
+\item
+  If $S$ implements \code{Map},
+  the inferred key and value type pair of $\ell$ is $(K, V)$,
+  where $K$ is the first and $V$ the second type argument of
+  $S$ at \code{Map}.
+  \commentary{%
+    This is the result of constraint matching for $X$ and $Y$ using
+    the constraint \code{$S$ <: Map<$X$, $Y$>}.%
+  }
+\item
+  If $S$ is \DYNAMIC,
+  the inferred key and value type pair of $\ell$ is
+
+  \noindent
+  $(\DYNAMIC, \DYNAMIC)$.
+\item
+  If $S$ is \code{Null} and the spread operator is \lit{...?},
+  the inferred key and value type pair $(\code{Null}, \code{Null})$.
+\item
+  Otherwise, a compile-time error occurs.
+\end{itemize}
+\vspace{-5mm}
+\EndCase
+
+\LMHash{}%
+\Case{If element}
+In this case $\ell$ is of the form
+\code{\IF\,\,($b$)\,\,$\ell_1$} or
+\code{\IF\,\,($b$)\,\,$\ell_1$\,\,\ELSE\,\,$\ell_2$}.
+The condition $b$ is always inferred with a context type of \code{bool}.
+
+Assume that \code{\ELSE\,\,$\ell_2$} is not present. Then:
+\begin{itemize}
+\item
+  If the inferred element type of $\ell_1$ is $S$,
+  the inferred element type of $\ell$ is $S$.
+\item
+  If the inferred key and value type pair of $\ell_1$ is $(K, V)$,
+  the inferred key and value type pair of $\ell$ is $(K, V)$.
+\end{itemize}
+
+Otherwise, \code{\ELSE\,\,$\ell_2$} is present.
+It is a compile error if $\ell_1$ must be a set and $\ell_2$ must be a map,
+or vice versa.
+
+\commentary{%
+This means that one cannot spread a map on one branch and a set on the other.
+Since \DYNAMIC{} provides both an element type and a key and value type pair,
+a \DYNAMIC{} spread in either branch does not cause the error to occur.%
+}
+
+Then:
+
+\begin{itemize}
+\item
+  If the inferred element type of $\ell_1$ is $S_1$ and
+  the inferred element type of $\ell_2$ is $S_2$,
+  the inferred element type of $\ell$ is
+  the least upper bound of $S_1$ and $S_2$.
+\item
+  If the inferred key and value type pair of $e_1$ is
+  $(K_1, V_1)$
+  and the inferred key and value type pair of $e_2$ is
+  $(K_2, V_2)$,
+  the inferred key and value type pair of $\ell$ is
+  $(K, V)$,
+  where $K$ is the least upper bound of $K_1$ and $K_2$, and
+  and $V$ is the least upper bound of $V_1$ and $V_2$.
+\end{itemize}
+\vspace{-5mm}
+\EndCase
+
+\LMHash{}%
+\Case{For element}
+In this case $\ell$ is of the form
+\code{\AWAIT?\,\,\FOR\,\,($P$)\,\,$\ell_1$}
+where $P$ is derived from \synt{forLoopParts} and
+`\AWAIT?' indicates that \AWAIT{} may be present or absent.
+
+Inference for the parts
+(\commentary{%
+  such as the iterable expression of a for-in,
+  or the \synt{forInitializerStatement} of a for loop%
+})
+is done as for the corresponding \FOR{} statement,
+including \AWAIT{} if and only if the element includes \AWAIT.
+
+\begin{itemize}
+\item
+  If the inferred element type of $\ell_1$ is $S$ then
+  the inferred element type of $\ell$ is $S$.
+\item
+  If the inferred key and value type pair of $e_1$ is $(K, V)$,
+  the inferred key and value type pair of $\ell$ is $(K, V)$.
+\end{itemize}
+
+\commentary{%
+In other words, inference flows upwards from the body element.%
+}
+\vspace{3mm}
+\EndCase
+
+\LMHash{}%
+Finally, we define
+\Index{type inference on a set or map literal}{%
+  type inference!set or map literal}
+as a whole.
+Assume that \metavar{collection} is derived from \synt{setOrMapLiteral},
+and the context type for \metavar{collection} is $P$.
+
+\begin{itemize}
+\item
+  If \metavar{collection} is unambiguously a set:
 
   \begin{itemize}
   \item
-    If $P$ is \lit{?} then
-    the static type of \metavar{collection} is \code{Set<$T$>} where $T$ is
-    the least upper bound of the inferred set element types of the elements.
+    If $P$ is \FreeContext{} then
+    the static type of \metavar{collection} is \code{Set<$T$>}
+    where $T$ is the least upper bound of
+    the inferred element types of the elements.
   \item
-    Otherwise, the static type of \metavar{collection} is $P$.
+    %% TODO(eernst): Feature spec says $P$, but how can we know that $P$ is a type?
+    Otherwise, the static type of \metavar{collection} is
+    the greatest closure of $P$.
 
     \commentary{%
-      Note that the element inference will never produce a key/value type here
-      given that downwards context.%
+      Note that the inference will never produce a key and value type pair
+      with the given context type.%
     }
   \end{itemize}
 \item
-  Else, if \metavar{collection} is unambiguously a map literal
-  where $P$ is \code{Map<$Pk$, $Pv$>}:
+  If \metavar{collection} is unambiguously a map
+  where $P$ is \code{Map<$P_k$, $P_v$>}
+  and the inferred key and value type pairs are
+  \KeyValueTypeList{K}{V}{1}{n}:
 
-  \begin{itemize}
-  \item
-    If $Pk$ is \lit{?} then
-    the static key type of \metavar{collection} is $K$ where $K$ is
-    the least upper bound of the inferred key types of the elements.
+  If $P_k$ is \FreeContext{},
+  the static key type of \metavar{collection} is $K$
+  where $K$ is the least upper bound of \List{K}{1}{n}.
+  Otherwise the static key type of \metavar{collection} is $K$
+  where $K$ is determined by downwards inference.
 
-  \item
-    Otherwise the static key type of \metavar{collection} is $K$ where $K$ is
-    determined by downwards inference.
-  \end{itemize}
+  If $P_v$ is \FreeContext{},
+  the static value type of \metavar{collection} is $V$
+  where $V$ is the least upper bound of \List{V}{1}{n}.
+  Otherwise the static value type of \metavar{collection} is $V$
+  where $V$ is determined by downwards inference.
+  \commentary{%
+    Note that the element inference will never produce a element type here
+    given this downwards context.%
+  }
 
-  And:
-
-  \begin{itemize}
-  \item
-    If $Pv$ is \lit{?} then
-    the static value type of \metavar{collection} is $V$ where $V$ is
-    the least upper bound of the inferred value types of the elements.
-  \item
-    Otherwise the static value type of \metavar{collection} is $V$ where $V$ is
-    determined by downwards inference.
-
-    The static type of \metavar{collection} is \code{Map<$K$, $V$>}.
-
-    \commentary{%
-      Note that the element inference will never produce a set element type here
-      given this downwards context.%
-    }
-  \end{itemize}
+  The static type of \metavar{collection} is then \code{Map<$K$, $V$>}.
 \item
   Otherwise, \metavar{collection} is still ambiguous,
-  the downwards context for the elements of \metavar{collection} is \lit{?},
+  the downwards context for the elements of \metavar{collection} is \FreeContext{},
   and the disambiguation is done using
   the immediate elements of \metavar{collection} as follows:
 
@@ -8351,7 +8464,7 @@ as follows:
     and at least one element must be a set,
     then \metavar{collection} is a set literal with
     static type \code{Set<$T$>} where $T$ is
-    the least upper bound of the set element types of the elements.
+    the least upper bound of the element types of the elements.
   \item
     If all elements can be a map,
     and at least one element must be a map, then $e$ is
@@ -8359,14 +8472,14 @@ as follows:
     the least upper bound of the key types of the elements and $V$ is
     the least upper bound of the value types.
   \item
-    Otherwise, the literal cannot be disambiguated
-    and it is a compile-time error.
+    Otherwise, a compile-time error occurs.
+    \commentary{In this case the literal cannot be disambiguated.}
   \end{itemize}
 \end{itemize}
 
 \commentary{%
-  This last case can occur if the literal \emph{must} be both a set and a map,
-  as in:%
+This last case can occur if the literal \emph{must} be both a set and a map.
+Here is an example:%
 }
 
 \begin{dartCode}
@@ -8393,7 +8506,7 @@ Or, if there is nothing indicates that it is \emph{either} a set or a map:%
 \LMHash{}%
 Create a fresh instance \metavar{set} of
 a class that implements \code{Set<$E$>} where $E$
-is the set element type of the literal.
+is the element type of the literal.
 
 \LMHash{}%
 For each \metavar{value} in \metavar{result}:
@@ -16223,12 +16336,12 @@ for the situation where $o$ was obtained as a fresh instance
 (\ref{redirectingFactoryConstructors},
 \ref{lists}, \ref{maps}, \ref{new}, \ref{functionInvocation}).
 
-\commentary{
+\commentary{%
 In particular, the dynamic type of an instance never changes.
 It is at times only specified that the given class implements
 a certain type, e.g., for a list literal.
 In these cases the dynamic type is implementation dependent,
-except of course that said subtype requirement must be satisfied.
+except of course that said superinterface constraint must be satisfied.%
 }
 
 \LMHash{}%
@@ -17128,7 +17241,7 @@ and which has a method named \CALL{},
 whose signature is the function type $C$ itself.
 \commentary{%
 Consequently, all function types are subtypes of \FUNCTION{}
-(\ref{subtypes}).
+(\ref{subtypes}).%
 }
 
 

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -7622,15 +7622,14 @@ the first applicable entry in the following list:
   $e$ has no \synt{typeArguments}, no elements, and $S$ is undefined:
   $e$ is a map literal.
   \commentary{%
-    In other words, an empty \code{\{\}} is a map ``by default''.%
+    In other words, an empty \code{\{\}} is a map by default.%
   }
 \item
   Otherwise, $e$ is still ambiguous.
   \commentary{%
-    This can only happen when $e$ is non-empty and $\cal L$ is empty.
-    It contains only spreads, possibly wrapped in
-    \synt{ifElement}s or \synt{forElement}s.
-    In this case disambiguation occurs during type inference
+    In this case $e$ contains only spreads,
+    wrapped zero or more times in \synt{ifElement}s or \synt{forElement}s.
+    Disambiguation will occur during type inference
     (\ref{collectionLiteralInference}).%
   }
 \end{itemize}

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -2484,9 +2484,9 @@ an instance $im$ of the predefined class \code{Invocation}
 such that:
 
 \begin{itemize}
-\item \code{$im$.isMethod} evaluates to \code{\TRUE{}} if{}f $m$ is a method.
-\item \code{$im$.isGetter} evaluates to \code{\TRUE{}} if{}f $m$ is a getter.
-\item \code{$im$.isSetter} evaluates to \code{\TRUE{}} if{}f $m$ is a setter.
+\item \code{$im$.isMethod} evaluates to \TRUE{} if{}f $m$ is a method.
+\item \code{$im$.isGetter} evaluates to \TRUE{} if{}f $m$ is a getter.
+\item \code{$im$.isSetter} evaluates to \TRUE{} if{}f $m$ is a setter.
 \item \code{$im$.memberName} evaluates to the symbol \code{m}.
 \item \code{$im$.positionalArguments} evaluates to an unmodifiable list
   containing the same objects as the list resulting from evaluation of
@@ -7088,1138 +7088,13 @@ The leaf elements is always a set of expression elements and/or map elements.%
 It is a compile-time error if the leaf elements of a \synt{listLiteral}
 contains a \synt{mapElement}.
 
-
-\subsubsection{Type Promotion}
-\LMLabel{collectionLiteralTypePromotion}
-
-\LMHash{}%
-An \synt{ifElement} interacts with type promotion
-in the same way that \IF{} statements do.
-Assume that $\ell$ is an \synt{ifElement} of the form
-\code{\IF{} ($b$) $\ell_1$} or
-\code{\IF{} ($b$) $\ell_1$ \ELSE{} $\ell_2$}.
-If $b$ shows that a local variable $v$ has type $T$, then
-the type of $v$ is known to be $T$ in $\ell_1$,
-unless any of the following are true:
-
-\begin{itemize}
-\item $v$ is potentially mutated in $\ell_1$,
-\item $v$ is potentially mutated within a function
-  other than the one where $v$ is declared, or
-\item $v$ is accessed by a function defined in $\ell_1$ and
-  $v$ is potentially mutated anywhere in the scope of $v$.
-\end{itemize}
-
-%% TODO(eernst): Come nnbd, update this.
 \commentary{%
-Type promotion will likely get more sophisticated in a future version of Dart.
-When that happens,
-\synt{ifElements} will continue to match \IF{} statements
-(\ref{if}).%
+It is also a compile-time error if a set literal contains a \synt{mapElement},
+or a map literal contains an \synt{expressionElement},
+but this is only detected during the disambiguation process
+where it is determined which kind of collection
+a given \synt{setOrMapLiteral} denotes.%
 }
-
-
-\subsubsection{Collection Literal Element Evaluation}
-\LMLabel{collectionLiteralElementEvaluation}
-
-\LMHash{}%
-The evaluation of a syntactic sequence of collection literal elements
-(\ref{collectionLiterals})
-yields a
-\IndexCustom{collection literal object sequence}{collection literal!object sequence},
-also called an \NoIndex{object sequence} when no ambiguity can arise.
-We use the notation
-\IndexCustom{\LiteralSequence{\ldots}}{[[...]]@\LiteralSequence{\ldots}}
-to denote an object sequence of specific elements.
-Each element in the sequence is an object $o$ or a pair $o_1: o_2$.
-It is left unspecified how an object sequence is implemented,
-it is only required that it contains specific objects or pairs,
-in a specific order.
-For each kind of collection the sequence is used in the given order
-to populate the collection,
-in a manner which is specific to the kind,
-and which is specified separately
-(\ref{lists}, \ref{maps}, \ref{sets}).
-
-\commentary{%
-There may be an actual data structure representing the sequence at run time,
-but it could also be eliminated
-because each element is inserted directly into the target collection
-as soon as it has been computed,
-or because the collection is a constant.
-Note that each object sequence will exclusively contain objects,
-or it will exclusively contain pairs,
-because any mixed sequence would cause
-an error at compile time or at run time.%
-}
-
-\LMHash{}%
-Assume that a target collection \metavar{target} is given,
-and the object sequence obtained as described below will be received
-by \metavar{target} for insertion.
-Let $T_{\metavar{target}}$ denote the dynamic type of \metavar{target}.
-
-\commentary{%
-Access to \metavar{target} and its type is needed in order to
-be able to raise dynamic errors at specific points during
-the evaluation of an object sequence.%
-}
-
-\LMHash{}%
-Assume that a code location and a dynamic context is given, that is,
-a binding of names declared by the current library exists,
-the current instance of the enclosing class is accessible as \THIS{}
-if the given location is in the instance scope of a class, etc.
-In such a context it is possible to evaluate
-a sequence of collection literal elements as follows.
-
-\LMHash{}%
-Let $s_{\metavar{syntax}}$ of the form \List{\ell}{1}{k} be
-a sequence of collection literal elements.
-The sequence of objects $s_{\metavar{object}}$
-obtained by evaluating $s_{\metavar{syntax}}$
-is the concatenation of the sequences of objects $s_{\metavar{object},j}$
-obtained by evaluating each element $\ell_j$, $j \in 1 .. k$:
-$s_{\metavar{object}} = s_{\metavar{object},1}+\ldots+s_{\metavar{object},k}$.
-
-\LMHash{}%
-A single collection literal element $\ell$ evaluates to
-an object sequence $s$ as follows:
-
-\LMHash{}%
-\Case{Expression elements}
-When $\ell$ is an \synt{expressionElement} of the form $e$,
-$e$ is evaluated to an object $o$,
-and the result $s$ is \LiteralSequence{o}.
-\EndCase
-
-\LMHash{}%
-\Case{Map elements}
-When $\ell$ is a \synt{mapElement} of the form
-\code{$e_1$:\,\,$e_2$},
-$e_1$ is evaluated to an object $o_1$,
-then $e_2$ is evaluated to an object $o_2$,
-and the result $s$ is \LiteralSequence{o_1:\,o_2}.
-\EndCase
-
-\begin{figure}[t]
-\begin{normativeDartCode}
-\VAR{} iterator = spread.entries.iterator;
-\WHILE{} (iterator.moveNext()) \{
-  \VAR{} entry = iterator.current;
-  Key key = entry.key;
-  Value value = entry.value;
-  $\ldots$ // \comment{Append the pair} key:\,value \comment{to the result $s$.}
-\}
-\end{normativeDartCode}
-\vspace{-3mm}
-  \caption{Evaluation of a map spread}
-  \label{fig:evaluationOfAMapSpread}
-\end{figure}
-
-\begin{figure}[t]
-\begin{normativeDartCode}
-\VAR{} iterator = spread.iterator;
-\WHILE{} (iterator.moveNext()) \{
-  Value value = iterator.current;
-  $\ldots$ // \comment{Append} value \comment{to the result $s$.}
-\}
-\end{normativeDartCode}
-\vspace{-3mm}
-  \caption{Evaluation of a list or set spread}
-  \label{fig:evaluationOfAnIterableSpread}
-\end{figure}
-
-\LMHash{}%
-\Case{Spread elements}
-\begin{enumerate}
-\item
-  When $\ell$ is a \synt{spreadElement} of the form
-  `\code{...?$e$}', $e$ is evaluated to an object $o$.
-  If $o$ is the null object then the result $s$ is the empty sequence
-  \LiteralSequence{}.
-  Otherwise evaluation proceeds with step 2.
-
-  When $\ell$ is a \synt{spreadElement} of the form
-  `\code{...$e$}', $e$ is evaluated to an object $o$.
-  %% TODO(eernst): Come NNBD, this error cannot occur any more: delete.
-  If $o$ is the null object then a dynamic error occurs.
-  Otherwise evaluation proceeds with step 2.
-\item
-  Let $T$ be the dynamic type of $o$.
-  \begin{itemize}
-  \item
-    %% TODO(eernst): Come NNBD, change to `Object?`.
-    When both $T$ and $T_{\metavar{target}}$ is a subtype of
-    \code{Map<Object, Object>},
-    the code in Fig.~\ref{fig:evaluationOfAMapSpread} is executed,
-    where \code{spread} is a fresh variable bound to $o$
-    whose type is the static type of $e$,
-    and \code{Key} and \code{Value} are fresh type variables
-    bound to the type variables of $T_{\metavar{target}}$ at \code{Map}.
-
-    \commentary{%
-      The code for appending the pair \code{key:value} is omitted,
-      because the representation of $s$ is implementation specific.%
-    }
-
-    % Will not change with nnbd: `spread` type arguments could be \DYNAMIC{}.
-    It is allowed for an implementation to delay the dynamic errors
-    that occur if the given \code{key} does not have the type \code{Key},
-    or the given \code{value} does not have the type \code{Value},
-    except that if an error occurs
-    then it must preempt appending the pair to $s$.
-  \item
-    %% TODO(eernst): Come NNBD, change to `Object?`.
-    When both $T$ and $T_{\metavar{target}}$ is a subtype of
-    \code{Iterable<Object>},
-    the code in Fig.~\ref{fig:evaluationOfAnIterableSpread} is executed,
-    where \code{spread} is a fresh variable bound to $o$
-    whose type is the static type of $e$,
-    and \code{Value} is a fresh type variable
-    bound to the type variable of $T_{\metavar{target}}$ at \code{Iterable}.
-
-    \commentary{%
-      The code for appending the \code{value} is again omitted,
-      because it is implementation specific.%
-    }
-  \item
-    Otherwise, a dynamic error occurs.
-
-    \commentary{%
-      This occurs when the target is a map respectively iterable,
-      and the spread is not.%
-    }
-  \end{itemize}
-\end{enumerate}
-
-\commentary{%
-This may not be the most efficient way to traverse the items in a collection.
-In order to give implementations more room to optimize,
-we allow the following deviations.%
-}
-
-\LMHash{}%
-If $o$ is an object whose class implements
-\code{List}, \code{Queue}, or \code{Set},
-an implementation may choose to call \code{length} on the object.
-
-\commentary{%
-This may let it allocate space for the resulting collection more efficiently.
-Classes that implement these are expected to have an efficient,
-side-effect free implementation of \code{length}.%
-}
-
-\LMHash{}%
-If $o$ is an object whose class implements \code{List},
-an implementation may choose to call operator \lit{[]}
-in order to access elements from the list.
-If it does so, it will only pass indices
-that are non-negative and less than the value returned by \code{length}.
-
-\LMHash{}%
-A Dart implementation may detect whether these options apply
-at compile time based on the static type of $e$,
-or at runtime based on the actual value.
-\EndCase
-
-!!!HERE!!!
-
-\LMHash{}%
-\Case{Elements}
-
-\EndCase
-
-\LMHash{}%
-\Case{Elements}
-
-\EndCase
-
-\LMHash{}%
-\Case{Elements}
-
-\EndCase
-
-\LMHash{}%
-\Case{Elements}
-
-\EndCase
-
-\LMHash{}%
-\Case{Elements}
-
-\EndCase
-
-\begin{enumerate}
-\item
-  Else, if $\ell$ is an \synt{ifElement}:
-  \begin{enumerate}
-  \item
-    Evaluate the condition expression to a value \metavar{condition}.
-    \begin{enumerate}
-    \item If \metavar{condition} is \TRUE:
-      \begin{enumerate}
-      \item Evaluate the "then" element using this procedure.
-      \end{enumerate}
-    \item Else, if \metavar{condition} is \FALSE:
-      \begin{enumerate}
-      \item If there is an "else" element of the \IF:
-        %% \begin{enumerate}
-        %% \item Evaluate the "else" element using this procedure.
-        %% \end{enumerate}
-      \end{enumerate}
-    \item Else, throw a dynamic error.
-    \end{enumerate}
-  \end{enumerate}
-\item
-  Else, if $\ell$ is a synchronous \synt{forElement} for a for-in loop:
-
-  \begin{enumerate}
-  \item Evaluate the iterator expression to a value \metavar{sequence}.
-  \item If \metavar{sequence} is not an instance of
-    a class that implements \code{Iterable},
-    throw a dynamic exception.
-  \item
-    Evaluate \code{sequence.iterator} to a value \metavar{iterator}.
-    \begin{enumerate}
-    \item Loop:
-      \begin{enumerate}
-      \item
-        Evaluate \code{iterator.moveNext()} to a value \metavar{hasValue}.
-      \item
-        If \metavar{hasValue} is \TRUE:
-        %% \begin{enumerate}
-        %% \item
-        %%   If the for-in element declares a variable,
-        %%   create a new namespace and a fresh \code{variable} for it.
-        %%   Otherwise, use the existing \code{variable} it refers to.
-        %% \item
-        %%   Bind \code{variable} to
-        %%   the result of evaluating \code{iterator.current}.
-        %% \item
-        %%   Evaluate the body element using this procedure
-        %%   in the scope of \code{variable}.
-        %% \end{enumerate}
-      \item
-        Else, if \metavar{hasValue} is \FALSE, exit the loop.
-      \item
-        Else, throw a dynamic error.
-      \end{enumerate}
-    \end{enumerate}
-  \end{enumerate}
-\item
-  Else, if $\ell$ is an asynchronous \AWAIT{} for-in element:
-  \begin{enumerate}
-  \item
-    Evaluate the stream expression to a value \metavar{stream}.
-  \item
-    If \metavar{stream} is not an instance of
-    a class that implements \code{Stream},
-    throw a dynamic error.
-  \item
-    Pause the subscription of any surrounding \AWAIT{} \FOR{} loop
-    in the current method.
-  \item
-    Let \metavar{streamDone} be a value implementing \code{Future<Null>}.
-  \item
-    Listen on \metavar{stream} and take the following actions on events:
-
-    \begin{itemize}
-    \item On a data event with value \metavar{value}:
-      \begin{enumerate}
-      \item
-        If the for-in element declares a variable,
-        create a new namespace and a fresh \code{variable} for it.
-        Otherwise, use the existing `variable` it refers to.
-      \item
-        Bind \code{variable} to \metavar{value}.
-      \item
-        Evaluate the body element using this procedure.
-      \item
-        If evaluation of the body throws an
-        error \metavar{error} and stack trace \metavar{stack}, then:
-        %% \begin{enumerate}
-        %% \item
-        %%   Stop listening on the stream by calling the \code{cancel()}
-        %%   method of the corresponding stream subscription, which
-        %%   returns a future $f$.
-        %% \item
-        %%   Wait for $f$ to complete.
-        %%   If $f$ completes with
-        %%   an error \metavar{error2} and stack trace \metavar{stack2},
-        %%   then complete \metavar{streamDone}
-        %%   with error \metavar{error2} and stack trace \metavar{stack2}.
-        %%   Otherwise complete \metavar{streamDone}
-        %%   with error \metavar{error} and stack trace \metavar{stack}.
-        %% \end{enumerate}
-      \item
-        Else, evaluation of the body element completes successfully.
-        %% \begin{enumerate}
-        %% \item Resume the stream subscription if it has been paused.
-        %% \end{enumerate}
-      \item
-        On an error event
-        with error \metavar{error} and stack trace \metavar{stack}:
-        %% \begin{enumerate}
-        %% \item
-        %%   Stop listening on the stream by calling the \code{cancel()} method of
-        %%   the corresponding stream subscription,
-        %%   which returns a future $f$.
-        %% \item
-        %%   Wait for $f$ to complete.
-        %%   If `f` completes
-        %%   with an error \metavar{error2} and stack trace \metavar{stack2},
-        %%   then complete \metavar{streamDone}
-        %%   with error \metavar{error2} and stack trace \metavar{stack2}.
-        %%   Otherwise complete \metavar{streamDone}
-        %%   with error \metavar{error} and stack trace \metavar{stack}.
-        %% \end{enumerate}
-      \item
-        On a done event, complete `streamDone` with the value `null`.
-      \end{enumerate}
-    \end{itemize}
-  \item
-    Evaluation of the for-in element completes
-    when \metavar{streamDone} completes.
-    If \metavar{streamDone} completes
-    with an error \metavar{error} and stack trace \metavar{stack},
-    then evaluation of the element
-    throws \metavar{error} with stack trace \metavar{stack},
-    otherwise the evaluation completes successfully.
-  \end{enumerate}
-\item
-  Else, $\ell$ is a C-style \synt{forElement}:
-  \begin{enumerate}
-  \item
-    Evaluate the initializer clause of the element, if there is one.
-  \item
-    Loop:
-    \begin{enumerate}
-    \item
-      If the initializer clause declares a variable,
-      create a new namespace and bind that variable in that namespace.
-    \item
-      Evaluate the condition expression to a value \metavar{condition}.
-      If there is no condition expression, use \TRUE.
-    \item
-      If \metavar{condition} is \TRUE:
-      \begin{enumerate}
-      \item
-        Evaluate the body element using this procedure in the namespace
-        of the variable declared by the initializer clause
-        if there is one.
-      \item
-        If there is an increment clause, execute it.
-      \end{enumerate}
-    \item
-      Else, if \metavar{condition} is \FALSE, exit the loop.
-    \item
-      Else, throw a dynamic error.
-    \end{enumerate}
-  \end{enumerate}
-\end{enumerate}
-
-\LMHash{}%
-The procedure theoretically supports a mixture of expressions and map entries,
-but the static semantics prohibit an actual literal containing that.
-
-\LMHash{}%
-Once the \metavar{result} series of values or entries is produced
-from the tree of elements,
-the final object is produced from that based on what kind of literal it is:
-
-
-\subsubsection{List}
-\LMLabel{uiAsCodeList}
-
-!!!HERE!!!
-
-\LMHash{}%
-The result of the literal expression is a fresh instance of
-a class that implements \code{List<$E$>} where $E$ is
-the element type of the literal.
-It contains the values in \metavar{result}, in order.
-If the literal is constant,
-the list is canonicalized and immutable,
-otherwise it is not.
-
-
-\subsubsection{Set}
-\LMLabel{uiAsCodeSet}
-
-!!!HERE!!!
-
-\LMHash{}%
-Create a fresh instance \metavar{set} of
-a class that implements \code{Set<$E$>} where $E$
-is the set element type of the literal.
-
-\LMHash{}%
-For each \metavar{value} in \metavar{result}:
-
-\begin{enumerate}
-\item
-  If \metavar{set} contains
-  a value \metavar{existing} that is equal to \metavar{value}
-  according to \metavar{existing}'s operator \lit{==}:
-\item
-  If the literal is constant, it is a compile-time error.
-\item
-  Else, do nothing.
-  \commentary{Duplicates are discarded and the first one wins.}
-\item
-  Else, add \metavar{value} to \metavar{set}.
-\end{enumerate}
-
-\LMHash{}%
-The result of the literal expression is \metavar{set}.
-If the literal is constant,
-canonicalize it make the set immutable.
-
-
-\subsubsection{Map}
-\LMLabel{uiAsCodeMap}
-
-!!!HERE!!!
-
-\LMHash{}%
-Allocate a fresh instance \metavar{map} of
-a class that implements \code{LinkedHashMap<$K$, $V$>} where $K$ is
-the key type of the literal and $V$ is
-the value type.
-
-\LMHash{}%
-For each entry \code{\metavar{key}: \metavar{value}} in \metavar{result}:
-
-\begin{enumerate}
-\item
-  If \metavar{map} contains an entry \metavar{existing}
-  whose key \metavar{existingKey} is equal to \metavar{key}
-  according to \metavar{existingKeys}'s operator \lit{==}:
-  \begin{enumerate}
-  \item
-    If the literal is constant, it is a compile-time error.
-  \item
-    Else, replace the value in \metavar{existing} with \metavar{value},
-    while keeping its position in the sequence of entries
-    and \metavar{existingKey} the same.
-  \end{enumerate}
-\item
-  Else add entry \code{\metavar{key}: \metavar{value}} to \metavar{map}.
-\end{enumerate}
-
-\LMHash{}%
-The result of the map literal expression is \metavar{map}.
-If the literal is constant,
-canonicalize it and make the map immutable.
-
-
-\subsubsection{Lists}
-\LMLabel{lists}
-
-\LMHash{}%
-A \IndexCustom{list literal}{literal!list}
-denotes a list, which is an integer indexed collection of objects.
-The grammar rule for \synt{listLiteral} is specified elsewhere
-(\ref{collectionLiterals}).
-
-\LMHash{}%
-When a given list literal $e$ has no type arguments,
-the type argument $T$ is selected as specified below
-(\ref{listLiteralInference}),
-and $e$ is henceforth treated as
-(\ref{notation})
-\code{<$T$>$e$}.
-
-\LMHash{}%
-A list may contain zero or more objects.
-The number of elements in a list is its size.
-A list has an associated set of indices.
-An empty list has an empty set of indices.
-A non-empty list has the index set $\{0, \ldots, n - 1\}$ where $n$ is the size of the list.
-It is a dynamic error to attempt to access a list
-using an index that is not a member of its set of indices.
-
-\LMHash{}%
-The sequence of elements of a given list literal
-is determined as described below
-(\ref{listEvaluation}).
-
-\LMHash{}%
-If a list literal $\ell$ begins with the reserved word \CONST{}
-or $\ell$ occurs in a constant context
-(\ref{constantContexts}),
-it is a
-\IndexCustom{constant list literal}{literal!list!constant},
-which is a constant expression
-(\ref{constants})
-and therefore evaluated at compile time.
-Otherwise, it is a
-\IndexCustom{run-time list literal}{literal!list!run-time}
-and it is evaluated at run time.
-Only run-time list literals can be mutated
-after they are created.
-% This error can occur because being constant is a dynamic property.
-Attempting to mutate a constant list literal will result in a dynamic error.
-
-\commentary{%
-% The following is true either directly or indirectly: There is a \CONST{}
-% modifier on the list literal, or the list literal as a whole occurs
-% in a constant context.
-Note that the element expressions of a constant list literal
-occur in a constant context
-(\ref{constantContexts}),
-which means that \CONST{} modifiers need not be specified explicitly.%
-}
-
-\LMHash{}%
-It is a compile-time error if an element of a constant list literal
-is not a constant expression.
-It is a compile-time error if the type argument of a constant list literal
-is not a constant type expression.
-
-\rationale{%
-The binding of a formal type parameter is not known at compile time,
-so we cannot use type parameters inside constant expressions.%
-}
-
-\LMHash{}%
-The value of a constant list literal
-\code{\CONST?\,\,<$E$>[$e_1, \ldots, e_n$]}
-is an object $a$ whose class implements the built-in class
-\code{List<$E$>}.
-Let $v_i$ be the value of the constant expression $e_i$, $i \in 1 .. n$.
-The $i$th element of $a$ (at index $i - 1$) is $v_i$.
-%
-%% TODO(eernst): If inference is specified to provide all type arguments,
-%% we should delete the following.
-The value of a constant list literal
-\code{\CONST?\,\,[$e_1, \ldots, e_n$]}
-is defined as the value of the constant list literal
-% For a constant list literal, it is never an error to have the \CONST, even if
-% it was omitted above. So we remove the `?`, making the next line well-defined.
-\code{\CONST\,\,<\DYNAMIC>[$e_1, \ldots, e_n$]}.
-
-\LMHash{}%
-Let
-$list_1 =$ \code{\CONST?\,\,<$V$>[$e_{11}, \ldots, e_{1n}$]}
-and
-$list_2 =$ \code{\CONST?\,\,<$U$>[$e_{21}, \ldots, e_{2n}$]}
-be two constant list literals and
-let the elements of $list_1$ and $list_2$ evaluate to
-$o_{11}, \ldots, o_{1n}$ and $o_{21}, \ldots, o_{2n}$ respectively.
-If{}f \code{identical($o_{1i}$, $o_{2i}$)} for $i \in 1 .. n$ and $V == U$
-then \code{identical($list_1$, $list_2$)}.
-
-\commentary{%
-In other words, constant list literals are canonicalized.%
-}
-
-\LMHash{}%
-A run-time list literal
-\code{<$E$>[$e_1, \ldots, e_n$]}
-is evaluated as follows:
-\begin{itemize}
-\item
-  First, the expressions $e_1, \ldots, e_n$ are evaluated
-  in order they appear in the program,
-  producing objects $o_1, \ldots, o_n$.
-\item
-  A fresh instance (\ref{generativeConstructors}) $a$, of size $n$,
-  whose class implements the built-in class \code{List<$E$>}
-  is allocated.
-\item
-  The operator \lit{[]=} is invoked on $a$ with
-  first argument $i$ and second argument
-  $o_{i+1}, 0 \le i < n$.
-\item
-  The result of the evaluation is $a$.
-\end{itemize}
-
-\LMHash{}%
-The objects created by list literals do not override
-the \lit{==} operator inherited from the \code{Object} class.
-
-\commentary{
-Note that this document does not specify an order
-in which the elements are set.
-This allows for parallel assignments into the list
-if an implementation so desires.
-The order can only be observed as follows (and may not be relied upon):
-if element $i$ is not a subtype of the element type of the list,
-a dynamic type error will occur when $a[i]$ is assigned $o_{i-1}$.
-}
-
-\LMHash{}%
-%% TODO(eernst): If inference is specified to provide all type arguments,
-%% we should delete the following.
-A run-time list literal
-\code{[$e_1, \ldots, e_n$]}
-is evaluated as
-\code{<\DYNAMIC>[$e_1, \ldots, e_n$]}.
-
-\commentary{
-There is no restriction precluding nesting of list literals.
-It follows from the rules above that
-\code{<List<int>{}>[<int>[1, 2, 3], <int>[4, 5, 6]]}
-is a list with type parameter \code{List<int>},
-containing two lists with type parameter \code{int}.
-}
-
-\LMHash{}%
-The static type of a list literal of the form
-\code{\CONST\,\,<$E$>[$e_1, \ldots, e_n$]}
-or the form
-\code{<$E$>[$e_1, \ldots, e_n$]}
-is \code{List<$E$>}.
-%
-%% TODO(eernst): If inference is specified to provide all type arguments,
-%% we should delete the following.
-The static type of a list literal of the form
-\code{\CONST\,\,[$e_1, \ldots, e_n$]}
-or the form
-\code{[$e_1, \ldots, e_n$]}
-is \code{List<\DYNAMIC>}.
-
-
-\subsubsection{List Literal Inference}
-\LMLabel{listLiteralInference}
-
-!!!HERE!!!
-
-\LMHash{}%
-Inference for list literals mostly follows that of set literals
-without the complexity around disambiguation with maps and
-using \code{List} or \code{Iterable} in a few places instead of \code{Set}.
-
-\LMHash{}%
-Inside a \synt{listLiteral} \metavar{listLiteral},
-the inferred type of an element $\ell$ is a list element type $T$.
-It is computed relative to a downwards element context type $P$,
-where $P$ is $T$
-if downwards inference constrains the type of \metavar{listLiteral}
-to \code{Iterable<$T$>} for some $T$.
-Otherwise, $P$ is \lit{?}.
-
-\begin{itemize}
-\item
-  If $\ell$ is an \synt{expressionElement} with expression $e1$:
-  \begin{itemize}
-  \item
-    The inferred list element type of $\ell$ is
-    the inferred type of the expression $e1$ in context $P$.
-  \end{itemize}
-\item
-  If $\ell$ is a \synt{spreadElement} with expression $e1$:
-
-  \begin{itemize}
-  \item
-    If $P$ is \lit{?} then let $S$ be
-    the inferred type of $e1$ in context \lit{?}:
-
-    \begin{itemize}
-    \item
-      If $S$ is a non-\code{Null} subtype of \code{Iterable<Object>}, then
-      the inferred list element type of $\ell$ is $T$ where $T$ is
-      the type such that \code{Iterable<$T$>} is
-      a superinterface of $S$
-      (\commentary{%
-        the result of constraint matching for $X$ using
-        the constraint \code{$S$ <: Iterable<$X$>}}).
-
-      \begin{itemize}
-      \item
-        If $S$ is \DYNAMIC{}, then
-        the inferred list element type of $\ell$ is \DYNAMIC{}.
-      \item
-        If $S$ is \code{Null} and the spread operator is \lit{...?}, then
-        the list element type is \code{Null}.
-      \item
-        Otherwise it is an error
-        (\commentary{%
-          because it is a spread of a non-spreadable type like Object%
-        }).
-      \end{itemize}
-    \item
-      Else, let $S$ be
-      the inferred type of $e1$ in context \code{Iterable<$P$>}:
-
-      \begin{itemize}
-      \item
-        If $S$ is a non-\code{Null} subtype of \code{Iterable<Object>}, then
-        the inferred list element type of $\ell$ is $T$ where $T$ is
-        the type such that \code{Iterable<$T$>} is
-        a superinterface of $S$
-        (\commentary{%
-          the result of constraint matching for $X$ using
-          the constraint \code{$S$ <: Iterable<$X$>}%
-        }).
-      \item
-        If $S$ is \DYNAMIC{}, then
-        the inferred list element type of $\ell$ is \DYNAMIC{}.
-      \item
-        Otherwise it is an error.
-      \end{itemize}
-    \end{itemize}
-  \item
-    If $\ell$ is an \synt{ifElement} with one $\ell$, $p1$,
-    and no "else" element:
-    The condition is inferred with a context type of \code{bool}.
-
-    The inferred list element type of $\ell$ is
-    the inferred list element type of $p1$ with element context type $P$.
-  \item
-    If $\ell$ is a \synt{ifElement} with two $\ell$s, $p1$ and $p2$:
-    The condition is inferred with a context type of \code{bool}.
-
-    The inferred list element type of $\ell$ is
-    the least upper bound of $S1$ and $S2$ where $S1$ is
-    the inferred list element type of $p1$ and $S2$ is
-    the inferred list element type of $p2$,
-    both with element context type $P$.
-
-  \item
-    If $\ell$ is a \synt{forElement} with $\ell$ $p1$ then:
-
-    Inference for the iterated expression and the controlling variable
-    is done as for the corresponding \FOR{} or \AWAIT{} \FOR{} statement.
-
-    The inferred list element type of $\ell$ is the inferred list element
-    type of $p1$ with element context type $P$.
-  \end{itemize}
-\end{itemize}
-
-\commentary{%
-Note: $\ell$ cannot be a \synt{mapElement} as
-those are not allowed inside list literals.%
-}
-
-\LMHash{}%
-Finally, we define inference on a \synt{listLiteral} \metavar{collection}
-as follows:
-
-\begin{itemize}
-\item
-  If $P$ is \lit{?} then
-  the static type of \metavar{collection} is \code{List<$T$>} where $T$ is
-  the least upper bound of the inferred list element types of the elements.
-\item
-  Otherwise,
-  the static type of \metavar{collection} is \code{List<$T$>} where $T$ is
-  determined by downwards inference.
-\end{itemize}
-
-
-\subsubsection{List Literal Evaluation}
-\LMLabel{listLiteralEvaluation}
-
-!!!HERE!!!
-
-\subsubsection{Maps}
-\LMLabel{maps}
-
-!!!HERE!!!
-
-\LMHash{}%
-A \IndexCustom{map literal}{literal!map} denotes a map object.
-The grammar rule for \synt{setOrMapLiteral} which covers both
-map literals and set literals occurs elsewhere
-(\ref{collectionLiterals}).
-
-\LMHash{}%
-A map literal consists of zero or more entries.
-Each entry has a \Index{key} and a \Index{value}.
-Each key and each value is denoted by an expression.
-It is a compile-time error if a map literal has one type argument,
-or more than two type arguments.
-
-\LMHash{}%
-If a map literal $\ell$ begins with the reserved word \CONST{},
-or if $\ell$ occurs in a constant context
-(\ref{constantContexts}),
-it is a
-\IndexCustom{constant map literal}{literal!map!constant}
-which is a constant expression
-(\ref{constants})
-and therefore evaluated at compile time.
-Otherwise, it is a
-\IndexCustom{run-time map literal}{literal!map!run-time}
-and it is evaluated at run time.
-Only run-time map literals can be mutated after they are created.
-% This error can occur because being constant is a dynamic property, here.
-Attempting to mutate a constant map literal will result in a dynamic error.
-
-\commentary{%
-% The following is true either directly or indirectly: There is a \CONST{}
-% modifier on the literal map, or we use the "immediate subexpression" rule
-% about constant contexts.
-Note that the key and value expressions of a constant list literal
-occur in a constant context
-(\ref{constantContexts}),
-which means that \CONST{} modifiers need not be specified explicitly.%
-}
-
-\LMHash{}%
-It is a compile-time error if
-either a key or a value of an entry in a constant map literal
-is not a constant expression.
-It is a compile-time error if
-the operator \lit{==} of the key of an entry in a constant map literal
-is not primitive
-(\ref{theOperatorEqualsEquals}).
-It is a compile-time error if a type argument of a constant map literal
-is not a constant type expression
-(\ref{constants}).
-
-\LMHash{}%
-The value of a constant map literal
-\code{\CONST?\,\,<$K, V$>\{$k_1:e_1, \ldots, k_n:e_n$\}}
-is an object $m$ whose class implements the built-in class
-\code{Map<$K, V$>}.
-The entries of $m$ are $u_i:v_i, i \in 1 .. n$,
-where $u_i$ is the value of the compile-time expression $k_i$,
-and $v_i$ is the value of the compile-time expression $e_i$.
-%
-%% TODO(eernst): If inference is specified to provide all type arguments,
-%% we should delete the following.
-The value of a constant map literal
-\code{\CONST?\,\,\{$k_1:e_1, \ldots, k_n:e_n$\}}
-is defined as the value of the constant map literal
-% For a constant map literal, it is never an error to have the \CONST, even if
-% it was omitted above. So we remove the `?`, making the next line well-defined.
-\code{\CONST\,\,<\DYNAMIC, \DYNAMIC>\{$k_1:e_1, \ldots, k_n:e_n$\}}.
-
-\LMHash{}%
-Let $map_1$ be a constant map literal of the form
-\code{\CONST?\,\,<$K, V$>\{$k_{11}:e_{11}, \ldots, k_{1n}:e_{1n}$\}}
-and $map_2$ a constant map literal of the form
-\code{\CONST?\,\,<$J, U$>\{$k_{21}:e_{21}, \ldots, k_{2n}:e_{2n}$\}}.
-Let the keys of $map_1$ and $map_2$ evaluate to
-$s_{11}, \ldots, s_{1n}$ and $s_{21}, \ldots, s_{2n}$, respectively,
-and let the elements of $map_1$ and $map_2$ evaluate to
-$o_{11}, \ldots, o_{1n}$ and $o_{21}, \ldots, o_{2n}$, respectively.
-If{}f
-\code{identical($o_{1i}$, $o_{2i}$)} and
-\code{identical($s_{1i}$, $s_{2i}$)}
-for $i \in 1 .. n$, and $K == J, V == U$, then \code{identical($map_1$, $map_2$)}.
-
-\commentary{%
-In other words, constant map literals are canonicalized.%
-}
-
-\LMHash{}%
-It is a compile-time error if two keys of a constant map literal are equal
-according to their \lit{==} operator (\ref{equality}).
-
-\LMHash{}%
-A run-time map literal
-\code{<$K, V$>\{$k_1:e_1, \ldots, k_n:e_n$\}}
-is evaluated as follows:
-\begin{itemize}
-\item
-  For each $i \in 1 .. n$ in numeric order,
-  first the expression $k_i$ is evaluated producing object $u_i$,
-  and then $e_i$ is evaluated producing object $o_i$.
-  This produces all the objects $u_1, o_1, \ldots, u_n, o_n$.
-\item
-  A fresh instance (\ref{generativeConstructors}) $m$
-  whose class implements the built-in class \code{Map<$K, V$>},
-  is allocated.
-\item
-  The operator \lit{[]=} is invoked on $m$
-  with first argument $u_i$ and second argument $o_i$
-  for each $i \in 1 .. n$.
-\item
-  The result of the evaluation is $m$.
-\end{itemize}
-
-\LMHash{}%
-The objects created by map literals do not override
-the \lit{==} operator inherited from the \code{Object} class.
-
-\LMHash{}%
-%% TODO(eernst): If inference is specified to provide all type arguments,
-%% we should delete the following.
-A run-time map literal
-\code{\{$k_1:e_1, \ldots, k_n:e_n$\}}
-is evaluated as
-
-\code{<\DYNAMIC, \DYNAMIC>\{$k_1:e_1, \ldots, k_n:e_n$\}}.
-
-\LMHash{}%
-A map literal is ordered:
-iterating over the keys and/or values of the maps
-always happens in the order the keys appeared in the source code.
-
-\commentary{
-Of course, if a key repeats, the order is defined by first occurrence,
-but the value is defined by the last.
-}
-
-\LMHash{}%
-The static type of a map literal of the form
-\code{\CONST{} <$K, V$>\{$k_1:e_1, \ldots, k_n:e_n$\}}
-or the form
-\code{<$K, V$>\{$k_1:e_1, \ldots, k_n:e_n$\}}
-is
-\code{Map<$K, V$>}.
-%
-%% TODO(eernst): If inference is specified to provide all type arguments,
-%% we should delete the following.
-The static type of a map literal of the form
-\code{\CONST{} \{$k_1:e_1, \ldots, k_n:e_n$\}}
-or the form
-\code{\{$k_1:e_1, \ldots, k_n:e_n$\}} is
-\code{Map<\DYNAMIC, \DYNAMIC>}.
-
-
-\subsubsection{Sets}
-\LMLabel{sets}
-
-!!!HERE!!!
-
-\LMHash{}%
-A \IndexCustom{set literal}{literal!set} denotes a set object.
-The grammar rule for \synt{setOrMapLiteral} which covers
-set literals as well as map literals occurs elsewhere
-(\ref{collectionLiterals}).
-
-\LMHash{}%
-A set literal consists of zero or more element expressions.
-It is a compile-time error if a set literal has more than one type argument.
-
-\rationale{%
-A set literal with no type argument is always converted to a literal
-with a type argument by type inference (\ref{overview}), so the following
-section only address the behavior of literals with type arguments.%
-}
-
-\LMHash{}%
-If a set literal $\ell$ begins with the reserved word \CONST{}
-or $\ell$ occurs in a constant context
-(\ref{constantContexts}),
-it is a
-\IndexCustom{constant set literal}{literal!set!constant}
-which is a constant expression
-(\ref{constants})
-and therefore evaluated at compile time.
-Otherwise, it is a
-\IndexCustom{run-time set literal}{literal!set!run-time}
-and it is evaluated at run time.
-Only run-time set literals can be mutated after they are created.
-% This error can occur because being constant is a dynamic property, here.
-Attempting to mutate a constant set literal will result in a dynamic error.
-
-\commentary{%
-% The following is true either directly or indirectly: There is a \CONST{}
-% modifier on the literal set, or we use the "immediate subexpression" rule
-% about constant contexts.
-Note that the element expressions of a constant set literal
-occur in a constant context
-(\ref{constantContexts}),
-which means that \CONST{} modifiers need not be specified explicitly.%
-}
-
-\LMHash{}%
-It is a compile-time error if an element expression in a constant set literal
-is not a constant expression.
-It is a compile-time error if
-the operator \lit{==} of an element expression in a constant map literal
-is not primitive
-(\ref{theOperatorEqualsEquals}).
-It is a compile-time error if the type argument of a constant set literal
-is not a constant type expression
-(\ref{constants}).
-It is a compile-time error if two elements of a constant set literal are equal
-according to their \lit{==} operator
-(\ref{equality}).
-
-\LMHash{}%
-The value of a constant set literal
-\code{\CONST?\,\,<$E$>\{$e_1, \ldots, e_n$\}}
-is an object $s$ whose class implements the built-in class
-\code{Set<$E$>}.
-The elements of $m$ are $v_i, i \in 1 .. n$,
-where $v_i$ is the value of the constant expression $e_i$.
-%
-%% TODO(eernst): If inference is specified to provide all type arguments,
-%% we should delete the following.
-The value of a constant set literal
-\code{\CONST?\,\,\{$e_1, \ldots, e_n$\}}
-is defined as the value of the constant set literal
-% For a constant set literal, it is never an error to have the \CONST, even if
-% it was omitted above. So we remove the `?`, making the next line well-defined.
-\code{\CONST\,\,<\DYNAMIC>\{$e_1, \ldots, e_n$\}}.
-
-\LMHash{}%
-Let $set_1$ be a constant set literal with type argument $E$
-and element expressions, in source order, $e_{11}, \ldots, e_{1n}$ evaluating
-to objects $v_{11}, \ldots, v_{1n}$.
-Let $set_2$ be a constant set literal with type argument $F$
-and element expressions, in source order, $e_{21}, \ldots, e_{2n}$ evaluating
-to objects $v_{21}, \ldots, v_{2n}$.
-If{}f \code{identical($v_{1i}$, $v_{2i}$)}
-for $i \in 1 .. n$, and $E$ and $F$ is the same type,
-then \code{identical($set_1$, $set_2$)}.
-
-\commentary{%
-In other words, constant set literals are canonicalized if they have
-the same type and the same values in the same order.
-Two constant set literals are never identical
-if they have a different number of elements.%
-}
-
-\LMHash{}%
-A run-time set literal with element expressions $e_1, \ldots, e_n$
-(in source order) and with type argument $E$
-is evaluated as follows:
-\begin{itemize}
-\item
-For each $i \in 1 .. n$ in numeric order,
-the expression $e_i$ is evaluated producing object $v_i$.
-\item A fresh object (\ref{generativeConstructors}) $s$
-implementing the built-in class \code{Set<$E$>}, is created.
-\item The set $s$ is made to have the objects $v_1, \ldots{} , v_n$ as elements,
-iterated in numerical order.
-\item
-The result of the evaluation is $s$.
-\end{itemize}
-
-\LMHash{}%
-The objects created by set literals do not override
-the \lit{==} operator inherited from the \code{Object} class.
-
-\LMHash{}%
-A set literal is ordered: iterating over the elements of the sets
-always happens in the order the elements first appeared in the source code.
-
-\commentary{
-If a value repeats, the order is defined by first occurrence, but the value is defined by the last.
-}
-
-\LMHash{}%
-%% TODO(eernst): If inference is specified to provide all type arguments,
-%% we should delete the following.
-A run-time set literal
-\code{\{$e_1, \ldots, e_n$\}}
-is evaluated as
-\code{<\DYNAMIC>\{$e_1, \ldots, e_n$\}}.
-
-\LMHash{}%
-The static type of a set literal of the form
-\code{\CONST\,\,<$E$>\{$e_1, \ldots, e_n$\}}
-or the form
-\code{<$E$>\{$e_1, \ldots, e_n$\}}
-is
-\code{Set<$E$>}.
-%
-%% TODO(eernst): If inference is specified to provide all type arguments,
-%% we should delete the following.
-The static type of a list literal of the form
-\code{\CONST\,\,\{$e_1, \ldots, e_n$\}}
-or the form
-\code{\{$e_1, \ldots, e_n$\}}
-is \code{Set<\DYNAMIC>}.
 
 
 \subsubsection{Set and Map Literal Disambiguation}
@@ -8268,37 +7143,35 @@ The disambiguation step of this section is
 the first applicable entry in the following list:
 
 \begin{itemize}
-\item When $e$ has type arguments \List{T}{1}{k}:
+\item When $e$ has type arguments \List{T}{1}{k}, $k > 0$:
   If $k = 1$ then $e$ is a set literal with static type
   \code{Set<$T_1$>}.
   If $k = 2$ then $e$ is a map literal with static type
   \code{Map<$T_1$, $T_2$>}.
-  If $k > 2$ a compile-time error occurs.
+  Otherwise a compile-time error occurs.
 \item
-  %% TODO(eernst): Come nnbd: `Object?`.
-  When $S <: \code{Iterable<Object>} \wedge S \not<: \code{Map<Object, Object>}$:
+  When \code{Iterable} is a superinterface of $S$ and \code{Map} is not,
   $e$ is a set literal.
-\item
-  %% TODO(eernst): Come nnbd: `Object?`.
-  When $S <: \code{Map<Object, Object>} \wedge S \not<: \code{Iterable<Object>}$:
+  When \code{Map} is a superinterface of $S$ and \code{Iterable} is not,
   $e$ is a map literal.
 \item
-  When ${\cal L} \not= \emptyset$ (\commentary{$e$ has leaf elements}):
-  If $\cal L$ contains both a \synt{mapElement} and an \synt{expressionElement},
+  When ${\cal L} \not= \emptyset$ (\commentary{that is, $e$ has leaf elements}):
+  If $\cal L$ contains a \synt{mapElement} as well as an \synt{expressionElement},
   a compile-time error occurs.
-  Otherwise, if $\cal L$ contains an \synt{expressionElement}
+  Otherwise, if $\cal L$ contains an \synt{expressionElement},
   $e$ is a set literal.
   Otherwise $\cal L$ contains a \synt{mapElement}, and $e$ is a map literal.
 \item
-  When $e$ has no \synt{typeArguments}, no elements, and $S$ is undefined:
+  When $e$ is of the form \code{\{\}} and $S$ is undefined,
   $e$ is a map literal.
   \commentary{%
-    In other words, an empty \code{\{\}} is a map by default.%
+    The fact that \code{\{\}} is a map by default limited the breakage
+    when set literals were introduced.%
   }
 \item
   Otherwise, $e$ is still ambiguous.
   \commentary{%
-    In this case $e$ is non-empty but contains only spreads,
+    In this case $e$ is non-empty, but contains only spreads
     wrapped zero or more times in \synt{ifElement}s or \synt{forElement}s.
     Disambiguation will occur during inference
     (\ref{setAndMapLiteralInference}).%
@@ -8687,7 +7560,7 @@ as follows:
 \end{dartCode}
 
 \commentary{%
-Or, if there is nothing indicates that it is \emph{either} a map or set:%
+Or, if there is nothing indicates that it is \emph{either} a set or a map:%
 }
 
 \begin{dartCode}
@@ -8696,8 +7569,1060 @@ Or, if there is nothing indicates that it is \emph{either} a map or set:%
 \end{dartCode}
 
 
+\subsubsection{Type Promotion}
+\LMLabel{collectionLiteralTypePromotion}
+
+\LMHash{}%
+An \synt{ifElement} interacts with type promotion
+in the same way that \IF{} statements do.
+Assume that $\ell$ is an \synt{ifElement} of the form
+\code{\IF{} ($b$) $\ell_1$} or
+\code{\IF{} ($b$) $\ell_1$ \ELSE{} $\ell_2$}.
+If $b$ shows that a local variable $v$ has type $T$, then
+the type of $v$ is known to be $T$ in $\ell_1$,
+unless any of the following are true:
+
+\begin{itemize}
+\item $v$ is potentially mutated in $\ell_1$,
+\item $v$ is potentially mutated within a function
+  other than the one where $v$ is declared, or
+\item $v$ is accessed by a function defined in $\ell_1$ and
+  $v$ is potentially mutated anywhere in the scope of $v$.
+\end{itemize}
+
+%% TODO(eernst): Come nnbd, update this.
+\commentary{%
+Type promotion will likely get more sophisticated in a future version of Dart.
+When that happens,
+\synt{ifElements} will continue to match \IF{} statements
+(\ref{if}).%
+}
+
+
+\subsubsection{Collection Literal Element Evaluation}
+\LMLabel{collectionLiteralElementEvaluation}
+
+\LMHash{}%
+The evaluation of a sequence of collection literal elements
+(\ref{collectionLiterals})
+yields a
+\IndexCustom{collection literal object sequence}{%
+  collection literal!object sequence},
+also called an \NoIndex{object sequence} when no ambiguity can arise.
+
+\LMHash{}%
+We use the notation
+\IndexCustom{\LiteralSequence{\ldots}}{[[...]]@\LiteralSequence{\ldots}}
+to denote an object sequence of specific elements,
+and we use `$+$' to compute the concatenation of object sequences
+(\commentary{as in $s_1 + s_2$}),
+which is an operation that will succeed and has no side-effects.
+Each element in the sequence is an object $o$ or a pair $o_1: o_2$.
+There is no notion of an element type for an object sequence,
+and hence no notion of dynamic errors arising from
+a type mismatch during concatenation.
+
+\commentary{%
+Object sequences can safely be treated in an untyped manner
+because every access to an object sequence occurs
+in code created by language defined desugaring
+on statically checked constructs.
+It is left unspecified how an object sequence is implemented,
+it is only required that it contains the indicated objects or pairs
+in the given order.
+For each kind of collection the sequence is used in the given order
+to populate the collection,
+in a manner which is specific to the kind,
+and which is specified separately
+(\ref{lists}, \ref{maps}, \ref{sets}).%
+
+There may be an actual data structure
+representing object sequences at run time,
+but object sequences could also be eliminated, e.g.,
+because each element is inserted directly into the target collection
+as soon as it has been computed.
+Note that each object sequence will exclusively contain objects,
+or it will exclusively contain pairs,
+because any mixed sequence would cause
+an error at compile time or
+(for a spread element with static type \DYNAMIC{})
+at run time.%
+}
+
+\LMHash{}%
+Assume that a literal collection \metavar{target} is given,
+and the object sequence obtained as described below will be used
+to populate \metavar{target}.
+Let $T_{\metavar{target}}$ denote the dynamic type of \metavar{target}.
+
+\commentary{%
+Access to the type of \metavar{target} is needed below
+in order to raise dynamic errors at specific points during
+the evaluation of an object sequence.
+Note that the dynamic type of \metavar{target} is statically known,
+except for the binding of any type variables in its \synt{typeArguments}.
+This implies that some questions can be answered at compile-time, e.g.,
+whether or not \code{Iterable} occurs as a superinterface of
+$T_{\metavar{target}}$.%
+}
+
+\LMHash{}%
+Assume that a location in code and a dynamic context is given,
+such that ordinary expression evaluation is possible.
+\IndexCustom{Evaluation of a collection literal element sequence}{%
+  collection literal element sequence!evaluation}
+at that location and in that context is specified as follows:
+
+\LMHash{}%
+Let $s_{\metavar{syntax}}$ of the form \List{\ell}{1}{k} be
+a sequence of collection literal elements.
+The sequence of objects $s_{\metavar{object}}$
+obtained by evaluating $s_{\metavar{syntax}}$
+is the concatenation of the sequences of objects
+obtained by evaluating each element $\ell_j$, $j \in 1 .. k$:
+$s_{\metavar{object}}=\EvaluateElement{\ell_1}+\ldots+\EvaluateElement{\ell_k}$,
+where \EvaluateElement{\ell_j} denotes the object sequence yielded by
+evaluation of a single collection literal element $\ell_j$.
+The object sequences for elements
+must be computed in the textual order,
+because the computations may have side effects.
+
+\LMHash{}%
+We use the notation $\EvaluateElement{\ell} := s$
+at specific points where the computation is complete,
+in order to specify that the value of \EvaluateElement{\ell} is $s$.
+\IndexCustom{Evaluation of a collection literal element $\ell$}{%
+  collection literal element!evaluation}
+in the given context
+to an object sequence \EvaluateElement{\ell}
+is then specified as follows:
+
+\LMHash{}%
+\Case{Expression element}
+When $\ell$ is an \synt{expressionElement} of the form $e$,
+$e$ is evaluated to an object $o$,
+and $\EvaluateElement{\ell} := \LiteralSequence{o}$.
+\EndCase
+
+\LMHash{}%
+\Case{Map element}
+When $\ell$ is a \synt{mapElement} of the form
+\code{$e_1$:\,\,$e_2$},
+$e_1$ is evaluated to an object $o_1$,
+then $e_2$ is evaluated to an object $o_2$,
+and $\EvaluateElement{\ell} := \LiteralSequence{o_1:o_2}$.
+\EndCase
+
+\begin{figure}[t]
+\begin{normativeDartCode}
+$S_{\metavar{spread}}$ spread = $o_{\metavar{spread}}$;
+\VAR{} $s$ = \LiteralSequence{};
+\FOR{} (\VAR{} v \IN{} spread) \{
+  Value value = v;
+  $s = s + \LiteralSequence{\code{value}}$;
+\}
+$\EvaluateElement{\ell} := s$;
+\end{normativeDartCode}
+\vspace{-3mm}
+  \caption{Evaluation of a list or set spread element $\ell$
+    with spread object $o_{\metavar{spread}}$.}
+  \label{fig:evaluationOfAnIterableSpreadElement}
+\end{figure}
+
+\begin{figure}[t]
+\begin{normativeDartCode}
+$S_{\metavar{spread}}$ spread = $o_{\metavar{spread}}$;
+\VAR{} $s$ = \LiteralSequence{};
+\FOR{} (\VAR{} entry \IN{} spread) \{
+  Key key = entry.key;
+  Value value = entry.value;
+  $s = s + \LiteralSequence{\code{key}:\,\code{value}}$;
+\}
+$\EvaluateElement{\ell} := s$;
+\end{normativeDartCode}
+\vspace{-3mm}
+  \caption{Evaluation of a map spread element $\ell$
+    with spread object $o_{\metavar{spread}}$.}
+  \label{fig:evaluationOfAMapSpreadElement}
+\end{figure}
+
+\LMHash{}%
+\Case{Spread element}
+\begin{enumerate}
+\item
+  When $\ell$ is a \synt{spreadElement} of the form
+  `\code{...?$e$}', $e$ is evaluated to an object $o_{\metavar{spread}}$.
+  If $o_{\metavar{spread}}$ is the null object then
+  $\EvaluateElement{\ell} := \LiteralSequence{}$.
+  Otherwise evaluation proceeds with step 2.
+
+  When $\ell$ is a \synt{spreadElement} of the form
+  `\code{...$e$}', $e$ is evaluated to an object $o_{\metavar{spread}}$.
+  %% TODO(eernst): Come NNBD, this error cannot occur any more: delete.
+  If $o_{\metavar{spread}}$ is the null object then a dynamic error occurs.
+  Otherwise evaluation proceeds with step 2.
+\item
+  Let $T_{\metavar{spread}}$ be the dynamic type of $o_{\metavar{spread}}$.
+  Let $S$ be the static type of $e$.
+  When $S$ is a top type
+  (\ref{superBoundedTypes}),
+  let $S_{\metavar{spread}}$ be \code{Iterable<\DYNAMIC>};
+  otherwise let $S_{\metavar{spread}}$ be $S$.
+  \commentary{%
+    It is a compile-time error if $S$
+    is not assignable to \code{Iterable<\DYNAMIC>}.%
+  }
+  \begin{itemize}
+  \item
+    When both $T_{\metavar{spread}}$ and $T_{\metavar{target}}$ implement
+    \code{Iterable},
+    the code in Fig.~\ref{fig:evaluationOfAnIterableSpreadElement} is executed
+    in the static and dynamic context where $\ell$ occurs,
+    where \code{spread}, $s$, \code{v}, and \code{value} are fresh variables,
+    and \code{Value} is a fresh type variable bound to the
+    actual type argument of $T_{\metavar{target}}$ at \code{Iterable}.
+
+    \commentary{%
+      The code makes use of a pseudo-variable $s$ denoting an object sequence.
+      We do not specify the type of $s$,
+      this variable is only used to indicate the required
+      semantic actions taken to gather the resulting object sequence.
+      In the case where the implementation does not have
+      a representation of $s$ at all,
+      the action may be to extend \metavar{target} immediately.
+      A similar approach is used in subsequent cases.%
+    }
+  \item
+    When both $T_{\metavar{spread}}$ and $T_{\metavar{target}}$ implement
+    \code{Map},
+    the code in Fig.~\ref{fig:evaluationOfAMapSpreadElement} is executed
+    in the static and dynamic context where $\ell$ occurs,
+    where \code{spread}, $s$, \code{entry}, \code{key}, and \code{value}
+    are fresh variables,
+    and \code{Key} and \code{Value} are fresh type variables bound to the
+    first respectively second actual type argument
+    of $T_{\metavar{target}}$ at \code{Map}.
+
+    % Will not change with nnbd: `spread` type arguments could be \DYNAMIC{}.
+    It is allowed for an implementation to delay the dynamic errors
+    that occur if the given \code{key} does not have the type \code{Key},
+    or the given \code{value} does not have the type \code{Value},
+    but it cannot occur after the pair has been appended to $s$.
+  \item
+    Otherwise, a dynamic error occurs.
+
+    \commentary{%
+      This occurs when the target is a map respectively iterable,
+      and the spread is not, which is possible for
+      a spread whose static type is \DYNAMIC{}.%
+    }
+  \end{itemize}
+\end{enumerate}
+
+\commentary{%
+This may not be the most efficient way to traverse the items in a collection,
+and implementations may of course use any other approach
+with the same observable behavior.
+However, in order to give implementations more room to optimize
+we also allow the following.%
+}
+
+\LMHash{}%
+If $o$ is an object whose dynamic type implements
+\code{List}, \code{Queue}, or \code{Set},
+an implementation may choose to call \code{length} on the object.
+
+\commentary{%
+This may let it allocate space for the resulting collection more efficiently.
+The given class is expected to have an efficient and
+side-effect free implementation of \code{length}.%
+}
+
+\LMHash{}%
+If $o$ is an object whose dynamic type implements \code{List},
+an implementation may choose to call operator \lit{[]}
+in order to access elements from the list.
+If it does so, it will only pass indices
+that are non-negative and less than the value returned by \code{length}.
+
+\LMHash{}%
+A Dart implementation may detect whether these options apply
+at compile time based on the static type of $e$,
+or at runtime based on the actual value.
+\EndCase
+
+\LMHash{}%
+\Case{If element}
+When $\ell$ is an \synt{ifElement} of the form
+\code{\IF{} ($b$) $\ell_1$} or
+\code{\IF{} ($b$) $\ell_1$ \ELSE{} $\ell_2$},
+the condition $b$ is evaluated to a value $o_b$.
+If $o_b$ is \TRUE{} then
+$\EvaluateElement{\ell} := \EvaluateElement{\ell_1}$.
+If $o_b$ is \FALSE{} and $\ell_2$ is present then
+$\EvaluateElement{\ell} := \EvaluateElement{\ell_2}$,
+and if $\ell_2$ is not present then
+$\EvaluateElement{\ell} := \LiteralSequence{}$.
+% $o_b$ can have type \DYNAMIC{}.
+If $o_b$ is neither \TRUE{} nor \FALSE{} then a dynamic error occurs.
+\EndCase
+
+\begin{figure}[t]
+\begin{normativeDartCode}
+\VAR{} $s$ = \LiteralSequence{};
+\AWAIT? \FOR{} ($D$ \id{} \IN{} $e$) \{
+  $s = s + \EvaluateElement{\ell_1}$;
+\}
+$\EvaluateElement{\ell} := s$;
+\end{normativeDartCode}
+\vspace{-3mm}
+  \caption{Evaluation of a \synt{forElement} $\ell$ of the form
+    \code{\AWAIT?\,\,\FOR\,\,($D$\,\,\id\,\,\IN\,\,$e$)\,\,$\ell_1$},
+    where \AWAIT{} is included in both the for element and the code,
+    or omitted in both.}
+  \label{fig:evaluationOfAForInElement}
+\end{figure}
+
+\begin{figure}[t]
+\begin{normativeDartCode}
+\VAR{} $s$ = \LiteralSequence{};
+\AWAIT? \FOR{} ($P$) \{
+  $s = s + \EvaluateElement{\ell_1}$;
+\}
+$\EvaluateElement{\ell} := s$;
+\end{normativeDartCode}
+\vspace{-3mm}
+  \caption{Evaluation of a \synt{forElement} $\ell$ of the form
+    \code{\AWAIT?\,\,\FOR\,\,($P$)\,\,$\ell_1$},
+    where $P$ is derived from \synt{forLoopParts}
+    and \AWAIT{} is included in both the for element and the code,
+    or omitted in both.}
+  \label{fig:evaluationOfAForLoopElement}
+\end{figure}
+
+\LMHash{}%
+\Case{For-in element}
+Let $D$ be derived from \syntax{<finalConstVarOrType>?} and
+let $\ell$ be a \synt{forElement} of the form
+\code{\AWAIT?\,\,\FOR\,\,($D$\,\,\id\,\,\IN\,\,$e$)\,\,$\ell_1$},
+where `\AWAIT?' indicates that \AWAIT{} may be present or absent.
+To evaluate $\ell$,
+the code in Fig.~\ref{fig:evaluationOfAForInElement} is executed
+in the static and dynamic context where $\ell$ occurs.
+\EndCase
+
+\LMHash{}%
+\Case{For loop element}
+Let $P$ be a term derived from \synt{forLoopParts} and
+let $\ell$ be a \synt{forElement} of the form
+\code{\AWAIT?\,\,\FOR\,\,($P$)\,\,$\ell_1$},
+where `\AWAIT?' indicates that \AWAIT{} may be present or absent.
+To evaluate $\ell$,
+the code in Fig.~\ref{fig:evaluationOfAForLoopElement} is executed
+in the static and dynamic context where $\ell$ occurs.
+\EndCase
+
+
+\subsubsection{List}
+\LMLabel{uiAsCodeList}
+
+!!!HERE!!! This should be moved into \ref{lists}.
+
+\LMHash{}%
+The result of the literal expression is a fresh instance of
+a class that implements \code{List<$E$>} where $E$ is
+the element type of the literal.
+It contains the values in \metavar{result}, in order.
+If the literal is constant,
+the list is canonicalized and immutable,
+otherwise it is not.
+
+
+\subsubsection{Set}
+\LMLabel{uiAsCodeSet}
+
+!!!HERE!!! This should be moved into \ref{sets}.
+
+\LMHash{}%
+Create a fresh instance \metavar{set} of
+a class that implements \code{Set<$E$>} where $E$
+is the set element type of the literal.
+
+\LMHash{}%
+For each \metavar{value} in \metavar{result}:
+
+\begin{enumerate}
+\item
+  If \metavar{set} contains
+  a value \metavar{existing} that is equal to \metavar{value}
+  according to \metavar{existing}'s operator \lit{==}:
+\item
+  If the literal is constant, it is a compile-time error.
+\item
+  Else, do nothing.
+  \commentary{Duplicates are discarded and the first one wins.}
+\item
+  Else, add \metavar{value} to \metavar{set}.
+\end{enumerate}
+
+\LMHash{}%
+The result of the literal expression is \metavar{set}.
+If the literal is constant,
+canonicalize it make the set immutable.
+
+
+\subsubsection{Map}
+\LMLabel{uiAsCodeMap}
+
+!!!HERE!!! This should be moved into \ref{maps}.
+
+\LMHash{}%
+Allocate a fresh instance \metavar{map} of
+a class that implements \code{LinkedHashMap<$K$, $V$>} where $K$ is
+the key type of the literal and $V$ is
+the value type.
+
+\LMHash{}%
+For each entry \code{\metavar{key}: \metavar{value}} in \metavar{result}:
+
+\begin{enumerate}
+\item
+  If \metavar{map} contains an entry \metavar{existing}
+  whose key \metavar{existingKey} is equal to \metavar{key}
+  according to \metavar{existingKeys}'s operator \lit{==}:
+  \begin{enumerate}
+  \item
+    If the literal is constant, it is a compile-time error.
+  \item
+    Else, replace the value in \metavar{existing} with \metavar{value},
+    while keeping its position in the sequence of entries
+    and \metavar{existingKey} the same.
+  \end{enumerate}
+\item
+  Else add entry \code{\metavar{key}: \metavar{value}} to \metavar{map}.
+\end{enumerate}
+
+\LMHash{}%
+The result of the map literal expression is \metavar{map}.
+If the literal is constant,
+canonicalize it and make the map immutable.
+
+
+\subsubsection{Lists}
+\LMLabel{lists}
+
+!!!HERE!!! Revise.
+
+\LMHash{}%
+A \IndexCustom{list literal}{literal!list}
+denotes a list, which is an integer indexed collection of objects.
+The grammar rule for \synt{listLiteral} is specified elsewhere
+(\ref{collectionLiterals}).
+
+\LMHash{}%
+When a given list literal $e$ has no type arguments,
+the type argument $T$ is selected as specified below
+(\ref{listLiteralInference}),
+and $e$ is henceforth treated as
+(\ref{notation})
+\code{<$T$>$e$}.
+
+\LMHash{}%
+A list may contain zero or more objects.
+The number of elements in a list is its size.
+A list has an associated set of indices.
+An empty list has an empty set of indices.
+A non-empty list has the index set $\{0, \ldots, n - 1\}$ where $n$ is the size of the list.
+It is a dynamic error to attempt to access a list
+using an index that is not a member of its set of indices.
+
+\LMHash{}%
+The sequence of elements of a given list literal
+is determined as described below
+(\ref{listEvaluation}).
+
+\LMHash{}%
+If a list literal $\ell$ begins with the reserved word \CONST{}
+or $\ell$ occurs in a constant context
+(\ref{constantContexts}),
+it is a
+\IndexCustom{constant list literal}{literal!list!constant},
+which is a constant expression
+(\ref{constants})
+and therefore evaluated at compile time.
+Otherwise, it is a
+\IndexCustom{run-time list literal}{literal!list!run-time}
+and it is evaluated at run time.
+Only run-time list literals can be mutated
+after they are created.
+% This error can occur because being constant is a dynamic property.
+Attempting to mutate a constant list literal will result in a dynamic error.
+
+\commentary{%
+% The following is true either directly or indirectly: There is a \CONST{}
+% modifier on the list literal, or the list literal as a whole occurs
+% in a constant context.
+Note that the element expressions of a constant list literal
+occur in a constant context
+(\ref{constantContexts}),
+which means that \CONST{} modifiers need not be specified explicitly.%
+}
+
+\LMHash{}%
+It is a compile-time error if an element of a constant list literal
+is not a constant expression.
+It is a compile-time error if the type argument of a constant list literal
+is not a constant type expression.
+
+\rationale{%
+The binding of a formal type parameter is not known at compile time,
+so we cannot use type parameters inside constant expressions.%
+}
+
+\LMHash{}%
+The value of a constant list literal
+\code{\CONST?\,\,<$E$>[$e_1, \ldots, e_n$]}
+is an object $a$ whose class implements the built-in class
+\code{List<$E$>}.
+Let $v_i$ be the value of the constant expression $e_i$, $i \in 1 .. n$.
+The $i$th element of $a$ (at index $i - 1$) is $v_i$.
+%
+%% TODO(eernst): If inference is specified to provide all type arguments,
+%% we should delete the following.
+The value of a constant list literal
+\code{\CONST?\,\,[$e_1, \ldots, e_n$]}
+is defined as the value of the constant list literal
+% For a constant list literal, it is never an error to have the \CONST, even if
+% it was omitted above. So we remove the `?`, making the next line well-defined.
+\code{\CONST\,\,<\DYNAMIC>[$e_1, \ldots, e_n$]}.
+
+\LMHash{}%
+Let
+$list_1 =$ \code{\CONST?\,\,<$V$>[$e_{11}, \ldots, e_{1n}$]}
+and
+$list_2 =$ \code{\CONST?\,\,<$U$>[$e_{21}, \ldots, e_{2n}$]}
+be two constant list literals and
+let the elements of $list_1$ and $list_2$ evaluate to
+$o_{11}, \ldots, o_{1n}$ and $o_{21}, \ldots, o_{2n}$ respectively.
+If{}f \code{identical($o_{1i}$, $o_{2i}$)} for $i \in 1 .. n$ and $V == U$
+then \code{identical($list_1$, $list_2$)}.
+
+\commentary{%
+In other words, constant list literals are canonicalized.%
+}
+
+\LMHash{}%
+A run-time list literal
+\code{<$E$>[$e_1, \ldots, e_n$]}
+is evaluated as follows:
+\begin{itemize}
+\item
+  First, the expressions $e_1, \ldots, e_n$ are evaluated
+  in order they appear in the program,
+  producing objects $o_1, \ldots, o_n$.
+\item
+  A fresh instance (\ref{generativeConstructors}) $a$, of size $n$,
+  whose class implements the built-in class \code{List<$E$>}
+  is allocated.
+\item
+  The operator \lit{[]=} is invoked on $a$ with
+  first argument $i$ and second argument
+  $o_{i+1}, 0 \le i < n$.
+\item
+  The result of the evaluation is $a$.
+\end{itemize}
+
+\LMHash{}%
+The objects created by list literals do not override
+the \lit{==} operator inherited from the \code{Object} class.
+
+\commentary{
+Note that this document does not specify an order
+in which the elements are set.
+This allows for parallel assignments into the list
+if an implementation so desires.
+The order can only be observed as follows (and may not be relied upon):
+if element $i$ is not a subtype of the element type of the list,
+a dynamic type error will occur when $a[i]$ is assigned $o_{i-1}$.
+}
+
+\LMHash{}%
+%% TODO(eernst): If inference is specified to provide all type arguments,
+%% we should delete the following.
+A run-time list literal
+\code{[$e_1, \ldots, e_n$]}
+is evaluated as
+\code{<\DYNAMIC>[$e_1, \ldots, e_n$]}.
+
+\commentary{
+There is no restriction precluding nesting of list literals.
+It follows from the rules above that
+\code{<List<int>{}>[<int>[1, 2, 3], <int>[4, 5, 6]]}
+is a list with type parameter \code{List<int>},
+containing two lists with type parameter \code{int}.
+}
+
+\LMHash{}%
+The static type of a list literal of the form
+\code{\CONST\,\,<$E$>[$e_1, \ldots, e_n$]}
+or the form
+\code{<$E$>[$e_1, \ldots, e_n$]}
+is \code{List<$E$>}.
+%
+%% TODO(eernst): If inference is specified to provide all type arguments,
+%% we should delete the following.
+The static type of a list literal of the form
+\code{\CONST\,\,[$e_1, \ldots, e_n$]}
+or the form
+\code{[$e_1, \ldots, e_n$]}
+is \code{List<\DYNAMIC>}.
+
+
+\subsubsection{List Literal Inference}
+\LMLabel{listLiteralInference}
+
+!!!HERE!!! Raw from feature spec.
+
+\LMHash{}%
+Inference for list literals mostly follows that of set literals
+without the complexity around disambiguation with maps and
+using \code{List} or \code{Iterable} in a few places instead of \code{Set}.
+
+\LMHash{}%
+Inside a \synt{listLiteral} \metavar{listLiteral},
+the inferred type of an element $\ell$ is a list element type $T$.
+It is computed relative to a downwards element context type $P$,
+where $P$ is $T$
+if downwards inference constrains the type of \metavar{listLiteral}
+to \code{Iterable<$T$>} for some $T$.
+Otherwise, $P$ is \lit{?}.
+
+\begin{itemize}
+\item
+  If $\ell$ is an \synt{expressionElement} with expression $e1$:
+  \begin{itemize}
+  \item
+    The inferred list element type of $\ell$ is
+    the inferred type of the expression $e1$ in context $P$.
+  \end{itemize}
+\item
+  If $\ell$ is a \synt{spreadElement} with expression $e1$:
+
+  \begin{itemize}
+  \item
+    If $P$ is \lit{?} then let $S$ be
+    the inferred type of $e1$ in context \lit{?}:
+
+    \begin{itemize}
+    \item
+      If $S$ is a non-\code{Null} subtype of \code{Iterable<Object>}, then
+      the inferred list element type of $\ell$ is $T$ where $T$ is
+      the type such that \code{Iterable<$T$>} is
+      a superinterface of $S$
+      (\commentary{%
+        the result of constraint matching for $X$ using
+        the constraint \code{$S$ <: Iterable<$X$>}}).
+
+      \begin{itemize}
+      \item
+        If $S$ is \DYNAMIC{}, then
+        the inferred list element type of $\ell$ is \DYNAMIC{}.
+      \item
+        If $S$ is \code{Null} and the spread operator is \lit{...?}, then
+        the list element type is \code{Null}.
+      \item
+        Otherwise it is an error
+        (\commentary{%
+          because it is a spread of a non-spreadable type like Object%
+        }).
+      \end{itemize}
+    \item
+      Else, let $S$ be
+      the inferred type of $e1$ in context \code{Iterable<$P$>}:
+
+      \begin{itemize}
+      \item
+        If $S$ is a non-\code{Null} subtype of \code{Iterable<Object>}, then
+        the inferred list element type of $\ell$ is $T$ where $T$ is
+        the type such that \code{Iterable<$T$>} is
+        a superinterface of $S$
+        (\commentary{%
+          the result of constraint matching for $X$ using
+          the constraint \code{$S$ <: Iterable<$X$>}%
+        }).
+      \item
+        If $S$ is \DYNAMIC{}, then
+        the inferred list element type of $\ell$ is \DYNAMIC{}.
+      \item
+        Otherwise it is an error.
+      \end{itemize}
+    \end{itemize}
+  \item
+    If $\ell$ is an \synt{ifElement} with one $\ell$, $p1$,
+    and no "else" element:
+    The condition is inferred with a context type of \code{bool}.
+
+    The inferred list element type of $\ell$ is
+    the inferred list element type of $p1$ with element context type $P$.
+  \item
+    If $\ell$ is a \synt{ifElement} with two $\ell$s, $p1$ and $p2$:
+    The condition is inferred with a context type of \code{bool}.
+
+    The inferred list element type of $\ell$ is
+    the least upper bound of $S1$ and $S2$ where $S1$ is
+    the inferred list element type of $p1$ and $S2$ is
+    the inferred list element type of $p2$,
+    both with element context type $P$.
+
+  \item
+    If $\ell$ is a \synt{forElement} with $\ell$ $p1$ then:
+
+    Inference for the iterated expression and the controlling variable
+    is done as for the corresponding \FOR{} or \AWAIT{} \FOR{} statement.
+
+    The inferred list element type of $\ell$ is the inferred list element
+    type of $p1$ with element context type $P$.
+  \end{itemize}
+\end{itemize}
+
+\commentary{%
+Note: $\ell$ cannot be a \synt{mapElement} as
+those are not allowed inside list literals.%
+}
+
+\LMHash{}%
+Finally, we define inference on a \synt{listLiteral} \metavar{collection}
+as follows:
+
+\begin{itemize}
+\item
+  If $P$ is \lit{?} then
+  the static type of \metavar{collection} is \code{List<$T$>} where $T$ is
+  the least upper bound of the inferred list element types of the elements.
+\item
+  Otherwise,
+  the static type of \metavar{collection} is \code{List<$T$>} where $T$ is
+  determined by downwards inference.
+\end{itemize}
+
+
+\subsubsection{List Literal Evaluation}
+\LMLabel{listLiteralEvaluation}
+
+!!!HERE!!! May not be needed: With element evaluation in place, it's just a short explanation in \ref{lists}.
+
+
+\subsubsection{Sets}
+\LMLabel{sets}
+
+!!!HERE!!! Revise.
+
+\LMHash{}%
+A \IndexCustom{set literal}{literal!set} denotes a set object.
+The grammar rule for \synt{setOrMapLiteral} which covers
+set literals as well as map literals occurs elsewhere
+(\ref{collectionLiterals}).
+
+\LMHash{}%
+A set literal consists of zero or more element expressions.
+It is a compile-time error if a set literal has more than one type argument.
+
+\rationale{%
+A set literal with no type argument is always converted to a literal
+with a type argument by type inference (\ref{overview}), so the following
+section only address the behavior of literals with type arguments.%
+}
+
+\LMHash{}%
+If a set literal $\ell$ begins with the reserved word \CONST{}
+or $\ell$ occurs in a constant context
+(\ref{constantContexts}),
+it is a
+\IndexCustom{constant set literal}{literal!set!constant}
+which is a constant expression
+(\ref{constants})
+and therefore evaluated at compile time.
+Otherwise, it is a
+\IndexCustom{run-time set literal}{literal!set!run-time}
+and it is evaluated at run time.
+Only run-time set literals can be mutated after they are created.
+% This error can occur because being constant is a dynamic property, here.
+Attempting to mutate a constant set literal will result in a dynamic error.
+
+\commentary{%
+% The following is true either directly or indirectly: There is a \CONST{}
+% modifier on the literal set, or we use the "immediate subexpression" rule
+% about constant contexts.
+Note that the element expressions of a constant set literal
+occur in a constant context
+(\ref{constantContexts}),
+which means that \CONST{} modifiers need not be specified explicitly.%
+}
+
+\LMHash{}%
+It is a compile-time error if an element expression in a constant set literal
+is not a constant expression.
+It is a compile-time error if
+the operator \lit{==} of an element expression in a constant map literal
+is not primitive
+(\ref{theOperatorEqualsEquals}).
+It is a compile-time error if the type argument of a constant set literal
+is not a constant type expression
+(\ref{constants}).
+It is a compile-time error if two elements of a constant set literal are equal
+according to their \lit{==} operator
+(\ref{equality}).
+
+\LMHash{}%
+The value of a constant set literal
+\code{\CONST?\,\,<$E$>\{$e_1, \ldots, e_n$\}}
+is an object $s$ whose class implements the built-in class
+\code{Set<$E$>}.
+The elements of $m$ are $v_i, i \in 1 .. n$,
+where $v_i$ is the value of the constant expression $e_i$.
+%
+%% TODO(eernst): If inference is specified to provide all type arguments,
+%% we should delete the following.
+The value of a constant set literal
+\code{\CONST?\,\,\{$e_1, \ldots, e_n$\}}
+is defined as the value of the constant set literal
+% For a constant set literal, it is never an error to have the \CONST, even if
+% it was omitted above. So we remove the `?`, making the next line well-defined.
+\code{\CONST\,\,<\DYNAMIC>\{$e_1, \ldots, e_n$\}}.
+
+\LMHash{}%
+Let $set_1$ be a constant set literal with type argument $E$
+and element expressions, in source order, $e_{11}, \ldots, e_{1n}$ evaluating
+to objects $v_{11}, \ldots, v_{1n}$.
+Let $set_2$ be a constant set literal with type argument $F$
+and element expressions, in source order, $e_{21}, \ldots, e_{2n}$ evaluating
+to objects $v_{21}, \ldots, v_{2n}$.
+If{}f \code{identical($v_{1i}$, $v_{2i}$)}
+for $i \in 1 .. n$, and $E$ and $F$ is the same type,
+then \code{identical($set_1$, $set_2$)}.
+
+\commentary{%
+In other words, constant set literals are canonicalized if they have
+the same type and the same values in the same order.
+Two constant set literals are never identical
+if they have a different number of elements.%
+}
+
+\LMHash{}%
+A run-time set literal with element expressions $e_1, \ldots, e_n$
+(in source order) and with type argument $E$
+is evaluated as follows:
+\begin{itemize}
+\item
+For each $i \in 1 .. n$ in numeric order,
+the expression $e_i$ is evaluated producing object $v_i$.
+\item A fresh object (\ref{generativeConstructors}) $s$
+implementing the built-in class \code{Set<$E$>}, is created.
+\item The set $s$ is made to have the objects $v_1, \ldots{} , v_n$ as elements,
+iterated in numerical order.
+\item
+The result of the evaluation is $s$.
+\end{itemize}
+
+\LMHash{}%
+The objects created by set literals do not override
+the \lit{==} operator inherited from the \code{Object} class.
+
+\LMHash{}%
+A set literal is ordered: iterating over the elements of the sets
+always happens in the order the elements first appeared in the source code.
+
+\commentary{
+If a value repeats, the order is defined by first occurrence, but the value is defined by the last.
+}
+
+\LMHash{}%
+%% TODO(eernst): If inference is specified to provide all type arguments,
+%% we should delete the following.
+A run-time set literal
+\code{\{$e_1, \ldots, e_n$\}}
+is evaluated as
+\code{<\DYNAMIC>\{$e_1, \ldots, e_n$\}}.
+
+\LMHash{}%
+The static type of a set literal of the form
+\code{\CONST\,\,<$E$>\{$e_1, \ldots, e_n$\}}
+or the form
+\code{<$E$>\{$e_1, \ldots, e_n$\}}
+is
+\code{Set<$E$>}.
+%
+%% TODO(eernst): If inference is specified to provide all type arguments,
+%% we should delete the following.
+The static type of a list literal of the form
+\code{\CONST\,\,\{$e_1, \ldots, e_n$\}}
+or the form
+\code{\{$e_1, \ldots, e_n$\}}
+is \code{Set<\DYNAMIC>}.
+
+
+\subsubsection{Maps}
+\LMLabel{maps}
+
+!!!HERE!!! Revise.
+
+\LMHash{}%
+A \IndexCustom{map literal}{literal!map} denotes a map object.
+The grammar rule for \synt{setOrMapLiteral} which covers both
+map literals and set literals occurs elsewhere
+(\ref{collectionLiterals}).
+
+\LMHash{}%
+A map literal consists of zero or more entries.
+Each entry has a \Index{key} and a \Index{value}.
+Each key and each value is denoted by an expression.
+It is a compile-time error if a map literal has one type argument,
+or more than two type arguments.
+
+\LMHash{}%
+If a map literal $\ell$ begins with the reserved word \CONST{},
+or if $\ell$ occurs in a constant context
+(\ref{constantContexts}),
+it is a
+\IndexCustom{constant map literal}{literal!map!constant}
+which is a constant expression
+(\ref{constants})
+and therefore evaluated at compile time.
+Otherwise, it is a
+\IndexCustom{run-time map literal}{literal!map!run-time}
+and it is evaluated at run time.
+Only run-time map literals can be mutated after they are created.
+% This error can occur because being constant is a dynamic property, here.
+Attempting to mutate a constant map literal will result in a dynamic error.
+
+\commentary{%
+% The following is true either directly or indirectly: There is a \CONST{}
+% modifier on the literal map, or we use the "immediate subexpression" rule
+% about constant contexts.
+Note that the key and value expressions of a constant list literal
+occur in a constant context
+(\ref{constantContexts}),
+which means that \CONST{} modifiers need not be specified explicitly.%
+}
+
+\LMHash{}%
+It is a compile-time error if
+either a key or a value of an entry in a constant map literal
+is not a constant expression.
+It is a compile-time error if
+the operator \lit{==} of the key of an entry in a constant map literal
+is not primitive
+(\ref{theOperatorEqualsEquals}).
+It is a compile-time error if a type argument of a constant map literal
+is not a constant type expression
+(\ref{constants}).
+
+\LMHash{}%
+The value of a constant map literal
+\code{\CONST?\,\,<$K, V$>\{$k_1:e_1, \ldots, k_n:e_n$\}}
+is an object $m$ whose class implements the built-in class
+\code{Map<$K, V$>}.
+The entries of $m$ are $u_i:v_i, i \in 1 .. n$,
+where $u_i$ is the value of the compile-time expression $k_i$,
+and $v_i$ is the value of the compile-time expression $e_i$.
+%
+%% TODO(eernst): If inference is specified to provide all type arguments,
+%% we should delete the following.
+The value of a constant map literal
+\code{\CONST?\,\,\{$k_1:e_1, \ldots, k_n:e_n$\}}
+is defined as the value of the constant map literal
+% For a constant map literal, it is never an error to have the \CONST, even if
+% it was omitted above. So we remove the `?`, making the next line well-defined.
+\code{\CONST\,\,<\DYNAMIC, \DYNAMIC>\{$k_1:e_1, \ldots, k_n:e_n$\}}.
+
+\LMHash{}%
+Let $map_1$ be a constant map literal of the form
+\code{\CONST?\,\,<$K, V$>\{$k_{11}:e_{11}, \ldots, k_{1n}:e_{1n}$\}}
+and $map_2$ a constant map literal of the form
+\code{\CONST?\,\,<$J, U$>\{$k_{21}:e_{21}, \ldots, k_{2n}:e_{2n}$\}}.
+Let the keys of $map_1$ and $map_2$ evaluate to
+$s_{11}, \ldots, s_{1n}$ and $s_{21}, \ldots, s_{2n}$, respectively,
+and let the elements of $map_1$ and $map_2$ evaluate to
+$o_{11}, \ldots, o_{1n}$ and $o_{21}, \ldots, o_{2n}$, respectively.
+If{}f
+\code{identical($o_{1i}$, $o_{2i}$)} and
+\code{identical($s_{1i}$, $s_{2i}$)}
+for $i \in 1 .. n$, and $K == J, V == U$, then \code{identical($map_1$, $map_2$)}.
+
+\commentary{%
+In other words, constant map literals are canonicalized.%
+}
+
+\LMHash{}%
+It is a compile-time error if two keys of a constant map literal are equal
+according to their \lit{==} operator (\ref{equality}).
+
+\LMHash{}%
+A run-time map literal
+\code{<$K, V$>\{$k_1:e_1, \ldots, k_n:e_n$\}}
+is evaluated as follows:
+\begin{itemize}
+\item
+  For each $i \in 1 .. n$ in numeric order,
+  first the expression $k_i$ is evaluated producing object $u_i$,
+  and then $e_i$ is evaluated producing object $o_i$.
+  This produces all the objects $u_1, o_1, \ldots, u_n, o_n$.
+\item
+  A fresh instance (\ref{generativeConstructors}) $m$
+  whose class implements the built-in class \code{Map<$K, V$>},
+  is allocated.
+\item
+  The operator \lit{[]=} is invoked on $m$
+  with first argument $u_i$ and second argument $o_i$
+  for each $i \in 1 .. n$.
+\item
+  The result of the evaluation is $m$.
+\end{itemize}
+
+\LMHash{}%
+The objects created by map literals do not override
+the \lit{==} operator inherited from the \code{Object} class.
+
+\LMHash{}%
+%% TODO(eernst): If inference is specified to provide all type arguments,
+%% we should delete the following.
+A run-time map literal
+\code{\{$k_1:e_1, \ldots, k_n:e_n$\}}
+is evaluated as
+
+\code{<\DYNAMIC, \DYNAMIC>\{$k_1:e_1, \ldots, k_n:e_n$\}}.
+
+\LMHash{}%
+A map literal is ordered:
+iterating over the keys and/or values of the maps
+always happens in the order the keys appeared in the source code.
+
+\commentary{
+Of course, if a key repeats, the order is defined by first occurrence,
+but the value is defined by the last.
+}
+
+\LMHash{}%
+The static type of a map literal of the form
+\code{\CONST{} <$K, V$>\{$k_1:e_1, \ldots, k_n:e_n$\}}
+or the form
+\code{<$K, V$>\{$k_1:e_1, \ldots, k_n:e_n$\}}
+is
+\code{Map<$K, V$>}.
+%
+%% TODO(eernst): If inference is specified to provide all type arguments,
+%% we should delete the following.
+The static type of a map literal of the form
+\code{\CONST{} \{$k_1:e_1, \ldots, k_n:e_n$\}}
+or the form
+\code{\{$k_1:e_1, \ldots, k_n:e_n$\}} is
+\code{Map<\DYNAMIC, \DYNAMIC>}.
+
+
 \subsubsection{Compile-time errors}
 \LMLabel{uiAsCodeCompileTimeErrors}
+
+!!!HERE!!! Integrate this into other sections.
 
 \LMHash{}%
 After type inference and disambiguation,
@@ -8836,7 +8761,7 @@ It is a compile-time error if:
   \end{dartCode}
 \end{itemize}
 
-!!!HERE!!!
+!!!HERE!!! End of UI-as-code material.
 
 
 \subsection{Throw}
@@ -10061,7 +9986,7 @@ Figure~\ref{fig:argumentsAndParameters} shows how this situation arises.
     \end{array}
   \end{displaymath}
   %
-  \caption{Possible actual argument parts and formal parameter parts}
+  \caption{Possible actual argument parts and formal parameter parts.}
   \label{fig:argumentsAndParameters}
 \end{figure}
 
@@ -10394,7 +10319,7 @@ and its result is then the result of evaluating $i$:
 Otherwise $o$ has no method named \CALL{}.
 A new instance $im$ of the predefined class \code{Invocation} is created, such that:
 \begin{itemize}
-\item \code{$im$.isMethod} evaluates to \code{\TRUE{}}.
+\item \code{$im$.isMethod} evaluates to \TRUE.
 \item \code{$im$.memberName} evaluates to the symbol \code{\#call}.
 \item \code{$im$.positionalArguments} evaluates to an unmodifiable list
   containing the objects resulting from evaluation of
@@ -10941,7 +10866,7 @@ Then the value of $i$ is the value of
 If getter lookup has also failed,
 then a new instance $im$ of the predefined class \code{Invocation} is created, such that:
 \begin{itemize}
-\item \code{$im$.isMethod} evaluates to \code{\TRUE{}}.
+\item \code{$im$.isMethod} evaluates to \TRUE.
 \item \code{$im$.memberName} evaluates to the symbol \code{m}.
 \item \code{$im$.positionalArguments} evaluates to an unmodifiable list
   containing the objects resulting from the evaluation of
@@ -11271,7 +11196,7 @@ The value of $i$ is the result returned by the call to the getter function.
 If the getter lookup has failed,
 then a new instance $im$ of the predefined class \code{Invocation} is created, such that:
 \begin{itemize}
-\item \code{$im$.isGetter} evaluates to \code{\TRUE{}}.
+\item \code{$im$.isGetter} evaluates to \TRUE.
 \item \code{$im$.memberName} evaluates to the symbol \code{m}.
 \item \code{$im$.positionalArguments} evaluates to an empty, unmodifiable instance of
 \code{List<Object>}.
@@ -12054,7 +11979,7 @@ Otherwise, the body of the setter is executed with its formal parameter bound to
 \LMHash{}%
 If the setter lookup has failed, then a new instance $im$ of the predefined class \code{Invocation} is created, such that:
 \begin{itemize}
-\item \code{$im$.isSetter} evaluates to \code{\TRUE{}}.
+\item \code{$im$.isSetter} evaluates to \TRUE.
 \item \code{$im$.memberName} evaluates to the symbol \code{v=}.
 \item \code{$im$.positionalArguments} evaluates to an unmodifiable list
   containing the same objects as
@@ -14152,7 +14077,8 @@ The \Index{for statement} supports iteration.
 \LMLabel{forLoop}
 
 \LMHash{}%
-Execution of a for statement of the form \code{\FOR{} (\VAR{} $v$ = $e_0$; $c$; $e$) $s$} proceeds as follows:
+Execution of a for statement of the form
+\code{\FOR{} (\VAR{} $v$ = $e_0$; $c$; $e$) $s$} proceeds as follows:
 
 \LMHash{}%
 If $c$ is empty then let $c'$ be \TRUE{} otherwise let $c'$ be $c$.
@@ -14236,9 +14162,9 @@ $T$ $\id_1$ = $e$;
 \noindent
 If the static type of $e$ is a top type
 (\ref{superBoundedTypes})
-then $T$ is \code{Iterable<dynamic>},
+then $T$ is \code{Iterable<\DYNAMIC>},
 otherwise $T$ is the static type of $e$.
-It is a compile-time error if $T$ is not assignable to \code{Iterable<dynamic>}.
+It is a compile-time error if $T$ is not assignable to \code{Iterable<\DYNAMIC>}.
 
 \commentary{
 It follows that it is a compile-time error
@@ -16668,7 +16594,7 @@ and the subtype relationship is always determined in the same way.
     \SubtypeStd{[S_1/X_1,\ldots,S_s/X_s]\code{$D$<\List{T}{1}{m}>}}{T}}{%
     \code{$C$<\List{S}{1}{s}>}\;}{\;T}
   %
-  \caption{Subtype rules}
+  \caption{Subtype rules.}
   \label{fig:subtypeRules}
 \end{figure}
 

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -17021,985 +17021,1360 @@ operator.
 \section*{Appendix: UI as code Feature Specification}
 \LMLabel{uiAsCode}
 
-# Unified Collections
 
-The Dart team is concurrently working on three proposals that affect collection
-literals:
+\subsection{Grammar}
+\LMLabel{uiAsCodeGrammar}
 
-* [Set Literals][]
-* [Spread Collections][]
-* [Control Flow Collections][]
+\LMHash{}%
+Remove \synt{setLiteral} and \synt{mapLiteral} entirely.
+Then change the grammar to:
 
-[set literals]: https://github.com/dart-lang/language/blob/master/accepted/2.2/set-literals/feature-specification.md
-[spread collections]: https://github.com/dart-lang/language/blob/master/accepted/2.3/spread-collections/feature-specification.md
-[control flow collections]: https://github.com/dart-lang/language/blob/master/accepted/2.3/control-flow-collections/feature-specification.md
+\begin{grammar}
+<setOrMapLiteral> ::= \CONST{}? <typeArguments>? `{' <elements>? `}'
 
-These features interact in several ways, some of which weren't obvious at first.
-To make things easier on implementers and anyone else trying to understand the
-entire set of changes, this specification unifies and subsumes all three of
-those proposals.
+<listLiteral> ::= \CONST{}? <typeArguments>? `[' <elements>? `]'
 
-**This document is now the source of truth for these language changes.** The
-other three proposals are useful because they contain motivation and other
-context, but the precise syntax and semantics may be out of date in those docs.
-This is where you should be looking if you're an implementer.
+<elements> ::= <element> (`,' <element>)* `,'?
 
-## Grammar
+<element> ::= <expressionElement>
+  \alt <mapEntry>
+  \alt <spreadElement>
+  \alt <ifElement>
+  \alt <forElement>
 
-Remove `setLiteral` and `mapLiteral` entirely. Then change the grammar to:
+<expressionElement> ::= <expression>
 
-```
-setOrMapLiteral   : 'const'? typeArguments? '{' elements? '}' ;
-listLiteral       : 'const'? typeArguments? '[' elements? ']' ;
+<mapEntry> ::= <expression> `:' <expression>
 
-elements          : element ( ',' element )* ','? ;
+<spreadElement> ::= (`...' | `...?') <expression>
 
-element           : expressionElement
-                  | mapEntry
-                  | spreadElement
-                  | ifElement
-                  | forElement
-                  ;
+<ifElement> ::= \IF{} `(' <expression> `)' <element> (\ELSE{} <element>)?
 
-expressionElement : expression ;
-mapEntry          : expression ':' expression ;
+<forElement> ::= \AWAIT{}? \FOR{} `(' <forLoopParts> `)' <element>
+\end{grammar}
 
-spreadElement     : ( '...' | '...?' ) expression ;
-ifElement         : 'if' '(' expression ')' element ( 'else' element )? ;
-forElement        : 'await'? 'for' '(' forLoopParts ')' element ;
-```
+\LMHash{}%
+Let the
+\Index{leaf elements} of $e$ be the concatenation of all of the
+leaf elements of each \synt{element} directly in $e$,
+where the
+\IndexCustom{leaf elements}{leaf elements!of element}
+of an element $\ell$ are:
 
-Let the *leaf elements* of *e* be the concatenation of all of the *leaf
-elements* of each `element` directly in *e* where the *leaf elements* of an
-`element` are:
+\begin{itemize}
+\item
+  If $\ell$ is an \synt{ifElement}, then the leaf elements are the
+  concatenation of the leaf elements of the "then" and "else" elements
+  of $\ell$.
+\item
+  Else, if $\ell$ is a \synt{forElement}, then the leaf elements are
+  the leaf elements of the body element of $\ell$.
+\item
+  Else, if $\ell$ is an \synt{expressionElement} or \synt{mapEntry},
+  then the leaf element is $\ell$ itself.
+\item
+  Else, the element has no leaf elements.
+  \commentary{A spread contains no leaf elements.}
+\end{itemize}
 
-*   If `element` is an `ifElement`, then the *leaf elements* are the
-    concatenation of the *leaf elements* of the "then" and "else" elements of
-    `element`.
+\LMHash{}%
+It is a compile-time error if any leaf elements of a \synt{listLiteral}
+are \synt{mapEntry} elements.
 
-*   Else, if `element` is a `forElement`, then the *leaf elements* are the *leaf
-    elements* of the body element of `element`.
+\commentary{%
+We could avoid this prose by duplicating the above rules for lists and
+removing \synt{mapEntry}, but this is simpler.%
+}
 
-*   Else, if `element` is an `expressionElement` or `mapEntry`, then the *leaf
-    element* is `element` itself.
+\LMHash{}%
+The existing rule that an expression statement cannot start with \lit{\{}
+now covers both map and set literals.
 
-*   Else, the element has no *leaf elements*. *A spread contains no leaf
-    elements.*
 
-It is a compile-time error if any *leaf elements* of a `listLiteral` are
-`mapEntry` elements. *(We could avoid this prose by duplicating the above rules
-for lists and removing `mapEntry`, but this is simpler.)*
+\subsection{Static Semantics}
+\LMLabel{uiAsCodeStaticSemantics}
 
-The existing rule that an expression statement cannot start with `{` now covers
-both map and set literals.
 
-## Static Semantics
+\subsubsection{Disambiguating sets and maps}
+\LMLabel{uiAsCodeDisambiguatingSetsAndMaps}
 
-### Disambiguating sets and maps
+\LMHash{}%
+Because sets and maps both use curly braces as delimiters,
+you can create collection literals that are not obviously either
+a set or a map, like:
 
-Because sets and maps both use curly braces as delimiters, you can create
-collection literals that are not obviously either a set or a map, like:
+\begin{dartCode}
+\VAR{} a = \{\};
+\VAR{} b = \{...other\};
+\end{dartCode}
 
-```dart
-var a = {};
-var b = {...other};
-```
+\LMHash{}%
+Inference and set/map disambiguation are done concurrently.
+When possible, we use syntax and the surrounding context type
+to disambiguate between a map and set:
 
-Inference and set/map disambiguation are done concurrently. When possible, we
-use syntax and the surrounding context type to disambiguate between a map and
-set:
+Let $e$ be a \synt{setOrMapLiteral}.
 
-Let *e* be a `setOrMapLiteral`.
+\LMHash{}%
+If $e$ has a context $C$,
+and the base type of $C$ is $Cbase$
+(\commentary{%
+that is, $Cbase$ is $C$ with all wrapping \code{FutureOr}'s removed%
+}),
+and $Cbase$ is not \lit{?},
+then let $S$ be the greatest closure.
 
-If *e* has a context `C`, and the base type of `C` is `Cbase` (that is, `Cbase`
-is `C` with all wrapping `FutureOr`s removed), and `Cbase` is not `?`, then let
-`S` be the greatest closure.
+\begin{enumerate}
+\item If $e$ has \synt{typeArguments} then:
+  \begin{itemize}
+  \item
+    If there is exactly one type argument $T$,
+    then $e$ is a set literal with static type \code{Set<$T$>}.
+  \item
+    If there are exactly two type arguments $K$ and $V$,
+    then $e$ is a map literal with static type \code{Map<$K$, $V$>}.
+  \item
+    Otherwise (three or more type arguments),
+    report a compile-time error.
+  \end{itemize}
+\item
+  Else, if $S$ is defined and is a subtype of \code{Iterable<Object>}
+  and $S$ is not a subtype of \code{Map<Object, Object>},
+  then $e$ is a set literal.
+\item
+  Else, if $S$ is defined and is a subtype of \code{Map<Object, Object>}
+  and $S$ is not a subtype of \code{Iterable<Object>}
+  then $e$ is a map literal.
+\item
+  Else, if leaf elements is not empty, then:
+  \begin{itemize}
+  \item
+    If leaf elements has at least one \synt{expressionElement}
+    and no \synt{mapEntry} elements,
+    then $e$ is a set literal with unknown static type.
+    The static type will be filled in by type inference, defined below.
+  \item
+    If leaf elements has at least one \synt{mapEntry}
+    and no \synt{expressionElement} elements,
+    then $e$ is a map literal with unknown static type.
+    The static type will be filled in by type inference, defined below.
+  \item
+    If leaf elements has at least one \synt{mapEntry}
+    and at least one \synt{expressionElement},
+    report a compile-time error.
 
-1.  If *e* has `typeArguments` then:
+    \commentary{%
+      In other words, at least one key-value pair anywhere in the collection
+      forces it to be a map,
+      and a bare expression forces it to be a set.
+      Having both is an error.%
+    }
+  \end{itemize}
+\item
+  Else, if $e$ has no \synt{typeArguments}, no useful context type,
+  and no \synt{elements},
+  then $e$ is treated as a map literal with unknown static type.
 
-    *   If there is exactly one type argument `T`, then *e* is a set literal
-        with static type `Set<T>`.
+  \commentary{%
+    In other words, an empty \code{\{\}} is a map
+    unless we have a context that indicates otherwise.%
+  }
+\item
+  Otherwise, $e$ is still ambiguous.
+  This can only happen when $e$ is non-empty but contains no leaf elements.
+  In other words, it contains only spreads or spreads wrapped in
+  an \synt{ifElement} or a \synt{forElement}.
+  In this case, the disambiguation will happen during type inference,
+  defined below.
+\end{enumerate}
 
-    *   If there are exactly two type arguments `K` and `V`, then *e* is a map
-        literal with static type `Map<K, V>`.
+\LMHash{}%
+If this process successfully disambiguates the literal,
+then we say that $e$ is
+\IndexCustom{unambiguously a map}{map!unambiguously}
+or
+\IndexCustom{unambiguously a set}{set!unambiguously},
+as appropriate.
 
-    *   Otherwise (three or more type arguments), report a compile-time error.
+\subsubsection{Type inference}
+\LMLabel{uiAsCodeTypeInference}
 
-1.  Else, if `S` is defined and is a subtype of `Iterable<Object>` and `S` is
-    not a subtype of `Map<Object, Object>`, then *e* is a set literal.
 
-1.  Else, if `S` is defined and is a subtype of `Map<Object, Object>` and `S` is
-    not a subtype of `Iterable<Object>` then *e* is a map literal.
+\paragraph{Maps and sets}
+\LMLabel{uiAsCodeMapsAndSets}
 
-1.  Else, if *leaf elements* is not empty, then:
+\LMHash{}%
+We perform inference on the literal,
+and collect up either a set element type
+(\commentary{indicating that the literal may/must be a set}),
+or a pair of a key type and a value type
+(\commentary{indicating that the literal may/must be a map}),
+or both.
+We allow both, because spreads of expressions of type \DYNAMIC{}
+do not disambiguate,
+and can be treated as either
+(\commentary{%
+it becomes a runtime error to spread a value into the wrong kind of literal%
+}).
 
-    *   If *leaf elements* has at least one `expressionElement` and no
-        `mapEntry` elements, then *e* is a set literal with unknown static type.
-        The static type will be filled in by type inference, defined below.
+\LMHash{}%
+We require that
+at least one component unambiguously determine the literal form,
+otherwise it is a compile-time error.
+So, given:
 
-    *   If *leaf elements* has at least one `mapEntry` and no
-        `expressionElement` elements, then *e* is a map literal with unknown
-        static type. The static type will be filled in by type inference,
-        defined below.
-
-    *   If *leaf elements* has at least one `mapEntry` and at least one
-        `expressionElement`, report a compile-time error.
-
-    *In other words, at least one key-value pair anywhere in the collection
-    forces it to be a map, and a bare expression forces it to be a set. Having
-    both is an error.*
-
-1.  Else, if *e* has no `typeArguments`, no useful context type, and no
-    `elements`, then *e* is treated as a map literal with unknown static type.
-    *In other words, an empty `{}` is a map unless we have a context that
-    indicates otherwise.*
-
-1.  Otherwise, *e* is still ambiguous. This can only happen when *e* is
-    non-empty but contains no *leaf elements*. In other words, it contains only
-    spreads or spreads wrapped in if and for elements. In this case, the
-    disambiguation will happen during type inference, defined below.
-
-If this process successfully disambiguates the literal, then we say that *e* is
-"unambiguously a map" or "unambiguously a set", as appropriate.
-
-### Type inference
-
-#### Maps and sets
-
-We perform inference on the literal, and collect up either a set element type
-(indicating that the literal may/must be a set), or a pair of a key type and a
-value type (indicating that the literal may/must be a map), or both. We allow
-both, because spreads of expressions of type `dynamic` do not disambiguate, and
-can be treated as either (it becomes a runtime error to spread a value into the
-wrong kind of literal).
-
-We require that at least one component unambiguously determine the literal form,
-otherwise it is a compile-time error. So, given:
-
-```dart
-dynamic x = <int, int>{};
+\begin{dartCode}
+\DYNAMIC{} x = <int, int>\{\};
 Iterable l = [];
 Map m = {};
-```
+\end{dartCode}
 
+\LMHash{}%
 Then:
 
-```dart
-{...x}       // Static error, because it is ambiguous.
-{...x, ...l} // Statically a set, runtime error when spreading x.
-{...x, ...m} // Statically a map, no runtime error.
-{...l, ...m} // Static error, because it must be both a set and a map.
-```
-
-In a `setOrMapLiteral` *collection*, the inferred type of an `element` is a set
-element type `T`, a pair of a key type `K` and a value type `V`, or both. It is
-computed relative to a context type `P`:
-
-*   If *collection* is unambiguously a set literal, then `P` is `Set<Pe>` where
-    `Pe` is determined by downwards inference, and may be `?` if downwards
-    inference does not constrain it.
-
-*   If *collection* is unambiguously a map literal then `P` is `Map<Pk, Pv>`
-    where `Pk` and `Pv` are determined by downwards inference, and may be `?` if
-    the downwards context does not constrain one or both.
-
-*   Otherwise, *collection* is ambiguous, and the downwards context for the
-    elements of *collection* is `?`.
-
-We say that an element *can be a set* if it has a set element type. Likewise, an
-element *can be a map* if it has a key and value type. We say that an element
-*must be a set* if it can be a set and has and no key type or value type. We say
-that an element *must be a map* if can be a map and has no set element type.
-
-To infer the type of `element`:
-
-*   If `element` is an `expressionElement` with expression `e1`:
-
-    *   If `P` is `?` then the inferred set element type of `element` is the
-        inferred type of the expression `e1` in context `?`.
-
-    *   If `P` is `Set<Ps>` then the inferred set element type of `element`
-        is the inferred type of the expression `e1` in context `Ps`.
-
-*   If `element` is a `mapEntry` `ek: ev`:
-
-    *   If `P` is `?` then the inferred key type of `element` is the inferred
-        type of `ek` in context `?` and the inferred value type of `element` is
-        the inferred type of `ev` in context `?`.
-
-    *   If `P` is `Map<Pk, Pv>` then the inferred key type of `element` is the
-        inferred type of `ek` in context `Pk` and the inferred value type of
-        `element` is the inferred type of `ev` in context `Pv`.
-
-*   If `element` is a `spreadElement` with expression `e1`:
-
-    *   If `P` is `?` then let `S` be the inferred type of `e1` in context `?`:
-
-        *   If `S` is a non-`Null` subtype of `Iterable<Object>`, then the
-            inferred set element type of `element` is `T` where `T` is the type
-            such that `Iterable<T>` is a superinterface of `S` (the result of
-            constraint matching for `X` using the constraint `S <:
-            Iterable<X>`).
-
-        *   If `S` is a non-`Null` subtype of `Map<Object, Object>`, then the
-            inferred key type of `element` is `K` and the inferred value type of
-            `element` is `V`, where `K` and `V` are the types such that `Map<K,
-            V>` is a superinterface of `S` (the result of constraint matching
-            for `X` and `Y` using the constraint `S <: Map<X, Y>`).
-
-            *Note that both this and the previous case can match on the same
-            element if `S` is a subtype of both `Iterable<Object>` and
-            `Map<Object, Object>`. In that case, we rely on other elements to
-            disambiguate.*
-
-        *   If `S` is `dynamic`, then the inferred set element type of `element`
-            is `dynamic`, the inferred key type of `element` is `dynamic`, and
-            the inferred value type of `element` is `dynamic`. *(We produce both
-            a set element type here, and a key/value pair here and rely on other
-            elements to disambiguate.)*
-
-        *   If `S` is `Null` and the spread operator is `...?` then the element
-            has set element type `Null`, map key type `Null` and map value type
-            `Null`.
-
-        *   If none of these cases match, it is an error.
-
-    *   If `P` is `Set<Ps>` then let `S` be the inferred type of `e1` in context
-        `Iterable<Ps>`:
-
-        *   If `S` is a non-`Null` subtype of `Iterable<Object>`, then the
-            inferred set element type of `element` is `T` where `T` is the type
-            such that `Iterable<T>` is a superinterface of `S` (the result of
-            constraint matching for `X` using the constraint `S <:
-            Iterable<X>`).
-
-        *   If `S` is `dynamic`, then the inferred set element type of `element`
-            is `dynamic`.
-
-        *   If `S` is `Null` and the spread operator is `...?`, then the set
-            element type is `Null`.
-
-        *   Otherwise it is an error.
-
-    *   If `P` is `Map<Pk, Pv>` then let `S` be the inferred type of `e1` in
-        context `P`:
-
-        *   If `S` is a non-`Null` subtype of `Map<Object, Object>`, then the
-            inferred key type of `element` is `K` and the inferred value type of
-            `element` is `V`, where `K` and `V` are the types such that `Map<K,
-            V>` is a superinterface of `S` (the result of constraint matching
-            for `X` and `Y` using the constraint `S <: Map<X, Y>`).
-
-        *   If `S` is `dynamic`, then the inferred key type of `element` is
-            `dynamic`, and the inferred value type of `element` is `dynamic`.
-
-        *   If `S` is `Null` and the spread operator is `...?`, then the key and
-            value element types are `Null`.
-
-        *   Otherwise it is an error.
-
-*   If `element` is an `ifElement` with one `element`, `p1`, and no "else"
-    element:
-
-    The condition is inferred with a context type of `bool`.
-
-    *   If the inferred set element type of `p1` is `S` then the inferred set
-        element type of `element` is `S`.
-
-    *   If the inferred key type of `p1` is `K` and the inferred value type of
-        `p1` is `V` then the inferred key and value types of `element` are `K`
-        and `V`.
-
-    *Note that both of the above cases can simultaneously apply because of
-    `dynamic` spreads.*
-
-*   If `element` is an `ifElement` with two `element`s, `e1` and `e2`:
-
-    The condition is inferred with a context type of `bool`.
-
-    It is a compile error if `e1` must be a set and `e2` must be a map or vice
-    versa. *In other words, you can't spread a map on one branch and a set on
-    the other. Since `dynamic` provides both set and map key/value types, a
-    `dynamic` in either branch does not run into this case.*
-
-    *   If the inferred set element type of `e1` is `S1` and the inferred set
-        element type of `e2` is `S2` then the inferred set element type of
-        `element` is the least upper bound of `S1` and `S2`.
-
-    *   If the inferred key type of `e1` is `K1` and the inferred key type of
-        `e1` is `V1` and the inferred key type of `e2` is `K2` and the inferred
-        key type of `e2` is `V2` then the inferred key type of `element` is the
-        least upper bound of `K1` and `K2` and the inferred value type is the
-        least upper bound of `V1` and `V2`.
-
-    *Note that both of the above cases can simultaneously apply because of
-    `dynamic` spreads.*
-
-*   If `element` is a `forElement` with `element` `e1` then:
-
-    Inference for the iterated expression and the controlling variable is done
-    as for the corresponding `for` or `await for` statement.
-
-    *   If the inferred set element type of `e1` is `S` then the inferred set
-        element type of `element` is `S`.
-
-    *   If the inferred key type of `e1` is `K` and the inferred key type of
-        `e1` is `V` then the inferred key and value types of `element` are `K`
-        and `V`.
-
-    *In other words, inference flows upwards from the body element. Note that
-    both of the above cases can validly apply because of `dynamic` spreads.*
-
-Finally, we define inference on a `setOrMapLiteral` *collection* as follows:
-
-*   If *collection* is unambiguously a set literal:
-
-    *   If `P` is `?` then the static type of *collection* is `Set<T>` where `T`
-        is the least upper bound of the inferred set element types of the
-        elements.
-
-    *   Otherwise, the static type of *collection* is `P`.
-
-    *Note that the element inference will never produce a key/value type here
-    given that downwards context.*
-
-*   Else, f *collection* is unambiguously a map literal where `P` is `Map<Pk,
-    Pv>`:
-
-    *   If `Pk` is `?` then the static key type of *collection* is `K` where `K`
-        is the least upper bound of the inferred key types of the elements.
-
-    *   Otherwise the static key type of *collection* is `K` where `K` is
-        determined by downwards inference.
-
-    And:
-
-    *   If `Pv` is `?` then the static value type of *collection* is `V` where
-        `V` is the least upper bound of the inferred value types of the
-        elements.
-
-    *   Otherwise the static value type of *collection* is `V` where `V` is
-        determined by downwards inference.
-
-    The static type of *collection* is `Map<K, V>`.
-
-    *Note that the element inference will never produce a set element type here
-    given this downwards context.*
-
-*   Otherwise, *collection* is still ambiguous, the downwards context for the
-    elements of *collection* is `?`, and the disambiguation is done using the
-    immediate `elements` of *collection* as follows:
-
-    *   If all elements can be a set, and at least one element must be a set,
-        then *collection* is a set literal with static type `Set<T>` where `T`
-        is the least upper bound of the set element types of the elements.
-
-    *   If all elements can be a map, and at least one element must be a map,
-        then *e* is a map literal with static type `Map<K, V>` where `K` is the
-        least upper bound of the key types of the elements and `V` is the least
-        upper bound of the value types.
-
-    *   Otherwise, the literal cannot be disambiguated and it is a compile-time
-        error. This can occur if the literal *must* be both a set and a map,
-        as in:
-
-        ```dart
-        var iterable = [1, 2];
-        var map = {1: 2};
-        var ambiguous = {...iterable, ...map};
-        ```
-
-        Or, if there is nothing indicates that it is *either* a map or set:
-
-        ```dart
-        dynamic dyn;
-        var ambiguous = {...dyn};
-        ```
-
-#### Lists
-
-Inference for list literals mostly follows that of set literals without the
-complexity around disambiguation with maps and using `List` or `Iterable` in a
-few places instead of `Set`.
-
-Inside a `listLiteral`, the inferred type of an `element` is a list element type
-`T`. It is computed relative to a downwards element context type `P`, where `P`
-is `T` if downwards inference constrains the type of `listLiteral` to
-`Iterable<T>` for some `T`. Otherwise, `P` is `?`.
-
-*   If `element` is an `expressionElement` with expression `e1`:
-
-    *   The inferred list element type of `element` is the inferred type of the
-        expression `e1` in context `P`.
-
-*   If `element` is a `spreadElement` with expression `e1`:
-
-    *   If `P` is `?` then let `S` be the inferred type of `e1` in context `?`:
-
-        *   If `S` is a non-`Null` subtype of `Iterable<Object>`, then the
-            inferred list element type of `element` is `T` where `T` is the type
-            such that `Iterable<T>` is a superinterface of `S` (the result of
-            constraint matching for `X` using the constraint `S <:
-            Iterable<X>`).
-
-        *   If `S` is `dynamic`, then the inferred list element type of
-            `element` is `dynamic`.
-
-        *   If `S` is `Null` and the spread operator is `...?`, then the list
-            element type is `Null`.
-
-        *   Otherwise it is an error (because it is a spread of a non-spreadable
-            type like Object).
-
-    *   Else, let `S` be the inferred type of `e1` in context `Iterable<P>`:
-
-        *   If `S` is a non-`Null` subtype of `Iterable<Object>`, then the
-            inferred list element type of `element` is `T` where `T` is the type
-            such that `Iterable<T>` is a superinterface of `S` (the result of
-            constraint matching for `X` using the constraint `S <:
-            Iterable<X>`).
-
-        *   If `S` is `dynamic`, then the inferred list element type of
-            `element` is `dynamic`.
-
-        *   Otherwise it is an error.
-
-*   If `element` is an `ifElement` with one `element`, `p1`, and no "else"
-    element:
-
-    The condition is inferred with a context type of `bool`.
-
-    The inferred list element type of `element` is the inferred list element
-    type of `p1` with element context type `P`.
-
-*   If `element` is a `ifElement` with two `element`s, `p1` and `p2`:
-
-    The condition is inferred with a context type of `bool`.
-
-    The inferred list element type of `element` is the least upper bound of `S1`
-    and `S2` where `S1` is the inferred list element type of `p1` and `S2` is
-    the inferred list element type of `p2`, both with element context type `P`.
-
-*   If `element` is a `forElement` with `element` `p1` then:
-
-    Inference for the iterated expression and the controlling variable is done
-    as for the corresponding `for` or `await for` statement.
-
-    The inferred list element type of `element` is the inferred list element
-    type of `p1` with element context type `P`.
-
-*Note: `element` cannot be a `mapEntry` as those are not allowed inside list
-literals.*
-
-Finally, we define inference on a `listLiteral` *collection* as follows:
-
-*   If `P` is `?` then the static type of *collection* is `List<T>` where
-    `T` is the least upper bound of the inferred list element types of the
-    elements.
-
-*   Otherwise, the static type of *collection* is `List<T>` where `T` is
+\begin{dartCode}
+\{...x\}       // \comment{Static error, because it is ambiguous.}
+\{...x, ...l\} // \comment{Statically a set, runtime error when spreading x.}
+\{...x, ...m\} // \comment{Statically a map, no runtime error.}
+\{...l, ...m\} // \comment{Static error, because it must be both a set and a map.}
+\end{dartCode}
+
+\LMHash{}%
+In a \synt{setOrMapLiteral} \metavar{collection},
+the inferred type of an \synt{element} is a set element type $T$,
+a pair of a key type $K$ and a value type $V$, or both.
+It is computed relative to a context type $P$:
+
+\begin{itemize}
+\item
+  If \metavar{collection} is unambiguously a set literal,
+  then $P$ is \code{Set<Pe>} where $Pe$ is determined by downwards inference,
+  and may be \lit{?} if downwards inference does not constrain it.
+\item
+  If \metavar{collection} is unambiguously a map literal
+  then $P$ is \code{Map<$Pk$, $Pv$>}
+  where $Pk$ and $Pv$ are determined by downwards inference,
+  and may be \lit{?}
+  if the downwards context does not constrain one or both.
+\item
+  Otherwise, \metavar{collection} is ambiguous,
+  and the downwards context for the elements of \metavar{collection} is lit{?}.
+\end{itemize}
+
+\LMHash{}%
+We say that an element
+\IndexCustom{can be a set}{element!can be a set}
+if it has a set element type.
+Likewise, an element
+\IndexCustom{can be a map}{element!can be a map}
+if it has a key and value type.
+We say that an element
+\IndexCustom{must be a set}{element!must be a set}
+if it can be a set and has and no key type or value type.
+We say that an element
+\IndexCustom{must be a map}{element!must be a map}
+if can be a map and has no set element type.
+
+\LMHash{}%
+To infer the type of $\ell$:
+
+\begin{itemize}
+\item
+  If $\ell$ is an \synt{expressionElement} with expression $e1$:
+  \begin{itemize}
+  \item
+    If $P$ is \lit{?} then the inferred set element type of $\ell$ is
+    the inferred type of the expression $e1$ in context \lit{?}.
+  \item
+    If $P$ is \code{Set<$Ps$>} then the inferred set element type of $\ell$ is
+    the inferred type of the expression $e1$ in context $Ps$.
+  \end{itemize}
+\item
+  If $\ell$ is a \synt{mapEntry} \code{$ek$:\,\,$ev$}:
+  \begin{itemize}
+  \item
+    If $P$ is \lit{?} then the inferred key type of $\ell$ is
+    the inferred type of $ek$ in context \lit{?} and
+    the inferred value type of $\ell$ is
+    the inferred type of $ev$ in context \lit{?}.
+  \item
+    If $P$ is \code{Map<$Pk$, $Pv$>} then
+    the inferred key type of $\ell$ is
+    the inferred type of $ek$ in context $Pk$ and
+    the inferred value type of $\ell$ is
+    the inferred type of $ev$ in context $Pv$.
+  \end{itemize}
+\item
+  If $\ell$ is a \synt{spreadElement} with expression $e1$:
+  \begin{itemize}
+  \item
+    If $P$ is \lit{?} then let $S$ be
+    the inferred type of $e1$ in context \lit{?}:
+    \begin{itemize}
+    \item
+      If $S$ is a non-\code{Null} subtype of \code{Iterable<Object>}, then
+      the inferred set element type of $\ell$ is $T$
+      where $T$ is the type such that \code{Iterable<$T$>} is
+      a superinterface of $S$
+      (\commentary{
+        the result of constraint matching for $X$ using the constraint
+        \code{$S$ <: Iterable<$X$>}}).
+    \item
+      If $S$ is a non-\code{Null} subtype of \code{Map<Object, Object>}, then
+      the inferred key type of $\ell$ is $K$ and
+      the inferred value type of $\ell$ is $V$,
+      where $K$ and $V$ are the types such that \code{Map<$K$, $V$>} is
+      a superinterface of $S$
+      (\commentary{%
+        the result of constraint matching for $X$ and $Y$ using
+        the constraint \code{$S$ <: Map<$X$, $Y$>}%
+      }).
+
+      \commentary{%
+        Note that both this and the previous case can match on
+        the same element if $S$ is a subtype of
+        both \code{Iterable<Object>} and \code{Map<Object, Object>}.
+        In that case, we rely on other elements to disambiguate.%
+      }
+    \item
+      If $S$ is \DYNAMIC{}, then
+      the inferred set element type of $\ell$ is \DYNAMIC{},
+      the inferred key type of $\ell$ is \DYNAMIC{}, and
+      the inferred value type of $\ell$ is \DYNAMIC{}.
+
+      \commentary{%
+        We produce both a set element type here,
+        and a key/value pair here
+        and rely on other elements to disambiguate.%
+      }
+    \item
+      If $S$ is \code{Null} and the spread operator is \lit{...?} then
+      the element has set element type \code{Null},
+      map key type \code{Null} and map value type \code{Null}.
+    \item
+      If none of these cases match, it is an error.
+    \end{itemize}
+  \item
+    If $P$ is \code{Set<$Ps$>} then let $S$ be
+    the inferred type of $e1$ in context \code{Iterable<$Ps$>}:
+    \begin{itemize}
+    \item
+      If $S$ is a non-\code{Null} subtype of \code{Iterable<Object>}, then
+      the inferred set element type of $\ell$ is $T$
+      where $T$ is the type such that \code{Iterable<T>} is
+      a superinterface of $S$
+      (\commentary{%
+        the result of constraint matching for $X$ using
+        the constraint \code{$S$ <: Iterable<$X$>}}).
+    \item
+      If $S$ is \DYNAMIC{}, then
+      the inferred set element type of $\ell$ is \DYNAMIC{}.
+    \item
+      If $S$ is \code{Null} and the spread operator is \lit{...?}, then
+      the set element type is \code{Null}.
+    \item
+      Otherwise it is an error.
+    \end{itemize}
+  \item
+    If $P$ is \code{Map<$Pk$, $Pv$>} then let $S$ be
+    the inferred type of $e1$ in context $P$:
+    \begin{itemize}
+    \item
+      If $S$ is a non-\code{Null} subtype of \code{Map<Object, Object>}, then
+      the inferred key type of $\ell$ is $K$ and
+      the inferred value type of $\ell$ is $V$,
+      where $K$ and $V$ are the types such that \code{Map<$K$, $V$>} is
+      a superinterface of $S$
+      (\commentary{%
+        the result of constraint matching for $X$ and $Y$ using
+        the constraint \code{$S$ <: Map<$X$, $Y$>}}).
+    \item
+      If $S$ is \DYNAMIC{}, then
+      the inferred key type of $\ell$ is \DYNAMIC{}, and
+      the inferred value type of $\ell$ is \DYNAMIC{}.
+    \item
+      If $S$ is \code{Null} and the spread operator is \lit{...?}, then
+      the key and value element types are \code{Null}.
+    \item
+      Otherwise it is an error.
+    \end{itemize}
+  \end{itemize}
+\item
+  If $\ell$ is an \synt{ifElement} with one $\ell$, $p1$, and no "else"
+  element:
+  The condition is inferred with a context type of \code{bool}.
+  \begin{itemize}
+  \item
+    If the inferred set element type of $p1$ is $S$ then
+    the inferred set element type of $\ell$ is $S$.
+  \item
+    If the inferred key type of $p1$ is $K$ and
+    the inferred value type of $p1$ is $V$ then
+    the inferred key and value types of $\ell$ are $K$ and $V$.
+
+    \commentary{%
+      Note that both of the above cases can simultaneously apply
+      because of \DYNAMIC{} spreads.%
+    }
+  \end{itemize}
+\item
+  If $\ell$ is an \synt{ifElement} with two elements $e1$ and $e2$:
+
+  The condition is inferred with a context type of \code{bool}.
+
+  It is a compile error if $e1$ must be a set and $e2$ must be a map
+  or vice versa.
+
+  \commentary{%
+    In other words, you can't spread
+    a map on one branch and a set on the other.
+    Since \DYNAMIC{} provides both set and map key/value types,
+    a \DYNAMIC{} in either branch does not run into this case.%
+  }
+  \begin{itemize}
+  \item
+    If the inferred set element type of $e1$ is $S1$ and
+    the inferred set element type of $e2$ is $S2$ then
+    the inferred set element type of $\ell$ is
+    the least upper bound of $S1$ and $S2$.
+  \item
+    If the inferred key type of $e1$ is $K1$ and
+    the inferred key type of $e1$ is $V1$ and
+    the inferred key type of $e2$ is $K2$ and
+    the inferred key type of $e2$ is $V2$ then
+    the inferred key type of $\ell$ is
+    the least upper bound of $K1$ and $K2$ and
+    the inferred value type is the least upper bound of $V1$ and $V2$.
+
+    \commentary{%
+      Note that both of the above cases can simultaneously apply
+      because of \DYNAMIC{} spreads.%
+    }
+  \end{itemize}
+\item
+  If $\ell$ is a \synt{forElement} with $\ell$ $e1$ then:
+
+  Inference for the iterated expression and the controlling variable is done
+  as for the corresponding \FOR{} or \AWAIT{} \FOR{} statement.
+
+  \begin{itemize}
+  \item
+    If the inferred set element type of $e1$ is $S$ then
+    the inferred set element type of $\ell$ is $S$.
+  \item
+    If the inferred key type of $e1$ is $K$ and
+    the inferred key type of $e1$ is $V$ then
+    the inferred key and value types of $\ell$ are $K$ and $V$.
+
+    \commentary{%
+      In other words, inference flows upwards from the body element.
+      Note that both of the above cases can validly apply
+      because of \DYNAMIC{} spreads.%
+    }
+  \end{itemize}
+\end{itemize}
+
+\LMHash{}%
+Finally, we define inference on a \synt{setOrMapLiteral} \metavar{collection}
+as follows:
+
+\begin{itemize}
+\item
+  If \metavar{collection} is unambiguously a set literal:
+
+  \begin{itemize}
+  \item
+    If $P$ is \lit{?} then
+    the static type of \metavar{collection} is \code{Set<$T$>} where $T$ is
+    the least upper bound of the inferred set element types of the elements.
+  \item
+    Otherwise, the static type of \metavar{collection} is $P$.
+
+    \commentary{%
+      Note that the element inference will never produce a key/value type here
+      given that downwards context.%
+    }
+  \end{itemize}
+\item
+  Else, if \metavar{collection} is unambiguously a map literal
+  where $P$ is \code{Map<$Pk$, $Pv$>}:
+
+  \begin{itemize}
+  \item
+    If $Pk$ is \lit{?} then
+    the static key type of \metavar{collection} is $K$ where $K$ is
+    the least upper bound of the inferred key types of the elements.
+
+  \item
+    Otherwise the static key type of \metavar{collection} is $K$ where $K$ is
+    determined by downwards inference.
+  \end{itemize}
+
+  And:
+
+  \begin{itemize}
+  \item
+    If $Pv$ is \lit{?} then
+    the static value type of \metavar{collection} is $V$ where $V$ is
+    the least upper bound of the inferred value types of the elements.
+  \item
+    Otherwise the static value type of \metavar{collection} is $V$ where $V$ is
     determined by downwards inference.
 
-### Type promotion
+    The static type of \metavar{collection} is \code{Map<$K$, $V$>}.
 
-An `ifElement` interacts with type promotion in the same way that `if`
-statements do. Given an `ifElement` with condition `condition`, then element
-`thenElement` and optional else element `elseElement`:
+    \commentary{%
+      Note that the element inference will never produce a set element type here
+      given this downwards context.%
+    }
+  \end{itemize}
+\item
+  Otherwise, \metavar{collection} is still ambiguous,
+  the downwards context for the elements of \metavar{collection} is \lit{?},
+  and the disambiguation is done using
+  the immediate elements of \metavar{collection} as follows:
 
-*   If `condition` shows that a local variable *v* has type `T`, then the type
-    of *v* is known to be `T` in `thenElement`, unless any of the following are
-    true:
+  \begin{itemize}
+  \item
+    If all elements can be a set,
+    and at least one element must be a set,
+    then \metavar{collection} is a set literal with
+    static type \code{Set<$T$>} where $T$ is
+    the least upper bound of the set element types of the elements.
+  \item
+    If all elements can be a map,
+    and at least one element must be a map, then $e$ is
+    a map literal with static type \code{Map<$K$, $V$>} where $K$ is
+    the least upper bound of the key types of the elements and $V$ is
+    the least upper bound of the value types.
+  \item
+    Otherwise, the literal cannot be disambiguated
+    and it is a compile-time error.
+  \end{itemize}
+\end{itemize}
 
-    *   *v* is potentially mutated in `thenElement`,
-    *   *v* is potentially mutated within a function other than the one where
-        *v* is declared, or
-    *   *v* is accessed by a function defined in `thenElement` and
-    *   *v* is potentially mutated anywhere in the scope of *v*.
+\commentary{%
+  This last case can occur if the literal \emph{must} be both a set and a map,
+  as in:%
+}
 
-*Note: The type promotion rules for `if` will likely get more sophisticated in a
-future version of Dart because of non-nullable types. When that happens, `if`
-elements should continue to match `if` statements.*
+\begin{dartCode}
+\VAR{} iterable = [1, 2];
+\VAR{} map = \{1: 2\};
+\VAR{} ambiguous = \{...iterable, ...map\};
+\end{dartCode}
 
-### Compile-time errors
+\commentary{%
+Or, if there is nothing indicates that it is \emph{either} a map or set:%
+}
 
-After type inference and disambiguation, the collection is checked for other
-compile-time errors. It is a compile-time error if:
+\begin{dartCode}
+\DYNAMIC{} dyn;
+\VAR{} ambiguous = \{...dyn\};
+\end{dartCode}
 
-*   The collection is a map literal and *leaf elements* contains any
-    `expressionElement` elements.
 
-    ```dart
-    <String, int>{"not entry"} // Error.
-    ```
+\paragraph{Lists}
 
-*   The collection is a set literal and *leaf elements* contains any `mapEntry`
-    elements.
+\LMHash{}%
+Inference for list literals mostly follows that of set literals
+without the complexity around disambiguation with maps and
+using \code{List} or \code{Iterable} in a few places instead of \code{Set}.
 
-    ```dart
+\LMHash{}%
+Inside a \synt{listLiteral} \metavar{listLiteral},
+the inferred type of an element $\ell$ is a list element type $T$.
+It is computed relative to a downwards element context type $P$,
+where $P$ is $T$
+if downwards inference constrains the type of \metavar{listLiteral}
+to \code{Iterable<$T$>} for some $T$.
+Otherwise, $P$ is \lit{?}.
+
+\begin{itemize}
+\item
+  If $\ell$ is an \synt{expressionElement} with expression $e1$:
+  \begin{itemize}
+  \item
+    The inferred list element type of $\ell$ is
+    the inferred type of the expression $e1$ in context $P$.
+  \end{itemize}
+\item
+  If $\ell$ is a \synt{spreadElement} with expression $e1$:
+
+  \begin{itemize}
+  \item
+    If $P$ is \lit{?} then let $S$ be
+    the inferred type of $e1$ in context \lit{?}:
+
+    \begin{itemize}
+    \item
+      If $S$ is a non-\code{Null} subtype of \code{Iterable<Object>}, then
+      the inferred list element type of $\ell$ is $T$ where $T$ is
+      the type such that \code{Iterable<$T$>} is
+      a superinterface of $S$
+      (\commentary{%
+        the result of constraint matching for $X$ using
+        the constraint \code{$S$ <: Iterable<$X$>}}).
+
+      \begin{itemize}
+      \item
+        If $S$ is \DYNAMIC{}, then
+        the inferred list element type of $\ell$ is \DYNAMIC{}.
+      \item
+        If $S$ is \code{Null} and the spread operator is \lit{...?}, then
+        the list element type is \code{Null}.
+      \item
+        Otherwise it is an error
+        (\commentary{%
+          because it is a spread of a non-spreadable type like Object%
+        }).
+      \end{itemize}
+    \item
+      Else, let $S$ be
+      the inferred type of $e1$ in context \code{Iterable<$P$>}:
+
+      \begin{itemize}
+      \item
+        If $S$ is a non-\code{Null} subtype of \code{Iterable<Object>}, then
+        the inferred list element type of $\ell$ is $T$ where $T$ is
+        the type such that \code{Iterable<$T$>} is
+        a superinterface of $S$
+        (\commentary{%
+          the result of constraint matching for $X$ using
+          the constraint \code{$S$ <: Iterable<$X$>}%
+        }).
+      \item
+        If $S$ is \DYNAMIC{}, then
+        the inferred list element type of $\ell$ is \DYNAMIC{}.
+      \item
+        Otherwise it is an error.
+      \end{itemize}
+    \end{itemize}
+  \item
+    If $\ell$ is an \synt{ifElement} with one $\ell$, $p1$,
+    and no "else" element:
+    The condition is inferred with a context type of \code{bool}.
+
+    The inferred list element type of $\ell$ is
+    the inferred list element type of $p1$ with element context type $P$.
+  \item
+    If $\ell$ is a \synt{ifElement} with two $\ell$s, $p1$ and $p2$:
+    The condition is inferred with a context type of \code{bool}.
+
+    The inferred list element type of $\ell$ is
+    the least upper bound of $S1$ and $S2$ where $S1$ is
+    the inferred list element type of $p1$ and $S2$ is
+    the inferred list element type of $p2$,
+    both with element context type $P$.
+
+  \item
+    If $\ell$ is a \synt{forElement} with $\ell$ $p1$ then:
+
+    Inference for the iterated expression and the controlling variable
+    is done as for the corresponding \FOR{} or \AWAIT{} \FOR{} statement.
+
+    The inferred list element type of $\ell$ is the inferred list element
+    type of $p1$ with element context type $P$.
+  \end{itemize}
+\end{itemize}
+
+\commentary{%
+Note: $\ell$ cannot be a \synt{mapEntry} as
+those are not allowed inside list literals.%
+}
+
+\LMHash{}%
+Finally, we define inference on a \synt{listLiteral} \metavar{collection}
+as follows:
+
+\begin{itemize}
+\item
+  If $P$ is \lit{?} then
+  the static type of \metavar{collection} is \code{List<$T$>} where $T$ is
+  the least upper bound of the inferred list element types of the elements.
+\item
+  Otherwise,
+  the static type of \metavar{collection} is \code{List<$T$>} where $T$ is
+  determined by downwards inference.
+\end{itemize}
+
+
+\subsubsection{Type promotion}
+\LMLabel{uiAsCodeTypePromotion}
+
+\LMHash{}%
+An \synt{ifElement} interacts with type promotion in
+the same way that \IF{} statements do.
+Given an \synt{ifElement} with condition \metavar{condition},
+then element \metavar{thenElement} and
+optional else element \metavar{elseElement}:
+
+\begin{itemize}
+\item
+  If \metavar{condition} shows that a local variable $v$ has type $T$, then
+  the type of $v$ is known to be $T$ in \metavar{thenElement},
+  unless any of the following are true:
+
+  \begin{itemize}
+  \item $v$ is potentially mutated in \metavar{thenElement},
+  \item $v$ is potentially mutated within a function
+    other than the one where $v$ is declared, or
+    \begin{itemize}
+    \item $v$ is accessed by a function defined in \metavar{thenElement}, and
+    \item $v$ is potentially mutated anywhere in the scope of $v$.
+    \end{itemize}
+  \end{itemize}
+\end{itemize}
+
+\commentary{%
+Note: The type promotion rules for \IF{} will likely get more sophisticated
+in a future version of Dart because of non-nullable types.
+When that happens,
+\synt{ifElements} should continue to match \IF{} statements.%
+}
+
+
+\subsubsection{Compile-time errors}
+\LMLabel{uiAsCodeCompileTimeErrors}
+
+\LMHash{}%
+After type inference and disambiguation,
+the collection is checked for other compile-time errors.
+It is a compile-time error if:
+
+%% TODO(eernst): Find a way to show Dart code examples inside itemize below.
+
+\begin{itemize}
+\item
+  The collection is a map literal and leaf elements contains any
+  \synt{expressionElement} elements.
+
+  \begin{dartCode}
+    <String, int>\{"not entry"\} // Error.
+  \end{dartCode}
+\item
+  The collection is a set literal and
+  leaf elements contains any \synt{mapEntry} elements.
+
+  \begin{dartCode}
     ["not": "expression"] // Error.
-    <String>{"not": "expression"} // Error.
-    ```
+    <String>\{"not": "expression"\} // Error.
+  \end{dartCode}
 
-    *We prohibit map entries in list literals syntacitcally, earlier in the
-    proposal.*
+  \commentary{%
+    We prohibit map entries in list literals syntactically,
+    earlier in the proposal.%
+  }
+\item
+  The collection is a list and the type of any of the leaf elements
+  may not be assigned to the list's element type.
 
-*   The collection is a list and the type of any of the *leaf elements* may not
-    be assigned to the list's element type.
-
-    ```dart
+  \begin{dartCode}
     <int>[if (true) "not int"] // Error.
-    ```
+  \end{dartCode}
+\item
+  The collection is a map and the key type of any of the leaf elements
+  may not be assigned to the map's key type.
 
-*   The collection is a map and the key type of any of the *leaf elements* may
-    not be assigned to the map's key type.
-
-    ```dart
+  \begin{dartCode}
     <int, int>{if (true) "not int": 1} // Error.
-    ```
+  \end{dartCode}
+\item
+  The collection is a map and the value type of any of the leaf elements
+  may not be assigned to the map's value type.
 
-*   The collection is a map and the value type of any of the *leaf elements* may
-    not be assigned to the map's value type.
-
-    ```dart
+  \begin{dartCode}
     <int, int>{if (true) 1: "not int"} // Error.
-    ```
+  \end{dartCode}
+\item
+  A non-null-aware spread element has static type \code{Null}.
+\item
+  A spread element in a list or set literal has a static type that is
+  not \DYNAMIC{} and not a subtype of \code{Iterable<Object>}.
+\item
+  A spread element in a list or set has a static type that
+  implements \code{Iterable<$T$>} for some $T$ and
+  $T$ is not assignable to the element type of the list.
+\item
+  A spread element in a map literal has a static type that is
+  not \DYNAMIC{} and not a subtype of \code{Map<Object, Object>}.
+\item
+  If a map spread element's static type
+  implements \code{Map<$K$, $V$>} for some $K$ and $V$ and
+  $K$ is not assignable to the key type of the map or
+  $V$ is not assignable to the value type of the map.
+\item
+  The variable in a \synt{forElement}
+  (\commentary{either a for-in element or C-style})
+  is declared outside of the element to be final or to not have a setter.
 
-*   A non-null-aware spread element has static type `Null`.
-
-*   A spread element in a list or set literal has a static type that is not
-    `dynamic` and not a subtype of `Iterable<Object>`.
-
-*   A spread element in a list or set has a static type that implements
-    `Iterable<T>` for some `T` and `T` is not assignable to the element type of
-    the list.
-
-*   A spread element in a map literal has a static type that is not `dynamic`
-    and not a subtype of `Map<Object, Object>`.
-
-*   If a map spread element's static type implements `Map<K, V>` for some `K`
-    and `V` and `K` is not assignable to the key type of the map or `V` is not
-    assignable to the value type of the map.
-
-*   The variable in a `for` element (either `for-in` or C-style) is declared
-    outside of the element to be `final` or to not have a setter.
-
-    ```dart
-    final i = 0;
+  \begin{dartCode}
+    \FINAL{} i = 0;
     [for (i in [1]) i] // Error.
-    ```
+  \end{dartCode}
+\item
+  The type of the iterator expression in a synchronous for-in element
+  may not be assigned to \code{Iterable<$T$>} for any type $T$.
+  Otherwise, the \Index{iterable type} of the iterator is $T$.
 
-*   The type of the iterator expression in a synchronous `for-in` element may
-    not be assigned to `Iterable<T>` for some type `T`. Otherwise, the *iterable
-    type* of the iterator is `T`.
-
-    ```dart
+  \begin{dartCode}
     [for (var i in "not iterable") i] // Error.
-    ```
+  \end{dartCode}
+\item
+  The iterable type of the iterator in a synchronous for-in element
+  may not be assigned to the for-in variable's type.
 
-*   The iterable type of the iterator in a synchronous `for-in` element may not
-    be assigned to the `for-in` variable's type.
-
-    ```dart
+  \begin{dartCode}
     [for (int i in ["not", "int"]) i] // Error.
-    ```
+  \end{dartCode}
+\item
+  The type of the stream expression in an asynchronous \AWAIT{} for-in element
+  may not be assigned to \code{Stream<$T$>} for any type $T$.
+  Otherwise, the \Index{stream type} of the stream is $T$.
 
-*   The type of the stream expression in an asynchronous `await for-in`
-    element may not be assigned to `Stream<T>` for some type `T`. Otherwise,
-    the *stream type* of the stream is `T`.
-
-    ```dart
+  \begin{dartCode}
     [await for (var i in "not stream") i] // Error.
-    ```
+  \end{dartCode}
+\item
+  The stream type of the iterator in an asynchronous \AWAIT{} for-in element
+  may not be assigned to the for-in variable's type.
 
-*   The stream type of the iterator in an asynchronous `await for-in` element
-    may not be assigned to the `for-in` variable's type.
-
-    ```dart
+  \begin{dartCode}
     [await for (int i in Stream.fromIterable(["not", "int"])) i] // Error.
-    ```
+  \end{dartCode}
 
-*   `await for` is used when the function immediately enclosing the collection
-    literal is not asynchronous.
+\item
+  \AWAIT{} \FOR{} is used when
+  the function immediately enclosing the collection literal
+  is not asynchronous.
 
-    ```dart
+  \begin{dartCode}
     main() {
       [await for (_ in stream)]; // Error.
     }
-    ```
+  \end{dartCode}
+\item
+  \AWAIT{} is used before a C-style \synt{forElement}.
+  \AWAIT{} can only be used with for-in loops.
 
-*   `await` is used before a C-style `for` element. `await` can only be used
-    with `for-in` loops.
-
-    ```dart
+  \begin{dartCode}
     main() {
       [await for (;;)]; // Error.
     }
-    ```
+  \end{dartCode}
 
-*   The type of the condition expression (the second clause) in a C-style `for`
-    element may not be assigned to `bool`.
+\item
+  The type of the condition expression
+  (\commentary{the second clause})
+  in a C-style \FOR{} element
+  may not be assigned to \code{bool}.
 
-    ```dart
+  \begin{dartCode}
     [for (; "not bool";) 1] // Error.
-    ```
+  \end{dartCode}
+\end{itemize}
 
-## Constant Semantics
 
-The runtime semantics below are used to determine the compile-time value of a
-constant collection literal, which is defined as a `listLiteral` or
-`setOrMapLiteral` that occurs in a constant context or directly preceded by
-`const`.
+\subsection{Constant Semantics}
+\LMLabel{uiAsCodeConstantSemantics}
 
-Elements in a collection may be constant, potentially constant, or neither. All
-`elements` directly inside in a constant collection must be constant elements.
+\LMHash{}%
+The runtime semantics below are used to determine the compile-time value of
+a constant collection literal,
+which is defined as a \synt{listLiteral} or \synt{setOrMapLiteral}
+that occurs in a constant context or directly preceded by \CONST{}.
+
+\LMHash{}%
+Elements in a collection may be constant, potentially constant, or neither.
+All \synt{elements} directly inside in a constant collection
+must be constant elements.
 They are defined as:
 
-*   An `expressionElement` is a constant element if its expression is a constant
-    expression, and a potentially constant element if it's expression is a
-    potentially constant expression.
+\begin{itemize}
+\item
+  An \synt{expressionElement} is a constant element if
+  its expression is a constant expression, and
+  a potentially constant element if
+  its expression is a potentially constant expression.
+\item
+  A \synt{mapEntry} is a constant element if
+  both its key and value expression are constant expressions, and
+  a potentially constant element if
+  both are potentially constant expressions.
+\item
+  A \synt{spreadElement} starting with \lit{...} is a constant element if
+  its expression is constant and
+  it evaluates to a constant \code{List}, \code{Set} or \code{Map}
+  instance originally created by a list, set or map literal.
+  It is a potentially constant element if
+  the expression is a potentially constant expression.
+\item
+  A \synt{spreadElement} starting with \lit{...?} is a constant element if
+  its expression is constant and it evaluates to \NULL{} or
+  a constant \code{List}, \code{Set} or \code{Map} instance
+  originally created by a list, set or map literal.
+  It is a potentially constant element if
+  the expression is potentially constant expression.
+\item
+  An \synt{ifElement} is a constant element if
+  its condition is a constant expression evaluating to
+  a value of type \code{bool} and either:
 
-*   A `mapEntry` is a constant element if both its key and value expression are
-    constant expressions, and a potentially constant element if both are
-    potentially constant expressions.
+  \begin{itemize}
+  \item
+    The condition evaluates to \TRUE{}, the "then" element is
+    a constant expression, and the "else" element, if any, is
+    a potentially constant element.
+  \item
+    The condition evaluates to \FALSE{}, the "then" element is
+    a potentially constant element, and the "else" element, if any, is
+    a constant element.
+  \end{itemize}
+\item
+  An \synt{ifElement} is potentially constant if
+  its condition, "then" element, and "else" element, if any, are
+  potentially constant expressions.
+\item
+  \commentary{%
+    A \synt{forElement} is never a constant or potentially constant element.
+    A \synt{forElement} cannot be used in constant collection literals.%
+  }
+\end{itemize}
 
-*   A `spreadElement` starting with `...` is a constant element if its
-    expression is constant and it evaluates to a constant `List`, `Set` or `Map`
-    instance originally created by a list, set or map literal. It is a
-    potentially constant element if the expression is a potentially constant
-    expression.
-
-*   A `spreadElement` starting with `...?` is a constant element if its
-    expression is constant and it evaluates to `null` or a constant `List`,
-    `Set` or `Map` instance originally created by a list, set or map literal. It
-    is a potentially constant element if the expression is potentially constant
-    expression.
-
-*   An `ifElement` is a constant element if its condition is a constant
-    expression evaluating to a value of type `bool` and either:
-
-    *   The condition evaluates to `true`, the "then" element is a constant
-        expression, and the "else" element (if it exists) is a potentially
-        constant element.
-
-    *   The condition evaluates to `false`, the "then" element is a potentially
-        constant element, and the "else" element (if it exists) is a constant
-        element.
-
-*   An `ifElement` is potentially constant if its condition, "then" element, and
-    "else" element (if any) are potentially constant expressions.
-
-*   A `forElement` is never a constant or potentially constant element. A `for`
-    element cannot be used in constant collection literals.
-
+\LMHash{}%
 Also:
 
-*   It is a compile-time error if any element in a constant set or key in a
-    constant map does not have a primitive operator `==`.
+\begin{itemize}
+\item
+  It is a compile-time error if
+  any element in a constant set or key in a constant map
+  does not have a primitive operator \lit{==}.
+\item
+  When evaluating a const collection literal,
+  if another const collection has previously been evaluated that:
 
-*   When evaluating a const collection literal, if another const collection has
-    previously been evaluated that:
+  \begin{itemize}
+  \item is of the same kind (map, set, or list),
+  \item has the same type arguments,
+  \item and contains the same (identical) elements or key/value entries
+    in the same order,
+  \end{itemize}
+  
+  then the current literal evaluates to the value of that previous literal.
 
-    *   is of the same kind (map, set, or list),
-    *   has the same type arguments,
-    *   and contains the same (identical) elements or key/value entries in the
-        same order,
+  \commentary{%
+    In other words, constants are canonicalized.
+    Note that maps and sets are only canonicalized if
+    they contain the same keys or elements \emph{in the same order}.%
+    }
+\end{itemize}
 
-    then the current literal evaluates to the value of that previous literal.
-    *In other words, constants are canonicalized.* Note that maps and sets are
-    only canonicalized if they contain the same keys or elements *in the same
-    order*.
+\subsection{Dynamic Semantics}
+\LMLabel{uiAsCodeDynamicSemantics}
 
-## Dynamic Semantics
+\LMHash{}%
+Spread, \IF{}, and \FOR{} behave similarly across all collection types.
+To simplify the spec, there is a single procedure used for
+all kinds of collections.
 
-Spread, `if`, and `for` behave similarly across all collection types. To
-simplify the spec, there is a single procedure used for all kinds of
-collections. This recursive procedure builds up either a *result* sequence of
-values or key-value pair map entries. Then a final step handles those
-appropriately for the given collection type.
+\LMHash{}%
+This recursive procedure builds up either a \metavar{result} sequence of
+values or key-value pair map entries.
+Then a final step handles those appropriately for the given collection type.
 
-### To evaluate a collection `element`:
+\subsubsection{To evaluate a collection element}
+\LMLabel{uiAsCodeToEvaluateACollectionElement}
 
-1.  If `element` is an expression element:
+%% TODO(eernst): Reshape the lists below to avoid 'too deeply nested'.
 
-    1.  Evaluate the element's expression and append it to *result*.
-
-1.  Else, `element` is a `mapEntry` `keyExpression: valueExpression`:
-
-    1.  Evaluate `keyExpression` to a value *key*.
-
-    1.  Evaluate `valueExpression` to a value *value*.
-
-    1.  Append an entry *key*: *value* to *result*.
-
-1.  Else, if `element` is a spread element:
-
-    1.  Evaluate the spread expression to a value `spread`.
-
-    1.  If `element` is not null-aware and `spread` is `null`, throw a dynamic
-        exception.
-
-    1.  Else, if `element` is null-aware and `spread` is `null`, do nothing.
-
-    1.  Else, if the collection is a map:
-
-        1.  If `spread` is not an instance of a class that implements `Map`,
-            throw a dynamic exception.
-
-        1.  Evaluate `spread.entries.iterator` to a value `iterator`.
-
-        1.  Loop:
-
-            1.  Evaluate `iterator.moveNext()` to a value `hasValue`.
-
-            1.  If `hasValue` is `true`:
-
-                1.  Evaluate `iterator.current` to a value `entry`.
-
-                1.  Evaluate `entry.key` to a value *key*.
-
-                1.  Evaluate `entry.value` to a value *value*.
-
-                1.  If *key* is not a subtype of the map's key type, throw a
-                    dynamic error.
-
-                1.  If *value* is not a subtype of the map's value type, throw a
-                    dynamic error.
-
-                An implementation is free to execute the previous four
-                operations in any order, except that obviously the key must be
-                evaluated before its type is checked, and likewise for the
-                value.
-
-                1.  Append an entry *key*: *value* to *result*.
-
-            1.  Else, if `hasValue` is `false`, exit the loop.
-
-            1.  Else, throw a dynamic error.
-
-    1.  Else, the collection is a list or set:
-
-        1.  If `spread` is not an instance of a class that implements
-            `Iterable`, throw a dynamic exception.
-
-        1.  Evaluate `spread.iterator` to *iterator*.
-
-        1.  Loop:
-
-            1.  Evaluate `iterator.moveNext()` to a value `hasValue`.
-
-            1.  If `hasValue` is `true`:
-
-                1.  Evaluate `iterator.current` to a value *value*.
-
-                1.  If *value* is not a subtype of the collection's element
-                    type, throw a dynamic error.
-
-                1.  Append *value* to *result*.
-
-            1.  Else, if `hasValue` is `false`, exit the loop.
-
-            1.  Else, throw a dynamic error.
-
-    The `iterator` API may not be the most efficient way to traverse the items
-    in a collection. In order to give implementations more room to optimize, we
-    loosen the semantics:
-
-    *   If `spread` is an object whose class implements List, Queue, or Set (all
-        from `dart:core`), an implementation *may* choose to call `length` on
-        the object. This may let it allocate space for the resulting collection
-        more efficiently. Classes that implement these are expected to have an
-        efficient, side-effect free implementation of `length`.
-
-    *   If `spread` is an object whose class implements List from `dart:core`,
-        an implementation may choose to call `[]` to access elements from the
-        list. If it does so, it will only pass indexes `>= 0` and `<` the value
-        returned by `length`.
-
-    A Dart implementation may detect whether these options apply at compile time
-    based on the static type of `spread` or at runtime based on the actual
-    value.
-
-1.  Else, if `element` is an `ifElement`:
-
-    1.  Evaluate the condition expression to a value `condition`.
-
-    1.  If `condition` is `true`:
-
-        1.  Evaluate the "then" element using this procedure.
-
-    1.  Else, if `condition` is `false`:
-
-        1.  If there is an "else" element of the `if`:
-
-            1.  Evaluate the "else" element using this procedure.
-
-    1.  Else, throw a dynamic error.
-
-1.  Else, if `element` is a synchronous `forElement` for a `for-in` loop:
-
-    1.  Evaluate the iterator expression to a value `sequence`.
-
-    1.  If `sequence` is not an instance of a class that implements `Iterable`,
+\begin{enumerate}
+\item
+  If $\ell$ is an expression element:
+  \begin{enumerate}
+  \item Evaluate the element's expression and append it to \metavar{result}.
+  \end{enumerate}
+\item
+  Else, $\ell$ is a \synt{mapEntry}
+  \code{\metavar{keyExpression}: \metavar{valueExpression}}:
+  \begin{enumerate}
+  \item Evaluate \metavar{keyExpression} to a value \metavar{key}.
+  \item Evaluate \metavar{valueExpression} to a value \metavar{value}.
+  \item Append an entry \code{\metavar{key}: \metavar{value}}
+    to \metavar{result}.
+  \end{enumerate}
+\item
+  Else, if $\ell$ is a spread element:
+  \begin{enumerate}
+  \item
+    Evaluate the spread expression to a value \metavar{spread}.
+    \begin{enumerate}
+    \item
+      If $\ell$ is not null-aware and \metavar{spread} is \NULL,
+      throw a dynamic exception.
+    \item
+      Else, if $\ell$ is null-aware and \metavar{spread} is \NULL,
+      do nothing.
+    \item
+      Else, if the collection is a map:
+      \begin{enumerate}
+      \item
+        If \metavar{spread} is not an instance
+        of a class that implements \code{Map},
         throw a dynamic exception.
+      \item
+        Evaluate \code{spread.entries.iterator} to a value \metavar{iterator}.
+        %% \begin{enumerate}
+        %% \item Loop:
+        %%   \begin{enumerate}
+        %%   \item
+        %%     Evaluate \code{iterator.moveNext()} to a value \metavar{hasValue}.
+        %%   \item
+        %%     If \metavar{hasValue} is \TRUE:
+        %%     \begin{enumerate}
+        %%     \item Evaluate \code{iterator.current} to a value \metavar{entry}.
+        %%     \item Evaluate \code{entry.key} to a value \metavar{key}.
+        %%     \item Evaluate \code{entry.value} to a value \metavar{value}.
+        %%       \begin{enumerate}
+        %%       \item If \metavar{key} is not a subtype of the map's key type,
+        %%         throw a dynamic error.
+        %%       \item If \metavar{value} is not a subtype of the map's value type,
+        %%         throw a dynamic error.
+        %%       \end{enumerate}
 
-    1.  Evaluate `sequence.iterator` to a value `iterator`.
+        %%       An implementation is free to execute
+        %%       the previous four operations in any order,
+        %%       except that obviously the key must be evaluated
+        %%       before its type is checked,
+        %%       and likewise for the value.
+              
+        %%     \item Append an entry \code{\metavar{key}: \metavar{value}}
+        %%       to \metavar{result}.
+        %%     \end{enumerate}
+        %%   \item
+        %%     Else, if \metavar{hasValue} is \FALSE, exit the loop.
+        %%   \item
+        %%     Else, throw a dynamic error.
+        %%   \end{enumerate}
+        %% \end{enumerate}
+      \end{enumerate}
+    \end{enumerate}
+  \item
+    Else, the collection is a list or set:
 
-    1.  Loop:
+    \begin{enumerate}
+    \item
+      If \metavar{spread} is not an instance of
+      a class that implements \code{Iterable},
+      throw a dynamic exception.
+    \item
+      Evaluate \code{spread.iterator} to \metavar{iterator}.
+    \item
+      Loop:
+      \begin{enumerate}
+      \item
+        Evaluate \code{iterator.moveNext()} to a value \metavar{hasValue}.
+      \item
+        If \metavar{hasValue} is \TRUE:
+        %% \begin{enumerate}
+        %% \item
+        %%   Evaluate \code{iterator.current} to a value \metavar{value}.
+        %% \item
+        %%   If \metavar{value} is not a subtype of the collection's element type,
+        %%   throw a dynamic error.
+        %% \item
+        %%   Append \metavar{value} to \metavar{result}.
+        %% \end{enumerate}
+      \item
+        Else, if \metavar{hasValue} is \FALSE, exit the loop.
+      \item
+        Else, throw a dynamic error.
+      \end{enumerate}
 
-        1.  Evaluate `iterator.moveNext()` to a value `hasValue`.
+      \commentary{%
+        The \code{iterator} API may not be
+        the most efficient way to traverse the items in a collection.
+        In order to give implementations more room to optimize,
+        we loosen the semantics:%
+      }
+      \begin{itemize}
+      \item
+        If \metavar{spread} is an object
+        whose class implements \code{List}, \code{Queue}, or \code{Set}
+        (\commentary{all from \code{dart:core}}),
+        an implementation may choose to call \code{length} on the object.
+        This may let it allocate space for the resulting collection
+        more efficiently.
+        Classes that implement these are expected to have an efficient,
+        side-effect free implementation of \code{length}.
+      \item
+        If \metavar{spread} is an object
+        whose class implements List from \code{dart:core},
+        an implementation may choose to call \lit{[]}
+        to access elements from the list.
+        If it does so, it will only pass indexes
+        \code{>= 0} and \code{<} the value returned by \code{length}.
+      \end{itemize}
+    \end{enumerate}
 
-        1.  If `hasValue` is `true`:
+    A Dart implementation may detect whether these options apply
+    at compile time based on the static type of \metavar{spread} or
+    at runtime based on the actual value.
+  \end{enumerate}
+\item
+  Else, if $\ell$ is an \synt{ifElement}:
+  \begin{enumerate}
+  \item
+    Evaluate the condition expression to a value \metavar{condition}.
+    \begin{enumerate}
+    \item If \metavar{condition} is \TRUE:
+      \begin{enumerate}
+      \item Evaluate the "then" element using this procedure.
+      \end{enumerate}
+    \item Else, if \metavar{condition} is \FALSE:
+      \begin{enumerate}
+      \item If there is an "else" element of the \IF:
+        %% \begin{enumerate}
+        %% \item Evaluate the "else" element using this procedure.
+        %% \end{enumerate}
+      \end{enumerate}
+    \item Else, throw a dynamic error.
+    \end{enumerate}
+  \end{enumerate}
+\item
+  Else, if $\ell$ is a synchronous \synt{forElement} for a for-in loop:
 
-            1.  If the `for-in` element declares a variable, create a new
-                namespace and a fresh `variable` for it. Otherwise, use the
-                existing `variable` it refers to.
+  \begin{enumerate}
+  \item Evaluate the iterator expression to a value \metavar{sequence}.
+  \item If \metavar{sequence} is not an instance of
+    a class that implements \code{Iterable},
+    throw a dynamic exception.
+  \item
+    Evaluate \code{sequence.iterator} to a value \metavar{iterator}.
+    \begin{enumerate}
+    \item Loop:
+      \begin{enumerate}
+      \item
+        Evaluate \code{iterator.moveNext()} to a value \metavar{hasValue}.
+      \item
+        If \metavar{hasValue} is \TRUE:
+        %% \begin{enumerate}
+        %% \item
+        %%   If the for-in element declares a variable,
+        %%   create a new namespace and a fresh \code{variable} for it.
+        %%   Otherwise, use the existing \code{variable} it refers to.
+        %% \item
+        %%   Bind \code{variable} to
+        %%   the result of evaluating \code{iterator.current}.
+        %% \item
+        %%   Evaluate the body element using this procedure
+        %%   in the scope of \code{variable}.
+        %% \end{enumerate}
+      \item
+        Else, if \metavar{hasValue} is \FALSE, exit the loop.
+      \item
+        Else, throw a dynamic error.
+      \end{enumerate}
+    \end{enumerate}
+  \end{enumerate}
+\item
+  Else, if $\ell$ is an asynchronous \AWAIT{} for-in element:
+  \begin{enumerate}
+  \item
+    Evaluate the stream expression to a value \metavar{stream}.
+  \item
+    If \metavar{stream} is not an instance of
+    a class that implements \code{Stream},
+    throw a dynamic error.
+  \item
+    Pause the subscription of any surrounding \AWAIT{} \FOR{} loop
+    in the current method.
+  \item
+    Let \metavar{streamDone} be a value implementing \code{Future<Null>}.
+  \item
+    Listen on \metavar{stream} and take the following actions on events:
 
-            1.  Bind `variable` to the result of evaluating `iterator.current`.
+    \begin{itemize}
+    \item On a data event with value \metavar{value}:
+      \begin{enumerate}
+      \item
+        If the for-in element declares a variable,
+        create a new namespace and a fresh \code{variable} for it.
+        Otherwise, use the existing `variable` it refers to.
+      \item
+        Bind \code{variable} to \metavar{value}.
+      \item
+        Evaluate the body element using this procedure.
+      \item
+        If evaluation of the body throws an
+        error \metavar{error} and stack trace \metavar{stack}, then:
+        %% \begin{enumerate}
+        %% \item
+        %%   Stop listening on the stream by calling the \code{cancel()}
+        %%   method of the corresponding stream subscription, which
+        %%   returns a future $f$.
+        %% \item
+        %%   Wait for $f$ to complete.
+        %%   If $f$ completes with
+        %%   an error \metavar{error2} and stack trace \metavar{stack2},
+        %%   then complete \metavar{streamDone}
+        %%   with error \metavar{error2} and stack trace \metavar{stack2}.
+        %%   Otherwise complete \metavar{streamDone}
+        %%   with error \metavar{error} and stack trace \metavar{stack}.
+        %% \end{enumerate}
+      \item
+        Else, evaluation of the body element completes successfully.
+        %% \begin{enumerate}
+        %% \item Resume the stream subscription if it has been paused.
+        %% \end{enumerate}
+      \item
+        On an error event
+        with error \metavar{error} and stack trace \metavar{stack}:
+        %% \begin{enumerate}
+        %% \item
+        %%   Stop listening on the stream by calling the \code{cancel()} method of
+        %%   the corresponding stream subscription,
+        %%   which returns a future $f$.
+        %% \item
+        %%   Wait for $f$ to complete.
+        %%   If `f` completes
+        %%   with an error \metavar{error2} and stack trace \metavar{stack2},
+        %%   then complete \metavar{streamDone}
+        %%   with error \metavar{error2} and stack trace \metavar{stack2}.
+        %%   Otherwise complete \metavar{streamDone}
+        %%   with error \metavar{error} and stack trace \metavar{stack}.
+        %% \end{enumerate}
+      \item
+        On a done event, complete `streamDone` with the value `null`.
+      \end{enumerate}
+    \end{itemize}
+  \item
+    Evaluation of the for-in element completes
+    when \metavar{streamDone} completes.
+    If \metavar{streamDone} completes
+    with an error \metavar{error} and stack trace \metavar{stack},
+    then evaluation of the element
+    throws \metavar{error} with stack trace \metavar{stack},
+    otherwise the evaluation completes successfully.
+  \end{enumerate}
+\item
+  Else, $\ell$ is a C-style \synt{forElement}:
+  \begin{enumerate}
+  \item
+    Evaluate the initializer clause of the element, if there is one.
+  \item
+    Loop:
+    \begin{enumerate}
+    \item
+      If the initializer clause declares a variable,
+      create a new namespace and bind that variable in that namespace.
+    \item
+      Evaluate the condition expression to a value \metavar{condition}.
+      If there is no condition expression, use \TRUE.
+    \item
+      If \metavar{condition} is \TRUE:
+      \begin{enumerate}
+      \item
+        Evaluate the body element using this procedure in the namespace
+        of the variable declared by the initializer clause
+        if there is one.
+      \item
+        If there is an increment clause, execute it.
+      \end{enumerate}
+    \item
+      Else, if \metavar{condition} is \FALSE, exit the loop.
+    \item
+      Else, throw a dynamic error.
+    \end{enumerate}
+  \end{enumerate}
+\end{enumerate}
 
-            1.  Evaluate the body element using this procedure in the scope of
-                `variable`.
-
-        1.  Else, if `hasValue` is `false`, exit the loop.
-
-        1.  Else, throw a dynamic error.
-
-1.  Else, if `element` is an asynchronous `await for-in` element:
-
-    1.  Evaluate the stream expression to a value `stream`.
-
-    1.  If `stream` is not an instance of a class that implements `Stream`,
-        throw a dynamic error.
-
-    1.  Pause the subscription of any surrounding `await for` loop in the
-        current method.
-
-    1.  Let `streamDone` be a value implementing `Future<Null>`.
-
-    1.  Listen on `stream` and take the following actions on events:
-
-        *   On a data event with value `value`:
-
-            1.  If the `for-in` element declares a variable, create a new
-                namespace and a fresh `variable` for it. Otherwise, use the
-                existing `variable` it refers to.
-
-            1.  Bind `variable` to `value`.
-
-            1.  Evaluate the body element using this procedure.
-
-            1.  If evaluation of the body throws an error `error` and stack
-                trace `stack`, then:
-
-                1.  Stop listening on the stream by calling the `cancel()`
-                    method of the corresponding stream subscription, which
-                    returns a future `f`.
-
-                1.  Wait for `f` to complete. If `f` completes with an error
-                    `error2` and stack trace `stack2`, then complete
-                    `streamDone` with error `error2` and stack trace `stack2`.
-                    Otherwise complete `streamDone` with error `error` and stack
-                    trace `stack`.
-
-            1.  Else, evaluation of the body element completes successfully.
-
-                1.  Resume the stream subscription if it has been paused.
-
-        *   On an error event with error `error` and stack trace `stack`:
-
-            1.  Stop listening on the stream by calling the `cancel()` method of
-                the corresponding stream subscription, which returns a future
-                `f`.
-
-            1.  Wait for `f` to complete. If `f` completes with an error
-                `error2` and stack trace `stack2`, then complete `streamDone`
-                with error `error2` and stack trace `stack2`. Otherwise complete
-                `streamDone` with error `error` and stack trace `stack`.
-
-        *   On a done event, complete `streamDone` with the value `null`.
-
-    1.  Evaluation of the `for-in` element completes when `streamDone`
-        completes. If `streamDone` completes with an error `error` and stack
-        trace `stack`, then evaluation of the element throws `error` with stack
-        trace `stack`, otherwise the evaluation completes successfully.
-
-1.  Else, `element` is a C-style `for` element:
-
-    1.  Evaluate the initializer clause of the element, if there is one.
-
-    1.  Loop:
-
-        1.  If the initializer clause declares a variable, create a new
-            namespace and bind that variable in that namespace.
-
-        1.  Evaluate the condition expression to a value `condition`. If there
-            is no condition expression, use `true`.
-
-        1.  If `condition` is `true`:
-
-            1.  Evaluate the body element using this procedure in the namespace
-                of the variable declared by the initializer clause if there is
-                one.
-
-            1.  If there is an increment clause, execute it.
-
-        1.  Else, if `condition` is `false`, exit the loop.
-
-        1.  Else, throw a dynamic error.
-
+\LMHash{}%
 The procedure theoretically supports a mixture of expressions and map entries,
 but the static semantics prohibit an actual literal containing that.
 
-Once the *result* series of values or entries is produced from the tree of
-elements, the final object is produced from that based on what kind of literal
-it is:
-
-### List
-
-1.  The result of the literal expression is a fresh instance of a class that
-    implements `List<E>` where `E` is the element type of the literal. It
-    contains the values in *result*, in order. If the literal is constant, the
-    list is canonicalized and immutable, otherwise it is not.
-
-### Set
-
-1.  Create a fresh instance *set* of a class that implements `Set<E>` where `E`
-    is the set element type of the literal.
-
-1.  For each *value* in *result*:
-
-    1.  If *set* contains a value *existing* that is equal to *value*
-        according to *existing*'s `==` operator:
-
-        1.  If the literal is constant, it is a compile-time error.
-
-        1.  Else, do nothing. *Duplicates are discarded and the first one wins.*
-
-    1.  Else, add *value* to *set*.
-
-1.  The result of the literal expression is *set*. If the literal is constant,
-    canonicalize it make the set immutable.
-
-### Map
-
-1.  Allocate a fresh instance *map* of a class that implements `LinkedHashMap<K,
-    V>` where `K` is the key type of the literal and `V` is the value type.
-
-1.  For each entry *key*: *value* in *result*:
-
-    1.  If *map* contains an entry *existing* whose key *existingKey* is equal
-        to *key* according to *existingKeys*'s `==` operator:
-
-        1.  If the literal is constant, it is a compile-time error.
-
-        1.  Else, replace the value in *existing* with *value*, while keeping
-            its position in the sequence of entries and *existingKey* the same.
-
-    1.  Else add entry *key*: *value* to *map*.
-
-1.  The result of the map literal expression is *map*. If the literal is
-    constant, canonicalize it and make the map immutable.
+\LMHash{}%
+Once the \metavar{result} series of values or entries is produced
+from the tree of elements,
+the final object is produced from that based on what kind of literal it is:
 
 
+\subsubsection{List}
+\LMLabel{uiAsCodeList}
+
+\LMHash{}%
+The result of the literal expression is a fresh instance of
+a class that implements \code{List<$E$>} where $E$ is
+the element type of the literal.
+It contains the values in \metavar{result}, in order.
+If the literal is constant,
+the list is canonicalized and immutable,
+otherwise it is not.
+
+
+\subsubsection{Set}
+\LMLabel{uiAsCodeSet}
+
+\LMHash{}%
+Create a fresh instance \metavar{set} of
+a class that implements \code{Set<$E$>} where $E$
+is the set element type of the literal.
+
+\LMHash{}%
+For each \metavar{value} in \metavar{result}:
+
+\begin{enumerate}
+\item
+  If \metavar{set} contains
+  a value \metavar{existing} that is equal to \metavar{value}
+  according to \metavar{existing}'s operator \lit{==}:
+\item
+  If the literal is constant, it is a compile-time error.
+\item
+  Else, do nothing.
+  \commentary{Duplicates are discarded and the first one wins.}
+\item
+  Else, add \metavar{value} to \metavar{set}.
+\end{enumerate}
+
+\LMHash{}%
+The result of the literal expression is \metavar{set}.
+If the literal is constant,
+canonicalize it make the set immutable.
+
+
+\subsubsection{Map}
+\LMLabel{uiAsCodeMap}
+
+\LMHash{}%
+Allocate a fresh instance \metavar{map} of
+a class that implements \code{LinkedHashMap<$K$, $V$>} where $K$ is
+the key type of the literal and $V$ is
+the value type.
+
+\LMHash{}%
+For each entry \code{\metavar{key}: \metavar{value}} in \metavar{result}:
+
+\begin{enumerate}
+\item
+  If \metavar{map} contains an entry \metavar{existing}
+  whose key \metavar{existingKey} is equal to \metavar{key}
+  according to \metavar{existingKeys}'s operator \lit{==}:
+  \begin{enumerate}
+  \item
+    If the literal is constant, it is a compile-time error.
+  \item
+    Else, replace the value in \metavar{existing} with \metavar{value},
+    while keeping its position in the sequence of entries
+    and \metavar{existingKey} the same.
+  \end{enumerate}
+\item
+  Else add entry \code{\metavar{key}: \metavar{value}} to \metavar{map}.
+\end{enumerate}
+
+\LMHash{}%
+The result of the map literal expression is \metavar{map}.
+If the literal is constant,
+canonicalize it and make the map immutable.
 
 
 \printindex

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -7244,7 +7244,7 @@ A \synt{forElement} can never occur in a constant collection literal.%
 %% - "A spread element in a list or set literal has a static type that is
 %%   not \DYNAMIC{} and not a subtype of \code{Iterable<Object>}".
 %%   List literal: case analysis on 'Spread element'.
-%%   Set literal: case analysis on 'Spread element': only succeeds if 
+%%   Set literal: case analysis on 'Spread element': only succeeds if
 %%   $S$ implements `Map` (and not `Iterable`), so it has a key/value
 %%   type and no element type, which is an error (\ref{sets}).
 %%
@@ -7397,7 +7397,10 @@ Note that the dynamic type of \metavar{target} is statically known,
 except for the binding of any type variables in its \synt{typeArguments}.
 This implies that some questions can be answered at compile-time, e.g.,
 whether or not \code{Iterable} occurs as a superinterface of
-$T_{\metavar{target}}$.%
+$T_{\metavar{target}}$.
+In any case, $T_{\metavar{target}}$ is guaranteed to implement
+\code{Iterable} (when \metavar{target} is a list or a set)
+or \code{Map} (when \metavar{target} is a map).%
 }
 
 \LMHash{}%
@@ -7427,8 +7430,8 @@ yielded by evaluation of $\ell$,
 but it also denotes the specification of actions taken to produce
 said object sequence,
 and to produce the side effects associated with this computation,
-as implied by evaluation of expressions which is specified below to be
-part of the evaluation of \EvaluateElement{\ell}.
+as implied by evaluation of expressions and execution of statements
+as specified below for the evaluation of \EvaluateElement{\ell}.
 
 \LMHash{}%
 When a pseudo-statement of the form
@@ -7476,17 +7479,19 @@ Evaluate $e$ to an object $o_{\metavar{spread}}$.
 \item
   Let $T_{\metavar{spread}}$ be the dynamic type of $o_{\metavar{spread}}$.
   Let $S$ be the static type of $e$.
-  When $S$ is a top type
+  When $S$ is not a top type
   (\ref{superBoundedTypes}),
+  let $S_{\metavar{spread}}$ be $S$.
+  When $S$ is a top type:
+  If \metavar{target} is a list or a set then
   let $S_{\metavar{spread}}$ be \code{Iterable<\DYNAMIC>};
-  otherwise let $S_{\metavar{spread}}$ be $S$.
-  \commentary{%
-    It is a compile-time error if $S$
-    is not assignable to \code{Iterable<\DYNAMIC>}.%
-  }
+  otherwise
+  (\commentary{where \metavar{target} is a map}),
+  let $S_{\metavar{spread}}$ be \code{Map<\DYNAMIC,\,\,\DYNAMIC>}.
+
   \begin{itemize}
   \item
-    When both $T_{\metavar{spread}}$ and $T_{\metavar{target}}$ implement
+    When \metavar{target} is a list or a set and $T_{\metavar{spread}}$ implements
     (\ref{interfaceSuperinterfaces})
     \code{Iterable},
     the following code is executed in the context where $\ell$ occurs,
@@ -7518,7 +7523,7 @@ $\EvaluateElement{\ell} := s$;
       A similar approach is used in subsequent cases.%
     }
   \item
-    When both $T_{\metavar{spread}}$ and $T_{\metavar{target}}$ implement
+    When \metavar{target} is a map and $T_{\metavar{spread}}$ implements
     \code{Map},
     the following code is executed in the context where $\ell$ occurs,
     where \code{spread}, $s$, \code{entry}, \code{key}, and \code{value}
@@ -7549,7 +7554,7 @@ $\EvaluateElement{\ell} := s$;
     Otherwise, a dynamic error occurs.
 
     \commentary{%
-      This occurs when the target is a map respectively iterable,
+      This occurs when the target is an iterable respectively a map,
       and the spread is not, which is possible for
       a spread whose static type is \DYNAMIC{}.%
     }
@@ -7644,7 +7649,11 @@ The context type $P$
 for each element of \metavar{list} is
 obtained from the context type of \metavar{list}.
 If downwards inference constrains the type of \metavar{list}
-to \code{Iterable<$P_e$>} for some $P_e$ then $P$ is $P_e$.
+%% TODO(eernst): Confirm that the context type should allow for
+%% `List` as well as `Iterable`. The implementations (unsurprisingly)
+%% do that, but the feature spec only allowed for `Iterable`.
+to \code{List<$P_e$>} or \code{Iterable<$P_e$>} for some $P_e$
+then $P$ is $P_e$.
 Otherwise, $P$ is \FreeContext{}
 (\ref{setAndMapLiteralDisambiguation}).
 
@@ -7665,9 +7674,17 @@ the inferred type of $e$ in context $P$.
 
 \LMHash{}%
 \Case{Map element}
-In this case, a compile-time error occurs.
+% We cannot really tell whether this or the error in \ref{lists} arises first
+% (say, when the list literal has an explicit type argument, it is not
+% guaranteed that the implementation performs type inference on it at all).
+% So we _must_ specify the error in \ref{lists}, and this location should
+% then be a commentary, because we already have the error elsewhere.
 \commentary{%
-A list literal can never contain a map element.%
+This case can not arise,
+because it is a compile-time error
+when the leaf elements of a list literal
+contains a map element
+(\ref{lists}).%
 }
 \EndCase
 
@@ -7710,11 +7727,11 @@ In this case $\ell$ is of the form
 \code{\IF\,\,($b$)\,\,$\ell_1$\,\,\ELSE\,\,$\ell_2$}.
 The condition $b$ is always inferred with a context type of \code{bool}.
 
-Assume that \code{\ELSE\,\,$\ell_2$} is not present.
+Assume that `\code{\ELSE\,\,$\ell_2$}' is not present.
 Then, if the inferred element type of $\ell_1$ is $S$,
 the inferred element type of $\ell$ is $S$.
 
-Otherwise, \code{\ELSE\,\,$\ell_2$} is present.
+Otherwise, `\code{\ELSE\,\,$\ell_2$}' is present.
 If the inferred element type of $\ell_1$ is $S_1$ and
 the inferred element type of $\ell_2$ is $S_2$,
 the inferred element type of $\ell$ is
@@ -7987,7 +8004,7 @@ the first applicable entry in the following list:
   If $k = 1$ then $e$ is a set literal with static type
   \code{Set<$T_1$>}.
   If $k = 2$ then $e$ is a map literal with static type
-  \code{Map<$T_1$, $T_2$>}.
+  \code{Map<$T_1$,\,\,$T_2$>}.
   Otherwise a compile-time error occurs.
 \item
   When $S$ implements
@@ -8124,7 +8141,7 @@ which is determined as follows:
   }
 \item
   If \metavar{collection} is unambiguously a map
-  then $P$ is \code{Map<$P_k$, $P_v$>}
+  then $P$ is \code{Map<$P_k$,\,\,$P_v$>}
   where $P_k$ and $P_v$ are determined by downwards inference,
   and may be \FreeContext{}
   if the downwards context does not constrain one or both.
@@ -8175,7 +8192,7 @@ where $K$ and $V$ is
 the inferred type of $e_k$ respectively $e_v$,
 in context \FreeContext.
 %
-If $P$ is \code{Map<$P_k$, $P_v$>},
+If $P$ is \code{Map<$P_k$,\,\,$P_v$>},
 the inferred key and value type pair of $\ell$ is $(K, V)$,
 where $K$ is
 the inferred type of $e_k$ in context $P_k$, and
@@ -8265,7 +8282,7 @@ the inferred type of $e$ in context \code{Iterable<$P_e$>}, and then:
 \end{itemize}
 
 \noindent
-Otherwise, if $P$ is \code{Map<$P_k$, $P_v$>} then let $S$ be
+Otherwise, if $P$ is \code{Map<$P_k$,\,\,$P_v$>} then let $S$ be
 the inferred type of $e$ in context $P$, and then:
 
 \begin{itemize}
@@ -8300,7 +8317,7 @@ In this case $\ell$ is of the form
 \code{\IF\,\,($b$)\,\,$\ell_1$\,\,\ELSE\,\,$\ell_2$}.
 The condition $b$ is always inferred with a context type of \code{bool}.
 
-Assume that \code{\ELSE\,\,$\ell_2$} is not present. Then:
+Assume that `\code{\ELSE\,\,$\ell_2$}' is not present. Then:
 \begin{itemize}
 \item
   If the inferred element type of $\ell_1$ is $S$,
@@ -8310,7 +8327,7 @@ Assume that \code{\ELSE\,\,$\ell_2$} is not present. Then:
   the inferred key and value type pair of $\ell$ is $(K, V)$.
 \end{itemize}
 
-Otherwise, \code{\ELSE\,\,$\ell_2$} is present.
+Otherwise, `\code{\ELSE\,\,$\ell_2$}' is present.
 It is a compile error if $\ell_1$ must be a set and $\ell_2$ must be a map,
 or vice versa.
 
@@ -8416,7 +8433,7 @@ and the context type for \metavar{collection} is $P$.
   The static type of \metavar{collection} is then \code{Set<$T$>}.
 \item
   If \metavar{collection} is unambiguously a map
-  where $P$ is \code{Map<$P_k$, $P_v$>}
+  where $P$ is \code{Map<$P_k$,\,\,$P_v$>}
   and the inferred key and value type pairs are
   \KeyValueTypeList{K}{V}{1}{n}:
 
@@ -8437,7 +8454,7 @@ and the context type for \metavar{collection} is $P$.
     given this downwards context.%
   }
 
-  The static type of \metavar{collection} is then \code{Map<$K$, $V$>}.
+  The static type of \metavar{collection} is then \code{Map<$K$,\,\,$V$>}.
 \item
   Otherwise, \metavar{collection} is still ambiguous,
   the downwards context for the elements of \metavar{collection} is \FreeContext{},
@@ -8454,7 +8471,7 @@ and the context type for \metavar{collection} is $P$.
   \item
     If all elements can be a map,
     and at least one element must be a map, then $e$ is
-    a map literal with static type \code{Map<$K$, $V$>} where $K$ is
+    a map literal with static type \code{Map<$K$,\,\,$V$>} where $K$ is
     the least upper bound of the key types of the elements and $V$ is
     the least upper bound of the value types.
   \item
@@ -8681,8 +8698,8 @@ and $e$ is henceforth treated as
 \code{<$K$,\,$V$>$e$}.
 
 \commentary{%
-The static type of a map literal of the form \code{<$K$,\,$V$>$e$}
-is \code{Map<$K$,\,$V$>}
+The static type of a map literal of the form \code{<$K$,\,\,$V$>$e$}
+is \code{Map<$K$,\,\,$V$>}
 (\ref{setAndMapLiteralInference}).%
 }
 
@@ -8782,7 +8799,7 @@ so we cannot use such type parameters inside constant expressions.%
 The value of a constant map literal
 \code{\CONST?\,\,<$K, V$>\{\List{\ell}{1}{m}\}}
 is an object $m$ whose class implements the built-in class
-\code{Map<$K, V$>}.
+\code{Map<$K$,\,\,$V$>}.
 The key and value pairs of $m$ is
 the pairs of the object sequence \KeyValueList{k}{v}{1}{n} obtained by
 evaluation of \List{\ell}{1}{m}
@@ -8818,7 +8835,7 @@ is evaluated as follows:
   to an object sequence \LiteralSequence{\KeyValueList{k}{v}{1}{n}}.
 \item
   A fresh instance (\ref{generativeConstructors}) $m$
-  whose class implements the built-in class \code{Map<$K, V$>},
+  whose class implements the built-in class \code{Map<$K$,\,\,$V$>},
   is allocated.
 \item
   The operator \lit{[]=} is invoked on $m$

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -1105,7 +1105,7 @@ will throw.
 % for instance variables also when a setter is called dynamically.
 It is a dynamic type error if the dynamic type of $o$ is not
 a subtype of the actual type of the variable $v$
-(\ref{actualTypeOfADeclaration}).
+(\ref{actualTypes}).
 
 
 \subsection{Evaluation of Implicit Variable Getters}
@@ -1782,7 +1782,7 @@ or instance method closurization
 applied to $F$,
 and let $t$ be the actual type corresponding to $T$
 at the occasion where $o$ was created
-(\ref{actualTypeOfADeclaration}).
+(\ref{actualTypes}).
 \commentary{$T$ may contain free type variables, but $t$ contains their actual values.}
 The following must then hold:
 $u$ is a class that implements the built-in class \FUNCTION{};
@@ -3016,13 +3016,13 @@ must be a potentially constant expression (\ref{constantConstructors}).
 % This error can occur due to a failed implicit cast.
 It is a dynamic type error if an actual argument passed
 in an invocation of a redirecting generative constructor $k$
-is not a subtype of the actual type (\ref{actualTypeOfADeclaration})
+is not a subtype of the actual type (\ref{actualTypes})
 of the corresponding formal parameter in the declaration of $k$.
 % This error can occur due to a failed implicit cast.
 It is a dynamic type error if an actual argument passed
 to the redirectee $k'$ of a redirecting generative constructor
 is not a subtype of the actual type
-(\ref{actualTypeOfADeclaration})
+(\ref{actualTypes})
 of the corresponding formal parameter in the declaration of the redirectee.
 
 
@@ -3214,7 +3214,7 @@ Then, the instance variable $v$ of $i$ is bound to $o$.
 % This error can occur due to an implicit cast.
 It is a dynamic type error if the dynamic type of $o$ is not
 a subtype of the actual type
-(\ref{actualTypeOfADeclaration})
+(\ref{actualTypes})
 of the instance variable $v$.
 
 \LMHash{}%
@@ -3279,7 +3279,7 @@ It is a compile-time error if $M$ is not the name of the immediately enclosing c
 % This error can occur due to an implicit cast.
 It is a dynamic type error if a factory returns a non-null object
 whose type is not a subtype of its actual
-(\ref{actualTypeOfADeclaration})
+(\ref{actualTypes})
 return type.
 
 \rationale{
@@ -3435,7 +3435,7 @@ and $k'$ is the redirectee of $k$.
 \LMHash{}%
 % This error can occur due to an implicit cast.
 It is a dynamic type error if an actual argument passed in an invocation of $k$
-is not a subtype of the actual type (\ref{actualTypeOfADeclaration})
+is not a subtype of the actual type (\ref{actualTypes})
 of the corresponding formal parameter in the declaration of $k$.
 
 \LMHash{}%
@@ -7185,8 +7185,8 @@ or
 
   $\ell$ is a constant element
   if $e$ is a constant expression that evaluates
-  to a \code{List}, \code{Set} or \code{Map} instance
-  originally created by a list, set or map literal.
+  to a \code{List}, \code{Set}, or \code{Map} instance
+  originally created by a list, set, or map literal.
 
   Moreover, $\ell$ is a constant element if it is `\code{...?$e$}',
   where $e$ is a constant expression that evaluates
@@ -7200,8 +7200,8 @@ or
 
   $\ell$ is a potentially constant element
   if $b$ is a potentially constant expression,
-  and $\ell_1$ as well as $\ell_2$, if present,
-  are potentially constant.
+  $\ell_1$ is potentially constant,
+  and so is $\ell_2$, if present.
 
   $\ell$ is a constant element if $b$ is a constant expression
   and:
@@ -7309,7 +7309,7 @@ A \synt{forElement} can never occur in a constant collection literal.%
 \LMHash{}%
 An \synt{ifElement} interacts with type promotion
 in the same way that \IF{} statements do.
-Assume that $\ell$ is an \synt{ifElement} of the form
+Let $\ell$ be an \synt{ifElement} of the form
 \code{\IF\,\,($b$)\,\,$\ell_1$} or
 \code{\IF\,\,($b$)\,\,$\ell_1$\,\,\ELSE\,\,$\ell_2$}.
 If $b$ shows that a local variable $v$ has type $T$, then
@@ -7357,15 +7357,16 @@ and hence no notion of dynamic errors arising from
 a type mismatch during concatenation.
 
 \commentary{%
-Object sequences can safely be treated in an untyped manner
+Object sequences can safely be treated as a low-level mechanism
+which may omit otherwise required actions like dynamic type checks
 because every access to an object sequence occurs
 in code created by language defined desugaring
 on statically checked constructs.
 It is left unspecified how an object sequence is implemented,
 it is only required that it contains the indicated objects or pairs
 in the given order.
-For each kind of collection the sequence is used in the given order
-to populate the collection,
+For each kind of collection,
+the sequence is used in the given order to populate the collection,
 in a manner which is specific to the kind,
 and which is specified separately
 (\ref{lists}, \ref{sets}, \ref{maps}).%
@@ -7378,9 +7379,8 @@ as soon as it has been computed.
 Note that each object sequence will exclusively contain objects,
 or it will exclusively contain pairs,
 because any attempt to create a mixed sequence would cause
-an error at compile time or
-(for a spread element with static type \DYNAMIC{})
-at run time.%
+an error at compile time or at run time
+(the latter may occur for a spread element with static type \DYNAMIC{}).%
 }
 
 \LMHash{}%
@@ -7400,7 +7400,8 @@ whether or not \code{Iterable} occurs as a superinterface of
 $T_{\metavar{target}}$.
 In any case, $T_{\metavar{target}}$ is guaranteed to implement
 \code{Iterable} (when \metavar{target} is a list or a set)
-or \code{Map} (when \metavar{target} is a map).%
+or \code{Map} (when \metavar{target} is a map),
+but never both.%
 }
 
 \LMHash{}%
@@ -7442,7 +7443,9 @@ and it specifies that the value of \EvaluateElement{\ell} is $s$.
 \IndexCustom{Evaluation of a collection literal element $\ell$}{%
   collection literal element!evaluation}
 in the given context
-to an object sequence \EvaluateElement{\ell}
+to an object sequence
+\IndexCustom{\EvaluateElement{\ell}}{%
+  evaluateElement(l)@\emph{evaluateElement}\code{($\ell$)}}
 is then specified as follows:
 
 \LMHash{}%
@@ -7526,7 +7529,7 @@ $\EvaluateElement{\ell} := s$;
     When \metavar{target} is a map and $T_{\metavar{spread}}$ implements
     \code{Map},
     the following code is executed in the context where $\ell$ occurs,
-    where \code{spread}, $s$, \code{entry}, \code{key}, and \code{value}
+    where \code{spread}, $s$, \code{v}, \code{key}, and \code{value}
     are fresh variables,
     and \code{Key} and \code{Value} are fresh type variables bound to the
     first respectively second actual type argument
@@ -7536,9 +7539,9 @@ $\EvaluateElement{\ell} := s$;
 \begin{normativeDartCode}
 $S_{\metavar{spread}}$ spread = $o_{\metavar{spread}}$;
 \VAR{} $s$ = \LiteralSequence{};
-\FOR{} (\VAR{} entry \IN{} spread) \{
-  Key key = entry.key;
-  Value value = entry.value;
+\FOR{} (\VAR{} v \IN{} spread) \{
+  Key key = v.key;
+  Value value = v.value;
   $s = s + \LiteralSequence{\code{key}:\,\code{value}}$;
 \}
 $\EvaluateElement{\ell} := s$;
@@ -7574,24 +7577,22 @@ If $o_{\metavar{spread}}$ is an object whose dynamic type implements
 (\ref{interfaceSuperinterfaces})
 \code{List}, \code{Queue}, or \code{Set},
 an implementation may choose to call \code{length} on the object.
-
-\rationale{%
-This may let it allocate space for the resulting collection more efficiently.
-The given class is expected to have an efficient and
-side-effect free implementation of \code{length}.%
-}
-
-\LMHash{}%
 If $o_{\metavar{spread}}$ is an object whose dynamic type implements \code{List},
 an implementation may choose to call operator \lit{[]}
 in order to access elements from the list.
 If it does so, it will only pass indices
 that are non-negative and less than the value returned by \code{length}.
 
-\LMHash{}%
+\rationale{%
+This may allow for more efficient code for
+allocating the collection and accessing its parts.
+The given classes are expected to have
+an efficient and side-effect free implementation
+of \code{length} and operator \lit{[]}.
 A Dart implementation may detect whether these options apply
 at compile time based on the static type of $e$,
-or at runtime based on the actual value.
+or at runtime based on the actual value.%
+}
 \EndCase
 
 \LMHash{}%
@@ -7680,10 +7681,9 @@ the inferred type of $e$ in context $P$.
 % So we _must_ specify the error in \ref{lists}, and this location should
 % then be a commentary, because we already have the error elsewhere.
 \commentary{%
-This case can not arise,
-because it is a compile-time error
-when the leaf elements of a list literal
-contains a map element
+This cannot occur:
+it is a compile-time error
+when a leaf element of a list literal is a map element
 (\ref{lists}).%
 }
 \EndCase
@@ -7695,6 +7695,8 @@ If $\ell$ is `\code{...$e$}',
 let $S$ be the inferred type of $e$ in context \code{Iterable<$P$>}.
 Otherwise
 (\commentary{when $\ell$ is `\code{...?$e$}'}),
+%% TODO(eernst): Come NNBD, add a \ref{} to the specification of
+%% 'the non-nullable type of'.
 let $S$ be the non-nullable type of
 %% TODO(eernst): Clarify whether inference will indeed have that context;
 %% it is clear that we need to eliminate `Null` from $S$, and also that $e$
@@ -7751,7 +7753,6 @@ the errors that would occur with the corresponding \FOR{} statement
 located in the same scope as $\ell$.
 Moreover, the errors and type analysis of $\ell$ is performed
 as if it occurred in the body scope of said \FOR{} statement.
-
 \commentary{%
 For instance, if $P$ is of the form
 \code{\VAR\,\,v\,\,\IN\,\,$e_1$}
@@ -7786,14 +7787,19 @@ and the context type for \metavar{list} is $P$.
 \begin{itemize}
 \item
   If $P$ is \FreeContext{} then
-  the static type of \metavar{list} is \code{List<$T$>},
+  the inferred element type for \metavar{list} is $T$,
   where $T$ is the least upper bound of
   the inferred element types of \List{\ell}{1}{n}.
+
 \item
   %% TODO(eernst): Feature spec says $P$, but how can we know that $P$ is a type?
-  Otherwise, the static type of \metavar{list} is \code{List<$T$>},
+  Otherwise,
+  the inferred element type for \metavar{list} is $T$,
   where $T$ is determined by downwards inference.
 \end{itemize}
+
+\LMHash{}%
+In both cases, the static type of \metavar{list} is \code{List<$T$>}.
 
 
 \subsubsection{Lists}
@@ -7837,10 +7843,9 @@ A non-empty list has the index set $\{0, \ldots, n - 1\}$ where $n$ is the size 
 It is a dynamic error to attempt to access a list
 using an index that is not a member of its set of indices.
 
-\commentary{%
-The system libraries support many operations on an instance
-whose type implements \code{List},
-but we specify only the minimal set of features
+\rationale{%
+The system libraries define many members for the type \code{List},
+but we specify only the minimal set of requirements
 which are used by the language itself.%
 }
 
@@ -7887,32 +7892,39 @@ so we cannot use such type parameters inside constant expressions.%
 
 \LMHash{}%
 The value of a constant list literal
-\code{\CONST?\,\,<$E$>[\List{\ell}{1}{m}]}
-is an object $a$ whose class implements the built-in class
-\code{List<$E$>},
+\code{\CONST?\,\,<$T$>[\List{\ell}{1}{m}]}
+is an object $o$ whose class implements the built-in class
+\code{List<$t$>}
+where $t$ is the actual value of $T$
+(\ref{actualTypes}),
 and whose contents is the object sequence \List{o}{1}{n} obtained by
 evaluation of \List{\ell}{1}{m}
 (\ref{collectionLiteralElementEvaluation}).
-The $i$th object of $a$ (at index $i - 1$) is then $o_i$.
+The $i$th object of $o$ (at index $i - 1$) is then $o_i$.
 
 \LMHash{}%
-Let
-$list_1 =$ \code{\CONST?\,\,<$V$>[$\ell_{11}, \ldots, \ell_{1m_1}$]}
-and
-$list_2 =$ \code{\CONST?\,\,<$U$>[$\ell_{21}, \ldots, \ell_{2m_2}$]}
-be two constant list literals and
-let the contents of $list_1$ and $list_2$ be
-$o_{11}, \ldots, o_{1n}$ and $o_{21}, \ldots, o_{2n}$ respectively.
-If{}f \code{identical($o_{1i}$, $o_{2i}$)} for $i \in 1 .. n$ and $V == U$
-then \code{identical($list_1$, $list_2$)}.
+Let \code{\CONST?\,\,<$T_1$>[$\ell_{11}, \ldots, \ell_{1m_1}$]}
+and \code{\CONST?\,\,<$T_2$>[$\ell_{21}, \ldots, \ell_{2m_2}$]}
+be two constant list literals.
+Let $o_1$ with contents $o_{11}, \ldots, o_{1n}$ and actual type argument $t_1$
+respectively
+$o_2$ with contents $o_{21}, \ldots, o_{2n}$ and actual type argument $t_2$
+be the result of evaluating them.
+Then \code{identical($o_1$, $o_2$)} evaluates to \TRUE{} if{}f
+\code{$t_1$ == $t_2$} and \code{identical($o_{1i}$, $o_{2i}$)}
+evaluates to \TRUE{} for all $i \in 1 .. n$.
 
 \commentary{%
-In other words, constant list literals are canonicalized.%
+In other words, constant list literals are canonicalized.
+There is no need to consider canonicalization
+for other instances of type \code{List},
+because such instances cannot be
+the result of evaluating a constant expression.%
 }
 
 \LMHash{}%
 A run-time list literal
-\code{<$E$>[\List{\ell}{1}{m}]}
+\code{<$T$>[\List{\ell}{1}{m}]}
 is evaluated as follows:
 \begin{itemize}
 \item
@@ -7920,15 +7932,17 @@ is evaluated as follows:
   (\ref{collectionLiteralElementEvaluation}),
   to an object sequence \LiteralSequence{\List{o}{1}{n}}.
 \item
-  A fresh instance (\ref{generativeConstructors}) $a$, of size $n$,
-  whose class implements the built-in class \code{List<$E$>}
-  is allocated.
+  A fresh instance (\ref{generativeConstructors}) $o$, of size $n$,
+  whose class implements the built-in class \code{List<$t$>}
+  is allocated,
+  where $t$ is the actual value of $T$
+  (\ref{actualTypes}).
 \item
-  The operator \lit{[]=} is invoked on $a$ with
+  The operator \lit{[]=} is invoked on $o$ with
   first argument $i$ and second argument
   $o_{i+1}, 0 \le i < n$.
 \item
-  The result of the evaluation is $a$.
+  The result of the evaluation is $o$.
 \end{itemize}
 
 \LMHash{}%
@@ -7945,20 +7959,12 @@ if element $i$ is not a subtype of the element type of the list,
 a dynamic type error will occur when $a[i]$ is assigned $o_{i-1}$.
 }
 
-\commentary{
-There is no restriction precluding nesting of list literals.
-It follows from the rules above that
-\code{<List<int>{}>[<int>[1, 2, 3], <int>[4, 5, 6]]}
-is a list with type parameter \code{List<int>},
-containing two lists with type parameter \code{int}.
-}
-
 
 \subsubsection{Set and Map Literal Disambiguation}
 \LMLabel{setAndMapLiteralDisambiguation}
 
 \LMHash{}%
-Some syntactic forms like \code{\{\}} and \code{\{...\id\}} are ambiguous:
+Some terms like \code{\{\}} and \code{\{\,...\id\,\}} are ambiguous:
 they may be either a set literal or a map literal.
 This ambiguity is eliminated in two steps.
 The first step uses only the syntax and context type,
@@ -7974,24 +7980,30 @@ with leaf elements $\cal L$ and context type $C$.
 If $C$ is \FreeContext{} then let $S$ be undefined.
 %% TODO(eernst): Define 'greatest closure' of a context type
 %% when we define 'context type'.
-Otherwise let $S$ be the greatest closure of $\futureOrBase{C}$
+Otherwise let $S$ be the greatest closure of \futureOrBase{C}
 (\ref{typeFutureOr}).
 
 %% TODO(eernst): Delete when 'context type', 'greatest closure' are defined.
 \commentary{%
 A future version of this document will specify context types.
-The basic intuition is that a context type is the type declared for a
-\emph{receiving entity} such as
+The basic intuition is that a
+\Index{context type}
+is the type declared for a
+receiving entity such as
 a formal parameter $p$ or a declared variable $v$.
 That type will be the context type for
 an actual argument passed to $p$,
 respectively an initializing expression for $v$.
 In some situations the context has no constraints,
 e.g., when a variable is declared with \VAR{} rather than a type annotation.
-This gives rise to an unconstrained context type, \FreeContext{},
+This gives rise to an
+\IndexCustom{unconstrained context type}{context type!unconstrained},
+\IndexCustom{\rm\FreeContext}{[]@\FreeContext},
 which may also occur in a composite term, e.g., \code{List<\FreeContext>}.
-%
-The greatest closure of a context type $C$ is a supertype of all types
+%% TODO(eernst): Clarify why we do not just use i2b, rather than
+%% introducing the notion of a greatest (and least) closure.
+The greatest closure of a context type $C$ is
+approximately the least common supertype of all types
 obtainable by replacing \FreeContext{} by a type.%
 }
 
@@ -8034,7 +8046,7 @@ the first applicable entry in the following list:
   \commentary{%
     In this case $e$ is non-empty, but contains only spreads
     wrapped zero or more times in \synt{ifElement}s or \synt{forElement}s.
-    Disambiguation will occur during inference
+    Disambiguation will then occur during inference
     (\ref{setAndMapLiteralInference}).%
   }
 \end{itemize}
@@ -8083,7 +8095,7 @@ and implementing \code{Map} when $e$ is a map),
 which means that it is a dynamic error if there is a mismatch.
 In other situations it is a compile-time error to have both
 an element type and a key and value type pair,
-because $e$ must then be both a set and a map.
+because $e$ must be both a set and a map.
 Here is an example:%
 }
 
@@ -8167,7 +8179,10 @@ if can be a map and has no element type.
 
 \LMHash{}%
 Let $\ell$ be a term derived from \synt{element}.
-Inference of the type of $\ell$ then proceeds as follows:
+\IndexCustom{Inference of the type of}{%
+  type inference!collection literal element}
+$\ell$ with context type $P$ then proceeds
+as follows:
 
 \LMHash{}%
 \Case{Expression element}
@@ -8229,7 +8244,7 @@ Then:
 
   \commentary{%
     This is the result of constraint matching for $X$ and $Y$ using
-    the constraint $S\,\,<:\,\,\code{Map<$X$, $Y$>}$.%
+    the constraint $S\,\,<:\,\,\code{Map<$X$,\,\,$Y$>}$.%
 
     Note that this case and the previous case
     can match on the same element simultaneously
@@ -8293,7 +8308,7 @@ the inferred type of $e$ in context $P$, and then:
   $S$ at \code{Map}.
   \commentary{%
     This is the result of constraint matching for $X$ and $Y$ using
-    the constraint \code{$S$ <: Map<$X$, $Y$>}.%
+    the constraint \code{$S$ <: Map<$X$,\,\,$Y$>}.%
   }
 \item
   If $S$ is \DYNAMIC,
@@ -8433,17 +8448,17 @@ and the context type for \metavar{collection} is $P$.
   The static type of \metavar{collection} is then \code{Set<$T$>}.
 \item
   If \metavar{collection} is unambiguously a map
-  where $P$ is \code{Map<$P_k$,\,\,$P_v$>}
+  where $P$ is \code{Map<$P_k$,\,\,$P_v$>} or $P$ is \FreeContext{}
   and the inferred key and value type pairs are
   \KeyValueTypeList{K}{V}{1}{n}:
 
-  If $P_k$ is \FreeContext{},
+  If $P_k$ is \FreeContext{} or $P$ is \FreeContext,
   the static key type of \metavar{collection} is $K$
   where $K$ is the least upper bound of \List{K}{1}{n}.
   Otherwise the static key type of \metavar{collection} is $K$
   where $K$ is determined by downwards inference.
 
-  If $P_v$ is \FreeContext{},
+  If $P_v$ is \FreeContext{} or $P$ is \FreeContext,
   the static value type of \metavar{collection} is $V$
   where $V$ is the least upper bound of \List{V}{1}{n}.
   Otherwise the static value type of \metavar{collection} is $V$
@@ -8488,7 +8503,7 @@ Here is an example:%
 \begin{dartCode}
 \VAR{} iterable = [1, 2];
 \VAR{} map = \{1: 2\};
-\VAR{} ambiguous = \{...iterable, ...map\};
+\VAR{} ambiguous = \{...iterable, ...map\}; // \comment{Compile-time error}
 \end{dartCode}
 
 \commentary{%
@@ -8498,7 +8513,7 @@ Or, if there is nothing indicates that it is \emph{either} a set or a map:%
 
 \begin{dartCode}
 \DYNAMIC{} dyn;
-\VAR{} ambiguous = \{...dyn\};
+\VAR{} ambiguous = \{...dyn\}; // \comment{Compile-time error}
 \end{dartCode}
 
 
@@ -8558,10 +8573,9 @@ A set is ordered: iteration over the elements of a set
 occurs in the order the elements were added to the set.
 
 \commentary{%
-The system libraries support many operations on an instance
-whose type implements \code{Set},
-but we specify only the minimal set of features
-which are used by the language itself.
+The system libraries define many members for the type \code{Set},
+but we specify only the minimal set of requirements
+which are used by the language itself.%
 
 Note that an implementation may require consistent definitions of several members
 of a class implementing \code{Set} in order to work correctly.
@@ -8618,36 +8632,45 @@ so we cannot use such type parameters inside constant expressions.%
 }
 
 \LMHash{}%
-The value of a constant set literal $e$ of the form
-\code{\CONST?\,\,<$E$>\{\List{\ell}{1}{m}\}}
-is an object $s$ whose class implements the built-in class
-\code{Set<$E$>},
+The value of a constant set literal
+\code{\CONST?\,\,<$T$>\{\List{\ell}{1}{m}\}}
+is an object $o$ whose class implements the built-in class
+\code{Set<$t$>}
+where $t$ is the actual value of $T$
+(\ref{actualTypes}),
 and whose contents is the set of objects in
 the object sequence \List{o}{1}{n} obtained by
 evaluation of \List{\ell}{1}{m}
 (\ref{collectionLiteralElementEvaluation}).
-The elements of $e$ occur in the same order as
+The elements of $o$ occur in the same order as
 the objects in said object sequence
 (\commentary{which can be observed by iteration}).
 
 \LMHash{}%
-Let $set_1$ be a constant set literal with type argument $E$
-containing, in that order, the objects $o_{11}, \ldots, o_{1n}$.
-Let $set_2$ be a constant set literal with type argument $F$
-containing, in that order, the objects $o_{21}, \ldots, o_{2n}$.
-If{}f \code{identical($o_{1i}$, $o_{2i}$)}
-for $i \in 1 .. n$, and $E$ and $F$ is the same type,
-then \code{identical($set_1$, $set_2$)}.
+Let \code{\CONST?\,\,<$T_1$>\{\,$\ell_{11}, \ldots, \ell_{1m_1}$\,\}}
+and \code{\CONST?\,\,<$T_2$>\{\,$\ell_{21}, \ldots, \ell_{2m_2}$\,\}}
+be two constant set literals.
+Let $o_1$ with contents $o_{11}, \ldots, o_{1n}$ and actual type argument $t_1$
+respectively
+$o_2$ with contents $o_{21}, \ldots, o_{2n}$ and actual type argument $t_2$
+be the result of evaluating them.
+Then \code{identical($o_1$, $o_2$)} evaluates to \TRUE{} if{}f
+\code{$t_1$ == $t_2$} and \code{identical($o_{1i}$, $o_{2i}$)}
+evaluates to \TRUE{} for all $i \in 1 .. n$.
 
 \commentary{%
 In other words, constant set literals are canonicalized if they have
-the same type and the same values in the same order.
+the same type argument and the same values in the same order.
 Two constant set literals are never identical
-if they have a different number of elements.%
+if they have a different number of elements.
+There is no need to consider canonicalization
+for other instances of type \code{Set},
+because such instances cannot be
+the result of evaluating a constant expression.%
 }
 
 \LMHash{}%
-A run-time set literal \code{<$E$>\{\List{\ell}{1}{n}\}}
+A run-time set literal \code{<$T$>\{\List{\ell}{1}{n}\}}
 is evaluated as follows:
 \begin{itemize}
 \item
@@ -8655,17 +8678,19 @@ is evaluated as follows:
   (\ref{collectionLiteralElementEvaluation}),
   to an object sequence \LiteralSequence{\List{o}{1}{n}}.
 \item
-  A fresh object (\ref{generativeConstructors}) $s$
-  implementing the built-in class \code{Set<$E$>}, is created.
+  A fresh object (\ref{generativeConstructors}) $o$
+  implementing the built-in class \code{Set<$t$>} is created,
+  where $t$ is the actual value of $T$
+  (\ref{actualTypes}).
 \item
   For each object $o_j$ in \List{o}{1}{n}, in order,
-  $o_j$ is inserted into $s$.
+  $o_j$ is inserted into $o$.
   \commentary{%
-    Note that this leaves $s$ unchanged when $s$ already contains
+    Note that this leaves $o$ unchanged when $o$ already contains
     and object $o$ which is equal to $o_j$ according to operator \lit{==}.%
   }
 \item
-  The result of the evaluation is $s$.
+  The result of the evaluation is $o$.
 \end{itemize}
 
 \LMHash{}%
@@ -8677,7 +8702,8 @@ the \lit{==} operator inherited from the \code{Object} class.
 \LMLabel{maps}
 
 \LMHash{}%
-A \IndexCustom{map literal}{literal!map} denotes a map object.
+A \IndexCustom{map literal}{literal!map} denotes a map object,
+which is a mapping from keys to values.
 The grammar rule for \synt{setOrMapLiteral} which covers both
 map literals and set literals occurs elsewhere
 (\ref{collectionLiterals}).
@@ -8698,8 +8724,8 @@ and $e$ is henceforth treated as
 \code{<$K$,\,$V$>$e$}.
 
 \commentary{%
-The static type of a map literal of the form \code{<$K$,\,\,$V$>$e$}
-is \code{Map<$K$,\,\,$V$>}
+The static type of a map literal of the form \code{<$K$,\,$V$>$e$}
+is \code{Map<$K$,\,$V$>}
 (\ref{setAndMapLiteralInference}).%
 }
 
@@ -8716,7 +8742,11 @@ $V_j$ may not be assigned to $V$.
 
 \LMHash{}%
 A map object consists of zero or more map entries.
-Each entry has a \Index{key} and a \Index{value}.
+Each entry has a \Index{key} and a \Index{value},
+and we say that the map
+\IndexCustom{binds}{map!binds} or
+\IndexCustom{maps}{map!maps}
+the key to the value.
 A key and value pair is
 added to a map using operator \lit{[]=},
 and the value for a given key is retrieved from a map using operator \lit{[]}.
@@ -8738,7 +8768,7 @@ occurs in the order in which the keys were added to the set.
 \commentary{%
 The system libraries support many operations on an instance
 whose type implements \code{Map},
-but we specify only the minimal set of features
+but we specify only the minimal set of requirements
 which are used by the language itself.
 
 Note that an implementation may require consistent definitions of several members
@@ -8797,36 +8827,44 @@ so we cannot use such type parameters inside constant expressions.%
 
 \LMHash{}%
 The value of a constant map literal
-\code{\CONST?\,\,<$K, V$>\{\List{\ell}{1}{m}\}}
-is an object $m$ whose class implements the built-in class
-\code{Map<$K$,\,\,$V$>}.
-The key and value pairs of $m$ is
+\code{\CONST?\,\,<$T_1$,\,$T_2$>\{\List{\ell}{1}{m}\}}
+is an object $o$ whose class implements the built-in class
+\code{Map<$t_1$,\,\,$t_2$>},
+where $t_1$ and $t_2$ is the actual value of $T_1$ respectively $T_2$
+(\ref{actualTypes}).
+The key and value pairs of $o$ is
 the pairs of the object sequence \KeyValueList{k}{v}{1}{n} obtained by
 evaluation of \List{\ell}{1}{m}
 (\ref{collectionLiteralElementEvaluation}),
 in that order.
 
 \LMHash{}%
-Let $map_1$ be a constant map literal of the form
-\code{\CONST?\,\,<$K, V$>\{\List{\ell}{1}{m_1}\}}
-and $map_2$ a constant map literal of the form
-\code{\CONST?\,\,<$J, U$>\{\List{\ell}{1}{m_2}\}}.
-Assume that the key and value pairs of $map_1$ are
-\KeyValueList{k_1}{v_1}{1}{n}
-and the key and value pairs of $map_2$ are
-\KeyValueList{k_2}{v_2}{1}{n}.
-If{}f
-\code{identical($k_{1i}$, $k_{2i}$)} and
+Let \code{\CONST?\,\,<$U_1$,\,$V_1$>\{\List{\ell}{1}{m_1}\}}
+and \code{\CONST?\,\,<$U_2$,\,$V_2$>\{\List{\ell}{1}{m_2}\}}
+be two constant map literals.
+Let $o_1$ with contents \KeyValueList{k_1}{v_1}{1}{n}
+and actual type arguments $u_1$, $v_1$
+respectively
+$o_2$ with contents \KeyValueList{k_2}{v_2}{1}{n}
+and actual type argument $u_2$, $v_2$
+be the result of evaluating them.
+Then \code{identical($o_1$, $o_2$)} evaluates to \TRUE{} if{}f
+\code{$u_1$ == $u_2$}, \code{$v_1$ == $v_2$},
+\code{identical($k_{1i}$, $k_{2i}$)}, and
 \code{identical($v_{1i}$, $v_{2i}$)}
-for $i \in 1 .. n$, and $K == J, V == U$, then \code{identical($map_1$, $map_2$)}.
+for all $i \in 1 .. n$.
 
 \commentary{%
-In other words, constant map literals are canonicalized.%
+In other words, constant map literals are canonicalized.
+There is no need to consider canonicalization
+for other instances of type \code{Map},
+because such instances cannot be
+the result of evaluating a constant expression.%
 }
 
 \LMHash{}%
 A run-time map literal
-\code{<$K, V$>\{\List{\ell}{1}{m}\}}
+\code{<$T_1, T_2$>\{\List{\ell}{1}{m}\}}
 is evaluated as follows:
 \begin{itemize}
 \item
@@ -8834,15 +8872,17 @@ is evaluated as follows:
   (\ref{collectionLiteralElementEvaluation}),
   to an object sequence \LiteralSequence{\KeyValueList{k}{v}{1}{n}}.
 \item
-  A fresh instance (\ref{generativeConstructors}) $m$
-  whose class implements the built-in class \code{Map<$K$,\,\,$V$>},
-  is allocated.
+  A fresh instance (\ref{generativeConstructors}) $o$
+  whose class implements the built-in class \code{Map<$t_1$,\,\,$t_2$>}
+  is allocated,
+  where $t_1$ and $t_2$ are the actual values of $T_1$ respectively $T_2$
+  (\ref{actualTypes}).
 \item
-  The operator \lit{[]=} is invoked on $m$
+  The operator \lit{[]=} is invoked on $o$
   with first argument $k_i$ and second argument $v_i$,
   for each $i \in 1 .. n$, in that order.
 \item
-  The result of the evaluation is $m$.
+  The result of the evaluation is $o$.
 \end{itemize}
 
 \LMHash{}%
@@ -9678,7 +9718,7 @@ If $f$ is marked \code{\SYNC*} (\ref{functions}),
 then a fresh instance (\ref{generativeConstructors}) $i$
 implementing \code{Iterable<$U$>} is immediately returned,
 where $U$ is determined as follows:
-Let $T$ be the actual return type of $f$ (\ref{actualTypeOfADeclaration}).
+Let $T$ be the actual return type of $f$ (\ref{actualTypes}).
 If $T$ is \code{Iterable<$S$>} for some type $S$, then $U$ is $S$,
 otherwise $U$ is \code{Object}.
 
@@ -9743,7 +9783,7 @@ Two executions of an iterator interact only via state outside the function.
 If $f$ is marked \ASYNC{} (\ref{functions}),
 then a fresh instance (\ref{generativeConstructors}) $o$ is associated with the invocation,
 where the dynamic type of $o$ implements \code{Future<$flatten(T)$>},
-and $T$ is the actual return type of $f$ (\ref{actualTypeOfADeclaration}).
+and $T$ is the actual return type of $f$ (\ref{actualTypes}).
 Then the body of $f$ is executed until it either suspends or completes, at which point $o$ is returned.
 \commentary{
 The body of $f$ may suspend during the evaluation of an \AWAIT{} expression or execution of an asynchronous \FOR{} loop.
@@ -9766,7 +9806,7 @@ If $f$ is marked \code{\ASYNC*} (\ref{functions}),
 then a fresh instance (\ref{generativeConstructors}) $s$
 implementing \code{Stream<$U$>} is immediately returned,
 where $U$ is determined as follows:
-Let $T$ be the actual return type of $f$ (\ref{actualTypeOfADeclaration}).
+Let $T$ be the actual return type of $f$ (\ref{actualTypes}).
 If $T$ is \code{Stream<$S$>} for some type $S$, then $U$ is $S$,
 otherwise $U$ is \code{Object}.
 When $s$ is listened to, execution of the body of $f$ will begin.
@@ -10178,19 +10218,19 @@ All of these remaining parameters are necessarily optional and thus have default
 % Check the type arguments.
 % This error can occur due to covariance and due to dynamic invocation.
 It is a dynamic type error if $t_i$ is not a subtype of the actual bound
-(\ref{actualTypeOfADeclaration})
+(\ref{actualTypes})
 of the $i$th type argument of $f$, for actual type arguments $t_1, \ldots, t_r$.
 % Check the types of positional arguments.
 % This error can occur due to implicit casts, covariance, and dynamic calls.
 It is a dynamic type error if $o_i$ is not the null object (\ref{null})
 and the actual type
-(\ref{actualTypeOfADeclaration})
+(\ref{actualTypes})
 of $p_i$ is not a supertype of the dynamic type of $o_i, i \in 1 .. m$.
 % Check the types of named arguments.
 % This error can occur due to implicit casts, covariance, and dynamic calls.
 It is a dynamic type error if $o_{m+j}$ is
 not the null object and the actual type
-(\ref{actualTypeOfADeclaration})
+(\ref{actualTypes})
 of $q_j$ is not a supertype of the dynamic type of $o_{m+j}, j \in 1 .. l$.
 
 
@@ -10461,7 +10501,7 @@ Function closurization applied to a function declaration $f$
 amounts to the creation of a function object $o$
 which is an instance of a class $C$ whose interface is
 a subtype of the actual type $F$
-(\ref{actualTypeOfADeclaration})
+(\ref{actualTypes})
 corresponding to the signature in the function declaration $f$,
 using the current bindings of type variables, if any.
 There does not exist a function type $F'$ which is a proper subtype of $F$
@@ -12059,7 +12099,7 @@ Then, the setter \code{$v$=} is looked up (\ref{lookup}) in $o_1$ with respect t
 % This error can occur due to implicit casts and dynamic calls.
 It is a dynamic type error if the dynamic type of $o_2$
 is not a subtype of the actual parameter type of said setter
-(\ref{actualTypeOfADeclaration}).
+(\ref{actualTypes}).
 Otherwise, the body of the setter is executed with its formal parameter bound to $o_2$ and \THIS{} bound to $o_1$.
 
 \LMHash{}%
@@ -12122,7 +12162,7 @@ The value of the assignment expression is $o$.
 It is a dynamic type error if $o$ is not the null object (\ref{null})
 and the dynamic type of $o$ is
 not a subtype of the actual type of the formal parameter of \code{$v$=}
-(\ref{actualTypeOfADeclaration}) in $S_{static}$.
+(\ref{actualTypes}) in $S_{static}$.
 \EndCase
 
 \LMHash{}%
@@ -14002,7 +14042,7 @@ Then, the variable $v$ is set to $o$.
 % This error can occur due to implicit casts.
 A dynamic type error occurs
 if the dynamic type of $o$ is not a subtype of the actual type
-(\ref{actualTypeOfADeclaration})
+(\ref{actualTypes})
 of $v$.
 
 % The local variable discussion does not mention how to read/write locals.
@@ -14971,7 +15011,7 @@ Executing a return statement \code{\RETURN{} $e$;} proceeds as follows:
 First the expression $e$ is evaluated, producing an object $o$.
 Let $S$ be the run-time type of $o$ and
 let $T$ be the actual return type of $f$
-(\ref{actualTypeOfADeclaration}).
+(\ref{actualTypes}).
 If the body of $f$ is marked \ASYNC{} (\ref{functions})
 and $S$ is a subtype of \code{Future<\flatten{T}>}
 then let $r$ be the result of evaluating \code{await $v$}
@@ -16344,7 +16384,7 @@ Certain dynamic type checks are performed during execution
 As specified in those locations,
 these dynamic checks are based on the dynamic types of instances,
 and the actual types of declarations
-(\ref{actualTypeOfADeclaration}).
+(\ref{actualTypes}).
 }
 
 \LMHash{}%
@@ -17893,8 +17933,8 @@ where $X_1, \ldots, X_n$ are the formal type parameters of $G$.
 %% `C<T>` for any `T`, and we have `class C<X> { void Function(X) f; }`.
 
 
-\subsubsection{Actual Type of Declaration}
-\LMLabel{actualTypeOfADeclaration}
+\subsubsection{Actual Types}
+\LMLabel{actualTypes}
 
 % NOTE(eernst): The actual type arguments in this section are dynamic entities,
 % not syntax (the concept of an 'actual type' and an 'actual bound' is used to
@@ -17911,39 +17951,36 @@ where $X_1, \ldots, X_n$ are the formal type parameters of $G$.
 % body.
 
 \LMHash{}%
-Let $T$ be the declared type of a declaration $d$,
-as it appears in the program source.
-Let $X_1, \ldots, X_n$ be the formal type parameters in scope at $d$.
+Let $T$ be a term derived from \synt{type}.
+Let \List{X}{1}{s} be the formal type parameters in scope
+at the location where $T$ occurs.
 In a context where the actual type arguments corresponding to
-$X_1, \ldots, X_n$
-are
-$t_1, \ldots, t_n$,
-the \Index{actual type} of $d$ is
-$[t_1/X_1, \ldots, t_n/X_n]T$.
+\List{X}{1}{s} are \List{t}{1}{s},
+the \Index{actual value of the type} $T$ is then
+$[t_1/X_1, \ldots, t_s/X_s]T$.
 
-\commentary{
-In the non-generic case where $n = 0$ the actual type is equal to the declared type.
-Note that
-$X_1, \ldots, X_n$
-may be declared by multiple entities, e.g.,
-one or more enclosing generic functions and an enclosing generic class.
+\LMHash{}%
+Let $D$ be a declaration with name $n$ and type annotation $T$.
+The \Index{actual type} of $D$ and of $n$ in a given context is
+then the actual value of $T$ in that context.
+
+\commentary{%
+In the non-generic case where $s = 0$,
+the actual type is equal to the declared type,
+in the sense that we use simple terms like \code{int} to denote both.
+Note that \List{X}{1}{s} may be declared by multiple entities, e.g.,
+one or more enclosing generic functions and an enclosing generic class.%
 }
 
 \LMHash{}%
 Let \code{$X$ \EXTENDS{} $B$} be a formal type parameter declaration.
-Let
-$X_1, \ldots, X_n$
-be the formal type parameters in scope at the declaration of $X$.
-In a context where the actual type arguments corresponding to
-$X_1, \ldots, X_n$
-are
-$t_1, \ldots, t_n$,
-the \Index{actual bound} for $X$ is
-$[t_1/X_1, \ldots, t_n/X_n]B$.
+The \Index{actual bound} of $X$ in a given context is
+the actual value of $B$ in that context.
 
-\commentary{
-Note that there exists a $j$ such that $X = X_j$,
-because each formal type parameter is in scope at its own declaration.
+\commentary{%
+Note that even though $X$ may occur in $B$
+it does not occur in the actual value of $B$,
+because no type has an actual value that includes a type variable.%
 }
 
 

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -4299,13 +4299,15 @@ $S$ cannot be a subtype of \code{Null}.%
 
 \LMHash{}%
 Assume that $S$ is a type and $G$ is a raw type such that $S$ implements $G$.
-It is then guaranteed that there exist \List{U}{1}{s} which are types such that
+Per definition there exist types \List{U}{1}{s} such that
 \code{$G$<\List{U}{1}{s}>} is a superinterface of $S$.
-We then say that \List{U}{1}{s} are
-\IndexCustom{the type arguments of $S$ at $G$}{type arguments!of a type at a raw type},
-and we say that $U_j$ is
-\IndexCustom{the $j$th type argument of $S$ at $G$}{%
-  type arguments!of a type at a raw type, $j$th}.
+We then say that \List{U}{1}{s} are the
+\IndexCustom{actual type arguments of $S$ at $G$}{
+  type arguments!of a type at a raw type},
+and we say that $U_j$ is the
+\IndexCustom{$j$th actual type argument of $S$ at $G$}{%
+  type arguments!of a type at a raw type, $j$th},
+for any $j \in 1 .. s$.
 
 \commentary{%
 For instance, the type argument of \code{List<int>} at \code{Iterable}
@@ -7438,51 +7440,18 @@ then $e_2$ is evaluated to an object $o_2$,
 and $\EvaluateElement{\ell} := \LiteralSequence{o_1:o_2}$.
 \EndCase
 
-\begin{figure}[t]
-\begin{normativeDartCode}
-$S_{\metavar{spread}}$ spread = $o_{\metavar{spread}}$;
-\VAR{} $s$ = \LiteralSequence{};
-\FOR{} (\VAR{} v \IN{} spread) \{
-  Value value = v;
-  $s = s + \LiteralSequence{\code{value}}$;
-\}
-$\EvaluateElement{\ell} := s$;
-\end{normativeDartCode}
-\vspace{-3mm}
-  \caption{Evaluation of a list or set spread element $\ell$
-    with spread object $o_{\metavar{spread}}$.}
-  \label{fig:evaluationOfAnIterableSpreadElement}
-\end{figure}
-
-\begin{figure}[t]
-\begin{normativeDartCode}
-$S_{\metavar{spread}}$ spread = $o_{\metavar{spread}}$;
-\VAR{} $s$ = \LiteralSequence{};
-\FOR{} (\VAR{} entry \IN{} spread) \{
-  Key key = entry.key;
-  Value value = entry.value;
-  $s = s + \LiteralSequence{\code{key}:\,\code{value}}$;
-\}
-$\EvaluateElement{\ell} := s$;
-\end{normativeDartCode}
-\vspace{-3mm}
-  \caption{Evaluation of a map spread element $\ell$
-    with spread object $o_{\metavar{spread}}$.}
-  \label{fig:evaluationOfAMapSpreadElement}
-\end{figure}
-
 \LMHash{}%
 \Case{Spread element}
+The element $\ell$ is of the form `\code{...$e$}' or `\code{...?$e$}'.
+Evaluate $e$ to an object $o_{\metavar{spread}}$.
 \begin{enumerate}
 \item
-  When $\ell$ is a \synt{spreadElement} of the form
-  `\code{...?$e$}', $e$ is evaluated to an object $o_{\metavar{spread}}$.
+  When $\ell$ is `\code{...?$e$}':
   If $o_{\metavar{spread}}$ is the null object then
   $\EvaluateElement{\ell} := \LiteralSequence{}$.
   Otherwise evaluation proceeds with step 2.
 
-  When $\ell$ is a \synt{spreadElement} of the form
-  `\code{...$e$}', $e$ is evaluated to an object $o_{\metavar{spread}}$.
+  When $\ell$ is `\code{...$e$}':
   %% TODO(eernst): Come NNBD, this error cannot occur any more: delete.
   If $o_{\metavar{spread}}$ is the null object then a dynamic error occurs.
   Otherwise evaluation proceeds with step 2.
@@ -7500,12 +7469,25 @@ $\EvaluateElement{\ell} := s$;
   \begin{itemize}
   \item
     When both $T_{\metavar{spread}}$ and $T_{\metavar{target}}$ implement
+    (\ref{interfaceSuperinterfaces})
     \code{Iterable},
-    the code in Fig.~\ref{fig:evaluationOfAnIterableSpreadElement} is executed
-    in the static and dynamic context where $\ell$ occurs,
+    the following code is executed in the context where $\ell$ occurs,
     where \code{spread}, $s$, \code{v}, and \code{value} are fresh variables,
     and \code{Value} is a fresh type variable bound to the
-    actual type argument of $T_{\metavar{target}}$ at \code{Iterable}.
+    actual type argument of $T_{\metavar{target}}$ at \code{Iterable}
+    (\ref{interfaceSuperinterfaces}):
+
+    \vspace{-2ex}\begin{minipage}[t]{\textwidth}
+\begin{normativeDartCode}
+$S_{\metavar{spread}}$ spread = $o_{\metavar{spread}}$;
+\VAR{} $s$ = \LiteralSequence{};
+\FOR{} (\VAR{} v \IN{} spread) \{
+  Value value = v;
+  $s = s + \LiteralSequence{\code{value}}$;
+\}
+$\EvaluateElement{\ell} := s$;
+\end{normativeDartCode}
+    \end{minipage}
 
     \commentary{%
       The code makes use of a pseudo-variable $s$ denoting an object sequence.
@@ -7520,13 +7502,25 @@ $\EvaluateElement{\ell} := s$;
   \item
     When both $T_{\metavar{spread}}$ and $T_{\metavar{target}}$ implement
     \code{Map},
-    the code in Fig.~\ref{fig:evaluationOfAMapSpreadElement} is executed
-    in the static and dynamic context where $\ell$ occurs,
+    the following code is executed in the context where $\ell$ occurs,
     where \code{spread}, $s$, \code{entry}, \code{key}, and \code{value}
     are fresh variables,
     and \code{Key} and \code{Value} are fresh type variables bound to the
     first respectively second actual type argument
-    of $T_{\metavar{target}}$ at \code{Map}.
+    of $T_{\metavar{target}}$ at \code{Map}:
+
+    \vspace{-2ex}\begin{minipage}[t]{\textwidth}
+\begin{normativeDartCode}
+$S_{\metavar{spread}}$ spread = $o_{\metavar{spread}}$;
+\VAR{} $s$ = \LiteralSequence{};
+\FOR{} (\VAR{} entry \IN{} spread) \{
+  Key key = entry.key;
+  Value value = entry.value;
+  $s = s + \LiteralSequence{\code{key}:\,\code{value}}$;
+\}
+$\EvaluateElement{\ell} := s$;
+\end{normativeDartCode}
+    \end{minipage}
 
     % Will not change with nnbd: `spread` type arguments could be \DYNAMIC{}.
     It is allowed for an implementation to delay the dynamic errors
@@ -7553,8 +7547,8 @@ we also allow the following.%
 }
 
 \LMHash{}%
-If $o$ is an object whose dynamic type implements
-(\ref{superinterfaces})
+If $o_{\metavar{spread}}$ is an object whose dynamic type implements
+(\ref{interfaceSuperinterfaces})
 \code{List}, \code{Queue}, or \code{Set},
 an implementation may choose to call \code{length} on the object.
 
@@ -7565,7 +7559,7 @@ side-effect free implementation of \code{length}.%
 }
 
 \LMHash{}%
-If $o$ is an object whose dynamic type implements \code{List},
+If $o_{\metavar{spread}}$ is an object whose dynamic type implements \code{List},
 an implementation may choose to call operator \lit{[]}
 in order to access elements from the list.
 If it does so, it will only pass indices
@@ -7593,23 +7587,17 @@ $\EvaluateElement{\ell} := \LiteralSequence{}$.
 If $o_b$ is neither \TRUE{} nor \FALSE{} then a dynamic error occurs.
 \EndCase
 
-\begin{figure}[t]
-\begin{normativeDartCode}
-\VAR{} $s$ = \LiteralSequence{};
-\AWAIT? \FOR{} ($D$ \id{} \IN{} $e$) \{
-  $s = s + \EvaluateElement{\ell_1}$;
-\}
-$\EvaluateElement{\ell} := s$;
-\end{normativeDartCode}
-\vspace{-3mm}
-  \caption{Evaluation of a \synt{forElement} $\ell$ of the form
-    \code{\AWAIT?\,\,\FOR\,\,($D$\,\,\id\,\,\IN\,\,$e$)\,\,$\ell_1$},
-    where \AWAIT{} is included in both the for element and the code,
-    or omitted in both.}
-  \label{fig:evaluationOfAForInElement}
-\end{figure}
+\LMHash{}%
+\Case{For element}
+Let $P$ be derived from \syntax{<forLoopParts>} and
+let $\ell$ be a \synt{forElement} of the form
+\code{\AWAIT?\,\,\FOR\,\,($P$)\,\,$\ell_1$},
+where `\AWAIT?' indicates that \AWAIT{} may be present or absent.
+To evaluate $\ell$,
+the following code is executed in the context where $\ell$ occurs,
+where \AWAIT{} is present if and only if it is present in $\ell$:
 
-\begin{figure}[t]
+\vspace{-2ex}\begin{minipage}[t]{\textwidth}
 \begin{normativeDartCode}
 \VAR{} $s$ = \LiteralSequence{};
 \AWAIT? \FOR{} ($P$) \{
@@ -7617,37 +7605,7 @@ $\EvaluateElement{\ell} := s$;
 \}
 $\EvaluateElement{\ell} := s$;
 \end{normativeDartCode}
-\vspace{-3mm}
-  \caption{Evaluation of a \synt{forElement} $\ell$ of the form
-    \code{\AWAIT?\,\,\FOR\,\,($P$)\,\,$\ell_1$},
-    where $P$ is derived from
-    % \syntax{<forInitializerStatement> <expression>? `;' <expressionList>?}
-    and \AWAIT{} is included in both the for element and the code,
-    or omitted in both.}
-  \label{fig:evaluationOfAForLoopElement}
-\end{figure}
-
-\LMHash{}%
-\Case{For-in element}
-Let $D$ be derived from \syntax{<finalConstVarOrType>?} and
-let $\ell$ be a \synt{forElement} of the form
-\code{\AWAIT?\,\,\FOR\,\,($D$\,\,\id\,\,\IN\,\,$e$)\,\,$\ell_1$},
-where `\AWAIT?' indicates that \AWAIT{} may be present or absent.
-To evaluate $\ell$,
-the code in Fig.~\ref{fig:evaluationOfAForInElement} is executed
-in the static and dynamic context where $\ell$ occurs.
-\EndCase
-
-\LMHash{}%
-\Case{For loop element}
-Let $P$ be a term derived from
-\syntax{<forInitializerStatement> <expression>? `;' <expressionList>?} and
-let $\ell$ be a \synt{forElement} of the form
-\code{\AWAIT?\,\,\FOR\,\,($P$)\,\,$\ell_1$},
-where `\AWAIT?' indicates that \AWAIT{} may be present or absent.
-To evaluate $\ell$,
-the code in Fig.~\ref{fig:evaluationOfAForLoopElement} is executed
-in the static and dynamic context where $\ell$ occurs.
+\end{minipage}
 \EndCase
 
 
@@ -8018,7 +7976,7 @@ the first applicable entry in the following list:
   Otherwise a compile-time error occurs.
 \item
   When $S$ implements
-  (\ref{superinterfaces})
+  (\ref{interfaceSuperinterfaces})
   \code{Iterable} but not \code{Map},
   $e$ is a set literal.
   When $S$ implements \code{Map} but not \code{Iterable},

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -7097,6 +7097,822 @@ a given \synt{setOrMapLiteral} denotes.%
 }
 
 
+\subsubsection{Compile-time errors}
+\LMLabel{uiAsCodeCompileTimeErrors}
+
+!!!HERE!!! Integrate this into other sections.
+
+\LMHash{}%
+After type inference and disambiguation,
+the collection is checked for other compile-time errors.
+It is a compile-time error if:
+
+%% TODO(eernst): Find a way to show Dart code examples inside itemize below.
+
+\begin{itemize}
+\item
+  The collection is a map literal and leaf elements contains any
+  \synt{expressionElement} elements.
+
+  \begin{dartCode}
+    <String, int>\{"not entry"\} // Error.
+  \end{dartCode}
+\item
+  The collection is a set literal and
+  leaf elements contains any \synt{mapElement} elements.
+
+  \begin{dartCode}
+    ["not": "expression"] // Error.
+    <String>\{"not": "expression"\} // Error.
+  \end{dartCode}
+
+  \commentary{%
+    We prohibit map entries in list literals syntactically,
+    earlier in the proposal.%
+  }
+\item
+  The collection is a list and the type of any of the leaf elements
+  may not be assigned to the list's element type.
+
+  \begin{dartCode}
+    <int>[if (true) "not int"] // Error.
+  \end{dartCode}
+\item
+  The collection is a map and the key type of any of the leaf elements
+  may not be assigned to the map's key type.
+
+  \begin{dartCode}
+    <int, int>{if (true) "not int": 1} // Error.
+  \end{dartCode}
+\item
+  The collection is a map and the value type of any of the leaf elements
+  may not be assigned to the map's value type.
+
+  \begin{dartCode}
+    <int, int>{if (true) 1: "not int"} // Error.
+  \end{dartCode}
+\item
+  A non-null-aware spread element has static type \code{Null}.
+\item
+  A spread element in a list or set literal has a static type that is
+  not \DYNAMIC{} and not a subtype of \code{Iterable<Object>}.
+\item
+  A spread element in a list or set has a static type that
+  implements \code{Iterable<$T$>} for some $T$ and
+  $T$ is not assignable to the element type of the list.
+\item
+  A spread element in a map literal has a static type that is
+  not \DYNAMIC{} and not a subtype of \code{Map<Object, Object>}.
+\item
+  If a map spread element's static type
+  implements \code{Map<$K$, $V$>} for some $K$ and $V$ and
+  $K$ is not assignable to the key type of the map or
+  $V$ is not assignable to the value type of the map.
+\item
+  The variable in a \synt{forElement}
+  (\commentary{either a for-in element or C-style})
+  is declared outside of the element to be final or to not have a setter.
+
+  \begin{dartCode}
+    \FINAL{} i = 0;
+    [for (i in [1]) i] // Error.
+  \end{dartCode}
+\item
+  The type of the iterator expression in a synchronous for-in element
+  may not be assigned to \code{Iterable<$T$>} for any type $T$.
+  Otherwise, the \Index{iterable type} of the iterator is $T$.
+
+  \begin{dartCode}
+    [for (var i in "not iterable") i] // Error.
+  \end{dartCode}
+\item
+  The iterable type of the iterator in a synchronous for-in element
+  may not be assigned to the for-in variable's type.
+
+  \begin{dartCode}
+    [for (int i in ["not", "int"]) i] // Error.
+  \end{dartCode}
+\item
+  The type of the stream expression in an asynchronous \AWAIT{} for-in element
+  may not be assigned to \code{Stream<$T$>} for any type $T$.
+  Otherwise, the \Index{stream type} of the stream is $T$.
+
+  \begin{dartCode}
+    [await for (var i in "not stream") i] // Error.
+  \end{dartCode}
+\item
+  The stream type of the iterator in an asynchronous \AWAIT{} for-in element
+  may not be assigned to the for-in variable's type.
+
+  \begin{dartCode}
+    [await for (int i in Stream.fromIterable(["not", "int"])) i] // Error.
+  \end{dartCode}
+
+\item
+  \AWAIT{} \FOR{} is used when
+  the function immediately enclosing the collection literal
+  is not asynchronous.
+
+  \begin{dartCode}
+    main() {
+      [await for (_ in stream)]; // Error.
+    }
+  \end{dartCode}
+\item
+  \AWAIT{} is used before a C-style \synt{forElement}.
+  \AWAIT{} can only be used with for-in loops.
+
+  \begin{dartCode}
+    main() {
+      [await for (;;)]; // Error.
+    }
+  \end{dartCode}
+
+\item
+  The type of the condition expression
+  (\commentary{the second clause})
+  in a C-style \FOR{} element
+  may not be assigned to \code{bool}.
+
+  \begin{dartCode}
+    [for (; "not bool";) 1] // Error.
+  \end{dartCode}
+\end{itemize}
+
+
+\subsubsection{Type Promotion}
+\LMLabel{collectionLiteralTypePromotion}
+
+\LMHash{}%
+An \synt{ifElement} interacts with type promotion
+in the same way that \IF{} statements do.
+Assume that $\ell$ is an \synt{ifElement} of the form
+\code{\IF{} ($b$) $\ell_1$} or
+\code{\IF{} ($b$) $\ell_1$ \ELSE{} $\ell_2$}.
+If $b$ shows that a local variable $v$ has type $T$, then
+the type of $v$ is known to be $T$ in $\ell_1$,
+unless any of the following are true:
+
+\begin{itemize}
+\item $v$ is potentially mutated in $\ell_1$,
+\item $v$ is potentially mutated within a function
+  other than the one where $v$ is declared, or
+\item $v$ is accessed by a function defined in $\ell_1$ and
+  $v$ is potentially mutated anywhere in the scope of $v$.
+\end{itemize}
+
+%% TODO(eernst): Come nnbd, update this.
+\commentary{%
+Type promotion will likely get more sophisticated in a future version of Dart.
+When that happens,
+\synt{ifElements} will continue to match \IF{} statements
+(\ref{if}).%
+}
+
+
+\subsubsection{Collection Literal Element Evaluation}
+\LMLabel{collectionLiteralElementEvaluation}
+
+\LMHash{}%
+The evaluation of a sequence of collection literal elements
+(\ref{collectionLiterals})
+yields a
+\IndexCustom{collection literal object sequence}{%
+  collection literal!object sequence},
+also called an \NoIndex{object sequence} when no ambiguity can arise.
+
+\LMHash{}%
+We use the notation
+\IndexCustom{\LiteralSequence{\ldots}}{[[...]]@\LiteralSequence{\ldots}}
+to denote an object sequence of specific elements,
+and we use `$+$' to compute the concatenation of object sequences
+(\commentary{as in $s_1 + s_2$}),
+which is an operation that will succeed and has no side-effects.
+Each element in the sequence is an object $o$ or a pair $o_1: o_2$.
+There is no notion of an element type for an object sequence,
+and hence no notion of dynamic errors arising from
+a type mismatch during concatenation.
+
+\commentary{%
+Object sequences can safely be treated in an untyped manner
+because every access to an object sequence occurs
+in code created by language defined desugaring
+on statically checked constructs.
+It is left unspecified how an object sequence is implemented,
+it is only required that it contains the indicated objects or pairs
+in the given order.
+For each kind of collection the sequence is used in the given order
+to populate the collection,
+in a manner which is specific to the kind,
+and which is specified separately
+(\ref{lists}, \ref{maps}, \ref{sets}).%
+
+There may be an actual data structure
+representing object sequences at run time,
+but object sequences could also be eliminated, e.g.,
+because each element is inserted directly into the target collection
+as soon as it has been computed.
+Note that each object sequence will exclusively contain objects,
+or it will exclusively contain pairs,
+because any mixed sequence would cause
+an error at compile time or
+(for a spread element with static type \DYNAMIC{})
+at run time.%
+}
+
+\LMHash{}%
+Assume that a literal collection \metavar{target} is given,
+and the object sequence obtained as described below will be used
+to populate \metavar{target}.
+Let $T_{\metavar{target}}$ denote the dynamic type of \metavar{target}.
+
+\commentary{%
+Access to the type of \metavar{target} is needed below
+in order to raise dynamic errors at specific points during
+the evaluation of an object sequence.
+Note that the dynamic type of \metavar{target} is statically known,
+except for the binding of any type variables in its \synt{typeArguments}.
+This implies that some questions can be answered at compile-time, e.g.,
+whether or not \code{Iterable} occurs as a superinterface of
+$T_{\metavar{target}}$.%
+}
+
+\LMHash{}%
+Assume that a location in code and a dynamic context is given,
+such that ordinary expression evaluation is possible.
+\IndexCustom{Evaluation of a collection literal element sequence}{%
+  collection literal element sequence!evaluation}
+at that location and in that context is specified as follows:
+
+\LMHash{}%
+Let $s_{\metavar{syntax}}$ of the form \List{\ell}{1}{k} be
+a sequence of collection literal elements.
+The sequence of objects $s_{\metavar{object}}$
+obtained by evaluating $s_{\metavar{syntax}}$
+is the concatenation of the sequences of objects
+obtained by evaluating each element $\ell_j$, $j \in 1 .. k$:
+$s_{\metavar{object}}=\EvaluateElement{\ell_1}+\ldots+\EvaluateElement{\ell_k}$,
+where \EvaluateElement{\ell_j} denotes the object sequence yielded by
+evaluation of a single collection literal element $\ell_j$.
+The object sequences for elements
+must be computed in the textual order,
+because the computations may have side effects.
+
+\LMHash{}%
+We use the notation $\EvaluateElement{\ell} := s$
+at specific points where the computation is complete,
+in order to specify that the value of \EvaluateElement{\ell} is $s$.
+\IndexCustom{Evaluation of a collection literal element $\ell$}{%
+  collection literal element!evaluation}
+in the given context
+to an object sequence \EvaluateElement{\ell}
+is then specified as follows:
+
+\LMHash{}%
+\Case{Expression element}
+When $\ell$ is an \synt{expressionElement} of the form $e$,
+$e$ is evaluated to an object $o$,
+and $\EvaluateElement{\ell} := \LiteralSequence{o}$.
+\EndCase
+
+\LMHash{}%
+\Case{Map element}
+When $\ell$ is a \synt{mapElement} of the form
+\code{$e_1$:\,\,$e_2$},
+$e_1$ is evaluated to an object $o_1$,
+then $e_2$ is evaluated to an object $o_2$,
+and $\EvaluateElement{\ell} := \LiteralSequence{o_1:o_2}$.
+\EndCase
+
+\begin{figure}[t]
+\begin{normativeDartCode}
+$S_{\metavar{spread}}$ spread = $o_{\metavar{spread}}$;
+\VAR{} $s$ = \LiteralSequence{};
+\FOR{} (\VAR{} v \IN{} spread) \{
+  Value value = v;
+  $s = s + \LiteralSequence{\code{value}}$;
+\}
+$\EvaluateElement{\ell} := s$;
+\end{normativeDartCode}
+\vspace{-3mm}
+  \caption{Evaluation of a list or set spread element $\ell$
+    with spread object $o_{\metavar{spread}}$.}
+  \label{fig:evaluationOfAnIterableSpreadElement}
+\end{figure}
+
+\begin{figure}[t]
+\begin{normativeDartCode}
+$S_{\metavar{spread}}$ spread = $o_{\metavar{spread}}$;
+\VAR{} $s$ = \LiteralSequence{};
+\FOR{} (\VAR{} entry \IN{} spread) \{
+  Key key = entry.key;
+  Value value = entry.value;
+  $s = s + \LiteralSequence{\code{key}:\,\code{value}}$;
+\}
+$\EvaluateElement{\ell} := s$;
+\end{normativeDartCode}
+\vspace{-3mm}
+  \caption{Evaluation of a map spread element $\ell$
+    with spread object $o_{\metavar{spread}}$.}
+  \label{fig:evaluationOfAMapSpreadElement}
+\end{figure}
+
+\LMHash{}%
+\Case{Spread element}
+\begin{enumerate}
+\item
+  When $\ell$ is a \synt{spreadElement} of the form
+  `\code{...?$e$}', $e$ is evaluated to an object $o_{\metavar{spread}}$.
+  If $o_{\metavar{spread}}$ is the null object then
+  $\EvaluateElement{\ell} := \LiteralSequence{}$.
+  Otherwise evaluation proceeds with step 2.
+
+  When $\ell$ is a \synt{spreadElement} of the form
+  `\code{...$e$}', $e$ is evaluated to an object $o_{\metavar{spread}}$.
+  %% TODO(eernst): Come NNBD, this error cannot occur any more: delete.
+  If $o_{\metavar{spread}}$ is the null object then a dynamic error occurs.
+  Otherwise evaluation proceeds with step 2.
+\item
+  Let $T_{\metavar{spread}}$ be the dynamic type of $o_{\metavar{spread}}$.
+  Let $S$ be the static type of $e$.
+  When $S$ is a top type
+  (\ref{superBoundedTypes}),
+  let $S_{\metavar{spread}}$ be \code{Iterable<\DYNAMIC>};
+  otherwise let $S_{\metavar{spread}}$ be $S$.
+  \commentary{%
+    It is a compile-time error if $S$
+    is not assignable to \code{Iterable<\DYNAMIC>}.%
+  }
+  \begin{itemize}
+  \item
+    When both $T_{\metavar{spread}}$ and $T_{\metavar{target}}$ implement
+    \code{Iterable},
+    the code in Fig.~\ref{fig:evaluationOfAnIterableSpreadElement} is executed
+    in the static and dynamic context where $\ell$ occurs,
+    where \code{spread}, $s$, \code{v}, and \code{value} are fresh variables,
+    and \code{Value} is a fresh type variable bound to the
+    actual type argument of $T_{\metavar{target}}$ at \code{Iterable}.
+
+    \commentary{%
+      The code makes use of a pseudo-variable $s$ denoting an object sequence.
+      We do not specify the type of $s$,
+      this variable is only used to indicate the required
+      semantic actions taken to gather the resulting object sequence.
+      In the case where the implementation does not have
+      a representation of $s$ at all,
+      the action may be to extend \metavar{target} immediately.
+      A similar approach is used in subsequent cases.%
+    }
+  \item
+    When both $T_{\metavar{spread}}$ and $T_{\metavar{target}}$ implement
+    \code{Map},
+    the code in Fig.~\ref{fig:evaluationOfAMapSpreadElement} is executed
+    in the static and dynamic context where $\ell$ occurs,
+    where \code{spread}, $s$, \code{entry}, \code{key}, and \code{value}
+    are fresh variables,
+    and \code{Key} and \code{Value} are fresh type variables bound to the
+    first respectively second actual type argument
+    of $T_{\metavar{target}}$ at \code{Map}.
+
+    % Will not change with nnbd: `spread` type arguments could be \DYNAMIC{}.
+    It is allowed for an implementation to delay the dynamic errors
+    that occur if the given \code{key} does not have the type \code{Key},
+    or the given \code{value} does not have the type \code{Value},
+    but it cannot occur after the pair has been appended to $s$.
+  \item
+    Otherwise, a dynamic error occurs.
+
+    \commentary{%
+      This occurs when the target is a map respectively iterable,
+      and the spread is not, which is possible for
+      a spread whose static type is \DYNAMIC{}.%
+    }
+  \end{itemize}
+\end{enumerate}
+
+\commentary{%
+This may not be the most efficient way to traverse the items in a collection,
+and implementations may of course use any other approach
+with the same observable behavior.
+However, in order to give implementations more room to optimize
+we also allow the following.%
+}
+
+\LMHash{}%
+If $o$ is an object whose dynamic type implements
+\code{List}, \code{Queue}, or \code{Set},
+an implementation may choose to call \code{length} on the object.
+
+\commentary{%
+This may let it allocate space for the resulting collection more efficiently.
+The given class is expected to have an efficient and
+side-effect free implementation of \code{length}.%
+}
+
+\LMHash{}%
+If $o$ is an object whose dynamic type implements \code{List},
+an implementation may choose to call operator \lit{[]}
+in order to access elements from the list.
+If it does so, it will only pass indices
+that are non-negative and less than the value returned by \code{length}.
+
+\LMHash{}%
+A Dart implementation may detect whether these options apply
+at compile time based on the static type of $e$,
+or at runtime based on the actual value.
+\EndCase
+
+\LMHash{}%
+\Case{If element}
+When $\ell$ is an \synt{ifElement} of the form
+\code{\IF{} ($b$) $\ell_1$} or
+\code{\IF{} ($b$) $\ell_1$ \ELSE{} $\ell_2$},
+the condition $b$ is evaluated to a value $o_b$.
+If $o_b$ is \TRUE{} then
+$\EvaluateElement{\ell} := \EvaluateElement{\ell_1}$.
+If $o_b$ is \FALSE{} and $\ell_2$ is present then
+$\EvaluateElement{\ell} := \EvaluateElement{\ell_2}$,
+and if $\ell_2$ is not present then
+$\EvaluateElement{\ell} := \LiteralSequence{}$.
+% $o_b$ can have type \DYNAMIC{}.
+If $o_b$ is neither \TRUE{} nor \FALSE{} then a dynamic error occurs.
+\EndCase
+
+\begin{figure}[t]
+\begin{normativeDartCode}
+\VAR{} $s$ = \LiteralSequence{};
+\AWAIT? \FOR{} ($D$ \id{} \IN{} $e$) \{
+  $s = s + \EvaluateElement{\ell_1}$;
+\}
+$\EvaluateElement{\ell} := s$;
+\end{normativeDartCode}
+\vspace{-3mm}
+  \caption{Evaluation of a \synt{forElement} $\ell$ of the form
+    \code{\AWAIT?\,\,\FOR\,\,($D$\,\,\id\,\,\IN\,\,$e$)\,\,$\ell_1$},
+    where \AWAIT{} is included in both the for element and the code,
+    or omitted in both.}
+  \label{fig:evaluationOfAForInElement}
+\end{figure}
+
+\begin{figure}[t]
+\begin{normativeDartCode}
+\VAR{} $s$ = \LiteralSequence{};
+\AWAIT? \FOR{} ($P$) \{
+  $s = s + \EvaluateElement{\ell_1}$;
+\}
+$\EvaluateElement{\ell} := s$;
+\end{normativeDartCode}
+\vspace{-3mm}
+  \caption{Evaluation of a \synt{forElement} $\ell$ of the form
+    \code{\AWAIT?\,\,\FOR\,\,($P$)\,\,$\ell_1$},
+    where $P$ is derived from \synt{forLoopParts}
+    and \AWAIT{} is included in both the for element and the code,
+    or omitted in both.}
+  \label{fig:evaluationOfAForLoopElement}
+\end{figure}
+
+\LMHash{}%
+\Case{For-in element}
+Let $D$ be derived from \syntax{<finalConstVarOrType>?} and
+let $\ell$ be a \synt{forElement} of the form
+\code{\AWAIT?\,\,\FOR\,\,($D$\,\,\id\,\,\IN\,\,$e$)\,\,$\ell_1$},
+where `\AWAIT?' indicates that \AWAIT{} may be present or absent.
+To evaluate $\ell$,
+the code in Fig.~\ref{fig:evaluationOfAForInElement} is executed
+in the static and dynamic context where $\ell$ occurs.
+\EndCase
+
+\LMHash{}%
+\Case{For loop element}
+Let $P$ be a term derived from \synt{forLoopParts} and
+let $\ell$ be a \synt{forElement} of the form
+\code{\AWAIT?\,\,\FOR\,\,($P$)\,\,$\ell_1$},
+where `\AWAIT?' indicates that \AWAIT{} may be present or absent.
+To evaluate $\ell$,
+the code in Fig.~\ref{fig:evaluationOfAForLoopElement} is executed
+in the static and dynamic context where $\ell$ occurs.
+\EndCase
+
+
+\subsubsection{List}
+\LMLabel{uiAsCodeList}
+
+!!!HERE!!! This should be moved into \ref{lists}.
+
+\LMHash{}%
+The result of the literal expression is a fresh instance of
+a class that implements \code{List<$E$>} where $E$ is
+the element type of the literal.
+It contains the values in \metavar{result}, in order.
+If the literal is constant,
+the list is canonicalized and immutable,
+otherwise it is not.
+
+
+\subsubsection{Lists}
+\LMLabel{lists}
+
+!!!HERE!!! Revise.
+
+\LMHash{}%
+A \IndexCustom{list literal}{literal!list}
+denotes a list, which is an integer indexed collection of objects.
+The grammar rule for \synt{listLiteral} is specified elsewhere
+(\ref{collectionLiterals}).
+
+\LMHash{}%
+When a given list literal $e$ has no type arguments,
+the type argument $T$ is selected as specified below
+(\ref{listLiteralInference}),
+and $e$ is henceforth treated as
+(\ref{notation})
+\code{<$T$>$e$}.
+
+\LMHash{}%
+A list may contain zero or more objects.
+The number of elements in a list is its size.
+A list has an associated set of indices.
+An empty list has an empty set of indices.
+A non-empty list has the index set $\{0, \ldots, n - 1\}$ where $n$ is the size of the list.
+It is a dynamic error to attempt to access a list
+using an index that is not a member of its set of indices.
+
+\LMHash{}%
+The sequence of elements of a given list literal
+is determined as described below
+(\ref{listEvaluation}).
+
+\LMHash{}%
+If a list literal $\ell$ begins with the reserved word \CONST{}
+or $\ell$ occurs in a constant context
+(\ref{constantContexts}),
+it is a
+\IndexCustom{constant list literal}{literal!list!constant},
+which is a constant expression
+(\ref{constants})
+and therefore evaluated at compile time.
+Otherwise, it is a
+\IndexCustom{run-time list literal}{literal!list!run-time}
+and it is evaluated at run time.
+Only run-time list literals can be mutated
+after they are created.
+% This error can occur because being constant is a dynamic property.
+Attempting to mutate a constant list literal will result in a dynamic error.
+
+\commentary{%
+% The following is true either directly or indirectly: There is a \CONST{}
+% modifier on the list literal, or the list literal as a whole occurs
+% in a constant context.
+Note that the element expressions of a constant list literal
+occur in a constant context
+(\ref{constantContexts}),
+which means that \CONST{} modifiers need not be specified explicitly.%
+}
+
+\LMHash{}%
+It is a compile-time error if an element of a constant list literal
+is not a constant expression.
+It is a compile-time error if the type argument of a constant list literal
+is not a constant type expression.
+
+\rationale{%
+The binding of a formal type parameter is not known at compile time,
+so we cannot use type parameters inside constant expressions.%
+}
+
+\LMHash{}%
+The value of a constant list literal
+\code{\CONST?\,\,<$E$>[$e_1, \ldots, e_n$]}
+is an object $a$ whose class implements the built-in class
+\code{List<$E$>}.
+Let $v_i$ be the value of the constant expression $e_i$, $i \in 1 .. n$.
+The $i$th element of $a$ (at index $i - 1$) is $v_i$.
+%
+%% TODO(eernst): If inference is specified to provide all type arguments,
+%% we should delete the following.
+The value of a constant list literal
+\code{\CONST?\,\,[$e_1, \ldots, e_n$]}
+is defined as the value of the constant list literal
+% For a constant list literal, it is never an error to have the \CONST, even if
+% it was omitted above. So we remove the `?`, making the next line well-defined.
+\code{\CONST\,\,<\DYNAMIC>[$e_1, \ldots, e_n$]}.
+
+\LMHash{}%
+Let
+$list_1 =$ \code{\CONST?\,\,<$V$>[$e_{11}, \ldots, e_{1n}$]}
+and
+$list_2 =$ \code{\CONST?\,\,<$U$>[$e_{21}, \ldots, e_{2n}$]}
+be two constant list literals and
+let the elements of $list_1$ and $list_2$ evaluate to
+$o_{11}, \ldots, o_{1n}$ and $o_{21}, \ldots, o_{2n}$ respectively.
+If{}f \code{identical($o_{1i}$, $o_{2i}$)} for $i \in 1 .. n$ and $V == U$
+then \code{identical($list_1$, $list_2$)}.
+
+\commentary{%
+In other words, constant list literals are canonicalized.%
+}
+
+\LMHash{}%
+A run-time list literal
+\code{<$E$>[$e_1, \ldots, e_n$]}
+is evaluated as follows:
+\begin{itemize}
+\item
+  First, the expressions $e_1, \ldots, e_n$ are evaluated
+  in order they appear in the program,
+  producing objects $o_1, \ldots, o_n$.
+\item
+  A fresh instance (\ref{generativeConstructors}) $a$, of size $n$,
+  whose class implements the built-in class \code{List<$E$>}
+  is allocated.
+\item
+  The operator \lit{[]=} is invoked on $a$ with
+  first argument $i$ and second argument
+  $o_{i+1}, 0 \le i < n$.
+\item
+  The result of the evaluation is $a$.
+\end{itemize}
+
+\LMHash{}%
+The objects created by list literals do not override
+the \lit{==} operator inherited from the \code{Object} class.
+
+\commentary{
+Note that this document does not specify an order
+in which the elements are set.
+This allows for parallel assignments into the list
+if an implementation so desires.
+The order can only be observed as follows (and may not be relied upon):
+if element $i$ is not a subtype of the element type of the list,
+a dynamic type error will occur when $a[i]$ is assigned $o_{i-1}$.
+}
+
+\LMHash{}%
+%% TODO(eernst): If inference is specified to provide all type arguments,
+%% we should delete the following.
+A run-time list literal
+\code{[$e_1, \ldots, e_n$]}
+is evaluated as
+\code{<\DYNAMIC>[$e_1, \ldots, e_n$]}.
+
+\commentary{
+There is no restriction precluding nesting of list literals.
+It follows from the rules above that
+\code{<List<int>{}>[<int>[1, 2, 3], <int>[4, 5, 6]]}
+is a list with type parameter \code{List<int>},
+containing two lists with type parameter \code{int}.
+}
+
+\LMHash{}%
+The static type of a list literal of the form
+\code{\CONST\,\,<$E$>[$e_1, \ldots, e_n$]}
+or the form
+\code{<$E$>[$e_1, \ldots, e_n$]}
+is \code{List<$E$>}.
+%
+%% TODO(eernst): If inference is specified to provide all type arguments,
+%% we should delete the following.
+The static type of a list literal of the form
+\code{\CONST\,\,[$e_1, \ldots, e_n$]}
+or the form
+\code{[$e_1, \ldots, e_n$]}
+is \code{List<\DYNAMIC>}.
+
+
+\subsubsection{List Literal Inference}
+\LMLabel{listLiteralInference}
+
+!!!HERE!!! Raw from feature spec.
+
+\LMHash{}%
+Inference for list literals mostly follows that of set literals
+without the complexity around disambiguation with maps and
+using \code{List} or \code{Iterable} in a few places instead of \code{Set}.
+
+\LMHash{}%
+Inside a \synt{listLiteral} \metavar{listLiteral},
+the inferred type of an element $\ell$ is a list element type $T$.
+It is computed relative to a downwards element context type $P$,
+where $P$ is $T$
+if downwards inference constrains the type of \metavar{listLiteral}
+to \code{Iterable<$T$>} for some $T$.
+Otherwise, $P$ is \lit{?}.
+
+\begin{itemize}
+\item
+  If $\ell$ is an \synt{expressionElement} with expression $e1$:
+  \begin{itemize}
+  \item
+    The inferred list element type of $\ell$ is
+    the inferred type of the expression $e1$ in context $P$.
+  \end{itemize}
+\item
+  If $\ell$ is a \synt{spreadElement} with expression $e1$:
+
+  \begin{itemize}
+  \item
+    If $P$ is \lit{?} then let $S$ be
+    the inferred type of $e1$ in context \lit{?}:
+
+    \begin{itemize}
+    \item
+      If $S$ is a non-\code{Null} subtype of \code{Iterable<Object>}, then
+      the inferred list element type of $\ell$ is $T$ where $T$ is
+      the type such that \code{Iterable<$T$>} is
+      a superinterface of $S$
+      (\commentary{%
+        the result of constraint matching for $X$ using
+        the constraint \code{$S$ <: Iterable<$X$>}}).
+
+      \begin{itemize}
+      \item
+        If $S$ is \DYNAMIC{}, then
+        the inferred list element type of $\ell$ is \DYNAMIC{}.
+      \item
+        If $S$ is \code{Null} and the spread operator is \lit{...?}, then
+        the list element type is \code{Null}.
+      \item
+        Otherwise it is an error
+        (\commentary{%
+          because it is a spread of a non-spreadable type like Object%
+        }).
+      \end{itemize}
+    \item
+      Else, let $S$ be
+      the inferred type of $e1$ in context \code{Iterable<$P$>}:
+
+      \begin{itemize}
+      \item
+        If $S$ is a non-\code{Null} subtype of \code{Iterable<Object>}, then
+        the inferred list element type of $\ell$ is $T$ where $T$ is
+        the type such that \code{Iterable<$T$>} is
+        a superinterface of $S$
+        (\commentary{%
+          the result of constraint matching for $X$ using
+          the constraint \code{$S$ <: Iterable<$X$>}%
+        }).
+      \item
+        If $S$ is \DYNAMIC{}, then
+        the inferred list element type of $\ell$ is \DYNAMIC{}.
+      \item
+        Otherwise it is an error.
+      \end{itemize}
+    \end{itemize}
+  \item
+    If $\ell$ is an \synt{ifElement} with one $\ell$, $p1$,
+    and no "else" element:
+    The condition is inferred with a context type of \code{bool}.
+
+    The inferred list element type of $\ell$ is
+    the inferred list element type of $p1$ with element context type $P$.
+  \item
+    If $\ell$ is a \synt{ifElement} with two $\ell$s, $p1$ and $p2$:
+    The condition is inferred with a context type of \code{bool}.
+
+    The inferred list element type of $\ell$ is
+    the least upper bound of $S1$ and $S2$ where $S1$ is
+    the inferred list element type of $p1$ and $S2$ is
+    the inferred list element type of $p2$,
+    both with element context type $P$.
+
+  \item
+    If $\ell$ is a \synt{forElement} with $\ell$ $p1$ then:
+
+    Inference for the iterated expression and the controlling variable
+    is done as for the corresponding \FOR{} or \AWAIT{} \FOR{} statement.
+
+    The inferred list element type of $\ell$ is the inferred list element
+    type of $p1$ with element context type $P$.
+  \end{itemize}
+\end{itemize}
+
+\commentary{%
+Note: $\ell$ cannot be a \synt{mapElement} as
+those are not allowed inside list literals.%
+}
+
+\LMHash{}%
+Finally, we define inference on a \synt{listLiteral} \metavar{collection}
+as follows:
+
+\begin{itemize}
+\item
+  If $P$ is \lit{?} then
+  the static type of \metavar{collection} is \code{List<$T$>} where $T$ is
+  the least upper bound of the inferred list element types of the elements.
+\item
+  Otherwise,
+  the static type of \metavar{collection} is \code{List<$T$>} where $T$ is
+  determined by downwards inference.
+\end{itemize}
+
+
+\subsubsection{List Literal Evaluation}
+\LMLabel{listLiteralEvaluation}
+
+!!!HERE!!! May not be needed: With element evaluation in place, it's just a short explanation in \ref{lists}.
+
+
 \subsubsection{Set and Map Literal Disambiguation}
 \LMLabel{setAndMapLiteralDisambigutation}
 
@@ -7569,375 +8385,6 @@ Or, if there is nothing indicates that it is \emph{either} a set or a map:%
 \end{dartCode}
 
 
-\subsubsection{Type Promotion}
-\LMLabel{collectionLiteralTypePromotion}
-
-\LMHash{}%
-An \synt{ifElement} interacts with type promotion
-in the same way that \IF{} statements do.
-Assume that $\ell$ is an \synt{ifElement} of the form
-\code{\IF{} ($b$) $\ell_1$} or
-\code{\IF{} ($b$) $\ell_1$ \ELSE{} $\ell_2$}.
-If $b$ shows that a local variable $v$ has type $T$, then
-the type of $v$ is known to be $T$ in $\ell_1$,
-unless any of the following are true:
-
-\begin{itemize}
-\item $v$ is potentially mutated in $\ell_1$,
-\item $v$ is potentially mutated within a function
-  other than the one where $v$ is declared, or
-\item $v$ is accessed by a function defined in $\ell_1$ and
-  $v$ is potentially mutated anywhere in the scope of $v$.
-\end{itemize}
-
-%% TODO(eernst): Come nnbd, update this.
-\commentary{%
-Type promotion will likely get more sophisticated in a future version of Dart.
-When that happens,
-\synt{ifElements} will continue to match \IF{} statements
-(\ref{if}).%
-}
-
-
-\subsubsection{Collection Literal Element Evaluation}
-\LMLabel{collectionLiteralElementEvaluation}
-
-\LMHash{}%
-The evaluation of a sequence of collection literal elements
-(\ref{collectionLiterals})
-yields a
-\IndexCustom{collection literal object sequence}{%
-  collection literal!object sequence},
-also called an \NoIndex{object sequence} when no ambiguity can arise.
-
-\LMHash{}%
-We use the notation
-\IndexCustom{\LiteralSequence{\ldots}}{[[...]]@\LiteralSequence{\ldots}}
-to denote an object sequence of specific elements,
-and we use `$+$' to compute the concatenation of object sequences
-(\commentary{as in $s_1 + s_2$}),
-which is an operation that will succeed and has no side-effects.
-Each element in the sequence is an object $o$ or a pair $o_1: o_2$.
-There is no notion of an element type for an object sequence,
-and hence no notion of dynamic errors arising from
-a type mismatch during concatenation.
-
-\commentary{%
-Object sequences can safely be treated in an untyped manner
-because every access to an object sequence occurs
-in code created by language defined desugaring
-on statically checked constructs.
-It is left unspecified how an object sequence is implemented,
-it is only required that it contains the indicated objects or pairs
-in the given order.
-For each kind of collection the sequence is used in the given order
-to populate the collection,
-in a manner which is specific to the kind,
-and which is specified separately
-(\ref{lists}, \ref{maps}, \ref{sets}).%
-
-There may be an actual data structure
-representing object sequences at run time,
-but object sequences could also be eliminated, e.g.,
-because each element is inserted directly into the target collection
-as soon as it has been computed.
-Note that each object sequence will exclusively contain objects,
-or it will exclusively contain pairs,
-because any mixed sequence would cause
-an error at compile time or
-(for a spread element with static type \DYNAMIC{})
-at run time.%
-}
-
-\LMHash{}%
-Assume that a literal collection \metavar{target} is given,
-and the object sequence obtained as described below will be used
-to populate \metavar{target}.
-Let $T_{\metavar{target}}$ denote the dynamic type of \metavar{target}.
-
-\commentary{%
-Access to the type of \metavar{target} is needed below
-in order to raise dynamic errors at specific points during
-the evaluation of an object sequence.
-Note that the dynamic type of \metavar{target} is statically known,
-except for the binding of any type variables in its \synt{typeArguments}.
-This implies that some questions can be answered at compile-time, e.g.,
-whether or not \code{Iterable} occurs as a superinterface of
-$T_{\metavar{target}}$.%
-}
-
-\LMHash{}%
-Assume that a location in code and a dynamic context is given,
-such that ordinary expression evaluation is possible.
-\IndexCustom{Evaluation of a collection literal element sequence}{%
-  collection literal element sequence!evaluation}
-at that location and in that context is specified as follows:
-
-\LMHash{}%
-Let $s_{\metavar{syntax}}$ of the form \List{\ell}{1}{k} be
-a sequence of collection literal elements.
-The sequence of objects $s_{\metavar{object}}$
-obtained by evaluating $s_{\metavar{syntax}}$
-is the concatenation of the sequences of objects
-obtained by evaluating each element $\ell_j$, $j \in 1 .. k$:
-$s_{\metavar{object}}=\EvaluateElement{\ell_1}+\ldots+\EvaluateElement{\ell_k}$,
-where \EvaluateElement{\ell_j} denotes the object sequence yielded by
-evaluation of a single collection literal element $\ell_j$.
-The object sequences for elements
-must be computed in the textual order,
-because the computations may have side effects.
-
-\LMHash{}%
-We use the notation $\EvaluateElement{\ell} := s$
-at specific points where the computation is complete,
-in order to specify that the value of \EvaluateElement{\ell} is $s$.
-\IndexCustom{Evaluation of a collection literal element $\ell$}{%
-  collection literal element!evaluation}
-in the given context
-to an object sequence \EvaluateElement{\ell}
-is then specified as follows:
-
-\LMHash{}%
-\Case{Expression element}
-When $\ell$ is an \synt{expressionElement} of the form $e$,
-$e$ is evaluated to an object $o$,
-and $\EvaluateElement{\ell} := \LiteralSequence{o}$.
-\EndCase
-
-\LMHash{}%
-\Case{Map element}
-When $\ell$ is a \synt{mapElement} of the form
-\code{$e_1$:\,\,$e_2$},
-$e_1$ is evaluated to an object $o_1$,
-then $e_2$ is evaluated to an object $o_2$,
-and $\EvaluateElement{\ell} := \LiteralSequence{o_1:o_2}$.
-\EndCase
-
-\begin{figure}[t]
-\begin{normativeDartCode}
-$S_{\metavar{spread}}$ spread = $o_{\metavar{spread}}$;
-\VAR{} $s$ = \LiteralSequence{};
-\FOR{} (\VAR{} v \IN{} spread) \{
-  Value value = v;
-  $s = s + \LiteralSequence{\code{value}}$;
-\}
-$\EvaluateElement{\ell} := s$;
-\end{normativeDartCode}
-\vspace{-3mm}
-  \caption{Evaluation of a list or set spread element $\ell$
-    with spread object $o_{\metavar{spread}}$.}
-  \label{fig:evaluationOfAnIterableSpreadElement}
-\end{figure}
-
-\begin{figure}[t]
-\begin{normativeDartCode}
-$S_{\metavar{spread}}$ spread = $o_{\metavar{spread}}$;
-\VAR{} $s$ = \LiteralSequence{};
-\FOR{} (\VAR{} entry \IN{} spread) \{
-  Key key = entry.key;
-  Value value = entry.value;
-  $s = s + \LiteralSequence{\code{key}:\,\code{value}}$;
-\}
-$\EvaluateElement{\ell} := s$;
-\end{normativeDartCode}
-\vspace{-3mm}
-  \caption{Evaluation of a map spread element $\ell$
-    with spread object $o_{\metavar{spread}}$.}
-  \label{fig:evaluationOfAMapSpreadElement}
-\end{figure}
-
-\LMHash{}%
-\Case{Spread element}
-\begin{enumerate}
-\item
-  When $\ell$ is a \synt{spreadElement} of the form
-  `\code{...?$e$}', $e$ is evaluated to an object $o_{\metavar{spread}}$.
-  If $o_{\metavar{spread}}$ is the null object then
-  $\EvaluateElement{\ell} := \LiteralSequence{}$.
-  Otherwise evaluation proceeds with step 2.
-
-  When $\ell$ is a \synt{spreadElement} of the form
-  `\code{...$e$}', $e$ is evaluated to an object $o_{\metavar{spread}}$.
-  %% TODO(eernst): Come NNBD, this error cannot occur any more: delete.
-  If $o_{\metavar{spread}}$ is the null object then a dynamic error occurs.
-  Otherwise evaluation proceeds with step 2.
-\item
-  Let $T_{\metavar{spread}}$ be the dynamic type of $o_{\metavar{spread}}$.
-  Let $S$ be the static type of $e$.
-  When $S$ is a top type
-  (\ref{superBoundedTypes}),
-  let $S_{\metavar{spread}}$ be \code{Iterable<\DYNAMIC>};
-  otherwise let $S_{\metavar{spread}}$ be $S$.
-  \commentary{%
-    It is a compile-time error if $S$
-    is not assignable to \code{Iterable<\DYNAMIC>}.%
-  }
-  \begin{itemize}
-  \item
-    When both $T_{\metavar{spread}}$ and $T_{\metavar{target}}$ implement
-    \code{Iterable},
-    the code in Fig.~\ref{fig:evaluationOfAnIterableSpreadElement} is executed
-    in the static and dynamic context where $\ell$ occurs,
-    where \code{spread}, $s$, \code{v}, and \code{value} are fresh variables,
-    and \code{Value} is a fresh type variable bound to the
-    actual type argument of $T_{\metavar{target}}$ at \code{Iterable}.
-
-    \commentary{%
-      The code makes use of a pseudo-variable $s$ denoting an object sequence.
-      We do not specify the type of $s$,
-      this variable is only used to indicate the required
-      semantic actions taken to gather the resulting object sequence.
-      In the case where the implementation does not have
-      a representation of $s$ at all,
-      the action may be to extend \metavar{target} immediately.
-      A similar approach is used in subsequent cases.%
-    }
-  \item
-    When both $T_{\metavar{spread}}$ and $T_{\metavar{target}}$ implement
-    \code{Map},
-    the code in Fig.~\ref{fig:evaluationOfAMapSpreadElement} is executed
-    in the static and dynamic context where $\ell$ occurs,
-    where \code{spread}, $s$, \code{entry}, \code{key}, and \code{value}
-    are fresh variables,
-    and \code{Key} and \code{Value} are fresh type variables bound to the
-    first respectively second actual type argument
-    of $T_{\metavar{target}}$ at \code{Map}.
-
-    % Will not change with nnbd: `spread` type arguments could be \DYNAMIC{}.
-    It is allowed for an implementation to delay the dynamic errors
-    that occur if the given \code{key} does not have the type \code{Key},
-    or the given \code{value} does not have the type \code{Value},
-    but it cannot occur after the pair has been appended to $s$.
-  \item
-    Otherwise, a dynamic error occurs.
-
-    \commentary{%
-      This occurs when the target is a map respectively iterable,
-      and the spread is not, which is possible for
-      a spread whose static type is \DYNAMIC{}.%
-    }
-  \end{itemize}
-\end{enumerate}
-
-\commentary{%
-This may not be the most efficient way to traverse the items in a collection,
-and implementations may of course use any other approach
-with the same observable behavior.
-However, in order to give implementations more room to optimize
-we also allow the following.%
-}
-
-\LMHash{}%
-If $o$ is an object whose dynamic type implements
-\code{List}, \code{Queue}, or \code{Set},
-an implementation may choose to call \code{length} on the object.
-
-\commentary{%
-This may let it allocate space for the resulting collection more efficiently.
-The given class is expected to have an efficient and
-side-effect free implementation of \code{length}.%
-}
-
-\LMHash{}%
-If $o$ is an object whose dynamic type implements \code{List},
-an implementation may choose to call operator \lit{[]}
-in order to access elements from the list.
-If it does so, it will only pass indices
-that are non-negative and less than the value returned by \code{length}.
-
-\LMHash{}%
-A Dart implementation may detect whether these options apply
-at compile time based on the static type of $e$,
-or at runtime based on the actual value.
-\EndCase
-
-\LMHash{}%
-\Case{If element}
-When $\ell$ is an \synt{ifElement} of the form
-\code{\IF{} ($b$) $\ell_1$} or
-\code{\IF{} ($b$) $\ell_1$ \ELSE{} $\ell_2$},
-the condition $b$ is evaluated to a value $o_b$.
-If $o_b$ is \TRUE{} then
-$\EvaluateElement{\ell} := \EvaluateElement{\ell_1}$.
-If $o_b$ is \FALSE{} and $\ell_2$ is present then
-$\EvaluateElement{\ell} := \EvaluateElement{\ell_2}$,
-and if $\ell_2$ is not present then
-$\EvaluateElement{\ell} := \LiteralSequence{}$.
-% $o_b$ can have type \DYNAMIC{}.
-If $o_b$ is neither \TRUE{} nor \FALSE{} then a dynamic error occurs.
-\EndCase
-
-\begin{figure}[t]
-\begin{normativeDartCode}
-\VAR{} $s$ = \LiteralSequence{};
-\AWAIT? \FOR{} ($D$ \id{} \IN{} $e$) \{
-  $s = s + \EvaluateElement{\ell_1}$;
-\}
-$\EvaluateElement{\ell} := s$;
-\end{normativeDartCode}
-\vspace{-3mm}
-  \caption{Evaluation of a \synt{forElement} $\ell$ of the form
-    \code{\AWAIT?\,\,\FOR\,\,($D$\,\,\id\,\,\IN\,\,$e$)\,\,$\ell_1$},
-    where \AWAIT{} is included in both the for element and the code,
-    or omitted in both.}
-  \label{fig:evaluationOfAForInElement}
-\end{figure}
-
-\begin{figure}[t]
-\begin{normativeDartCode}
-\VAR{} $s$ = \LiteralSequence{};
-\AWAIT? \FOR{} ($P$) \{
-  $s = s + \EvaluateElement{\ell_1}$;
-\}
-$\EvaluateElement{\ell} := s$;
-\end{normativeDartCode}
-\vspace{-3mm}
-  \caption{Evaluation of a \synt{forElement} $\ell$ of the form
-    \code{\AWAIT?\,\,\FOR\,\,($P$)\,\,$\ell_1$},
-    where $P$ is derived from \synt{forLoopParts}
-    and \AWAIT{} is included in both the for element and the code,
-    or omitted in both.}
-  \label{fig:evaluationOfAForLoopElement}
-\end{figure}
-
-\LMHash{}%
-\Case{For-in element}
-Let $D$ be derived from \syntax{<finalConstVarOrType>?} and
-let $\ell$ be a \synt{forElement} of the form
-\code{\AWAIT?\,\,\FOR\,\,($D$\,\,\id\,\,\IN\,\,$e$)\,\,$\ell_1$},
-where `\AWAIT?' indicates that \AWAIT{} may be present or absent.
-To evaluate $\ell$,
-the code in Fig.~\ref{fig:evaluationOfAForInElement} is executed
-in the static and dynamic context where $\ell$ occurs.
-\EndCase
-
-\LMHash{}%
-\Case{For loop element}
-Let $P$ be a term derived from \synt{forLoopParts} and
-let $\ell$ be a \synt{forElement} of the form
-\code{\AWAIT?\,\,\FOR\,\,($P$)\,\,$\ell_1$},
-where `\AWAIT?' indicates that \AWAIT{} may be present or absent.
-To evaluate $\ell$,
-the code in Fig.~\ref{fig:evaluationOfAForLoopElement} is executed
-in the static and dynamic context where $\ell$ occurs.
-\EndCase
-
-
-\subsubsection{List}
-\LMLabel{uiAsCodeList}
-
-!!!HERE!!! This should be moved into \ref{lists}.
-
-\LMHash{}%
-The result of the literal expression is a fresh instance of
-a class that implements \code{List<$E$>} where $E$ is
-the element type of the literal.
-It contains the values in \metavar{result}, in order.
-If the literal is constant,
-the list is canonicalized and immutable,
-otherwise it is not.
-
-
 \subsubsection{Set}
 \LMLabel{uiAsCodeSet}
 
@@ -7969,347 +8416,6 @@ For each \metavar{value} in \metavar{result}:
 The result of the literal expression is \metavar{set}.
 If the literal is constant,
 canonicalize it make the set immutable.
-
-
-\subsubsection{Map}
-\LMLabel{uiAsCodeMap}
-
-!!!HERE!!! This should be moved into \ref{maps}.
-
-\LMHash{}%
-Allocate a fresh instance \metavar{map} of
-a class that implements \code{LinkedHashMap<$K$, $V$>} where $K$ is
-the key type of the literal and $V$ is
-the value type.
-
-\LMHash{}%
-For each entry \code{\metavar{key}: \metavar{value}} in \metavar{result}:
-
-\begin{enumerate}
-\item
-  If \metavar{map} contains an entry \metavar{existing}
-  whose key \metavar{existingKey} is equal to \metavar{key}
-  according to \metavar{existingKeys}'s operator \lit{==}:
-  \begin{enumerate}
-  \item
-    If the literal is constant, it is a compile-time error.
-  \item
-    Else, replace the value in \metavar{existing} with \metavar{value},
-    while keeping its position in the sequence of entries
-    and \metavar{existingKey} the same.
-  \end{enumerate}
-\item
-  Else add entry \code{\metavar{key}: \metavar{value}} to \metavar{map}.
-\end{enumerate}
-
-\LMHash{}%
-The result of the map literal expression is \metavar{map}.
-If the literal is constant,
-canonicalize it and make the map immutable.
-
-
-\subsubsection{Lists}
-\LMLabel{lists}
-
-!!!HERE!!! Revise.
-
-\LMHash{}%
-A \IndexCustom{list literal}{literal!list}
-denotes a list, which is an integer indexed collection of objects.
-The grammar rule for \synt{listLiteral} is specified elsewhere
-(\ref{collectionLiterals}).
-
-\LMHash{}%
-When a given list literal $e$ has no type arguments,
-the type argument $T$ is selected as specified below
-(\ref{listLiteralInference}),
-and $e$ is henceforth treated as
-(\ref{notation})
-\code{<$T$>$e$}.
-
-\LMHash{}%
-A list may contain zero or more objects.
-The number of elements in a list is its size.
-A list has an associated set of indices.
-An empty list has an empty set of indices.
-A non-empty list has the index set $\{0, \ldots, n - 1\}$ where $n$ is the size of the list.
-It is a dynamic error to attempt to access a list
-using an index that is not a member of its set of indices.
-
-\LMHash{}%
-The sequence of elements of a given list literal
-is determined as described below
-(\ref{listEvaluation}).
-
-\LMHash{}%
-If a list literal $\ell$ begins with the reserved word \CONST{}
-or $\ell$ occurs in a constant context
-(\ref{constantContexts}),
-it is a
-\IndexCustom{constant list literal}{literal!list!constant},
-which is a constant expression
-(\ref{constants})
-and therefore evaluated at compile time.
-Otherwise, it is a
-\IndexCustom{run-time list literal}{literal!list!run-time}
-and it is evaluated at run time.
-Only run-time list literals can be mutated
-after they are created.
-% This error can occur because being constant is a dynamic property.
-Attempting to mutate a constant list literal will result in a dynamic error.
-
-\commentary{%
-% The following is true either directly or indirectly: There is a \CONST{}
-% modifier on the list literal, or the list literal as a whole occurs
-% in a constant context.
-Note that the element expressions of a constant list literal
-occur in a constant context
-(\ref{constantContexts}),
-which means that \CONST{} modifiers need not be specified explicitly.%
-}
-
-\LMHash{}%
-It is a compile-time error if an element of a constant list literal
-is not a constant expression.
-It is a compile-time error if the type argument of a constant list literal
-is not a constant type expression.
-
-\rationale{%
-The binding of a formal type parameter is not known at compile time,
-so we cannot use type parameters inside constant expressions.%
-}
-
-\LMHash{}%
-The value of a constant list literal
-\code{\CONST?\,\,<$E$>[$e_1, \ldots, e_n$]}
-is an object $a$ whose class implements the built-in class
-\code{List<$E$>}.
-Let $v_i$ be the value of the constant expression $e_i$, $i \in 1 .. n$.
-The $i$th element of $a$ (at index $i - 1$) is $v_i$.
-%
-%% TODO(eernst): If inference is specified to provide all type arguments,
-%% we should delete the following.
-The value of a constant list literal
-\code{\CONST?\,\,[$e_1, \ldots, e_n$]}
-is defined as the value of the constant list literal
-% For a constant list literal, it is never an error to have the \CONST, even if
-% it was omitted above. So we remove the `?`, making the next line well-defined.
-\code{\CONST\,\,<\DYNAMIC>[$e_1, \ldots, e_n$]}.
-
-\LMHash{}%
-Let
-$list_1 =$ \code{\CONST?\,\,<$V$>[$e_{11}, \ldots, e_{1n}$]}
-and
-$list_2 =$ \code{\CONST?\,\,<$U$>[$e_{21}, \ldots, e_{2n}$]}
-be two constant list literals and
-let the elements of $list_1$ and $list_2$ evaluate to
-$o_{11}, \ldots, o_{1n}$ and $o_{21}, \ldots, o_{2n}$ respectively.
-If{}f \code{identical($o_{1i}$, $o_{2i}$)} for $i \in 1 .. n$ and $V == U$
-then \code{identical($list_1$, $list_2$)}.
-
-\commentary{%
-In other words, constant list literals are canonicalized.%
-}
-
-\LMHash{}%
-A run-time list literal
-\code{<$E$>[$e_1, \ldots, e_n$]}
-is evaluated as follows:
-\begin{itemize}
-\item
-  First, the expressions $e_1, \ldots, e_n$ are evaluated
-  in order they appear in the program,
-  producing objects $o_1, \ldots, o_n$.
-\item
-  A fresh instance (\ref{generativeConstructors}) $a$, of size $n$,
-  whose class implements the built-in class \code{List<$E$>}
-  is allocated.
-\item
-  The operator \lit{[]=} is invoked on $a$ with
-  first argument $i$ and second argument
-  $o_{i+1}, 0 \le i < n$.
-\item
-  The result of the evaluation is $a$.
-\end{itemize}
-
-\LMHash{}%
-The objects created by list literals do not override
-the \lit{==} operator inherited from the \code{Object} class.
-
-\commentary{
-Note that this document does not specify an order
-in which the elements are set.
-This allows for parallel assignments into the list
-if an implementation so desires.
-The order can only be observed as follows (and may not be relied upon):
-if element $i$ is not a subtype of the element type of the list,
-a dynamic type error will occur when $a[i]$ is assigned $o_{i-1}$.
-}
-
-\LMHash{}%
-%% TODO(eernst): If inference is specified to provide all type arguments,
-%% we should delete the following.
-A run-time list literal
-\code{[$e_1, \ldots, e_n$]}
-is evaluated as
-\code{<\DYNAMIC>[$e_1, \ldots, e_n$]}.
-
-\commentary{
-There is no restriction precluding nesting of list literals.
-It follows from the rules above that
-\code{<List<int>{}>[<int>[1, 2, 3], <int>[4, 5, 6]]}
-is a list with type parameter \code{List<int>},
-containing two lists with type parameter \code{int}.
-}
-
-\LMHash{}%
-The static type of a list literal of the form
-\code{\CONST\,\,<$E$>[$e_1, \ldots, e_n$]}
-or the form
-\code{<$E$>[$e_1, \ldots, e_n$]}
-is \code{List<$E$>}.
-%
-%% TODO(eernst): If inference is specified to provide all type arguments,
-%% we should delete the following.
-The static type of a list literal of the form
-\code{\CONST\,\,[$e_1, \ldots, e_n$]}
-or the form
-\code{[$e_1, \ldots, e_n$]}
-is \code{List<\DYNAMIC>}.
-
-
-\subsubsection{List Literal Inference}
-\LMLabel{listLiteralInference}
-
-!!!HERE!!! Raw from feature spec.
-
-\LMHash{}%
-Inference for list literals mostly follows that of set literals
-without the complexity around disambiguation with maps and
-using \code{List} or \code{Iterable} in a few places instead of \code{Set}.
-
-\LMHash{}%
-Inside a \synt{listLiteral} \metavar{listLiteral},
-the inferred type of an element $\ell$ is a list element type $T$.
-It is computed relative to a downwards element context type $P$,
-where $P$ is $T$
-if downwards inference constrains the type of \metavar{listLiteral}
-to \code{Iterable<$T$>} for some $T$.
-Otherwise, $P$ is \lit{?}.
-
-\begin{itemize}
-\item
-  If $\ell$ is an \synt{expressionElement} with expression $e1$:
-  \begin{itemize}
-  \item
-    The inferred list element type of $\ell$ is
-    the inferred type of the expression $e1$ in context $P$.
-  \end{itemize}
-\item
-  If $\ell$ is a \synt{spreadElement} with expression $e1$:
-
-  \begin{itemize}
-  \item
-    If $P$ is \lit{?} then let $S$ be
-    the inferred type of $e1$ in context \lit{?}:
-
-    \begin{itemize}
-    \item
-      If $S$ is a non-\code{Null} subtype of \code{Iterable<Object>}, then
-      the inferred list element type of $\ell$ is $T$ where $T$ is
-      the type such that \code{Iterable<$T$>} is
-      a superinterface of $S$
-      (\commentary{%
-        the result of constraint matching for $X$ using
-        the constraint \code{$S$ <: Iterable<$X$>}}).
-
-      \begin{itemize}
-      \item
-        If $S$ is \DYNAMIC{}, then
-        the inferred list element type of $\ell$ is \DYNAMIC{}.
-      \item
-        If $S$ is \code{Null} and the spread operator is \lit{...?}, then
-        the list element type is \code{Null}.
-      \item
-        Otherwise it is an error
-        (\commentary{%
-          because it is a spread of a non-spreadable type like Object%
-        }).
-      \end{itemize}
-    \item
-      Else, let $S$ be
-      the inferred type of $e1$ in context \code{Iterable<$P$>}:
-
-      \begin{itemize}
-      \item
-        If $S$ is a non-\code{Null} subtype of \code{Iterable<Object>}, then
-        the inferred list element type of $\ell$ is $T$ where $T$ is
-        the type such that \code{Iterable<$T$>} is
-        a superinterface of $S$
-        (\commentary{%
-          the result of constraint matching for $X$ using
-          the constraint \code{$S$ <: Iterable<$X$>}%
-        }).
-      \item
-        If $S$ is \DYNAMIC{}, then
-        the inferred list element type of $\ell$ is \DYNAMIC{}.
-      \item
-        Otherwise it is an error.
-      \end{itemize}
-    \end{itemize}
-  \item
-    If $\ell$ is an \synt{ifElement} with one $\ell$, $p1$,
-    and no "else" element:
-    The condition is inferred with a context type of \code{bool}.
-
-    The inferred list element type of $\ell$ is
-    the inferred list element type of $p1$ with element context type $P$.
-  \item
-    If $\ell$ is a \synt{ifElement} with two $\ell$s, $p1$ and $p2$:
-    The condition is inferred with a context type of \code{bool}.
-
-    The inferred list element type of $\ell$ is
-    the least upper bound of $S1$ and $S2$ where $S1$ is
-    the inferred list element type of $p1$ and $S2$ is
-    the inferred list element type of $p2$,
-    both with element context type $P$.
-
-  \item
-    If $\ell$ is a \synt{forElement} with $\ell$ $p1$ then:
-
-    Inference for the iterated expression and the controlling variable
-    is done as for the corresponding \FOR{} or \AWAIT{} \FOR{} statement.
-
-    The inferred list element type of $\ell$ is the inferred list element
-    type of $p1$ with element context type $P$.
-  \end{itemize}
-\end{itemize}
-
-\commentary{%
-Note: $\ell$ cannot be a \synt{mapElement} as
-those are not allowed inside list literals.%
-}
-
-\LMHash{}%
-Finally, we define inference on a \synt{listLiteral} \metavar{collection}
-as follows:
-
-\begin{itemize}
-\item
-  If $P$ is \lit{?} then
-  the static type of \metavar{collection} is \code{List<$T$>} where $T$ is
-  the least upper bound of the inferred list element types of the elements.
-\item
-  Otherwise,
-  the static type of \metavar{collection} is \code{List<$T$>} where $T$ is
-  determined by downwards inference.
-\end{itemize}
-
-
-\subsubsection{List Literal Evaluation}
-\LMLabel{listLiteralEvaluation}
-
-!!!HERE!!! May not be needed: With element evaluation in place, it's just a short explanation in \ref{lists}.
 
 
 \subsubsection{Sets}
@@ -8459,6 +8565,43 @@ The static type of a list literal of the form
 or the form
 \code{\{$e_1, \ldots, e_n$\}}
 is \code{Set<\DYNAMIC>}.
+
+
+\subsubsection{Map}
+\LMLabel{uiAsCodeMap}
+
+!!!HERE!!! This should be moved into \ref{maps}.
+
+\LMHash{}%
+Allocate a fresh instance \metavar{map} of
+a class that implements \code{LinkedHashMap<$K$, $V$>} where $K$ is
+the key type of the literal and $V$ is
+the value type.
+
+\LMHash{}%
+For each entry \code{\metavar{key}: \metavar{value}} in \metavar{result}:
+
+\begin{enumerate}
+\item
+  If \metavar{map} contains an entry \metavar{existing}
+  whose key \metavar{existingKey} is equal to \metavar{key}
+  according to \metavar{existingKeys}'s operator \lit{==}:
+  \begin{enumerate}
+  \item
+    If the literal is constant, it is a compile-time error.
+  \item
+    Else, replace the value in \metavar{existing} with \metavar{value},
+    while keeping its position in the sequence of entries
+    and \metavar{existingKey} the same.
+  \end{enumerate}
+\item
+  Else add entry \code{\metavar{key}: \metavar{value}} to \metavar{map}.
+\end{enumerate}
+
+\LMHash{}%
+The result of the map literal expression is \metavar{map}.
+If the literal is constant,
+canonicalize it and make the map immutable.
 
 
 \subsubsection{Maps}
@@ -8617,151 +8760,6 @@ The static type of a map literal of the form
 or the form
 \code{\{$k_1:e_1, \ldots, k_n:e_n$\}} is
 \code{Map<\DYNAMIC, \DYNAMIC>}.
-
-
-\subsubsection{Compile-time errors}
-\LMLabel{uiAsCodeCompileTimeErrors}
-
-!!!HERE!!! Integrate this into other sections.
-
-\LMHash{}%
-After type inference and disambiguation,
-the collection is checked for other compile-time errors.
-It is a compile-time error if:
-
-%% TODO(eernst): Find a way to show Dart code examples inside itemize below.
-
-\begin{itemize}
-\item
-  The collection is a map literal and leaf elements contains any
-  \synt{expressionElement} elements.
-
-  \begin{dartCode}
-    <String, int>\{"not entry"\} // Error.
-  \end{dartCode}
-\item
-  The collection is a set literal and
-  leaf elements contains any \synt{mapElement} elements.
-
-  \begin{dartCode}
-    ["not": "expression"] // Error.
-    <String>\{"not": "expression"\} // Error.
-  \end{dartCode}
-
-  \commentary{%
-    We prohibit map entries in list literals syntactically,
-    earlier in the proposal.%
-  }
-\item
-  The collection is a list and the type of any of the leaf elements
-  may not be assigned to the list's element type.
-
-  \begin{dartCode}
-    <int>[if (true) "not int"] // Error.
-  \end{dartCode}
-\item
-  The collection is a map and the key type of any of the leaf elements
-  may not be assigned to the map's key type.
-
-  \begin{dartCode}
-    <int, int>{if (true) "not int": 1} // Error.
-  \end{dartCode}
-\item
-  The collection is a map and the value type of any of the leaf elements
-  may not be assigned to the map's value type.
-
-  \begin{dartCode}
-    <int, int>{if (true) 1: "not int"} // Error.
-  \end{dartCode}
-\item
-  A non-null-aware spread element has static type \code{Null}.
-\item
-  A spread element in a list or set literal has a static type that is
-  not \DYNAMIC{} and not a subtype of \code{Iterable<Object>}.
-\item
-  A spread element in a list or set has a static type that
-  implements \code{Iterable<$T$>} for some $T$ and
-  $T$ is not assignable to the element type of the list.
-\item
-  A spread element in a map literal has a static type that is
-  not \DYNAMIC{} and not a subtype of \code{Map<Object, Object>}.
-\item
-  If a map spread element's static type
-  implements \code{Map<$K$, $V$>} for some $K$ and $V$ and
-  $K$ is not assignable to the key type of the map or
-  $V$ is not assignable to the value type of the map.
-\item
-  The variable in a \synt{forElement}
-  (\commentary{either a for-in element or C-style})
-  is declared outside of the element to be final or to not have a setter.
-
-  \begin{dartCode}
-    \FINAL{} i = 0;
-    [for (i in [1]) i] // Error.
-  \end{dartCode}
-\item
-  The type of the iterator expression in a synchronous for-in element
-  may not be assigned to \code{Iterable<$T$>} for any type $T$.
-  Otherwise, the \Index{iterable type} of the iterator is $T$.
-
-  \begin{dartCode}
-    [for (var i in "not iterable") i] // Error.
-  \end{dartCode}
-\item
-  The iterable type of the iterator in a synchronous for-in element
-  may not be assigned to the for-in variable's type.
-
-  \begin{dartCode}
-    [for (int i in ["not", "int"]) i] // Error.
-  \end{dartCode}
-\item
-  The type of the stream expression in an asynchronous \AWAIT{} for-in element
-  may not be assigned to \code{Stream<$T$>} for any type $T$.
-  Otherwise, the \Index{stream type} of the stream is $T$.
-
-  \begin{dartCode}
-    [await for (var i in "not stream") i] // Error.
-  \end{dartCode}
-\item
-  The stream type of the iterator in an asynchronous \AWAIT{} for-in element
-  may not be assigned to the for-in variable's type.
-
-  \begin{dartCode}
-    [await for (int i in Stream.fromIterable(["not", "int"])) i] // Error.
-  \end{dartCode}
-
-\item
-  \AWAIT{} \FOR{} is used when
-  the function immediately enclosing the collection literal
-  is not asynchronous.
-
-  \begin{dartCode}
-    main() {
-      [await for (_ in stream)]; // Error.
-    }
-  \end{dartCode}
-\item
-  \AWAIT{} is used before a C-style \synt{forElement}.
-  \AWAIT{} can only be used with for-in loops.
-
-  \begin{dartCode}
-    main() {
-      [await for (;;)]; // Error.
-    }
-  \end{dartCode}
-
-\item
-  The type of the condition expression
-  (\commentary{the second clause})
-  in a C-style \FOR{} element
-  may not be assigned to \code{bool}.
-
-  \begin{dartCode}
-    [for (; "not bool";) 1] // Error.
-  \end{dartCode}
-\end{itemize}
-
-!!!HERE!!! End of UI-as-code material.
 
 
 \subsection{Throw}

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -7162,23 +7162,22 @@ or
 
 \begin{itemize}
 \item
-  Assume that $\ell$ is an \synt{expressionElement},
-  and that it is the expression $e$.
+  When $\ell$ is an \synt{expressionElement} of the form $e$:
 
   $\ell$ is a potentially constant element
   if $e$ is a potentially constant expression,
   and $\ell$ is a constant element
   if $e$ is a constant expression.
 \item
-  Assume that $\ell$ is a \synt{mapElement}
-  of the form \code{$e_1$:\,$e_2$}.
+  When $\ell$ is a \synt{mapElement}
+  of the form `\code{$e_1$:\,$e_2$}':
 
   $\ell$ is a potentially constant element
   if both $e_1$ and $e_2$ are potentially constant expressions,
   and it is a constant element if they are constant expressions.
 \item
-  Assume that $\ell$ is a \synt{spreadElement}
-  of the form `\code{...$e$}' or `\code{...?$e$}'.
+  When $\ell$ is a \synt{spreadElement}
+  of the form `\code{...$e$}' or `\code{...?$e$}':
 
   $\ell$ is a potentially constant element
   if $e$ is a potentially constant expression.
@@ -7192,11 +7191,11 @@ or
   where $e$ is a constant expression that evaluates
   to the null object.
 \item
-  Assume that $\ell$ is an \synt{ifElement}
+  When $\ell$ is an \synt{ifElement}
   of the form
   \code{\IF\,\,($b$)\,\,$\ell_1$}
-  or of the form
-  \code{\IF\,\,($b$)\,\,$\ell_1$\,\,\ELSE\,\,$\ell_2$}.
+  or the form
+  \code{\IF\,\,($b$)\,\,$\ell_1$\,\,\ELSE\,\,$\ell_2$}:
 
   $\ell$ is a potentially constant element
   if $b$ is a potentially constant expression,
@@ -7424,7 +7423,7 @@ evaluation of a single collection literal element $\ell_j$.
 
 \LMHash{}%
 When a pseudo-statement of the form
-\code{$s = s + \EvaluateElement{\ell}$;}
+\code{$s := s + \EvaluateElement{\ell}$;}
 is used in normative code below,
 it denotes the extension of $s$ with the object sequence
 yielded by evaluation of $\ell$,
@@ -7509,7 +7508,7 @@ $S_{\metavar{spread}}$ spread = $o_{\metavar{spread}}$;
 \VAR{} $s$ = \LiteralSequence{};
 \FOR{} (\VAR{} v \IN{} spread) \{
   Value value = v;
-  $s = s + \LiteralSequence{\code{value}}$;
+  $s := s + \LiteralSequence{\code{value}}$;
 \}
 $\EvaluateElement{\ell} := s$;
 \end{normativeDartCode}
@@ -7542,7 +7541,7 @@ $S_{\metavar{spread}}$ spread = $o_{\metavar{spread}}$;
 \FOR{} (\VAR{} v \IN{} spread) \{
   Key key = v.key;
   Value value = v.value;
-  $s = s + \LiteralSequence{\code{key}:\,\code{value}}$;
+  $s := s + \LiteralSequence{\code{key}:\,\code{value}}$;
 \}
 $\EvaluateElement{\ell} := s$;
 \end{normativeDartCode}
@@ -7625,7 +7624,7 @@ where \AWAIT{} is present if and only if it is present in $\ell$:
 \begin{normativeDartCode}
 \VAR{} $s$ = \LiteralSequence{};
 \AWAIT? \FOR{} ($P$) \{
-  $s = s + \EvaluateElement{\ell_1}$;
+  $s := s + \EvaluateElement{\ell_1}$;
 \}
 $\EvaluateElement{\ell} := s$;
 \end{normativeDartCode}
@@ -7650,9 +7649,6 @@ The context type $P$
 for each element of \metavar{list} is
 obtained from the context type of \metavar{list}.
 If downwards inference constrains the type of \metavar{list}
-%% TODO(eernst): Confirm that the context type should allow for
-%% `List` as well as `Iterable`. The implementations (unsurprisingly)
-%% do that, but the feature spec only allowed for `Iterable`.
 to \code{List<$P_e$>} or \code{Iterable<$P_e$>} for some $P_e$
 then $P$ is $P_e$.
 Otherwise, $P$ is \FreeContext{}
@@ -8611,10 +8607,11 @@ which means that \CONST{} modifiers need not be specified explicitly.%
 }
 
 \LMHash{}%
-It is a compile-time error if a collection literal element in a constant set literal
+It is a compile-time error if
+a collection literal element in a constant set literal
 is not a constant expression.
 It is a compile-time error if
-the operator \lit{==} of an element expression in a constant map literal
+the operator \lit{==} of an element expression in a constant set literal
 is not primitive
 (\ref{theOperatorEqualsEquals}).
 It is a compile-time error if two elements of a constant set literal are equal

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -7126,6 +7126,13 @@ or it may be a computational element specifying
 how to obtain zero or more entities,
 of the form \synt{ifElement} or \synt{forElement}.
 
+\commentary{%
+Terms derived from \synt{element},
+and the ability to build collections from them,
+is also known as
+\Index{UI-as-code}.%
+}
+
 \LMHash{}%
 The \Index{leaf elements} of an element $\ell$ derived from
 \synt{expressionElement} or \synt{mapElement}

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -4302,7 +4302,7 @@ Assume that $S$ is a type and $G$ is a raw type such that $S$ implements $G$.
 Per definition there exist types \List{U}{1}{s} such that
 \code{$G$<\List{U}{1}{s}>} is a superinterface of $S$.
 We then say that \List{U}{1}{s} are the
-\IndexCustom{actual type arguments of $S$ at $G$}{
+\IndexCustom{actual type arguments of $S$ at $G$}{%
   type arguments!of a type at a raw type},
 and we say that $U_j$ is the
 \IndexCustom{$j$th actual type argument of $S$ at $G$}{%
@@ -7072,7 +7072,7 @@ This section specifies several literal expressions denoting collections.
 Some syntactic forms may denote more than one kind of collection,
 in which case a disambiguation step is performed
 in order to determine the kind
-(\ref{setAndMapLiteralDisambigutation}).
+(\ref{setAndMapLiteralDisambiguation}).
 
 \begin{grammar}
 <listLiteral> ::= \CONST{}? <typeArguments>? `[' <elements>? `]'
@@ -7126,19 +7126,76 @@ is the union of the leaf elements of $\ell_1$ and $\ell_2$.
 The leaf elements of a \synt{spreadElement} is the empty set.
 
 \commentary{%
-The leaf elements is always a set of expression elements and/or map elements.%
+The leaf elements of a collection literal is always
+a set of expression elements and/or map elements.%
 }
 
 \LMHash{}%
-It is a compile-time error if the leaf elements of a \synt{listLiteral}
-contains a \synt{mapElement}.
+In order to allow collection literals to occur as constant expressions,
+we specify what it means for an element $\ell$
+to be constant or potentially constant:
+
+\begin{itemize}
+\item
+  $\ell$ is a potentially constant respectively constant element
+  if it is derived from \synt{expressionElement},
+  of the form $e$,
+  and $e$ is a potentially constant respectively constant expression.
+\item
+  $\ell$ is a potentially constant respectively constant element
+  if it is derived from \synt{mapElement},
+  of the form \code{$e_1$:\,$e_2$},
+  and both $e_1$ and $e_2$ are
+  potentially constant respectively constant expressions.
+\item
+  Assume that $\ell$ is derived from \synt{spreadElement},
+  of the form `\code{...$e$}' or `\code{...?$e$}'.
+
+  $\ell$ is a potentially constant element
+  if $e$ is a potentially constant expression.
+
+  $\ell$ is a constant element
+  if $e$ is a constant expression that evaluates
+  to a \code{List}, \code{Set} or \code{Map} instance
+  originally created by a list, set or map literal.
+
+  Moreover, $\ell$ is a constant element if it is `\code{...?$e$}',
+  where $e$ is a constant expression that evaluates
+  to the null object.
+\item
+  Assume that $\ell$ is derived from \synt{ifElement},
+  of the form
+  \code{\IF\,\,($b$)\,\,$\ell_1$}
+  or the form
+  \code{\IF\,\,($b$)\,\,$\ell_1$\,\,\ELSE\,\,$\ell_2$}.
+
+  $\ell$ is a potentially constant element
+  if $b$ is a potentially constant expression
+  and $\ell_1$ as well as $\ell_2$, if present,
+  are potentially constant.
+
+  Assume that $\ell$ is \code{\IF\,\,($b$)\,\,$\ell_1$}.
+  Then $\ell$ is a constant element
+  if $b$ is a constant expression that evaluates to \TRUE{}
+  and $\ell_1$ is constant;
+  and it is a constant element
+  if $b$ is a constant expression that evaluates to \FALSE{}
+  and $\ell_1$ is potentially constant.
+
+  Otherwise, $\ell$ is
+  \code{\IF\,\,($b$)\,\,$\ell_1$\,\,\ELSE\,\,$\ell_2$}.
+  Then $\ell$ is a constant element
+  if $b$ is a constant expression that evaluates to \TRUE,
+  $\ell_1$ is constant,
+  and $\ell_2$ is potentially constant;
+  and it is a constant element
+  if $b$ is a constant expression that evaluates to \FALSE,
+  $\ell_1$ is potentially constant,
+  and $\ell_2$ is constant.
+\end{itemize}
 
 \commentary{%
-It is also a compile-time error if a set literal contains a \synt{mapElement},
-or a map literal contains an \synt{expressionElement},
-but this is only detected during the disambiguation process
-where it is determined which kind of collection
-a given \synt{setOrMapLiteral} denotes.%
+A \synt{forElement} can never occur in a constant collection literal.%
 }
 
 
@@ -7329,7 +7386,7 @@ also called an \NoIndex{object sequence} when no ambiguity can arise.
 \LMHash{}%
 We use the notation
 \IndexCustom{\LiteralSequence{\ldots}}{[[...]]@\LiteralSequence{\ldots}}
-to denote an object sequence of specific elements,
+to denote an object sequence with explicitly listed elements,
 and we use `$+$' to compute the concatenation of object sequences
 (\commentary{as in $s_1 + s_2$}),
 which is an operation that will succeed and has no side-effects.
@@ -7350,7 +7407,7 @@ For each kind of collection the sequence is used in the given order
 to populate the collection,
 in a manner which is specific to the kind,
 and which is specified separately
-(\ref{lists}, \ref{maps}, \ref{sets}).%
+(\ref{lists}, \ref{sets}, \ref{maps}).%
 
 There may be an actual data structure
 representing the object sequence at run time,
@@ -7416,8 +7473,8 @@ part of the evaluation of \EvaluateElement{\ell}.
 When a pseudo-statement of the form
 \code{$\EvaluateElement{\ell} := s$;}
 occurs in normative code below,
-at a point where the computation is complete,
-it specifies that the value of \EvaluateElement{\ell} is $s$.
+it occurs at a point where the computation is complete
+and it specifies that the value of \EvaluateElement{\ell} is $s$.
 \IndexCustom{Evaluation of a collection literal element $\ell$}{%
   collection literal element!evaluation}
 in the given context
@@ -7426,16 +7483,16 @@ is then specified as follows:
 
 \LMHash{}%
 \Case{Expression element}
-When $\ell$ is an \synt{expressionElement} of the form $e$,
-$e$ is evaluated to an object $o$,
+In this case $\ell$ is an expression $e$;
+$e$ is evaluated to an object $o$
 and $\EvaluateElement{\ell} := \LiteralSequence{o}$.
 \EndCase
 
 \LMHash{}%
 \Case{Map element}
-When $\ell$ is a \synt{mapElement} of the form
-\code{$e_1$:\,\,$e_2$},
-$e_1$ is evaluated to an object $o_1$,
+In this case $\ell$ is pair of expressions
+\code{$e_1$:$e_2$};
+first $e_1$ is evaluated to an object $o_1$,
 then $e_2$ is evaluated to an object $o_2$,
 and $\EvaluateElement{\ell} := \LiteralSequence{o_1:o_2}$.
 \EndCase
@@ -7446,14 +7503,14 @@ The element $\ell$ is of the form `\code{...$e$}' or `\code{...?$e$}'.
 Evaluate $e$ to an object $o_{\metavar{spread}}$.
 \begin{enumerate}
 \item
-  When $\ell$ is `\code{...?$e$}':
-  If $o_{\metavar{spread}}$ is the null object then
-  $\EvaluateElement{\ell} := \LiteralSequence{}$.
-  Otherwise evaluation proceeds with step 2.
-
   When $\ell$ is `\code{...$e$}':
   %% TODO(eernst): Come NNBD, this error cannot occur any more: delete.
   If $o_{\metavar{spread}}$ is the null object then a dynamic error occurs.
+  Otherwise evaluation proceeds with step 2.
+
+  When $\ell$ is `\code{...?$e$}':
+  If $o_{\metavar{spread}}$ is the null object then
+  $\EvaluateElement{\ell} := \LiteralSequence{}$.
   Otherwise evaluation proceeds with step 2.
 \item
   Let $T_{\metavar{spread}}$ be the dynamic type of $o_{\metavar{spread}}$.
@@ -7612,150 +7669,143 @@ $\EvaluateElement{\ell} := s$;
 \subsubsection{List Literal Inference}
 \LMLabel{listLiteralInference}
 
-!!!HERE!!! Raw from feature spec.
+\LMHash{}%
+This section specifies how a list literal \metavar{list} is traversed and an
+\IndexCustom{inferred element type}{list literal!element type}
+for \metavar{list} is determined.
+We specify first how to infer the element type of a single element,
+then how to use that result to infer
+the element type of \metavar{list} as a whole.
 
 \LMHash{}%
-Inference for list literals mostly follows that of set literals
-without the complexity around disambiguation with maps and
-using \code{List} or \code{Iterable} in a few places instead of \code{Set}.
-
-\LMHash{}%
-Inside a \synt{listLiteral} \metavar{listLiteral},
-the inferred type of an element $\ell$ is a list element type $T$.
-It is computed relative to a downwards element context type $P$,
-where $P$ is $T$
-if downwards inference constrains the type of \metavar{listLiteral}
-to \code{Iterable<$T$>} for some $T$.
+The context type $P$
+(\ref{setAndMapLiteralDisambiguation})
+for each element of \metavar{list} is
+obtained from the context type of \metavar{list}.
+If downwards inference constrains the type of \metavar{list}
+to \code{Iterable<$P_e$>} for some $P_e$ then $P$ is $P_e$.
 Otherwise, $P$ is \FreeContext{}.
+
+\LMHash{}%
+Let $\ell$ be a term derived from \synt{element}.
+Inference of the element type of $\ell$ with context type $P$
+proceeds as follows,
+where the context type for an element type is always $P$
+unless anything is said to the contrary:
+
+\LMHash{}%
+\Case{Expression element}
+In this case $\ell$ is an expression $e$.
+The inferred element type of $\ell$ is
+% The type of $e$ is not an element type, so we mention $P$.
+the inferred type of $e$ in context $P$.
+\EndCase
+
+\LMHash{}%
+\Case{Map element}
+In this case, a compile-time error occurs.
+\commentary{%
+A list literal can never contain a map element.%
+}
+\EndCase
+
+\LMHash{}%
+\Case{Spread element}
+Let $e$ be the expression of $\ell$.
+If $\ell$ is `\code{...$e$}',
+let $S$ be the inferred type of $e$ in context \code{Iterable<$P$>}.
+Otherwise
+(\commentary{when $\ell$ is `\code{...?$e$}'}),
+let $S$ be the non-nullable type of
+%% TODO(eernst): Clarify whether inference will indeed have that context;
+%% it is clear that we need to eliminate `Null` from $S$, and also that $e$
+%% is allowed to have a potentially nullable type, and it seems inconvenient
+%% if we use `Iterable<$P$>` as context type and fail in the case where $e$,
+%% say, has type `List<$U$>?` for some $U$.
+the inferred type of $e$ in context \code{Iterable<$P$>?}.
 
 \begin{itemize}
 \item
-  If $\ell$ is an \synt{expressionElement} with expression $e_1$:
-  \begin{itemize}
-  \item
-    The inferred list element type of $\ell$ is
-    the inferred type of the expression $e_1$ in context $P$.
-  \end{itemize}
+  If $S$ implements \code{Iterable},
+  the inferred element type of $\ell$ is
+  the type argument of $S$ at \code{Iterable}.
 \item
-  If $\ell$ is a \synt{spreadElement} with expression $e_1$:
-
-  \begin{itemize}
-  \item
-    If $P$ is \FreeContext{} then let $S$ be
-    the inferred type of $e_1$ in context \FreeContext{}:
-
-    \begin{itemize}
-    \item
-      If $S$ is a non-\code{Null} subtype of \code{Iterable<Object>}, then
-      the inferred list element type of $\ell$ is $T$ where $T$ is
-      the type such that \code{Iterable<$T$>} is
-      a superinterface of $S$
-      (\commentary{%
-        the result of constraint matching for $X$ using
-        the constraint \code{$S$ <: Iterable<$X$>}}).
-
-      \begin{itemize}
-      \item
-        If $S$ is \DYNAMIC{}, then
-        the inferred list element type of $\ell$ is \DYNAMIC{}.
-      \item
-        If $S$ is \code{Null} and the spread operator is \lit{...?}, then
-        the list element type is \code{Null}.
-      \item
-        Otherwise it is an error
-        (\commentary{%
-          because it is a spread of a non-spreadable type like Object%
-        }).
-      \end{itemize}
-    \item
-      Else, let $S$ be
-      the inferred type of $e_1$ in context \code{Iterable<$P$>}:
-
-      \begin{itemize}
-      \item
-        If $S$ is a non-\code{Null} subtype of \code{Iterable<Object>}, then
-        the inferred list element type of $\ell$ is $T$ where $T$ is
-        the type such that \code{Iterable<$T$>} is
-        a superinterface of $S$
-        (\commentary{%
-          the result of constraint matching for $X$ using
-          the constraint \code{$S$ <: Iterable<$X$>}%
-        }).
-      \item
-        If $S$ is \DYNAMIC{}, then
-        the inferred list element type of $\ell$ is \DYNAMIC{}.
-      \item
-        Otherwise it is an error.
-      \end{itemize}
-    \end{itemize}
-  \item
-    If $\ell$ is an \synt{ifElement} with one $\ell$, $p1$,
-    and no "else" element:
-    The condition is inferred with a context type of \code{bool}.
-
-    The inferred list element type of $\ell$ is
-    the inferred list element type of $p1$ with element context type $P$.
-  \item
-    If $\ell$ is a \synt{ifElement} with two $\ell$s, $p1$ and $p2$:
-    The condition is inferred with a context type of \code{bool}.
-
-    The inferred list element type of $\ell$ is
-    the least upper bound of $S1$ and $S2$ where $S1$ is
-    the inferred list element type of $p1$ and $S2$ is
-    the inferred list element type of $p2$,
-    both with element context type $P$.
-
-  \item
-    If $\ell$ is a \synt{forElement} with $\ell$ $p1$ then:
-
-    Inference for the iterated expression and the controlling variable
-    is done as for the corresponding \FOR{} or \AWAIT{} \FOR{} statement.
-
-    The inferred list element type of $\ell$ is the inferred list element
-    type of $p1$ with element context type $P$.
-  \end{itemize}
+  If $S$ is \DYNAMIC{},
+  the inferred element type of $\ell$ is \DYNAMIC.
+\item
+  If $S$ is \code{Null} and the spread operator is \lit{...?},
+  the inferred element type of $\ell$ is \code{Null}.
+\item
+  Otherwise, a compile-time error occurs.
 \end{itemize}
-
-\commentary{%
-Note: $\ell$ cannot be a \synt{mapElement} as
-those are not allowed inside list literals.%
-}
+\vspace{-5mm}
+\EndCase
 
 \LMHash{}%
-Finally, we define inference on a \synt{listLiteral} \metavar{collection}
-as follows:
+\Case{If element}
+In this case $\ell$ is of the form
+\code{\IF\,\,($b$)\,\,$\ell_1$} or
+\code{\IF\,\,($b$)\,\,$\ell_1$\,\,\ELSE\,\,$\ell_2$}.
+The condition $b$ is always inferred with a context type of \code{bool}.
+
+Assume that \code{\ELSE\,\,$\ell_2$} is not present.
+Then, if the inferred element type of $\ell_1$ is $S$,
+the inferred element type of $\ell$ is $S$.
+
+Otherwise, \code{\ELSE\,\,$\ell_2$} is present.
+If the inferred element type of $\ell_1$ is $S_1$ and
+the inferred element type of $\ell_2$ is $S_2$,
+the inferred element type of $\ell$ is
+the least upper bound of $S_1$ and $S_2$.
+\EndCase
+
+\LMHash{}%
+\Case{For element}
+In this case $\ell$ is of the form
+\code{\AWAIT?\,\,\FOR\,\,($P$)\,\,$\ell_1$}
+where $P$ is derived from \synt{forLoopParts} and
+`\AWAIT?' indicates that \AWAIT{} may be present or absent.
+
+Inference for the parts
+(\commentary{%
+  such as the iterable expression of a for-in,
+  or the \synt{forInitializerStatement} of a for loop%
+})
+is done as for the corresponding \FOR{} statement,
+including \AWAIT{} if and only if the element includes \AWAIT.
+Then, if the inferred element type of $\ell_1$ is $S$,
+the inferred element type of $\ell$ is $S$.
+
+\commentary{%
+In other words, inference flows upwards from the body element.%
+}
+\vspace{3mm}
+\EndCase
+
+\LMHash{}%
+Finally, we define
+\IndexCustom{type inference on a list literal}{%
+  type inference!list literal}
+as a whole.
+Assume that \metavar{list} is derived from \synt{listLiteral}
+and contains the elements \List{\ell}{1}{n},
+and the context type for \metavar{list} is $P$.
 
 \begin{itemize}
 \item
   If $P$ is \FreeContext{} then
-  the static type of \metavar{collection} is \code{List<$T$>} where $T$ is
-  the least upper bound of the inferred list element types of the elements.
+  the static type of \metavar{list} is \code{List<$T$>},
+  where $T$ is the least upper bound of
+  the inferred element types of \List{\ell}{1}{n}.
 \item
-  Otherwise,
-  the static type of \metavar{collection} is \code{List<$T$>} where $T$ is
-  determined by downwards inference.
+  %% TODO(eernst): Feature spec says $P$, but how can we know that $P$ is a type?
+  Otherwise, the static type of \metavar{list} is \code{List<$T$>},
+  where $T$ is determined by downwards inference.
 \end{itemize}
-
-
-\subsubsection{List}
-\LMLabel{uiAsCodeList}
-
-!!!HERE!!! This should be moved into \ref{lists}.
-
-\LMHash{}%
-The result of the literal expression is a fresh instance of
-a class that implements \code{List<$E$>} where $E$ is
-the element type of the literal.
-It contains the values in \metavar{result}, in order.
-If the literal is constant,
-the list is canonicalized and immutable,
-otherwise it is not.
 
 
 \subsubsection{Lists}
 \LMLabel{lists}
-
-!!!HERE!!! Revise.
 
 \LMHash{}%
 A \IndexCustom{list literal}{literal!list}
@@ -7765,7 +7815,7 @@ The grammar rule for \synt{listLiteral} is specified elsewhere
 
 \LMHash{}%
 When a given list literal $e$ has no type arguments,
-the type argument $T$ is selected as specified below
+the type argument $T$ is selected as specified elsewhere
 (\ref{listLiteralInference}),
 and $e$ is henceforth treated as
 (\ref{notation})
@@ -7782,8 +7832,8 @@ using an index that is not a member of its set of indices.
 
 \LMHash{}%
 The sequence of elements of a given list literal
-is determined as described below
-(\ref{listEvaluation}).
+is determined by evaluation of its elements
+(\ref{collectionLiteralElementEvaluation}).
 
 \LMHash{}%
 If a list literal $\ell$ begins with the reserved word \CONST{}
@@ -7825,14 +7875,15 @@ so we cannot use type parameters inside constant expressions.%
 
 \LMHash{}%
 The value of a constant list literal
-\code{\CONST?\,\,<$E$>[$e_1, \ldots, e_n$]}
+\code{\CONST?\,\,<$E$>[$\ell_1, \ldots, \ell_n$]}
 is an object $a$ whose class implements the built-in class
 \code{List<$E$>}.
-Let $v_i$ be the value of the constant expression $e_i$, $i \in 1 .. n$.
+Let $s_i$ be the value of the constant expression $e_i$, $i \in 1 .. n$.
 The $i$th element of $a$ (at index $i - 1$) is $v_i$.
 %
 %% TODO(eernst): If inference is specified to provide all type arguments,
 %% we should delete the following.
+!!!HERE!!!
 The value of a constant list literal
 \code{\CONST?\,\,[$e_1, \ldots, e_n$]}
 is defined as the value of the constant list literal
@@ -7923,7 +7974,7 @@ is \code{List<\DYNAMIC>}.
 
 
 \subsubsection{Set and Map Literal Disambiguation}
-\LMLabel{setAndMapLiteralDisambigutation}
+\LMLabel{setAndMapLiteralDisambiguation}
 
 \LMHash{}%
 Some syntactic forms like \code{\{\}} and \code{\{...\id\}} are ambiguous:
@@ -8074,19 +8125,19 @@ derived from \synt{setOrMapLiteral}.
 The inferred type of an \synt{element} is an element type $T$,
 a pair of a key and value type $(K, V)$, or both.
 It is computed relative to a context type $P$
-(\ref{setAndMapLiteralDisambigutation}),
+(\ref{setAndMapLiteralDisambiguation}),
 which is determined as follows:
 
 \begin{itemize}
 \item
   If \metavar{collection} is unambiguously a set
-  (\ref{setAndMapLiteralDisambigutation})
+  (\ref{setAndMapLiteralDisambiguation})
   then $P$ is \code{Set<$P_e$>},
   %% TODO(eernst): Add reference when we specify inference.
   where $P_e$ is determined by downwards inference,
   and may be \FreeContext{}
   %% TODO(eernst): Correct this reference when we specify context types.
-  (\ref{setAndMapLiteralDisambigutation})
+  (\ref{setAndMapLiteralDisambiguation})
   if downwards inference does not constrain it.
 
   %% TODO(eernst): Remove this when we specify inference.
@@ -8173,7 +8224,7 @@ the inferred type of $e_v$ in context $P_v$.
 In this case $\ell$ is of the form
 `\code{...$e$}' or `\code{...?$e$}'.
 If $P$ is \FreeContext{} then let $S$ be
-the inferred type of $e_1$ in context \FreeContext.
+the inferred type of $e$ in context \FreeContext.
 Then:
 
 \begin{itemize}
@@ -8187,7 +8238,7 @@ Then:
     using the constraint $S\,\,<:\,\,\code{Iterable<$X$>}$.
     Note that when $S$ implements a class like \code{Map} or \code{Iterable},
     it cannot be a subtype of \code{Null}
-    (\ref{superinterfaces}).
+    (\ref{interfaceSuperinterfaces}).
   }
 \item
   If $S$ implements \code{Map},
@@ -8217,15 +8268,18 @@ Then:
   }
 \item
   If $S$ is \code{Null} and the spread operator is \lit{...?} then
-  the element has element type \code{Null},
-  and key and value type pair $(\code{Null}, \code{Null})$.
+  the inferred element type of $\ell$ is \code{Null},
+  and the inferred key and value type pair $(\code{Null}, \code{Null})$.
 \item
   Otherwise, a compile-time error occurs.
 \end{itemize}
 
 \noindent
+%% TODO(eernst): Clarify why we shouldn't be able to use a context type of
+%% `Iterable<$P_e$>` in the same way: infer $e$ in context `Iterable<$P_e$>`
+%% as well.
 Otherwise, if $P$ is \code{Set<$P_e$>} then let $S$ be
-the inferred type of $e_1$ in context \code{Iterable<$P_e$>}, and then:
+the inferred type of $e$ in context \code{Iterable<$P_e$>}, and then:
 
 \begin{itemize}
 \item
@@ -8248,7 +8302,7 @@ the inferred type of $e_1$ in context \code{Iterable<$P_e$>}, and then:
 
 \noindent
 Otherwise, if $P$ is \code{Map<$P_k$, $P_v$>} then let $S$ be
-the inferred type of $e_1$ in context $P$, and then:
+the inferred type of $e$ in context $P$, and then:
 
 \begin{itemize}
 \item
@@ -8373,8 +8427,8 @@ and the context type for \metavar{collection} is $P$.
     the inferred element types of the elements.
   \item
     %% TODO(eernst): Feature spec says $P$, but how can we know that $P$ is a type?
-    Otherwise, the static type of \metavar{collection} is
-    the greatest closure of $P$.
+    Otherwise, the static type of \metavar{collection} is $T$
+    where $T$ is determined by downwards inference.
 
     \commentary{%
       Note that the inference will never produce a key and value type pair

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -3,7 +3,6 @@
 \usepackage{epsfig}
 \usepackage{xcolor}
 \usepackage{syntax}
-\usepackage{amssymb}
 \usepackage[fleqn]{amsmath}
 \usepackage{amssymb}
 \usepackage{semantic}
@@ -4932,7 +4931,7 @@ This enables typechecking code such as:
 \}
 
 \CLASS{} Sorter<T \EXTENDS{} Ordered<T\gtgt{} \{
-   sort(List<T> l) {... l[n] < l[n+1] ...}
+   sort(List<T> l) \{... l[n] < l[n+1] ...\}
 \}
 
 \end{dartCode}
@@ -5931,10 +5930,8 @@ Every object has an associated dynamic type (\ref{dynamicTypeSystem}).
   \alt <numericLiteral>
   \alt <stringLiteral>
   \alt <symbolLiteral>
-  \alt <mapLiteral>
-  \alt <setLiteral>
-  \alt <setOrMapLiteral>
   \alt <listLiteral>
+  \alt <setOrMapLiteral>
 \end{grammar}
 
 \LMHash{}%
@@ -7022,16 +7019,85 @@ The fact that symbols are easy to type and can often act as convenient substitut
 The static type of a symbol literal is \code{Symbol}.
 
 
-\subsection{Lists}
+\subsection{Collection Literals}
+\LMLabel{collectionLiterals}
+
+\LMHash{}%
+This section specifies several literal expressions denoting collections.
+Some syntactic forms may denote more than one kind of collection,
+in which case a disambiguation step is performed
+in order to determine the kind
+(\ref{collectionLiteralDisambiguation}).
+
+\begin{grammar}
+<listLiteral> ::= \CONST{}? <typeArguments>? `[' <elements>? `]'
+
+<setOrMapLiteral> ::= \CONST{}? <typeArguments>? `{' <elements>? `}'
+
+<elements> ::= <element> (`,' <element>)* `,'?
+
+<element> ::= <expressionElement>
+  \alt <mapElement>
+  \alt <spreadElement>
+  \alt <ifElement>
+  \alt <forElement>
+
+<expressionElement> ::= <expression>
+
+<mapElement> ::= <expression> `:' <expression>
+
+<spreadElement> ::= (`...' | `...?') <expression>
+
+<ifElement> ::= \IF{} `(' <expression> `)' <element> (\ELSE{} <element>)?
+
+<forElement> ::= \AWAIT{}? \FOR{} `(' <forLoopParts> `)' <element>
+\end{grammar}
+
+\LMHash{}%
+Syntactically, a \Index{collection literal} can be
+a \synt{listLiteral} or a \synt{setOrMapLiteral}.
+The contents of the collection is specified as a sequence of
+\IndexCustom{collection literal elements}{collection literal!elements},
+in short \Index{elements}.
+Each element may be a declarative specification of a single entity,
+such as an \synt{expressionElement} or a \synt{mapElement},
+it may specify a collection which is to be included,
+of the form \synt{spreadElement},
+or it may be a computational element specifying zero or more entities,
+of the form \synt{ifElement} or \synt{forElement}.
+
+\LMHash{}%
+The \Index{leaf elements} of an element $\ell$ derived from
+\synt{expressionElement} or \synt{mapElement}
+is $\{\ell\}$.
+The leaf elements of an element of the form
+\code{\IF\,($e$)\,$\ell$} or
+\code{\FOR\,(\metavar{forLoopParts})\,$\ell$}
+is the leaf elements of $\ell$.
+The leaf elements of an element of the form
+\code{\IF\,($e$)\,$\ell_1$\,\ELSE\,$\ell_2$}
+is the union of the leaf elements of $\ell_1$ and $\ell_2$.
+The leaf elements of a \synt{spreadElement} is the empty set.
+
+\commentary{%
+The leaf elements is always a set of expression elements and/or map elements.%
+}
+
+\LMHash{}%
+It is a compile-time error if the leaf elements of a \synt{listLiteral}
+contains a \synt{mapElement}.
+
+
+\subsubsection{Lists}
 \LMLabel{lists}
+
+!!!HERE!!!
 
 \LMHash{}%
 A \IndexCustom{list literal}{literal!list}
 denotes a list, which is an integer indexed collection of objects.
-
-\begin{grammar}
-<listLiteral> ::= \CONST{}? <typeArguments>? `[' (<expressionList> `,'?)? `]'
-\end{grammar}
+The grammar rule for \synt{listLiteral} is specified elsewhere
+(\ref{collectionLiterals}).
 
 \LMHash{}%
 A list may contain zero or more objects.
@@ -7179,36 +7245,16 @@ or the form
 is \code{List<\DYNAMIC>}.
 
 
-\subsection{Maps}
+\subsubsection{Maps}
 \LMLabel{maps}
+
+!!!HERE!!!
 
 \LMHash{}%
 A \IndexCustom{map literal}{literal!map} denotes a map object.
-
-\begin{grammar}
-<mapLiteral> ::= \CONST{}? <typeArguments>?
-  \gnewline{} `{' <mapLiteralEntry> (`,' <mapLiteralEntry>)* `,'? `}'
-
-<mapLiteralEntry> ::= <expression> `:' <expression>
-
-<setOrMapLiteral> ::= \CONST{}? <typeArguments>? `{' `}'
-\end{grammar}
-
-\LMHash{}%
-A \synt{setOrMapLiteral} $e$ is either a set literal (\ref {sets}) or a map literal,
-determined by the type parameters or static context type.
-If $e$ has exactly one type argument, then it is a set literal.
-If $e$ has two type arguments, then it is a map literal.
-If $e$ has three or more type arguments, it is a compile-time error.
-If $e$ has \emph{no} type arguments,
-then let $S$ be the static context type of the literal.
-If $\futureOrBase{S}$ (\ref{typeFutureOr}) is a subtype of \code{Iterable<Object>}
-and $\futureOrBase{S}$ is not a subtype of \code{Map<Object, Object>},
-then $e$ is set literal,
-and otherwise it is a map literal.
-A map literal derived from \synt{setOrMapLiteral}
-is treated the same way as one derived from \synt{mapLiteral},
-as described below.
+The grammar rule for \synt{setOrMapLiteral} which covers both
+map literals and set literals occurs elsewhere
+(\ref{collectionLiterals}).
 
 \LMHash{}%
 A map literal consists of zero or more entries.
@@ -7357,23 +7403,16 @@ or the form
 \code{Map<\DYNAMIC, \DYNAMIC>}.
 
 
-\subsection{Sets}
+\subsubsection{Sets}
 \LMLabel{sets}
+
+!!!HERE!!!
 
 \LMHash{}%
 A \IndexCustom{set literal}{literal!set} denotes a set object.
-
-\begin{grammar}
-<setLiteral> ::= \CONST{}? <typeArguments>?
-  \gnewline{} `{' <expression> (`,' <expression>)* `,'? `\}'
-\end{grammar}
-
-\LMHash{}%
-A \synt{setOrMapLiteral} is either a set literal or a map literal
-(\ref{maps}).
-A set literal derived from \synt{setOrMapLiteral}
-is treated the same way as one derived from \synt{setLiteral},
-as described below.
+The grammar rule for \synt{setOrMapLiteral} which covers
+set literals as well as map literals occurs elsewhere
+(\ref{collectionLiterals}).
 
 \LMHash{}%
 A set literal consists of zero or more element expressions.
@@ -7511,6 +7550,784 @@ The static type of a list literal of the form
 or the form
 \code{\{$e_1, \ldots, e_n$\}}
 is \code{Set<\DYNAMIC>}.
+
+
+\subsubsection{Collection Literal Disambiguation}
+\LMLabel{collectionLiteralDisambiguation}
+
+\LMHash{}%
+Some syntactic forms like \code{\{\}} and \code{\{...\id\}} are ambiguous:
+they may be either a set literal or a map literal.
+This ambiguity is eliminated in two steps.
+The first step uses only the syntax and context type,
+%% TODO(eernst): Enable this reference when 'context type' gets defined.
+%% (\ref{contextType})
+and is described in this section.
+The second step uses expression types and is described next
+(\ref{collectionLiteralInference}).
+
+\LMHash{}%
+Let $e$ be a \synt{setOrMapLiteral}
+with leaf elements $\cal L$ and context type $C$.
+If $C$ is \FreeContext{} then let $S$ be undefined.
+%% TODO(eernst): Define 'greatest closure' of a context type
+%% when we define 'context type'.
+Otherwise let $S$ be the greatest closure of $\futureOrBase{C}$
+(\ref{typeFutureOr}).
+
+%% TODO(eernst): Delete when 'context type', 'greatest closure' are defined.
+\commentary{%
+A future version of this document will specify context types.
+The basic intuition is that a context type is the type declared for a
+\emph{receiving entity} such as
+a formal parameter $p$ or a declared variable $v$.
+That type will be the context type for
+an actual argument passed to $p$,
+respectively an initializing expression for $v$.
+In some situations the context has no constraints,
+e.g., when a variable is declared with \VAR{} rather than a type annotation.
+This gives rise to an unconstrained context type, \FreeContext{},
+which may also occur in a composite term, e.g., \code{List<\FreeContext>}.
+%
+The greatest closure of a context type $C$ is a supertype of all types
+obtainable by replacing \FreeContext{} by a type.%
+}
+
+\LMHash{}%
+The disambiguation step of this section is
+the first applicable entry in the following list:
+
+\begin{itemize}
+\item $e$ has \synt{typeArguments}:
+  With exactly one type argument $T$,
+  $e$ is a set literal with static type \code{Set<$T$>}.
+  With exactly two type arguments $K$ and $V$,
+  $e$ is a map literal with static type \code{Map<$K$, $V$>}.
+  With any other number of type arguments a compile-time error occurs.
+\item
+  $S <: \code{Iterable<Object>} \wedge S \not<: \code{Map<Object, Object>}$:
+  $e$ is a set literal.
+\item
+  $S <: \code{Map<Object, Object>} \wedge S \not<: \code{Iterable<Object>}$:
+  $e$ is a map literal.
+\item
+  ${\cal L} \not= \emptyset$ (\commentary{$e$ has leaf elements}):
+  When $\cal L$ contains an \synt{expressionElement} but no \synt{mapElement},
+  $e$ is a set literal.
+  When $\cal L$ contains a \synt{mapElement} but no \synt{expressionElement},
+  $e$ is a map literal.
+  When $\cal L$ contains both a \synt{mapElement} and an \synt{expressionElement},
+  a compile-time error occurs.
+\item
+  $e$ has no \synt{typeArguments}, no elements, and $S$ is undefined:
+  $e$ is a map literal.
+  \commentary{%
+    In other words, an empty \code{\{\}} is a map ``by default''.%
+  }
+\item
+  Otherwise, $e$ is still ambiguous.
+  \commentary{%
+    This can only happen when $e$ is non-empty and $\cal L$ is empty.
+    It contains only spreads, possibly wrapped in
+    \synt{ifElement}s or \synt{forElement}s.
+    In this case disambiguation occurs during type inference
+    (\ref{collectionLiteralInference}).%
+  }
+\end{itemize}
+
+\commentary{%
+When this step does not determine a static type,
+it will be determined by type inference
+(\ref{collectionLiteralInference}).%
+}
+
+\LMHash{}%
+If this process successfully disambiguates the literal
+then we say that $e$ is
+\IndexCustom{unambiguously a map}{map!unambiguously}
+or
+\IndexCustom{unambiguously a set}{set!unambiguously},
+as appropriate.
+
+
+\subsubsection{Collection Literal Inference}
+\LMLabel{collectionLiteralInference}
+
+\paragraph{Maps and sets}
+\LMLabel{uiAsCodeMapsAndSets}
+
+\LMHash{}%
+We perform inference on the literal,
+and collect up either a set element type
+(\commentary{indicating that the literal may/must be a set}),
+or a pair of a key type and a value type
+(\commentary{indicating that the literal may/must be a map}),
+or both.
+We allow both, because spreads of expressions of type \DYNAMIC{}
+do not disambiguate,
+and can be treated as either
+(\commentary{%
+it becomes a runtime error to spread a value into the wrong kind of literal%
+}).
+
+\LMHash{}%
+We require that
+at least one component unambiguously determine the literal form,
+otherwise it is a compile-time error.
+So, given:
+
+\begin{dartCode}
+\DYNAMIC{} x = <int, int>\{\};
+Iterable l = [];
+Map m = {};
+\end{dartCode}
+
+\LMHash{}%
+Then:
+
+\begin{dartCode}
+\{...x\}       // \comment{Static error, because it is ambiguous.}
+\{...x, ...l\} // \comment{Statically a set, runtime error when spreading x.}
+\{...x, ...m\} // \comment{Statically a map, no runtime error.}
+\{...l, ...m\} // \comment{Static error, because it must be both a set and a map.}
+\end{dartCode}
+
+\LMHash{}%
+In a \synt{setOrMapLiteral} \metavar{collection},
+the inferred type of an \synt{element} is a set element type $T$,
+a pair of a key type $K$ and a value type $V$, or both.
+It is computed relative to a context type $P$:
+
+\begin{itemize}
+\item
+  If \metavar{collection} is unambiguously a set literal,
+  then $P$ is \code{Set<Pe>} where $Pe$ is determined by downwards inference,
+  and may be \lit{?} if downwards inference does not constrain it.
+\item
+  If \metavar{collection} is unambiguously a map literal
+  then $P$ is \code{Map<$Pk$, $Pv$>}
+  where $Pk$ and $Pv$ are determined by downwards inference,
+  and may be \lit{?}
+  if the downwards context does not constrain one or both.
+\item
+  Otherwise, \metavar{collection} is ambiguous,
+  and the downwards context for the elements of \metavar{collection} is lit{?}.
+\end{itemize}
+
+\LMHash{}%
+We say that an element
+\IndexCustom{can be a set}{element!can be a set}
+if it has a set element type.
+Likewise, an element
+\IndexCustom{can be a map}{element!can be a map}
+if it has a key and value type.
+We say that an element
+\IndexCustom{must be a set}{element!must be a set}
+if it can be a set and has and no key type or value type.
+We say that an element
+\IndexCustom{must be a map}{element!must be a map}
+if can be a map and has no set element type.
+
+\LMHash{}%
+To infer the type of $\ell$:
+
+\begin{itemize}
+\item
+  If $\ell$ is an \synt{expressionElement} with expression $e1$:
+  \begin{itemize}
+  \item
+    If $P$ is \lit{?} then the inferred set element type of $\ell$ is
+    the inferred type of the expression $e1$ in context \lit{?}.
+  \item
+    If $P$ is \code{Set<$Ps$>} then the inferred set element type of $\ell$ is
+    the inferred type of the expression $e1$ in context $Ps$.
+  \end{itemize}
+\item
+  If $\ell$ is a \synt{mapElement} \code{$ek$:\,\,$ev$}:
+  \begin{itemize}
+  \item
+    If $P$ is \lit{?} then the inferred key type of $\ell$ is
+    the inferred type of $ek$ in context \lit{?} and
+    the inferred value type of $\ell$ is
+    the inferred type of $ev$ in context \lit{?}.
+  \item
+    If $P$ is \code{Map<$Pk$, $Pv$>} then
+    the inferred key type of $\ell$ is
+    the inferred type of $ek$ in context $Pk$ and
+    the inferred value type of $\ell$ is
+    the inferred type of $ev$ in context $Pv$.
+  \end{itemize}
+\item
+  If $\ell$ is a \synt{spreadElement} with expression $e1$:
+  \begin{itemize}
+  \item
+    If $P$ is \lit{?} then let $S$ be
+    the inferred type of $e1$ in context \lit{?}:
+    \begin{itemize}
+    \item
+      If $S$ is a non-\code{Null} subtype of \code{Iterable<Object>}, then
+      the inferred set element type of $\ell$ is $T$
+      where $T$ is the type such that \code{Iterable<$T$>} is
+      a superinterface of $S$
+      (\commentary{
+        the result of constraint matching for $X$ using the constraint
+        \code{$S$ <: Iterable<$X$>}}).
+    \item
+      If $S$ is a non-\code{Null} subtype of \code{Map<Object, Object>}, then
+      the inferred key type of $\ell$ is $K$ and
+      the inferred value type of $\ell$ is $V$,
+      where $K$ and $V$ are the types such that \code{Map<$K$, $V$>} is
+      a superinterface of $S$
+      (\commentary{%
+        the result of constraint matching for $X$ and $Y$ using
+        the constraint \code{$S$ <: Map<$X$, $Y$>}%
+      }).
+
+      \commentary{%
+        Note that both this and the previous case can match on
+        the same element if $S$ is a subtype of
+        both \code{Iterable<Object>} and \code{Map<Object, Object>}.
+        In that case, we rely on other elements to disambiguate.%
+      }
+    \item
+      If $S$ is \DYNAMIC{}, then
+      the inferred set element type of $\ell$ is \DYNAMIC{},
+      the inferred key type of $\ell$ is \DYNAMIC{}, and
+      the inferred value type of $\ell$ is \DYNAMIC{}.
+
+      \commentary{%
+        We produce both a set element type here,
+        and a key/value pair here
+        and rely on other elements to disambiguate.%
+      }
+    \item
+      If $S$ is \code{Null} and the spread operator is \lit{...?} then
+      the element has set element type \code{Null},
+      map key type \code{Null} and map value type \code{Null}.
+    \item
+      If none of these cases match, it is an error.
+    \end{itemize}
+  \item
+    If $P$ is \code{Set<$Ps$>} then let $S$ be
+    the inferred type of $e1$ in context \code{Iterable<$Ps$>}:
+    \begin{itemize}
+    \item
+      If $S$ is a non-\code{Null} subtype of \code{Iterable<Object>}, then
+      the inferred set element type of $\ell$ is $T$
+      where $T$ is the type such that \code{Iterable<T>} is
+      a superinterface of $S$
+      (\commentary{%
+        the result of constraint matching for $X$ using
+        the constraint \code{$S$ <: Iterable<$X$>}}).
+    \item
+      If $S$ is \DYNAMIC{}, then
+      the inferred set element type of $\ell$ is \DYNAMIC{}.
+    \item
+      If $S$ is \code{Null} and the spread operator is \lit{...?}, then
+      the set element type is \code{Null}.
+    \item
+      Otherwise it is an error.
+    \end{itemize}
+  \item
+    If $P$ is \code{Map<$Pk$, $Pv$>} then let $S$ be
+    the inferred type of $e1$ in context $P$:
+    \begin{itemize}
+    \item
+      If $S$ is a non-\code{Null} subtype of \code{Map<Object, Object>}, then
+      the inferred key type of $\ell$ is $K$ and
+      the inferred value type of $\ell$ is $V$,
+      where $K$ and $V$ are the types such that \code{Map<$K$, $V$>} is
+      a superinterface of $S$
+      (\commentary{%
+        the result of constraint matching for $X$ and $Y$ using
+        the constraint \code{$S$ <: Map<$X$, $Y$>}}).
+    \item
+      If $S$ is \DYNAMIC{}, then
+      the inferred key type of $\ell$ is \DYNAMIC{}, and
+      the inferred value type of $\ell$ is \DYNAMIC{}.
+    \item
+      If $S$ is \code{Null} and the spread operator is \lit{...?}, then
+      the key and value element types are \code{Null}.
+    \item
+      Otherwise it is an error.
+    \end{itemize}
+  \end{itemize}
+\item
+  If $\ell$ is an \synt{ifElement} with one $\ell$, $p1$, and no "else"
+  element:
+  The condition is inferred with a context type of \code{bool}.
+  \begin{itemize}
+  \item
+    If the inferred set element type of $p1$ is $S$ then
+    the inferred set element type of $\ell$ is $S$.
+  \item
+    If the inferred key type of $p1$ is $K$ and
+    the inferred value type of $p1$ is $V$ then
+    the inferred key and value types of $\ell$ are $K$ and $V$.
+
+    \commentary{%
+      Note that both of the above cases can simultaneously apply
+      because of \DYNAMIC{} spreads.%
+    }
+  \end{itemize}
+\item
+  If $\ell$ is an \synt{ifElement} with two elements $e1$ and $e2$:
+
+  The condition is inferred with a context type of \code{bool}.
+
+  It is a compile error if $e1$ must be a set and $e2$ must be a map
+  or vice versa.
+
+  \commentary{%
+    In other words, you can't spread
+    a map on one branch and a set on the other.
+    Since \DYNAMIC{} provides both set and map key/value types,
+    a \DYNAMIC{} in either branch does not run into this case.%
+  }
+  \begin{itemize}
+  \item
+    If the inferred set element type of $e1$ is $S1$ and
+    the inferred set element type of $e2$ is $S2$ then
+    the inferred set element type of $\ell$ is
+    the least upper bound of $S1$ and $S2$.
+  \item
+    If the inferred key type of $e1$ is $K1$ and
+    the inferred key type of $e1$ is $V1$ and
+    the inferred key type of $e2$ is $K2$ and
+    the inferred key type of $e2$ is $V2$ then
+    the inferred key type of $\ell$ is
+    the least upper bound of $K1$ and $K2$ and
+    the inferred value type is the least upper bound of $V1$ and $V2$.
+
+    \commentary{%
+      Note that both of the above cases can simultaneously apply
+      because of \DYNAMIC{} spreads.%
+    }
+  \end{itemize}
+\item
+  If $\ell$ is a \synt{forElement} with $\ell$ $e1$ then:
+
+  Inference for the iterated expression and the controlling variable is done
+  as for the corresponding \FOR{} or \AWAIT{} \FOR{} statement.
+
+  \begin{itemize}
+  \item
+    If the inferred set element type of $e1$ is $S$ then
+    the inferred set element type of $\ell$ is $S$.
+  \item
+    If the inferred key type of $e1$ is $K$ and
+    the inferred key type of $e1$ is $V$ then
+    the inferred key and value types of $\ell$ are $K$ and $V$.
+
+    \commentary{%
+      In other words, inference flows upwards from the body element.
+      Note that both of the above cases can validly apply
+      because of \DYNAMIC{} spreads.%
+    }
+  \end{itemize}
+\end{itemize}
+
+\LMHash{}%
+Finally, we define inference on a \synt{setOrMapLiteral} \metavar{collection}
+as follows:
+
+\begin{itemize}
+\item
+  If \metavar{collection} is unambiguously a set literal:
+
+  \begin{itemize}
+  \item
+    If $P$ is \lit{?} then
+    the static type of \metavar{collection} is \code{Set<$T$>} where $T$ is
+    the least upper bound of the inferred set element types of the elements.
+  \item
+    Otherwise, the static type of \metavar{collection} is $P$.
+
+    \commentary{%
+      Note that the element inference will never produce a key/value type here
+      given that downwards context.%
+    }
+  \end{itemize}
+\item
+  Else, if \metavar{collection} is unambiguously a map literal
+  where $P$ is \code{Map<$Pk$, $Pv$>}:
+
+  \begin{itemize}
+  \item
+    If $Pk$ is \lit{?} then
+    the static key type of \metavar{collection} is $K$ where $K$ is
+    the least upper bound of the inferred key types of the elements.
+
+  \item
+    Otherwise the static key type of \metavar{collection} is $K$ where $K$ is
+    determined by downwards inference.
+  \end{itemize}
+
+  And:
+
+  \begin{itemize}
+  \item
+    If $Pv$ is \lit{?} then
+    the static value type of \metavar{collection} is $V$ where $V$ is
+    the least upper bound of the inferred value types of the elements.
+  \item
+    Otherwise the static value type of \metavar{collection} is $V$ where $V$ is
+    determined by downwards inference.
+
+    The static type of \metavar{collection} is \code{Map<$K$, $V$>}.
+
+    \commentary{%
+      Note that the element inference will never produce a set element type here
+      given this downwards context.%
+    }
+  \end{itemize}
+\item
+  Otherwise, \metavar{collection} is still ambiguous,
+  the downwards context for the elements of \metavar{collection} is \lit{?},
+  and the disambiguation is done using
+  the immediate elements of \metavar{collection} as follows:
+
+  \begin{itemize}
+  \item
+    If all elements can be a set,
+    and at least one element must be a set,
+    then \metavar{collection} is a set literal with
+    static type \code{Set<$T$>} where $T$ is
+    the least upper bound of the set element types of the elements.
+  \item
+    If all elements can be a map,
+    and at least one element must be a map, then $e$ is
+    a map literal with static type \code{Map<$K$, $V$>} where $K$ is
+    the least upper bound of the key types of the elements and $V$ is
+    the least upper bound of the value types.
+  \item
+    Otherwise, the literal cannot be disambiguated
+    and it is a compile-time error.
+  \end{itemize}
+\end{itemize}
+
+\commentary{%
+  This last case can occur if the literal \emph{must} be both a set and a map,
+  as in:%
+}
+
+\begin{dartCode}
+\VAR{} iterable = [1, 2];
+\VAR{} map = \{1: 2\};
+\VAR{} ambiguous = \{...iterable, ...map\};
+\end{dartCode}
+
+\commentary{%
+Or, if there is nothing indicates that it is \emph{either} a map or set:%
+}
+
+\begin{dartCode}
+\DYNAMIC{} dyn;
+\VAR{} ambiguous = \{...dyn\};
+\end{dartCode}
+
+
+\paragraph{Lists}
+
+\LMHash{}%
+Inference for list literals mostly follows that of set literals
+without the complexity around disambiguation with maps and
+using \code{List} or \code{Iterable} in a few places instead of \code{Set}.
+
+\LMHash{}%
+Inside a \synt{listLiteral} \metavar{listLiteral},
+the inferred type of an element $\ell$ is a list element type $T$.
+It is computed relative to a downwards element context type $P$,
+where $P$ is $T$
+if downwards inference constrains the type of \metavar{listLiteral}
+to \code{Iterable<$T$>} for some $T$.
+Otherwise, $P$ is \lit{?}.
+
+\begin{itemize}
+\item
+  If $\ell$ is an \synt{expressionElement} with expression $e1$:
+  \begin{itemize}
+  \item
+    The inferred list element type of $\ell$ is
+    the inferred type of the expression $e1$ in context $P$.
+  \end{itemize}
+\item
+  If $\ell$ is a \synt{spreadElement} with expression $e1$:
+
+  \begin{itemize}
+  \item
+    If $P$ is \lit{?} then let $S$ be
+    the inferred type of $e1$ in context \lit{?}:
+
+    \begin{itemize}
+    \item
+      If $S$ is a non-\code{Null} subtype of \code{Iterable<Object>}, then
+      the inferred list element type of $\ell$ is $T$ where $T$ is
+      the type such that \code{Iterable<$T$>} is
+      a superinterface of $S$
+      (\commentary{%
+        the result of constraint matching for $X$ using
+        the constraint \code{$S$ <: Iterable<$X$>}}).
+
+      \begin{itemize}
+      \item
+        If $S$ is \DYNAMIC{}, then
+        the inferred list element type of $\ell$ is \DYNAMIC{}.
+      \item
+        If $S$ is \code{Null} and the spread operator is \lit{...?}, then
+        the list element type is \code{Null}.
+      \item
+        Otherwise it is an error
+        (\commentary{%
+          because it is a spread of a non-spreadable type like Object%
+        }).
+      \end{itemize}
+    \item
+      Else, let $S$ be
+      the inferred type of $e1$ in context \code{Iterable<$P$>}:
+
+      \begin{itemize}
+      \item
+        If $S$ is a non-\code{Null} subtype of \code{Iterable<Object>}, then
+        the inferred list element type of $\ell$ is $T$ where $T$ is
+        the type such that \code{Iterable<$T$>} is
+        a superinterface of $S$
+        (\commentary{%
+          the result of constraint matching for $X$ using
+          the constraint \code{$S$ <: Iterable<$X$>}%
+        }).
+      \item
+        If $S$ is \DYNAMIC{}, then
+        the inferred list element type of $\ell$ is \DYNAMIC{}.
+      \item
+        Otherwise it is an error.
+      \end{itemize}
+    \end{itemize}
+  \item
+    If $\ell$ is an \synt{ifElement} with one $\ell$, $p1$,
+    and no "else" element:
+    The condition is inferred with a context type of \code{bool}.
+
+    The inferred list element type of $\ell$ is
+    the inferred list element type of $p1$ with element context type $P$.
+  \item
+    If $\ell$ is a \synt{ifElement} with two $\ell$s, $p1$ and $p2$:
+    The condition is inferred with a context type of \code{bool}.
+
+    The inferred list element type of $\ell$ is
+    the least upper bound of $S1$ and $S2$ where $S1$ is
+    the inferred list element type of $p1$ and $S2$ is
+    the inferred list element type of $p2$,
+    both with element context type $P$.
+
+  \item
+    If $\ell$ is a \synt{forElement} with $\ell$ $p1$ then:
+
+    Inference for the iterated expression and the controlling variable
+    is done as for the corresponding \FOR{} or \AWAIT{} \FOR{} statement.
+
+    The inferred list element type of $\ell$ is the inferred list element
+    type of $p1$ with element context type $P$.
+  \end{itemize}
+\end{itemize}
+
+\commentary{%
+Note: $\ell$ cannot be a \synt{mapElement} as
+those are not allowed inside list literals.%
+}
+
+\LMHash{}%
+Finally, we define inference on a \synt{listLiteral} \metavar{collection}
+as follows:
+
+\begin{itemize}
+\item
+  If $P$ is \lit{?} then
+  the static type of \metavar{collection} is \code{List<$T$>} where $T$ is
+  the least upper bound of the inferred list element types of the elements.
+\item
+  Otherwise,
+  the static type of \metavar{collection} is \code{List<$T$>} where $T$ is
+  determined by downwards inference.
+\end{itemize}
+
+
+\subsubsection{Type promotion}
+\LMLabel{uiAsCodeTypePromotion}
+
+\LMHash{}%
+An \synt{ifElement} interacts with type promotion in
+the same way that \IF{} statements do.
+Given an \synt{ifElement} with condition \metavar{condition},
+then element \metavar{thenElement} and
+optional else element \metavar{elseElement}:
+
+\begin{itemize}
+\item
+  If \metavar{condition} shows that a local variable $v$ has type $T$, then
+  the type of $v$ is known to be $T$ in \metavar{thenElement},
+  unless any of the following are true:
+
+  \begin{itemize}
+  \item $v$ is potentially mutated in \metavar{thenElement},
+  \item $v$ is potentially mutated within a function
+    other than the one where $v$ is declared, or
+    \begin{itemize}
+    \item $v$ is accessed by a function defined in \metavar{thenElement}, and
+    \item $v$ is potentially mutated anywhere in the scope of $v$.
+    \end{itemize}
+  \end{itemize}
+\end{itemize}
+
+\commentary{%
+Note: The type promotion rules for \IF{} will likely get more sophisticated
+in a future version of Dart because of non-nullable types.
+When that happens,
+\synt{ifElements} should continue to match \IF{} statements.%
+}
+
+
+\subsubsection{Compile-time errors}
+\LMLabel{uiAsCodeCompileTimeErrors}
+
+\LMHash{}%
+After type inference and disambiguation,
+the collection is checked for other compile-time errors.
+It is a compile-time error if:
+
+%% TODO(eernst): Find a way to show Dart code examples inside itemize below.
+
+\begin{itemize}
+\item
+  The collection is a map literal and leaf elements contains any
+  \synt{expressionElement} elements.
+
+  \begin{dartCode}
+    <String, int>\{"not entry"\} // Error.
+  \end{dartCode}
+\item
+  The collection is a set literal and
+  leaf elements contains any \synt{mapElement} elements.
+
+  \begin{dartCode}
+    ["not": "expression"] // Error.
+    <String>\{"not": "expression"\} // Error.
+  \end{dartCode}
+
+  \commentary{%
+    We prohibit map entries in list literals syntactically,
+    earlier in the proposal.%
+  }
+\item
+  The collection is a list and the type of any of the leaf elements
+  may not be assigned to the list's element type.
+
+  \begin{dartCode}
+    <int>[if (true) "not int"] // Error.
+  \end{dartCode}
+\item
+  The collection is a map and the key type of any of the leaf elements
+  may not be assigned to the map's key type.
+
+  \begin{dartCode}
+    <int, int>{if (true) "not int": 1} // Error.
+  \end{dartCode}
+\item
+  The collection is a map and the value type of any of the leaf elements
+  may not be assigned to the map's value type.
+
+  \begin{dartCode}
+    <int, int>{if (true) 1: "not int"} // Error.
+  \end{dartCode}
+\item
+  A non-null-aware spread element has static type \code{Null}.
+\item
+  A spread element in a list or set literal has a static type that is
+  not \DYNAMIC{} and not a subtype of \code{Iterable<Object>}.
+\item
+  A spread element in a list or set has a static type that
+  implements \code{Iterable<$T$>} for some $T$ and
+  $T$ is not assignable to the element type of the list.
+\item
+  A spread element in a map literal has a static type that is
+  not \DYNAMIC{} and not a subtype of \code{Map<Object, Object>}.
+\item
+  If a map spread element's static type
+  implements \code{Map<$K$, $V$>} for some $K$ and $V$ and
+  $K$ is not assignable to the key type of the map or
+  $V$ is not assignable to the value type of the map.
+\item
+  The variable in a \synt{forElement}
+  (\commentary{either a for-in element or C-style})
+  is declared outside of the element to be final or to not have a setter.
+
+  \begin{dartCode}
+    \FINAL{} i = 0;
+    [for (i in [1]) i] // Error.
+  \end{dartCode}
+\item
+  The type of the iterator expression in a synchronous for-in element
+  may not be assigned to \code{Iterable<$T$>} for any type $T$.
+  Otherwise, the \Index{iterable type} of the iterator is $T$.
+
+  \begin{dartCode}
+    [for (var i in "not iterable") i] // Error.
+  \end{dartCode}
+\item
+  The iterable type of the iterator in a synchronous for-in element
+  may not be assigned to the for-in variable's type.
+
+  \begin{dartCode}
+    [for (int i in ["not", "int"]) i] // Error.
+  \end{dartCode}
+\item
+  The type of the stream expression in an asynchronous \AWAIT{} for-in element
+  may not be assigned to \code{Stream<$T$>} for any type $T$.
+  Otherwise, the \Index{stream type} of the stream is $T$.
+
+  \begin{dartCode}
+    [await for (var i in "not stream") i] // Error.
+  \end{dartCode}
+\item
+  The stream type of the iterator in an asynchronous \AWAIT{} for-in element
+  may not be assigned to the for-in variable's type.
+
+  \begin{dartCode}
+    [await for (int i in Stream.fromIterable(["not", "int"])) i] // Error.
+  \end{dartCode}
+
+\item
+  \AWAIT{} \FOR{} is used when
+  the function immediately enclosing the collection literal
+  is not asynchronous.
+
+  \begin{dartCode}
+    main() {
+      [await for (_ in stream)]; // Error.
+    }
+  \end{dartCode}
+\item
+  \AWAIT{} is used before a C-style \synt{forElement}.
+  \AWAIT{} can only be used with for-in loops.
+
+  \begin{dartCode}
+    main() {
+      [await for (;;)]; // Error.
+    }
+  \end{dartCode}
+
+\item
+  The type of the condition expression
+  (\commentary{the second clause})
+  in a C-style \FOR{} element
+  may not be assigned to \code{bool}.
+
+  \begin{dartCode}
+    [for (; "not bool";) 1] // Error.
+  \end{dartCode}
+\end{itemize}
+
+!!!HERE!!!
 
 
 \subsection{Throw}
@@ -17021,859 +17838,7 @@ operator.
 \section*{Appendix: UI as code Feature Specification}
 \LMLabel{uiAsCode}
 
-
-\subsection{Grammar}
-\LMLabel{uiAsCodeGrammar}
-
-\LMHash{}%
-Remove \synt{setLiteral} and \synt{mapLiteral} entirely.
-Then change the grammar to:
-
-\begin{grammar}
-<setOrMapLiteral> ::= \CONST{}? <typeArguments>? `{' <elements>? `}'
-
-<listLiteral> ::= \CONST{}? <typeArguments>? `[' <elements>? `]'
-
-<elements> ::= <element> (`,' <element>)* `,'?
-
-<element> ::= <expressionElement>
-  \alt <mapEntry>
-  \alt <spreadElement>
-  \alt <ifElement>
-  \alt <forElement>
-
-<expressionElement> ::= <expression>
-
-<mapEntry> ::= <expression> `:' <expression>
-
-<spreadElement> ::= (`...' | `...?') <expression>
-
-<ifElement> ::= \IF{} `(' <expression> `)' <element> (\ELSE{} <element>)?
-
-<forElement> ::= \AWAIT{}? \FOR{} `(' <forLoopParts> `)' <element>
-\end{grammar}
-
-\LMHash{}%
-Let the
-\Index{leaf elements} of $e$ be the concatenation of all of the
-leaf elements of each \synt{element} directly in $e$,
-where the
-\IndexCustom{leaf elements}{leaf elements!of element}
-of an element $\ell$ are:
-
-\begin{itemize}
-\item
-  If $\ell$ is an \synt{ifElement}, then the leaf elements are the
-  concatenation of the leaf elements of the "then" and "else" elements
-  of $\ell$.
-\item
-  Else, if $\ell$ is a \synt{forElement}, then the leaf elements are
-  the leaf elements of the body element of $\ell$.
-\item
-  Else, if $\ell$ is an \synt{expressionElement} or \synt{mapEntry},
-  then the leaf element is $\ell$ itself.
-\item
-  Else, the element has no leaf elements.
-  \commentary{A spread contains no leaf elements.}
-\end{itemize}
-
-\LMHash{}%
-It is a compile-time error if any leaf elements of a \synt{listLiteral}
-are \synt{mapEntry} elements.
-
-\commentary{%
-We could avoid this prose by duplicating the above rules for lists and
-removing \synt{mapEntry}, but this is simpler.%
-}
-
-\LMHash{}%
-The existing rule that an expression statement cannot start with \lit{\{}
-now covers both map and set literals.
-
-
-\subsection{Static Semantics}
-\LMLabel{uiAsCodeStaticSemantics}
-
-
-\subsubsection{Disambiguating sets and maps}
-\LMLabel{uiAsCodeDisambiguatingSetsAndMaps}
-
-\LMHash{}%
-Because sets and maps both use curly braces as delimiters,
-you can create collection literals that are not obviously either
-a set or a map, like:
-
-\begin{dartCode}
-\VAR{} a = \{\};
-\VAR{} b = \{...other\};
-\end{dartCode}
-
-\LMHash{}%
-Inference and set/map disambiguation are done concurrently.
-When possible, we use syntax and the surrounding context type
-to disambiguate between a map and set:
-
-Let $e$ be a \synt{setOrMapLiteral}.
-
-\LMHash{}%
-If $e$ has a context $C$,
-and the base type of $C$ is $Cbase$
-(\commentary{%
-that is, $Cbase$ is $C$ with all wrapping \code{FutureOr}'s removed%
-}),
-and $Cbase$ is not \lit{?},
-then let $S$ be the greatest closure.
-
-\begin{enumerate}
-\item If $e$ has \synt{typeArguments} then:
-  \begin{itemize}
-  \item
-    If there is exactly one type argument $T$,
-    then $e$ is a set literal with static type \code{Set<$T$>}.
-  \item
-    If there are exactly two type arguments $K$ and $V$,
-    then $e$ is a map literal with static type \code{Map<$K$, $V$>}.
-  \item
-    Otherwise (three or more type arguments),
-    report a compile-time error.
-  \end{itemize}
-\item
-  Else, if $S$ is defined and is a subtype of \code{Iterable<Object>}
-  and $S$ is not a subtype of \code{Map<Object, Object>},
-  then $e$ is a set literal.
-\item
-  Else, if $S$ is defined and is a subtype of \code{Map<Object, Object>}
-  and $S$ is not a subtype of \code{Iterable<Object>}
-  then $e$ is a map literal.
-\item
-  Else, if leaf elements is not empty, then:
-  \begin{itemize}
-  \item
-    If leaf elements has at least one \synt{expressionElement}
-    and no \synt{mapEntry} elements,
-    then $e$ is a set literal with unknown static type.
-    The static type will be filled in by type inference, defined below.
-  \item
-    If leaf elements has at least one \synt{mapEntry}
-    and no \synt{expressionElement} elements,
-    then $e$ is a map literal with unknown static type.
-    The static type will be filled in by type inference, defined below.
-  \item
-    If leaf elements has at least one \synt{mapEntry}
-    and at least one \synt{expressionElement},
-    report a compile-time error.
-
-    \commentary{%
-      In other words, at least one key-value pair anywhere in the collection
-      forces it to be a map,
-      and a bare expression forces it to be a set.
-      Having both is an error.%
-    }
-  \end{itemize}
-\item
-  Else, if $e$ has no \synt{typeArguments}, no useful context type,
-  and no \synt{elements},
-  then $e$ is treated as a map literal with unknown static type.
-
-  \commentary{%
-    In other words, an empty \code{\{\}} is a map
-    unless we have a context that indicates otherwise.%
-  }
-\item
-  Otherwise, $e$ is still ambiguous.
-  This can only happen when $e$ is non-empty but contains no leaf elements.
-  In other words, it contains only spreads or spreads wrapped in
-  an \synt{ifElement} or a \synt{forElement}.
-  In this case, the disambiguation will happen during type inference,
-  defined below.
-\end{enumerate}
-
-\LMHash{}%
-If this process successfully disambiguates the literal,
-then we say that $e$ is
-\IndexCustom{unambiguously a map}{map!unambiguously}
-or
-\IndexCustom{unambiguously a set}{set!unambiguously},
-as appropriate.
-
-\subsubsection{Type inference}
-\LMLabel{uiAsCodeTypeInference}
-
-
-\paragraph{Maps and sets}
-\LMLabel{uiAsCodeMapsAndSets}
-
-\LMHash{}%
-We perform inference on the literal,
-and collect up either a set element type
-(\commentary{indicating that the literal may/must be a set}),
-or a pair of a key type and a value type
-(\commentary{indicating that the literal may/must be a map}),
-or both.
-We allow both, because spreads of expressions of type \DYNAMIC{}
-do not disambiguate,
-and can be treated as either
-(\commentary{%
-it becomes a runtime error to spread a value into the wrong kind of literal%
-}).
-
-\LMHash{}%
-We require that
-at least one component unambiguously determine the literal form,
-otherwise it is a compile-time error.
-So, given:
-
-\begin{dartCode}
-\DYNAMIC{} x = <int, int>\{\};
-Iterable l = [];
-Map m = {};
-\end{dartCode}
-
-\LMHash{}%
-Then:
-
-\begin{dartCode}
-\{...x\}       // \comment{Static error, because it is ambiguous.}
-\{...x, ...l\} // \comment{Statically a set, runtime error when spreading x.}
-\{...x, ...m\} // \comment{Statically a map, no runtime error.}
-\{...l, ...m\} // \comment{Static error, because it must be both a set and a map.}
-\end{dartCode}
-
-\LMHash{}%
-In a \synt{setOrMapLiteral} \metavar{collection},
-the inferred type of an \synt{element} is a set element type $T$,
-a pair of a key type $K$ and a value type $V$, or both.
-It is computed relative to a context type $P$:
-
-\begin{itemize}
-\item
-  If \metavar{collection} is unambiguously a set literal,
-  then $P$ is \code{Set<Pe>} where $Pe$ is determined by downwards inference,
-  and may be \lit{?} if downwards inference does not constrain it.
-\item
-  If \metavar{collection} is unambiguously a map literal
-  then $P$ is \code{Map<$Pk$, $Pv$>}
-  where $Pk$ and $Pv$ are determined by downwards inference,
-  and may be \lit{?}
-  if the downwards context does not constrain one or both.
-\item
-  Otherwise, \metavar{collection} is ambiguous,
-  and the downwards context for the elements of \metavar{collection} is lit{?}.
-\end{itemize}
-
-\LMHash{}%
-We say that an element
-\IndexCustom{can be a set}{element!can be a set}
-if it has a set element type.
-Likewise, an element
-\IndexCustom{can be a map}{element!can be a map}
-if it has a key and value type.
-We say that an element
-\IndexCustom{must be a set}{element!must be a set}
-if it can be a set and has and no key type or value type.
-We say that an element
-\IndexCustom{must be a map}{element!must be a map}
-if can be a map and has no set element type.
-
-\LMHash{}%
-To infer the type of $\ell$:
-
-\begin{itemize}
-\item
-  If $\ell$ is an \synt{expressionElement} with expression $e1$:
-  \begin{itemize}
-  \item
-    If $P$ is \lit{?} then the inferred set element type of $\ell$ is
-    the inferred type of the expression $e1$ in context \lit{?}.
-  \item
-    If $P$ is \code{Set<$Ps$>} then the inferred set element type of $\ell$ is
-    the inferred type of the expression $e1$ in context $Ps$.
-  \end{itemize}
-\item
-  If $\ell$ is a \synt{mapEntry} \code{$ek$:\,\,$ev$}:
-  \begin{itemize}
-  \item
-    If $P$ is \lit{?} then the inferred key type of $\ell$ is
-    the inferred type of $ek$ in context \lit{?} and
-    the inferred value type of $\ell$ is
-    the inferred type of $ev$ in context \lit{?}.
-  \item
-    If $P$ is \code{Map<$Pk$, $Pv$>} then
-    the inferred key type of $\ell$ is
-    the inferred type of $ek$ in context $Pk$ and
-    the inferred value type of $\ell$ is
-    the inferred type of $ev$ in context $Pv$.
-  \end{itemize}
-\item
-  If $\ell$ is a \synt{spreadElement} with expression $e1$:
-  \begin{itemize}
-  \item
-    If $P$ is \lit{?} then let $S$ be
-    the inferred type of $e1$ in context \lit{?}:
-    \begin{itemize}
-    \item
-      If $S$ is a non-\code{Null} subtype of \code{Iterable<Object>}, then
-      the inferred set element type of $\ell$ is $T$
-      where $T$ is the type such that \code{Iterable<$T$>} is
-      a superinterface of $S$
-      (\commentary{
-        the result of constraint matching for $X$ using the constraint
-        \code{$S$ <: Iterable<$X$>}}).
-    \item
-      If $S$ is a non-\code{Null} subtype of \code{Map<Object, Object>}, then
-      the inferred key type of $\ell$ is $K$ and
-      the inferred value type of $\ell$ is $V$,
-      where $K$ and $V$ are the types such that \code{Map<$K$, $V$>} is
-      a superinterface of $S$
-      (\commentary{%
-        the result of constraint matching for $X$ and $Y$ using
-        the constraint \code{$S$ <: Map<$X$, $Y$>}%
-      }).
-
-      \commentary{%
-        Note that both this and the previous case can match on
-        the same element if $S$ is a subtype of
-        both \code{Iterable<Object>} and \code{Map<Object, Object>}.
-        In that case, we rely on other elements to disambiguate.%
-      }
-    \item
-      If $S$ is \DYNAMIC{}, then
-      the inferred set element type of $\ell$ is \DYNAMIC{},
-      the inferred key type of $\ell$ is \DYNAMIC{}, and
-      the inferred value type of $\ell$ is \DYNAMIC{}.
-
-      \commentary{%
-        We produce both a set element type here,
-        and a key/value pair here
-        and rely on other elements to disambiguate.%
-      }
-    \item
-      If $S$ is \code{Null} and the spread operator is \lit{...?} then
-      the element has set element type \code{Null},
-      map key type \code{Null} and map value type \code{Null}.
-    \item
-      If none of these cases match, it is an error.
-    \end{itemize}
-  \item
-    If $P$ is \code{Set<$Ps$>} then let $S$ be
-    the inferred type of $e1$ in context \code{Iterable<$Ps$>}:
-    \begin{itemize}
-    \item
-      If $S$ is a non-\code{Null} subtype of \code{Iterable<Object>}, then
-      the inferred set element type of $\ell$ is $T$
-      where $T$ is the type such that \code{Iterable<T>} is
-      a superinterface of $S$
-      (\commentary{%
-        the result of constraint matching for $X$ using
-        the constraint \code{$S$ <: Iterable<$X$>}}).
-    \item
-      If $S$ is \DYNAMIC{}, then
-      the inferred set element type of $\ell$ is \DYNAMIC{}.
-    \item
-      If $S$ is \code{Null} and the spread operator is \lit{...?}, then
-      the set element type is \code{Null}.
-    \item
-      Otherwise it is an error.
-    \end{itemize}
-  \item
-    If $P$ is \code{Map<$Pk$, $Pv$>} then let $S$ be
-    the inferred type of $e1$ in context $P$:
-    \begin{itemize}
-    \item
-      If $S$ is a non-\code{Null} subtype of \code{Map<Object, Object>}, then
-      the inferred key type of $\ell$ is $K$ and
-      the inferred value type of $\ell$ is $V$,
-      where $K$ and $V$ are the types such that \code{Map<$K$, $V$>} is
-      a superinterface of $S$
-      (\commentary{%
-        the result of constraint matching for $X$ and $Y$ using
-        the constraint \code{$S$ <: Map<$X$, $Y$>}}).
-    \item
-      If $S$ is \DYNAMIC{}, then
-      the inferred key type of $\ell$ is \DYNAMIC{}, and
-      the inferred value type of $\ell$ is \DYNAMIC{}.
-    \item
-      If $S$ is \code{Null} and the spread operator is \lit{...?}, then
-      the key and value element types are \code{Null}.
-    \item
-      Otherwise it is an error.
-    \end{itemize}
-  \end{itemize}
-\item
-  If $\ell$ is an \synt{ifElement} with one $\ell$, $p1$, and no "else"
-  element:
-  The condition is inferred with a context type of \code{bool}.
-  \begin{itemize}
-  \item
-    If the inferred set element type of $p1$ is $S$ then
-    the inferred set element type of $\ell$ is $S$.
-  \item
-    If the inferred key type of $p1$ is $K$ and
-    the inferred value type of $p1$ is $V$ then
-    the inferred key and value types of $\ell$ are $K$ and $V$.
-
-    \commentary{%
-      Note that both of the above cases can simultaneously apply
-      because of \DYNAMIC{} spreads.%
-    }
-  \end{itemize}
-\item
-  If $\ell$ is an \synt{ifElement} with two elements $e1$ and $e2$:
-
-  The condition is inferred with a context type of \code{bool}.
-
-  It is a compile error if $e1$ must be a set and $e2$ must be a map
-  or vice versa.
-
-  \commentary{%
-    In other words, you can't spread
-    a map on one branch and a set on the other.
-    Since \DYNAMIC{} provides both set and map key/value types,
-    a \DYNAMIC{} in either branch does not run into this case.%
-  }
-  \begin{itemize}
-  \item
-    If the inferred set element type of $e1$ is $S1$ and
-    the inferred set element type of $e2$ is $S2$ then
-    the inferred set element type of $\ell$ is
-    the least upper bound of $S1$ and $S2$.
-  \item
-    If the inferred key type of $e1$ is $K1$ and
-    the inferred key type of $e1$ is $V1$ and
-    the inferred key type of $e2$ is $K2$ and
-    the inferred key type of $e2$ is $V2$ then
-    the inferred key type of $\ell$ is
-    the least upper bound of $K1$ and $K2$ and
-    the inferred value type is the least upper bound of $V1$ and $V2$.
-
-    \commentary{%
-      Note that both of the above cases can simultaneously apply
-      because of \DYNAMIC{} spreads.%
-    }
-  \end{itemize}
-\item
-  If $\ell$ is a \synt{forElement} with $\ell$ $e1$ then:
-
-  Inference for the iterated expression and the controlling variable is done
-  as for the corresponding \FOR{} or \AWAIT{} \FOR{} statement.
-
-  \begin{itemize}
-  \item
-    If the inferred set element type of $e1$ is $S$ then
-    the inferred set element type of $\ell$ is $S$.
-  \item
-    If the inferred key type of $e1$ is $K$ and
-    the inferred key type of $e1$ is $V$ then
-    the inferred key and value types of $\ell$ are $K$ and $V$.
-
-    \commentary{%
-      In other words, inference flows upwards from the body element.
-      Note that both of the above cases can validly apply
-      because of \DYNAMIC{} spreads.%
-    }
-  \end{itemize}
-\end{itemize}
-
-\LMHash{}%
-Finally, we define inference on a \synt{setOrMapLiteral} \metavar{collection}
-as follows:
-
-\begin{itemize}
-\item
-  If \metavar{collection} is unambiguously a set literal:
-
-  \begin{itemize}
-  \item
-    If $P$ is \lit{?} then
-    the static type of \metavar{collection} is \code{Set<$T$>} where $T$ is
-    the least upper bound of the inferred set element types of the elements.
-  \item
-    Otherwise, the static type of \metavar{collection} is $P$.
-
-    \commentary{%
-      Note that the element inference will never produce a key/value type here
-      given that downwards context.%
-    }
-  \end{itemize}
-\item
-  Else, if \metavar{collection} is unambiguously a map literal
-  where $P$ is \code{Map<$Pk$, $Pv$>}:
-
-  \begin{itemize}
-  \item
-    If $Pk$ is \lit{?} then
-    the static key type of \metavar{collection} is $K$ where $K$ is
-    the least upper bound of the inferred key types of the elements.
-
-  \item
-    Otherwise the static key type of \metavar{collection} is $K$ where $K$ is
-    determined by downwards inference.
-  \end{itemize}
-
-  And:
-
-  \begin{itemize}
-  \item
-    If $Pv$ is \lit{?} then
-    the static value type of \metavar{collection} is $V$ where $V$ is
-    the least upper bound of the inferred value types of the elements.
-  \item
-    Otherwise the static value type of \metavar{collection} is $V$ where $V$ is
-    determined by downwards inference.
-
-    The static type of \metavar{collection} is \code{Map<$K$, $V$>}.
-
-    \commentary{%
-      Note that the element inference will never produce a set element type here
-      given this downwards context.%
-    }
-  \end{itemize}
-\item
-  Otherwise, \metavar{collection} is still ambiguous,
-  the downwards context for the elements of \metavar{collection} is \lit{?},
-  and the disambiguation is done using
-  the immediate elements of \metavar{collection} as follows:
-
-  \begin{itemize}
-  \item
-    If all elements can be a set,
-    and at least one element must be a set,
-    then \metavar{collection} is a set literal with
-    static type \code{Set<$T$>} where $T$ is
-    the least upper bound of the set element types of the elements.
-  \item
-    If all elements can be a map,
-    and at least one element must be a map, then $e$ is
-    a map literal with static type \code{Map<$K$, $V$>} where $K$ is
-    the least upper bound of the key types of the elements and $V$ is
-    the least upper bound of the value types.
-  \item
-    Otherwise, the literal cannot be disambiguated
-    and it is a compile-time error.
-  \end{itemize}
-\end{itemize}
-
-\commentary{%
-  This last case can occur if the literal \emph{must} be both a set and a map,
-  as in:%
-}
-
-\begin{dartCode}
-\VAR{} iterable = [1, 2];
-\VAR{} map = \{1: 2\};
-\VAR{} ambiguous = \{...iterable, ...map\};
-\end{dartCode}
-
-\commentary{%
-Or, if there is nothing indicates that it is \emph{either} a map or set:%
-}
-
-\begin{dartCode}
-\DYNAMIC{} dyn;
-\VAR{} ambiguous = \{...dyn\};
-\end{dartCode}
-
-
-\paragraph{Lists}
-
-\LMHash{}%
-Inference for list literals mostly follows that of set literals
-without the complexity around disambiguation with maps and
-using \code{List} or \code{Iterable} in a few places instead of \code{Set}.
-
-\LMHash{}%
-Inside a \synt{listLiteral} \metavar{listLiteral},
-the inferred type of an element $\ell$ is a list element type $T$.
-It is computed relative to a downwards element context type $P$,
-where $P$ is $T$
-if downwards inference constrains the type of \metavar{listLiteral}
-to \code{Iterable<$T$>} for some $T$.
-Otherwise, $P$ is \lit{?}.
-
-\begin{itemize}
-\item
-  If $\ell$ is an \synt{expressionElement} with expression $e1$:
-  \begin{itemize}
-  \item
-    The inferred list element type of $\ell$ is
-    the inferred type of the expression $e1$ in context $P$.
-  \end{itemize}
-\item
-  If $\ell$ is a \synt{spreadElement} with expression $e1$:
-
-  \begin{itemize}
-  \item
-    If $P$ is \lit{?} then let $S$ be
-    the inferred type of $e1$ in context \lit{?}:
-
-    \begin{itemize}
-    \item
-      If $S$ is a non-\code{Null} subtype of \code{Iterable<Object>}, then
-      the inferred list element type of $\ell$ is $T$ where $T$ is
-      the type such that \code{Iterable<$T$>} is
-      a superinterface of $S$
-      (\commentary{%
-        the result of constraint matching for $X$ using
-        the constraint \code{$S$ <: Iterable<$X$>}}).
-
-      \begin{itemize}
-      \item
-        If $S$ is \DYNAMIC{}, then
-        the inferred list element type of $\ell$ is \DYNAMIC{}.
-      \item
-        If $S$ is \code{Null} and the spread operator is \lit{...?}, then
-        the list element type is \code{Null}.
-      \item
-        Otherwise it is an error
-        (\commentary{%
-          because it is a spread of a non-spreadable type like Object%
-        }).
-      \end{itemize}
-    \item
-      Else, let $S$ be
-      the inferred type of $e1$ in context \code{Iterable<$P$>}:
-
-      \begin{itemize}
-      \item
-        If $S$ is a non-\code{Null} subtype of \code{Iterable<Object>}, then
-        the inferred list element type of $\ell$ is $T$ where $T$ is
-        the type such that \code{Iterable<$T$>} is
-        a superinterface of $S$
-        (\commentary{%
-          the result of constraint matching for $X$ using
-          the constraint \code{$S$ <: Iterable<$X$>}%
-        }).
-      \item
-        If $S$ is \DYNAMIC{}, then
-        the inferred list element type of $\ell$ is \DYNAMIC{}.
-      \item
-        Otherwise it is an error.
-      \end{itemize}
-    \end{itemize}
-  \item
-    If $\ell$ is an \synt{ifElement} with one $\ell$, $p1$,
-    and no "else" element:
-    The condition is inferred with a context type of \code{bool}.
-
-    The inferred list element type of $\ell$ is
-    the inferred list element type of $p1$ with element context type $P$.
-  \item
-    If $\ell$ is a \synt{ifElement} with two $\ell$s, $p1$ and $p2$:
-    The condition is inferred with a context type of \code{bool}.
-
-    The inferred list element type of $\ell$ is
-    the least upper bound of $S1$ and $S2$ where $S1$ is
-    the inferred list element type of $p1$ and $S2$ is
-    the inferred list element type of $p2$,
-    both with element context type $P$.
-
-  \item
-    If $\ell$ is a \synt{forElement} with $\ell$ $p1$ then:
-
-    Inference for the iterated expression and the controlling variable
-    is done as for the corresponding \FOR{} or \AWAIT{} \FOR{} statement.
-
-    The inferred list element type of $\ell$ is the inferred list element
-    type of $p1$ with element context type $P$.
-  \end{itemize}
-\end{itemize}
-
-\commentary{%
-Note: $\ell$ cannot be a \synt{mapEntry} as
-those are not allowed inside list literals.%
-}
-
-\LMHash{}%
-Finally, we define inference on a \synt{listLiteral} \metavar{collection}
-as follows:
-
-\begin{itemize}
-\item
-  If $P$ is \lit{?} then
-  the static type of \metavar{collection} is \code{List<$T$>} where $T$ is
-  the least upper bound of the inferred list element types of the elements.
-\item
-  Otherwise,
-  the static type of \metavar{collection} is \code{List<$T$>} where $T$ is
-  determined by downwards inference.
-\end{itemize}
-
-
-\subsubsection{Type promotion}
-\LMLabel{uiAsCodeTypePromotion}
-
-\LMHash{}%
-An \synt{ifElement} interacts with type promotion in
-the same way that \IF{} statements do.
-Given an \synt{ifElement} with condition \metavar{condition},
-then element \metavar{thenElement} and
-optional else element \metavar{elseElement}:
-
-\begin{itemize}
-\item
-  If \metavar{condition} shows that a local variable $v$ has type $T$, then
-  the type of $v$ is known to be $T$ in \metavar{thenElement},
-  unless any of the following are true:
-
-  \begin{itemize}
-  \item $v$ is potentially mutated in \metavar{thenElement},
-  \item $v$ is potentially mutated within a function
-    other than the one where $v$ is declared, or
-    \begin{itemize}
-    \item $v$ is accessed by a function defined in \metavar{thenElement}, and
-    \item $v$ is potentially mutated anywhere in the scope of $v$.
-    \end{itemize}
-  \end{itemize}
-\end{itemize}
-
-\commentary{%
-Note: The type promotion rules for \IF{} will likely get more sophisticated
-in a future version of Dart because of non-nullable types.
-When that happens,
-\synt{ifElements} should continue to match \IF{} statements.%
-}
-
-
-\subsubsection{Compile-time errors}
-\LMLabel{uiAsCodeCompileTimeErrors}
-
-\LMHash{}%
-After type inference and disambiguation,
-the collection is checked for other compile-time errors.
-It is a compile-time error if:
-
-%% TODO(eernst): Find a way to show Dart code examples inside itemize below.
-
-\begin{itemize}
-\item
-  The collection is a map literal and leaf elements contains any
-  \synt{expressionElement} elements.
-
-  \begin{dartCode}
-    <String, int>\{"not entry"\} // Error.
-  \end{dartCode}
-\item
-  The collection is a set literal and
-  leaf elements contains any \synt{mapEntry} elements.
-
-  \begin{dartCode}
-    ["not": "expression"] // Error.
-    <String>\{"not": "expression"\} // Error.
-  \end{dartCode}
-
-  \commentary{%
-    We prohibit map entries in list literals syntactically,
-    earlier in the proposal.%
-  }
-\item
-  The collection is a list and the type of any of the leaf elements
-  may not be assigned to the list's element type.
-
-  \begin{dartCode}
-    <int>[if (true) "not int"] // Error.
-  \end{dartCode}
-\item
-  The collection is a map and the key type of any of the leaf elements
-  may not be assigned to the map's key type.
-
-  \begin{dartCode}
-    <int, int>{if (true) "not int": 1} // Error.
-  \end{dartCode}
-\item
-  The collection is a map and the value type of any of the leaf elements
-  may not be assigned to the map's value type.
-
-  \begin{dartCode}
-    <int, int>{if (true) 1: "not int"} // Error.
-  \end{dartCode}
-\item
-  A non-null-aware spread element has static type \code{Null}.
-\item
-  A spread element in a list or set literal has a static type that is
-  not \DYNAMIC{} and not a subtype of \code{Iterable<Object>}.
-\item
-  A spread element in a list or set has a static type that
-  implements \code{Iterable<$T$>} for some $T$ and
-  $T$ is not assignable to the element type of the list.
-\item
-  A spread element in a map literal has a static type that is
-  not \DYNAMIC{} and not a subtype of \code{Map<Object, Object>}.
-\item
-  If a map spread element's static type
-  implements \code{Map<$K$, $V$>} for some $K$ and $V$ and
-  $K$ is not assignable to the key type of the map or
-  $V$ is not assignable to the value type of the map.
-\item
-  The variable in a \synt{forElement}
-  (\commentary{either a for-in element or C-style})
-  is declared outside of the element to be final or to not have a setter.
-
-  \begin{dartCode}
-    \FINAL{} i = 0;
-    [for (i in [1]) i] // Error.
-  \end{dartCode}
-\item
-  The type of the iterator expression in a synchronous for-in element
-  may not be assigned to \code{Iterable<$T$>} for any type $T$.
-  Otherwise, the \Index{iterable type} of the iterator is $T$.
-
-  \begin{dartCode}
-    [for (var i in "not iterable") i] // Error.
-  \end{dartCode}
-\item
-  The iterable type of the iterator in a synchronous for-in element
-  may not be assigned to the for-in variable's type.
-
-  \begin{dartCode}
-    [for (int i in ["not", "int"]) i] // Error.
-  \end{dartCode}
-\item
-  The type of the stream expression in an asynchronous \AWAIT{} for-in element
-  may not be assigned to \code{Stream<$T$>} for any type $T$.
-  Otherwise, the \Index{stream type} of the stream is $T$.
-
-  \begin{dartCode}
-    [await for (var i in "not stream") i] // Error.
-  \end{dartCode}
-\item
-  The stream type of the iterator in an asynchronous \AWAIT{} for-in element
-  may not be assigned to the for-in variable's type.
-
-  \begin{dartCode}
-    [await for (int i in Stream.fromIterable(["not", "int"])) i] // Error.
-  \end{dartCode}
-
-\item
-  \AWAIT{} \FOR{} is used when
-  the function immediately enclosing the collection literal
-  is not asynchronous.
-
-  \begin{dartCode}
-    main() {
-      [await for (_ in stream)]; // Error.
-    }
-  \end{dartCode}
-\item
-  \AWAIT{} is used before a C-style \synt{forElement}.
-  \AWAIT{} can only be used with for-in loops.
-
-  \begin{dartCode}
-    main() {
-      [await for (;;)]; // Error.
-    }
-  \end{dartCode}
-
-\item
-  The type of the condition expression
-  (\commentary{the second clause})
-  in a C-style \FOR{} element
-  may not be assigned to \code{bool}.
-
-  \begin{dartCode}
-    [for (; "not bool";) 1] // Error.
-  \end{dartCode}
-\end{itemize}
-
+% !!!TODO!!!
 
 \subsection{Constant Semantics}
 \LMLabel{uiAsCodeConstantSemantics}
@@ -17897,7 +17862,7 @@ They are defined as:
   a potentially constant element if
   its expression is a potentially constant expression.
 \item
-  A \synt{mapEntry} is a constant element if
+  A \synt{mapElement} is a constant element if
   both its key and value expression are constant expressions, and
   a potentially constant element if
   both are potentially constant expressions.
@@ -17994,7 +17959,7 @@ Then a final step handles those appropriately for the given collection type.
   \item Evaluate the element's expression and append it to \metavar{result}.
   \end{enumerate}
 \item
-  Else, $\ell$ is a \synt{mapEntry}
+  Else, $\ell$ is a \synt{mapElement}
   \code{\metavar{keyExpression}: \metavar{valueExpression}}:
   \begin{enumerate}
   \item Evaluate \metavar{keyExpression} to a value \metavar{key}.

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -7651,6 +7651,134 @@ in the static and dynamic context where $\ell$ occurs.
 \EndCase
 
 
+\subsubsection{List Literal Inference}
+\LMLabel{listLiteralInference}
+
+!!!HERE!!! Raw from feature spec.
+
+\LMHash{}%
+Inference for list literals mostly follows that of set literals
+without the complexity around disambiguation with maps and
+using \code{List} or \code{Iterable} in a few places instead of \code{Set}.
+
+\LMHash{}%
+Inside a \synt{listLiteral} \metavar{listLiteral},
+the inferred type of an element $\ell$ is a list element type $T$.
+It is computed relative to a downwards element context type $P$,
+where $P$ is $T$
+if downwards inference constrains the type of \metavar{listLiteral}
+to \code{Iterable<$T$>} for some $T$.
+Otherwise, $P$ is \FreeContext{}.
+
+\begin{itemize}
+\item
+  If $\ell$ is an \synt{expressionElement} with expression $e_1$:
+  \begin{itemize}
+  \item
+    The inferred list element type of $\ell$ is
+    the inferred type of the expression $e_1$ in context $P$.
+  \end{itemize}
+\item
+  If $\ell$ is a \synt{spreadElement} with expression $e_1$:
+
+  \begin{itemize}
+  \item
+    If $P$ is \FreeContext{} then let $S$ be
+    the inferred type of $e_1$ in context \FreeContext{}:
+
+    \begin{itemize}
+    \item
+      If $S$ is a non-\code{Null} subtype of \code{Iterable<Object>}, then
+      the inferred list element type of $\ell$ is $T$ where $T$ is
+      the type such that \code{Iterable<$T$>} is
+      a superinterface of $S$
+      (\commentary{%
+        the result of constraint matching for $X$ using
+        the constraint \code{$S$ <: Iterable<$X$>}}).
+
+      \begin{itemize}
+      \item
+        If $S$ is \DYNAMIC{}, then
+        the inferred list element type of $\ell$ is \DYNAMIC{}.
+      \item
+        If $S$ is \code{Null} and the spread operator is \lit{...?}, then
+        the list element type is \code{Null}.
+      \item
+        Otherwise it is an error
+        (\commentary{%
+          because it is a spread of a non-spreadable type like Object%
+        }).
+      \end{itemize}
+    \item
+      Else, let $S$ be
+      the inferred type of $e_1$ in context \code{Iterable<$P$>}:
+
+      \begin{itemize}
+      \item
+        If $S$ is a non-\code{Null} subtype of \code{Iterable<Object>}, then
+        the inferred list element type of $\ell$ is $T$ where $T$ is
+        the type such that \code{Iterable<$T$>} is
+        a superinterface of $S$
+        (\commentary{%
+          the result of constraint matching for $X$ using
+          the constraint \code{$S$ <: Iterable<$X$>}%
+        }).
+      \item
+        If $S$ is \DYNAMIC{}, then
+        the inferred list element type of $\ell$ is \DYNAMIC{}.
+      \item
+        Otherwise it is an error.
+      \end{itemize}
+    \end{itemize}
+  \item
+    If $\ell$ is an \synt{ifElement} with one $\ell$, $p1$,
+    and no "else" element:
+    The condition is inferred with a context type of \code{bool}.
+
+    The inferred list element type of $\ell$ is
+    the inferred list element type of $p1$ with element context type $P$.
+  \item
+    If $\ell$ is a \synt{ifElement} with two $\ell$s, $p1$ and $p2$:
+    The condition is inferred with a context type of \code{bool}.
+
+    The inferred list element type of $\ell$ is
+    the least upper bound of $S1$ and $S2$ where $S1$ is
+    the inferred list element type of $p1$ and $S2$ is
+    the inferred list element type of $p2$,
+    both with element context type $P$.
+
+  \item
+    If $\ell$ is a \synt{forElement} with $\ell$ $p1$ then:
+
+    Inference for the iterated expression and the controlling variable
+    is done as for the corresponding \FOR{} or \AWAIT{} \FOR{} statement.
+
+    The inferred list element type of $\ell$ is the inferred list element
+    type of $p1$ with element context type $P$.
+  \end{itemize}
+\end{itemize}
+
+\commentary{%
+Note: $\ell$ cannot be a \synt{mapElement} as
+those are not allowed inside list literals.%
+}
+
+\LMHash{}%
+Finally, we define inference on a \synt{listLiteral} \metavar{collection}
+as follows:
+
+\begin{itemize}
+\item
+  If $P$ is \FreeContext{} then
+  the static type of \metavar{collection} is \code{List<$T$>} where $T$ is
+  the least upper bound of the inferred list element types of the elements.
+\item
+  Otherwise,
+  the static type of \metavar{collection} is \code{List<$T$>} where $T$ is
+  determined by downwards inference.
+\end{itemize}
+
+
 \subsubsection{List}
 \LMLabel{uiAsCodeList}
 
@@ -7834,140 +7962,6 @@ The static type of a list literal of the form
 or the form
 \code{[$e_1, \ldots, e_n$]}
 is \code{List<\DYNAMIC>}.
-
-
-\subsubsection{List Literal Inference}
-\LMLabel{listLiteralInference}
-
-!!!HERE!!! Raw from feature spec.
-
-\LMHash{}%
-Inference for list literals mostly follows that of set literals
-without the complexity around disambiguation with maps and
-using \code{List} or \code{Iterable} in a few places instead of \code{Set}.
-
-\LMHash{}%
-Inside a \synt{listLiteral} \metavar{listLiteral},
-the inferred type of an element $\ell$ is a list element type $T$.
-It is computed relative to a downwards element context type $P$,
-where $P$ is $T$
-if downwards inference constrains the type of \metavar{listLiteral}
-to \code{Iterable<$T$>} for some $T$.
-Otherwise, $P$ is \FreeContext{}.
-
-\begin{itemize}
-\item
-  If $\ell$ is an \synt{expressionElement} with expression $e_1$:
-  \begin{itemize}
-  \item
-    The inferred list element type of $\ell$ is
-    the inferred type of the expression $e_1$ in context $P$.
-  \end{itemize}
-\item
-  If $\ell$ is a \synt{spreadElement} with expression $e_1$:
-
-  \begin{itemize}
-  \item
-    If $P$ is \FreeContext{} then let $S$ be
-    the inferred type of $e_1$ in context \FreeContext{}:
-
-    \begin{itemize}
-    \item
-      If $S$ is a non-\code{Null} subtype of \code{Iterable<Object>}, then
-      the inferred list element type of $\ell$ is $T$ where $T$ is
-      the type such that \code{Iterable<$T$>} is
-      a superinterface of $S$
-      (\commentary{%
-        the result of constraint matching for $X$ using
-        the constraint \code{$S$ <: Iterable<$X$>}}).
-
-      \begin{itemize}
-      \item
-        If $S$ is \DYNAMIC{}, then
-        the inferred list element type of $\ell$ is \DYNAMIC{}.
-      \item
-        If $S$ is \code{Null} and the spread operator is \lit{...?}, then
-        the list element type is \code{Null}.
-      \item
-        Otherwise it is an error
-        (\commentary{%
-          because it is a spread of a non-spreadable type like Object%
-        }).
-      \end{itemize}
-    \item
-      Else, let $S$ be
-      the inferred type of $e_1$ in context \code{Iterable<$P$>}:
-
-      \begin{itemize}
-      \item
-        If $S$ is a non-\code{Null} subtype of \code{Iterable<Object>}, then
-        the inferred list element type of $\ell$ is $T$ where $T$ is
-        the type such that \code{Iterable<$T$>} is
-        a superinterface of $S$
-        (\commentary{%
-          the result of constraint matching for $X$ using
-          the constraint \code{$S$ <: Iterable<$X$>}%
-        }).
-      \item
-        If $S$ is \DYNAMIC{}, then
-        the inferred list element type of $\ell$ is \DYNAMIC{}.
-      \item
-        Otherwise it is an error.
-      \end{itemize}
-    \end{itemize}
-  \item
-    If $\ell$ is an \synt{ifElement} with one $\ell$, $p1$,
-    and no "else" element:
-    The condition is inferred with a context type of \code{bool}.
-
-    The inferred list element type of $\ell$ is
-    the inferred list element type of $p1$ with element context type $P$.
-  \item
-    If $\ell$ is a \synt{ifElement} with two $\ell$s, $p1$ and $p2$:
-    The condition is inferred with a context type of \code{bool}.
-
-    The inferred list element type of $\ell$ is
-    the least upper bound of $S1$ and $S2$ where $S1$ is
-    the inferred list element type of $p1$ and $S2$ is
-    the inferred list element type of $p2$,
-    both with element context type $P$.
-
-  \item
-    If $\ell$ is a \synt{forElement} with $\ell$ $p1$ then:
-
-    Inference for the iterated expression and the controlling variable
-    is done as for the corresponding \FOR{} or \AWAIT{} \FOR{} statement.
-
-    The inferred list element type of $\ell$ is the inferred list element
-    type of $p1$ with element context type $P$.
-  \end{itemize}
-\end{itemize}
-
-\commentary{%
-Note: $\ell$ cannot be a \synt{mapElement} as
-those are not allowed inside list literals.%
-}
-
-\LMHash{}%
-Finally, we define inference on a \synt{listLiteral} \metavar{collection}
-as follows:
-
-\begin{itemize}
-\item
-  If $P$ is \FreeContext{} then
-  the static type of \metavar{collection} is \code{List<$T$>} where $T$ is
-  the least upper bound of the inferred list element types of the elements.
-\item
-  Otherwise,
-  the static type of \metavar{collection} is \code{List<$T$>} where $T$ is
-  determined by downwards inference.
-\end{itemize}
-
-
-\subsubsection{List Literal Evaluation}
-\LMLabel{listLiteralEvaluation}
-
-!!!HERE!!! May not be needed: With element evaluation in place, it's just a short explanation in \ref{lists}.
 
 
 \subsubsection{Set and Map Literal Disambiguation}

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -7821,9 +7821,15 @@ and $e$ is henceforth treated as
 (\ref{notation})
 \code{<$T$>$e$}.
 
+\commentary{%
+The static type of a list literal of the form \code{<$T$>$e$}
+is \code{List<$T$>}
+(\ref{listLiteralInference}).%
+}
+
 \LMHash{}%
 A list may contain zero or more objects.
-The number of elements in a list is its size.
+The number of objects in a list is its size.
 A list has an associated set of indices.
 An empty list has an empty set of indices.
 A non-empty list has the index set $\{0, \ldots, n - 1\}$ where $n$ is the size of the list.
@@ -7831,13 +7837,13 @@ It is a dynamic error to attempt to access a list
 using an index that is not a member of its set of indices.
 
 \LMHash{}%
-The sequence of elements of a given list literal
-is determined by evaluation of its elements
+The objects in a given list literal
+is determined by evaluation of its collection literal elements
 (\ref{collectionLiteralElementEvaluation}).
 
 \LMHash{}%
-If a list literal $\ell$ begins with the reserved word \CONST{}
-or $\ell$ occurs in a constant context
+If a list literal $e$ begins with the reserved word \CONST{}
+or $e$ occurs in a constant context
 (\ref{constantContexts}),
 it is a
 \IndexCustom{constant list literal}{literal!list!constant},
@@ -7856,7 +7862,7 @@ Attempting to mutate a constant list literal will result in a dynamic error.
 % The following is true either directly or indirectly: There is a \CONST{}
 % modifier on the list literal, or the list literal as a whole occurs
 % in a constant context.
-Note that the element expressions of a constant list literal
+Note that the collection literal elements of a constant list literal
 occur in a constant context
 (\ref{constantContexts}),
 which means that \CONST{} modifiers need not be specified explicitly.%
@@ -7864,8 +7870,9 @@ which means that \CONST{} modifiers need not be specified explicitly.%
 
 \LMHash{}%
 It is a compile-time error if an element of a constant list literal
-is not a constant expression.
+is not constant.
 It is a compile-time error if the type argument of a constant list literal
+(\commentary{no matter whether it is explicit or inferred})
 is not a constant type expression.
 
 \rationale{%
@@ -7875,29 +7882,21 @@ so we cannot use type parameters inside constant expressions.%
 
 \LMHash{}%
 The value of a constant list literal
-\code{\CONST?\,\,<$E$>[$\ell_1, \ldots, \ell_n$]}
+\code{\CONST?\,\,<$E$>[\List{\ell}{1}{m}]}
 is an object $a$ whose class implements the built-in class
-\code{List<$E$>}.
-Let $s_i$ be the value of the constant expression $e_i$, $i \in 1 .. n$.
-The $i$th element of $a$ (at index $i - 1$) is $v_i$.
-%
-%% TODO(eernst): If inference is specified to provide all type arguments,
-%% we should delete the following.
-!!!HERE!!!
-The value of a constant list literal
-\code{\CONST?\,\,[$e_1, \ldots, e_n$]}
-is defined as the value of the constant list literal
-% For a constant list literal, it is never an error to have the \CONST, even if
-% it was omitted above. So we remove the `?`, making the next line well-defined.
-\code{\CONST\,\,<\DYNAMIC>[$e_1, \ldots, e_n$]}.
+\code{List<$E$>},
+and whose contents is the object sequence \List{o}{1}{n} obtained by
+evaluation of \List{\ell}{1}{m}
+(\ref{collectionLiteralElementEvaluation}).
+The $i$th object of $a$ (at index $i - 1$) is then $o_i$.
 
 \LMHash{}%
 Let
-$list_1 =$ \code{\CONST?\,\,<$V$>[$e_{11}, \ldots, e_{1n}$]}
+$list_1 =$ \code{\CONST?\,\,<$V$>[$\ell_{11}, \ldots, \ell_{1m_1}$]}
 and
-$list_2 =$ \code{\CONST?\,\,<$U$>[$e_{21}, \ldots, e_{2n}$]}
+$list_2 =$ \code{\CONST?\,\,<$U$>[$\ell_{21}, \ldots, \ell_{2m_2}$]}
 be two constant list literals and
-let the elements of $list_1$ and $list_2$ evaluate to
+let the contents of $list_1$ and $list_2$ be
 $o_{11}, \ldots, o_{1n}$ and $o_{21}, \ldots, o_{2n}$ respectively.
 If{}f \code{identical($o_{1i}$, $o_{2i}$)} for $i \in 1 .. n$ and $V == U$
 then \code{identical($list_1$, $list_2$)}.
@@ -7908,12 +7907,12 @@ In other words, constant list literals are canonicalized.%
 
 \LMHash{}%
 A run-time list literal
-\code{<$E$>[$e_1, \ldots, e_n$]}
+\code{<$E$>[$\ell_1, \ldots, \ell_m$]}
 is evaluated as follows:
 \begin{itemize}
 \item
-  First, the expressions $e_1, \ldots, e_n$ are evaluated
-  in order they appear in the program,
+  The elements $\ell_1, \ldots, \ell_m$ are evaluated
+  (\ref{collectionLiteralElementEvaluation}),
   producing objects $o_1, \ldots, o_n$.
 \item
   A fresh instance (\ref{generativeConstructors}) $a$, of size $n$,
@@ -7941,14 +7940,6 @@ if element $i$ is not a subtype of the element type of the list,
 a dynamic type error will occur when $a[i]$ is assigned $o_{i-1}$.
 }
 
-\LMHash{}%
-%% TODO(eernst): If inference is specified to provide all type arguments,
-%% we should delete the following.
-A run-time list literal
-\code{[$e_1, \ldots, e_n$]}
-is evaluated as
-\code{<\DYNAMIC>[$e_1, \ldots, e_n$]}.
-
 \commentary{
 There is no restriction precluding nesting of list literals.
 It follows from the rules above that
@@ -7956,21 +7947,6 @@ It follows from the rules above that
 is a list with type parameter \code{List<int>},
 containing two lists with type parameter \code{int}.
 }
-
-\LMHash{}%
-The static type of a list literal of the form
-\code{\CONST\,\,<$E$>[$e_1, \ldots, e_n$]}
-or the form
-\code{<$E$>[$e_1, \ldots, e_n$]}
-is \code{List<$E$>}.
-%
-%% TODO(eernst): If inference is specified to provide all type arguments,
-%% we should delete the following.
-The static type of a list literal of the form
-\code{\CONST\,\,[$e_1, \ldots, e_n$]}
-or the form
-\code{[$e_1, \ldots, e_n$]}
-is \code{List<\DYNAMIC>}.
 
 
 \subsubsection{Set and Map Literal Disambiguation}
@@ -8495,6 +8471,7 @@ Here is an example:%
 \end{dartCode}
 
 \commentary{%
+\noindent
 Or, if there is nothing indicates that it is \emph{either} a set or a map:%
 }
 

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -7627,7 +7627,7 @@ the first applicable entry in the following list:
 \item
   Otherwise, $e$ is still ambiguous.
   \commentary{%
-    In this case $e$ contains only spreads,
+    In this case $e$ is non-empty but contains only spreads,
     wrapped zero or more times in \synt{ifElement}s or \synt{forElement}s.
     Disambiguation will occur during type inference
     (\ref{collectionLiteralInference}).%


### PR DESCRIPTION
We have a couple of issues with the completeness of the language specification with this addition: It refers to context types and type inference many times, with no definitions.

The current approach is to simply give a brief intuitive explanation when those concepts are first used, such that we just need to adjust references to these concepts when we add suitable sections about inference etc.

Note that I've changed the specification of element evaluation such that they rely on the simplest possible syntax (\FOR{} statements), rather than specifying actions such as evaluating `collection.iterator` etc., because the \FOR{} statements are already specified to do just that.

Similarly, I'm using the notion of `$S$ implements $T$` which means that `$T$` is a superinterface (not just a supertype) of `$S$`, which means that we already know that `$S$` cannot be a bottom/null type when `$T$` is `Iterable` or `Map`. This usage of the word `implements` is consistent with everything in the spec already, but it hasn't been defined explicitly before now.

Also, I'm using the phrase `the type argument of $S$ at 'Iterable'` which will map the actual type arguments of `$S$` through the suitable superinterface links, substituting type arguments as needed (for instance, the type argument of `List<int>` at `Iterable` is `int`, and with `class C<X> extends B<Map<X, X>> {}`, the type argument of `C<int>` at `B` is `Map<int, int>`). 

I've changed a number of compile-time errors to a big comment at the end of \ref{collectionLiterals}, because they are already implied by other parts of the text. We could mention them in commentary or delete them, whatever is considered more useful for the reader.
