### PR TITLE
Added FINAL? to grammar of formal parameters

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -863,11 +863,11 @@ Variables are storage locations in memory.
 \begin{grammar}
 <variableDeclaration> ::= <declaredIdentifier> (`,' <identifier>)*
 
-<declaredIdentifier> ::= <metadata> \COVARIANT{}? <finalConstVarOrType> <identifier>
+<declaredIdentifier> ::= \COVARIANT? <finalConstVarOrType> <identifier>
 
-<finalConstVarOrType> ::= \LATE{}? \FINAL{} <type>?
+<finalConstVarOrType> ::= \LATE? \FINAL{} <type>?
   \alt \CONST{} <type>?
-  \alt \LATE{}? <varOrType>
+  \alt \LATE? <varOrType>
 
 <varOrType> ::= \VAR{}
   \alt <type>
@@ -1184,7 +1184,7 @@ Functions abstract over executable actions.
 
 <formalParameterPart> ::= <typeParameters>? <formalParameterList>
 
-<functionBody> ::= \ASYNC{}? `=>' <expression> `;'
+<functionBody> ::= \ASYNC? `=>' <expression> `;'
   \alt (\ASYNC{} `*'? | \SYNC{} `*')? <block>
 
 <block> ::= `{' <statements> `}'
@@ -1486,10 +1486,10 @@ It is a compile-time error if any default values are specified in the signature 
   \alt <simpleFormalParameter>
 
 <functionFormalParameter> ::= \gnewline{}
-  \COVARIANT{}? <type>? <identifier> <formalParameterPart> `?'?
+  \COVARIANT? \FINAL? <type>? <identifier> <formalParameterPart> `?'?
 
 <simpleFormalParameter> ::= <declaredIdentifier>
-  \alt \COVARIANT{}? <identifier>
+  \alt \COVARIANT? \FINAL? <identifier>
 
 <fieldFormalParameter> ::= \gnewline{}
   <finalConstVarOrType>? \THIS{} `.' <identifier> <formalParameterPart>?
@@ -1528,8 +1528,8 @@ Optional parameters may be specified and provided with default values.
 \begin{grammar}
 <defaultFormalParameter> ::= <normalFormalParameter> (`=' <expression>)?
 
-<defaultNamedParameter> ::= \REQUIRED{}? <normalFormalParameter> (`=' <expression>)?
-  \alt \REQUIRED{}? <normalFormalParameter> ( `:' <expression>)?
+<defaultNamedParameter> ::= \gnewline{}
+  \REQUIRED? <normalFormalParameter> ((`=' | `:') <expression>)?
 \end{grammar}
 
 The form \syntax{<normalFormalParameter> `:' <expression>}
@@ -12782,7 +12782,7 @@ also known as a \Index{local variable declaration},
 has the following form:
 
 \begin{grammar}
-<localVariableDeclaration> ::= <initializedVariableDeclaration> `;'
+<localVariableDeclaration> ::= <metadata> <initializedVariableDeclaration> `;'
 \end{grammar}
 
 \LMHash{}%


### PR DESCRIPTION
This PR adds an optional `final` to the syntax of formal parameters, as proposed in language issue #502 and supported by Leaf and Bob. Lasse, if you support this then we can land this PR and resolve #502. It will then need to be implemented, but it is a non-breaking change and could be done when we have the resources.

Otherwise we can just delete those two occurrences of `\FINAL?` from this PR, and land the remaining changes (which are bug fixes that came up as I checked these changes and detected differences between Dart.g and the spec).