### PR TITLE
Clarified constraints on string literals in libraryImport

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -14420,23 +14420,24 @@ refer to a library declaration.
 The interpretation of URIs is described in section \ref{uris} below.
 
 \LMHash{}%
-It is a dynamic error if the specified URI of a deferred import does not
-refer to a library declaration when the library is loaded.
-
-\rationale{%
-The problem cannot be detected at compile time because
-one does not know what the URI refers to when the library is loaded.
-However the development environment should detect the problem.%
-}
+It is a dynamic error if
+the execution of \code{loadLibrary} that loads a deferred import
+does not load the library that
+the specified URI referred to at compile-time.
 
 \LMHash{}%
 The \Index{current library} is the library currently being compiled.
-The import modifies the namespace of the current library in a manner that is determined by the imported library and by the optional elements of the import.
+The import modifies the namespace of the current library
+in a manner that is determined by the imported library and
+by the optional elements of the import.
 
 \LMHash{}%
-An immediate import directive $I$ may optionally include a prefix clause of the form \code{\AS{} \id} used to prefix names imported by $I$.
+An immediate import directive $I$ may optionally include
+a prefix clause of the form \code{\AS{} \id}
+used to prefix names imported by $I$.
 A deferred import must include a prefix clause or a compile-time error occurs.
-It is a compile-time error if a prefix used in a deferred import is used in another import clause.
+It is a compile-time error if a prefix used in a deferred import
+is used in another import clause.
 
 \LMHash{}%
 An import directive $I$ may optionally include namespace combinator clauses
@@ -14980,7 +14981,7 @@ URIs are specified by means of string literals:
 \LMHash{}%
 It is a compile-time error if a string literal that describes a URI
 or a string literal that is used in a \synt{uriTest}
-contains string interpolation.
+contains a string interpolation.
 
 \LMHash{}%
 A \Index{configurable URI} $c$ of the form

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -14415,15 +14415,19 @@ A deferred import is distinguished by the appearance of the built-in identifier 
 Any import that is not deferred is immediate.
 
 \LMHash{}%
-It is a compile-time error if the specified URI of an immediate import does not refer to a library declaration.
+It is a compile-time error if the specified URI of an import does not
+refer to a library declaration.
 The interpretation of URIs is described in section \ref{uris} below.
 
 \LMHash{}%
-It is a compile-time error if the specified URI of a deferred import does not refer to a library declaration.
+It is a dynamic error if the specified URI of a deferred import does not
+refer to a library declaration when the library is loaded.
 
-\rationale{
-One cannot detect the problem at compile time because compilation often occurs during execution and one does not know what the URI refers to.
-However the development environment should detect the problem.
+\rationale{%
+One cannot detect the problem at compile time
+because compilation often occurs during execution and
+one does not know what the URI refers to.
+However the development environment should detect the problem.%
 }
 
 \LMHash{}%
@@ -14975,10 +14979,9 @@ URIs are specified by means of string literals:
 \end{grammar}
 
 \LMHash{}%
-It is a compile-time error if the string literal $x$ that describes a URI contains a string interpolation.
-
-\LMHash{}%
-It is a compile-time error if the string literal $x$ that is used in a \synt{uriTest} is not a constant expression, or if $x$ involves string interpolation.
+It is a compile-time error if a string literal that describes a URI
+or a string literal that is used in a \synt{uriTest}
+contains string interpolation.
 
 \LMHash{}%
 A \Index{configurable URI} $c$ of the form

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -14424,9 +14424,8 @@ It is a dynamic error if the specified URI of a deferred import does not
 refer to a library declaration when the library is loaded.
 
 \rationale{%
-One cannot detect the problem at compile time
-because compilation often occurs during execution and
-one does not know what the URI refers to.
+The problem cannot be detected at compile time because
+one does not know what the URI refers to when the library is loaded.
 However the development environment should detect the problem.%
 }
 

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -30,6 +30,10 @@
 % 2.6
 % - Specify static analysis of a "callable object" invocation (where
 %   the callee is an instance of a class that has a `call` method).
+% - Specify that <libraryImport> string literals cannot use string
+%   interpolation; specify that it is a dynamic error for `loadLibrary`
+%   to load a different library than the one which was used for
+%   compile-time checks.
 %
 % 2.4
 % - Clarify the section 'Exports'.


### PR DESCRIPTION
One more thing: Right after the `<uri>` string literal sentences we had 2 identical copies of 'it's a compile-time error if the uri doesn't provide a library'. Obviously (based on the `\rationale{}` in the next paragraph), this used to be a compile-time vs. a run-time error.

So I changed the first one to cover both deferred libraries and non-deferred ones (assuming that we do want to check that a deferred library exists already at compile-time, because otherwise we couldn't emit errors for, say, calling a function exported by such a library), and the second one to be a dynamic error.

We don't indicate that it might be an error if the compile-time inspection of a deferred import yields a different library than the one that is loaded during the execution of `loadLibrary`. Obviously, if we call `f` imported by a deferred library _L_, and there is a suitable `f` in the exported namespace of _L_ at compile-time but not when loaded by `loadLibrary`, then we can't invoke `f` so there must be an error.

We could claim that this would be a 'compile-time error during loading of the library', and as such it is already covered by all the rules about compile-time errors.

However, if the actually loaded library doesn't provide an `f` then it might not be a compile-time error, because it could then just change the meaning of `f()` in some instance method body from being an invocation of the global `f` from _L_ into an invocation of `this.f()`.

So I believe we would actually have to say that the deferred library has a "library signature" and it can't change from whatever compile-time means to the time where `loadLibrary` is executed.