### PR TITLE
Strip windows carriage returns from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,4 +42,3 @@ See [LICENSE][license] and [PATENTS][patents].
 [website]: https://www.dartlang.org
 [license]: https://github.com/dart-lang/language/blob/master/LICENSE
 [patents]: https://github.com/dart-lang/language/blob/master/PATENTS
-


### PR DESCRIPTION
These show up as trailing whitespace in the default configuration of
`git diff-index --check`.