### PR TITLE
Spec fix cascades

### DIFF
--- a/specification/dart.sty
+++ b/specification/dart.sty
@@ -67,6 +67,9 @@
 \def\WITH{\keyword{with}}
 \def\YIELD{\keyword{yield}}
 
+% Used for desugaring.
+\def\LET{\keyword{let}}
+
 % Used for inline code snippets.
 \def\code#1{\texttt{#1}}
 

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -9665,23 +9665,15 @@ Notice that the wording avoids re-evaluating the receiver $o$ and the arguments 
 \EndCase
 
 
-\subsubsection{Cascaded Invocations}
-\LMLabel{cascadedInvocations}
+\subsubsection{Cascades}
+\LMLabel{cascades}
 
 \LMHash{}%
-A \IndexCustom{cascaded method invocation}{method invocation!cascaded}
-has the form \code{$e$..\metavar{suffix}} or \code{$e$?..\metavar{suffix}},
-where $e$ is an expression
-and \metavar{suffix} is derived from \synt{cascadeSection}.
-
-\rationale{%
-A \synt{cascadeSection} basically allows for accessing members
-including setters.
-The motivation for having cascaded invocations is that they can be
-!!!HERE!!!
-}
-
-is a sequence of operator, method, getter or setter invocations.
+A \Index{cascade} is a kind of expression that allows for performing
+multiple operations on a given object
+without storing it in a variable and and accessing it via a name.
+Cascades can have different syntactic forms,
+but will always contain two periods \lit{..}.
 
 \begin{grammar}
 <cascadeSequence> ::= (`?..' | `..') <cascadeSection> (`..' <cascadeSection>)*
@@ -9701,22 +9693,125 @@ is a sequence of operator, method, getter or setter invocations.
 \end{grammar}
 
 \LMHash{}%
-Evaluation of a cascaded method invocation expression $c$ of the form \code{$e$..\metavar{suffix}} proceeds as follows:
+A \IndexCustom{cascaded member access}{cascaded member access}
+is an expression of the form
+\code{$e$..\metavar{suffix}} or \code{$e$?..\metavar{suffix}},
+% The grammar enforces that $e$ is a \synt{conditionalExpression},
+% but that is also an expression.
+where $e$ is an expression
+and \metavar{suffix} is derived from \synt{cascadeSection}.
+The form
+\code{$e$?..\metavar{suffix}}
+is also known as a
+\IndexCustom{conditional cascaded member access}{%
+  cascaded member access!conditional}.
 
+\rationale{%
+A \synt{cascadeSection} allows for accessing members, including setters.
+The motivation for having a cascaded member access is that it allows for
+performing a chain of operations based on an object
+while preserving a reference to that object for further processing.%
+}
+
+\commentary{%
+For example, \code{C()..foo.bar()} allows us to obtain a reference to
+the object $o$ which is the result of evaluating \code{C()},
+and at the same time use $o$ to invoke the getter \code{foo} and
+invoke \code{bar()} on the value returned by that getter.%
+}
+
+\LMHash{}%
+Using \synt{cascadeSequence}, an expression can include
+multiple cascade sections
+(\ref{expressions}).
+
+\LMHash{}%
+For some $k > 0$,
+let $e$ be an expression of the form
+\code{$e_0$..$s_1$\,\,$\cdots$\,\,..$s_k$}
+where $s_j$ is derived from \synt{cascadeSection}, $j \in 1 .. k$,
+such that $k$ is maximal.
+That is, there is no $s_{k+1}$ derived from \synt{cascadeSection}
+such that $e$ is a subexpression of the larger expression
+\code{$e$..$s_{k+1}$}.
+Then $e$ is treated as
+(\ref{notation})
+\code{(($e_0$..$s_1$)\,\,$\cdots$\,\,)..$s_k$}.
+
+\LMHash{}%
+For some $k > 0$,
+let $e$ be an expression of the form
+\code{$e_0$?..$s_1$\,\,$\cdots$\,\,..$s_k$}
+where $s_j$ is derived from \synt{cascadeSection}, $j \in 1 .. k$,
+such that $k$ is maximal in the same sense as above.
+Then $e$ is treated as
+\code{(($e_0$?..$s_1$)\,\,$\cdots$\,\,)?..$s_k$}.
+
+\commentary{%
+With these transformations in place,
+there will never be an expression that includes multiple cascade sections.
+So we need only specify the static analysis and dynamic semantics for
+expressions that contain a \synt{cascadeSequence}
+which contains exactly one \synt{cascadeSection}.%
+}
+
+\LMHash{}%
+% Note that the use of <conditionalExpression> here prevents a sequence of
+% multiple <cascadeSection>s, but it does allow ($e_1$..$s_1$)..$s$,
+% because (<expression>) is a primary.
+Let $e$ be an expression of the form \code{$e_0$..$s$}
+where $e_0$ is a \synt{conditionalExpression}
+and $s$ is a \synt{cascadeSection}.
+Exactly the same compile-time errors are raised for $e$
+as would be raised for \code{$e_0$.$s$}.
+The static type of $e$ is the static type of $e_0$.
+
+\LMHash{}%
+%% TODO(eernst): Come nnbd, adjust for nullability of type of $e_0$.
+Let $e$ be an expression of the form \code{$e_0$?..$s$}
+where $e_0$ is a \synt{conditionalExpression}
+and $s$ is a \synt{cascadeSection}.
+Exactly the same compile-time errors are raised for $e$
+as would be raised for \code{$e_0$?.$s$}.
+% This means that `e?.s` can has a non-nullable type when `e` has a
+% non-nullable type. But that case is a warning, so the anomaly will
+% be flagged.
+The static type of $e$ is the static type of $e_0$.
+
+\LMHash{}%
+Evaluation of a cascaded member access expression $c$ of the form
+\code{$e$..\metavar{suffix}}
+where \metavar{suffix} is derived from \synt{cascadeSection}
+proceeds as follows:
 Evaluate $e$ to an object $o$.
 Let $t$ be a fresh variable bound to $o$.
 Evaluate \code{$t$.\metavar{suffix}} to an object.
 Then $c$ evaluates to $o$.
 
 \LMHash{}%
-The static type of $c$ is the static type of $e$.
+Evaluation of a conditional cascaded member access expression $c$ of the form
+\code{$e$?..\metavar{suffix}}
+where \metavar{suffix} is derived from \synt{cascadeSection}
+proceeds as follows:
+Evaluate $e$ to an object $o$.
+If $o$ is the null object then $e$ evaluates to $o$.
+Otherwise let $t$ be a fresh variable bound to $o$ and
+evaluate \code{$t$.\metavar{suffix}} to an object.
+Then $c$ evaluates to $o$.
 
-\rationale{
-With the introduction of null-aware conditional assignable expressions (\ref{assignableExpressions}), it would make sense to extend cascades with a null-aware conditional form as well.
-One might define \code{$e$?..\metavar{suffix}} to be equivalent to the expression \code{$t$ == \NULL{} ? \NULL{} : $t$.\metavar{suffix}} where $t$ is a fresh variable bound to the value of $e$.
-
-The present specification has not added such a construct, in the interests of simplicity and rapid language evolution.
-However, Dart implementations may experiment with such constructs, as noted in section \ref{ecmaConformance}.
+\commentary{%
+Note that an expression of the form
+\code{(($e_0$?..$s_1$)\,\,$\cdots$\,\,)?..$s_k$}
+is guaranteed to have the same observable behavior as the following
+expression, where \code{\LET\,..\,\IN} is a pseudo-code expression
+that allows for the introduction and use of a local variable
+inside an expression:
+%% TODO(eernst): If we add a \LET{} to the language, make this the
+%% official desugaring of `e?..s`.
+\code{\LET\,\,v = $e_0$\,\,\IN\,\,(v == null)?%
+  \,\,null\,:\,v..$s_1$\,\,$\cdots$\,\,..$s_k$}.
+This fact can be used by implementations to avoid the repeated checks
+for null implied by the original form.%
 }
 
 

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -9744,7 +9744,7 @@ Let $e$ be an expression of the form \code{$e_0$..$s$}
 where $e_0$ is an \synt{expression}
 such that $e$ is not initially conditional.
 Exactly the same compile-time errors are raised for $e$
-as would be raised for \code{$e_0$.$s$}.
+as would be raised for \code{($e_0$).$s$}.
 The static type of $e$ is the static type of $e_0$.
 
 \LMHash{}%
@@ -9754,12 +9754,12 @@ where $e_0$ is a \synt{conditionalExpression},
 exactly the same compile-time errors are raised for $e$
 % This rule is NNBD-ready, so we use it even though we could
 % use a slightly simpler set of rules today.
-as would be raised for \code{$e_0$?.$s$}.
+as would be raised for \code{($e_0$)?.$s$}.
 If $e$ is an expression of the form \code{$e_0$..$s$}
 where $e_0$ is an \synt{expression}
 such that $e$ is initially conditional,
 exactly the same compile-time errors are raised for $e$
-as would be raised for \code{$e_0$?.$s$}.
+as would be raised for \code{($e_0$)?.$s$}.
 In both cases, the static type of $e$ is the static type of $e_0$.
 
 \LMHash{}%
@@ -9775,23 +9775,34 @@ Evaluate \code{$t$.$s$} to an object
 (\commentary{which is discarded}).
 Then $e$ evaluates to $o$.
 
+\commentary{%
+The expressions \code{($e_0$).$s$} and \code{($e_0$)?.$s$} may have
+a very different syntactic structure than
+the expression that gave rise to them
+(namely an expression of the form \code{$e_0$..$s$} or \code{$e_0$?..$s$}).
+In particular, the cascade section $s$ may end in a cascade assignment
+such that \code{$e_0$..$s$} is of the form \code{$e_0$..$s'$ = $e_1$},
+where the cascade section \code{$s'$ = $e_1$} is a subterm of the cascade.
+However, \code{($e_0$).$s'$ = $e_1$} is an \synt{assignment} whose subterms are
+\code{($e_0$).$s'$} and \code{$e_1$}.
+This is possible because the grammar rules for \synt{cascadeSection}
+have been designed in such a way that it is guaranteed
+that \code{($e_0$).$s'$} can be parsed as an \synt{assignableExpression},
+and $e_1$ can be parsed as an \synt{expression}.%
+}
+
 \LMHash{}%
-% We should say that $e$ is an expression in the current program,
-% because this is a non-context-free property. It makes no sense to say that
-% "$e$ isn't a subexpression of $e$..$s$ for any $s$", unless we say "the
-% specific occurrence of $e$ in the program that we are now considering
-% isn't a subexpression of $e$..$s$ for any $s$". If this is considered
-% confusing then we can spell it out, but for now we trust the reader to
-% either understand this already, or to not notice that there is a
-% problem.
 For some $k > 0$,
 let $e$ be an expression of the form
 \code{$e_0$?..$s_1$..$s_2$ $\cdots$ ..$s_k$}
-where $e_0$ is a \synt{conditionalExpression}
-and $s_j$ is a \synt{cascadeSection} for each $j \in 1 .. k$.
+that occurs at some location $\ell$,
+such that $e_0$ is a \synt{conditionalExpression} and
+$s_j$ is a \synt{cascadeSection}, $j \in 1 .. k$.
 Assume that $e$ is maximal,
 in the sense that there does not exist a \synt{cascadeSection} $s$
-such that $e$ is a subexpression of \code{$e$..$s$}.
+such that there is an expression at location $\ell$
+of the form \code{$e$..$s$}
+(\commentary{in short, we can not make $e$ bigger}).
 Evaluation of $e$ proceeds as follows:
 Evaluate $e_0$ to an object $o$.
 If $o$ is the null object then $e$ evaluates to $o$.

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -9774,8 +9774,9 @@ and $s$ is a \synt{cascadeSection}.
 Exactly the same compile-time errors are raised for $e$
 as would be raised for \code{$e_0$?.$s$}.
 % This means that `e?.s` can has a non-nullable type when `e` has a
-% non-nullable type. But that case is a warning, so the anomaly will
-% be flagged.
+% non-nullable type. But that case is a warning, so the surprising type
+% will be flagged; also, it is sound to use the non-nullable type as-is.
+% PS: The nnbd feature spec does not specify any static type for $e$.
 The static type of $e$ is the static type of $e_0$.
 
 \LMHash{}%

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -9670,8 +9670,18 @@ Notice that the wording avoids re-evaluating the receiver $o$ and the arguments 
 
 \LMHash{}%
 A \IndexCustom{cascaded method invocation}{method invocation!cascaded}
-has the form \code{$e$..\metavar{suffix}}
-where $e$ is an expression and \metavar{suffix} is a sequence of operator, method, getter or setter invocations.
+has the form \code{$e$..\metavar{suffix}} or \code{$e$?..\metavar{suffix}},
+where $e$ is an expression
+and \metavar{suffix} is derived from \synt{cascadeSection}.
+
+\rationale{%
+A \synt{cascadeSection} basically allows for accessing members
+including setters.
+The motivation for having cascaded invocations is that they can be
+!!!HERE!!!
+}
+
+is a sequence of operator, method, getter or setter invocations.
 
 \begin{grammar}
 <cascadeSequence> ::= (`?..' | `..') <cascadeSection> (`..' <cascadeSection>)*

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -3054,7 +3054,9 @@ There are three kinds of initializers.
   \alt <assertion>
 
 <fieldInitializer> ::= \gnewline{}
-  (\THIS{} `.')? <identifier> `=' <conditionalExpression> <cascadeSequence>?
+  (\THIS{} `.')? <identifier> `=' <initializerExpression>
+
+<initializerExpression> ::= <conditionalExpression> | <cascade>
 \end{grammar}
 
 \LMHash{}%
@@ -5931,7 +5933,8 @@ Every object has an associated dynamic type (\ref{dynamicTypeSystem}).
 
 \begin{grammar}
 <expression> ::= <assignableExpression> <assignmentOperator> <expression>
-  \alt <conditionalExpression> <cascadeSequence>?
+  \alt <conditionalExpression>
+  \alt <cascade>
   \alt <throwExpression>
 
 <expressionWithoutCascade> ::= \gnewline{}
@@ -9672,11 +9675,12 @@ Notice that the wording avoids re-evaluating the receiver $o$ and the arguments 
 A \Index{cascade} is a kind of expression that allows for performing
 multiple operations on a given object
 without storing it in a variable and accessing it via a name.
-Cascades can have different syntactic forms,
-but will always contain two periods \lit{..}.
+In general, a cascade can be recognized by the use of two periods,
+\lit{..}.
 
 \begin{grammar}
-<cascadeSequence> ::= (`?..' | `..') <cascadeSection> (`..' <cascadeSection>)*
+<cascade> ::= <cascade> `..' <cascadeSection>
+  \alt <conditionalExpression> (`?..' | `..') <cascadeSection>
 
 <cascadeSection> ::= <cascadeSelector> <cascadeSectionTail>
 
@@ -9687,21 +9691,16 @@ but will always contain two periods \lit{..}.
   \alt <selector>* (<assignableSelector> <cascadeAssignment>)?
 
 <cascadeAssignment> ::= <assignmentOperator> <expressionWithoutCascade>
-
-<argumentPart> ::=
-  <typeArguments>? <arguments>
 \end{grammar}
 
 \LMHash{}%
 A \IndexCustom{cascaded member access}{cascaded member access}
 is an expression of the form
-\code{$e$..\metavar{suffix}} or \code{$e$?..\metavar{suffix}},
-% The grammar enforces that $e$ is a \synt{conditionalExpression},
-% but that is also an expression.
+\code{$e$..$s$} or \code{$e$?..$s$},
 where $e$ is an expression
-and \metavar{suffix} is derived from \synt{cascadeSection}.
+and $s$ is derived from \synt{cascadeSection}.
 The form
-\code{$e$?..\metavar{suffix}}
+\code{$e$?..$s$}
 is also known as a
 \IndexCustom{conditional cascaded member access}{%
   cascaded member access!conditional}.
@@ -9714,115 +9713,91 @@ while preserving a reference to that object for further processing.%
 }
 
 \commentary{%
-For example, \code{C()..foo.bar()} allows us to obtain a reference to
+For example, \code{C()..foo.bar = 2} allows us to obtain a reference to
 the object $o$ which is the result of evaluating \code{C()},
 and at the same time use $o$ to invoke the getter \code{foo} and
-invoke \code{bar()} on the value returned by that getter.%
+the setter \code{bar=} on the value returned by that getter.%
 }
 
 \LMHash{}%
-Using \synt{cascadeSequence}, an expression can include
-multiple cascade sections
-(\ref{expressions}).
-
-\LMHash{}%
-For some $k > 0$,
-let $e$ be an expression of the form
-\code{$e_0$..$s_1$\,\,$\cdots$\,\,..$s_k$}
-where $s_j$ is derived from \synt{cascadeSection}, $j \in 1 .. k$,
-such that $k$ is maximal.
-That is, there is no $s_{k+1}$ derived from \synt{cascadeSection}
-such that $e$ is a subexpression of the larger expression
-\code{$e$..$s_{k+1}$}.
-Then $e$ is treated as
-(\ref{notation})
-\code{(($e_0$..$s_1$)\,\,$\cdots$\,\,)..$s_k$}.
-
-\LMHash{}%
-For some $k > 0$,
-let $e$ be an expression of the form
-\code{$e_0$?..$s_1$\,\,$\cdots$\,\,..$s_k$}
-where $s_j$ is derived from \synt{cascadeSection}, $j \in 1 .. k$,
-such that $k$ is maximal in the same sense as above.
-Then $e$ is treated as
-\code{(($e_0$?..$s_1$)\,\,$\cdots$\,\,)?..$s_k$}.
+An expression of the form \code{$e_0$?..$s$} where
+$e_0$ is a \synt{conditionalExpression} and
+$s$ is a \synt{cascadeSection} is an
+\IndexCustom{initially conditional cascaded member access}{%
+  cascaded member access!initially conditional}.
+Moreover, if \code{$e_0$} is
+an initially conditional cascaded member access and
+$s$ is derived from \synt{cascadeSection} then
+\code{$e_0$..$s$} is also initially conditional.
 
 \commentary{%
-With these transformations in place,
-there will never be an expression that includes multiple cascade sections.
-So we need only specify the static analysis and dynamic semantics for
-expressions that contain a \synt{cascadeSequence}
-which contains exactly one \synt{cascadeSection}.%
+In short, a cascade is initially conditional if
+the ``innermost dots'' are \lit{?..} rather than \lit{..}.
+Note that only the innermost dots can have the \lit{?}.
+All the non-innermost ones are implicitly skipped if the receiver is null,
+so any \lit{?} on a non-innermost \lit{..} would be useless.%
 }
 
 \LMHash{}%
-% Note that the use of <conditionalExpression> here prevents a sequence of
-% multiple <cascadeSection>s, but it does allow ($e_1$..$s_1$)..$s$,
-% because (<expression>) is a primary.
+Let $s$ be a \synt{cascadeSection}.
 Let $e$ be an expression of the form \code{$e_0$..$s$}
-where $e_0$ is a \synt{conditionalExpression}
-and $s$ is a \synt{cascadeSection}.
+where $e_0$ is an \synt{expression}
+such that $e$ is not initially conditional.
 Exactly the same compile-time errors are raised for $e$
 as would be raised for \code{$e_0$.$s$}.
 The static type of $e$ is the static type of $e_0$.
 
 \LMHash{}%
-%% TODO(eernst): Come nnbd, adjust for nullability of type of $e_0$.
-Let $e$ be an expression of the form \code{$e_0$?..$s$}
-where $e_0$ is a \synt{conditionalExpression}
-and $s$ is a \synt{cascadeSection}.
-Exactly the same compile-time errors are raised for $e$
+Let $s$ be a \synt{cascadeSection}.
+If $e$ is an expression of the form \code{$e_0$?..$s$}
+where $e_0$ is a \synt{conditionalExpression},
+exactly the same compile-time errors are raised for $e$
+% This rule is NNBD-ready, so we use it even though we could
+% use a slightly simpler set of rules today.
 as would be raised for \code{$e_0$?.$s$}.
-% This means that `e?.s` can has a non-nullable type when `e` has a
-% non-nullable type. But that case is a warning, so the surprising type
-% will be flagged; also, it is sound to use the non-nullable type as-is.
-% PS: The nnbd feature spec does not specify any static type for $e$.
-The static type of $e$ is the static type of $e_0$.
+If $e$ is an expression of the form \code{$e_0$..$s$}
+where $e_0$ is an \synt{expression}
+such that $e$ is initially conditional,
+exactly the same compile-time errors are raised for $e$
+as would be raised for \code{$e_0$?.$s$}.
+In both cases, the static type of $e$ is the static type of $e_0$.
 
 \LMHash{}%
-Evaluation of a cascaded member access expression $c$ of the form
-\code{$e$..\metavar{suffix}}
-where \metavar{suffix} is derived from \synt{cascadeSection}
+Evaluation of a cascaded member access $e$
+of the form \code{$e_0$..$s$}
+where $e$ is an \synt{expression} and
+$s$ is a \synt{cascadeSection}
+such that $e$ is not initially conditional
 proceeds as follows:
-Evaluate $e$ to an object $o$.
+Evaluate $e_0$ to an object $o$.
 Let $t$ be a fresh variable bound to $o$.
-Evaluate \code{$t$.\metavar{suffix}} to an object.
-Then $c$ evaluates to $o$.
+Evaluate \code{$t$.$s$} to an object
+(\commentary{which is discarded}).
+Then $e$ evaluates to $o$.
 
 \LMHash{}%
-Evaluation of a conditional cascaded member access expression $c$ of the form
-\code{$e$?..\metavar{suffix}}
-where \metavar{suffix} is derived from \synt{cascadeSection}
-proceeds as follows:
-Evaluate $e$ to an object $o$.
+% We should say that $e$ is an expression in the current program,
+% because this is a non-context-free property. It makes no sense to say that
+% "$e$ isn't a subexpression of $e$..$s$ for any $s$", unless we say "the
+% specific occurrence of $e$ in the program that we are now considering
+% isn't a subexpression of $e$..$s$ for any $s$". If this is considered
+% confusing then we can spell it out, but for now we trust the reader to
+% either understand this already, or to not notice that there is a
+% problem.
+For some $k > 0$,
+let $e$ be an expression of the form
+\code{$e_0$?..$s_1$..$s_2$ $\cdots$ ..$s_k$}
+where $e_0$ is a \synt{conditionalExpression}
+and $s_j$ is a \synt{cascadeSection} for each $j \in 1 .. k$.
+Assume that $e$ is maximal,
+in the sense that there does not exist a \synt{cascadeSection} $s$
+such that $e$ is a subexpression of \code{$e$..$s$}.
+Evaluation of $e$ proceeds as follows:
+Evaluate $e_0$ to an object $o$.
 If $o$ is the null object then $e$ evaluates to $o$.
-Otherwise let $t$ be a fresh variable bound to $o$ and
-evaluate \code{$t$.\metavar{suffix}} to an object.
-Then $c$ evaluates to $o$.
-
-\commentary{%
-%% TODO(eernst): If we add a \LET{} to the language, or even just as an
-%% "official" mechanism for specification, we should make this the
-%% official desugaring of `e?..s`.
-An expression of the form
-\code{(($e_0$?..$s_1$)\,\,$\cdots$\,\,)?..$s_k$}
-is guaranteed to have the same observable behavior as the following
-expression, where \code{v} is a fresh variable:
-\code{\LET\,\,v = $e_0$\,\,\IN\,\,v == null?%
-  \,\,null\,:\,v..$s_1$\,\,$\cdots$\,\,..$s_k$}.
-In this expression, \code{\LET\,..\,\IN\,..} is
-a hypothetical expression (not currently part of Dart) that allows for
-the introduction and use of a local variable inside an expression.
-Note that in the case where $e_0$ evaluates to the null object,
-evaluation of the expression
-\code{(($e_0$?..$s_1$)\,\,$\cdots$\,\,)?..$s_k$}
-will repeatedly check for null and skip the execution of $s_j$ for all $j$.
-When $e_0$ is not the null object,
-it will repeatedly be checked and found different from null,
-and all $s_j$ will be executed.
-The equivalence with the \LET{} form can be used by implementations
-to perform the null check just once.%
-}
+Otherwise, let \code{v} be a fresh variable bound to $o$.
+Then $e$ evaluates to the result of
+evaluating \code{v..$s_1$..$s_2$ $\cdots$ ..$s_k$}.
 
 
 \subsubsection{Super Invocation}
@@ -11683,6 +11658,9 @@ Postfix expressions invoke the postfix operators on objects.
 <selector> ::= `!'
   \alt <assignableSelector>
   \alt <argumentPart>
+
+<argumentPart> ::=
+  <typeArguments>? <arguments>
 
 <incrementOperator> ::= `++'
   \alt `-\mbox-'

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -9671,7 +9671,7 @@ Notice that the wording avoids re-evaluating the receiver $o$ and the arguments 
 \LMHash{}%
 A \Index{cascade} is a kind of expression that allows for performing
 multiple operations on a given object
-without storing it in a variable and and accessing it via a name.
+without storing it in a variable and accessing it via a name.
 Cascades can have different syntactic forms,
 but will always contain two periods \lit{..}.
 

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -9801,18 +9801,27 @@ evaluate \code{$t$.\metavar{suffix}} to an object.
 Then $c$ evaluates to $o$.
 
 \commentary{%
-Note that an expression of the form
+%% TODO(eernst): If we add a \LET{} to the language, or even just as an
+%% "official" mechanism for specification, we should make this the
+%% official desugaring of `e?..s`.
+An expression of the form
 \code{(($e_0$?..$s_1$)\,\,$\cdots$\,\,)?..$s_k$}
 is guaranteed to have the same observable behavior as the following
-expression, where \code{\LET\,..\,\IN} is a pseudo-code expression
-that allows for the introduction and use of a local variable
-inside an expression:
-%% TODO(eernst): If we add a \LET{} to the language, make this the
-%% official desugaring of `e?..s`.
-\code{\LET\,\,v = $e_0$\,\,\IN\,\,(v == null)?%
+expression, where \code{v} is a fresh variable:
+\code{\LET\,\,v = $e_0$\,\,\IN\,\,v == null?%
   \,\,null\,:\,v..$s_1$\,\,$\cdots$\,\,..$s_k$}.
-This fact can be used by implementations to avoid the repeated checks
-for null implied by the original form.%
+In this expression, \code{\LET\,..\,\IN\,..} is
+a hypothetical expression (not currently part of Dart) that allows for
+the introduction and use of a local variable inside an expression.
+Note that in the case where $e_0$ evaluates to the null object,
+evaluation of the expression
+\code{(($e_0$?..$s_1$)\,\,$\cdots$\,\,)?..$s_k$}
+will repeatedly check for null and skip the execution of $s_j$ for all $j$.
+When $e_0$ is not the null object,
+it will repeatedly be checked and found different from null,
+and all $s_j$ will be executed.
+The equivalence with the \LET{} form can be used by implementations
+to perform the null check just once.%
 }
 
 


### PR DESCRIPTION
The section on cascades had no specification matching expressions like `e..m1..m2` (anything containing more than one `<cascadeSection>` was either incorrectly specified or completely unspecified, depending on the interpretation of the unspecified term _suffix_).

This PR fixes that issue, and includes conditional cascades (`?..`) as well.

It uses a `let ..` in commentary (only) because we don't otherwise use that in the specification, but is prepared for using it as normative text by having a `TODO` comment to that effect.