### PR TITLE
Add a link from the NNBD roadmap to the spec draft

### DIFF
--- a/accepted/future-releases/nnbd/roadmap.md
+++ b/accepted/future-releases/nnbd/roadmap.md
@@ -1,5 +1,7 @@
 # Sound non-nullable (by default) types with incremental migration 
 
+Note: the current draft spec is [here](feature-specification.md)
+
 Author: leafp@google.com
 
 This document proposes a roadmap for implementing a sound null tracking type


### PR DESCRIPTION
We had at least one person in PDX who was able to find the roadmap but not the spec :)