### PR TITLE
Fix markdown. Escape column end character

### DIFF
--- a/accepted/2.6/static-extension-members/feature-specification.md
+++ b/accepted/2.6/static-extension-members/feature-specification.md
@@ -128,7 +128,7 @@ A *simple member invocation* on a target expression `X` is an expression of one 
 | `X.id<types>(args)`           | `id`                                                         |
 | `-X`                          | `unary-`                                                     |
 | `~X`                          | `~`                                                          |
-| `X binop expr2`               | `+`, `-`, `*`, `/` , `~/`, `%`, `<`, `<=`, `>`, `>=`, `<<`, `>>`, `>>>`, `^`, `|`, `&` |
+| `X binop expr2`               | `+`, `-`, `*`, `/` , `~/`, `%`, `<`, `<=`, `>`, `>=`, `<<`, `>>`, `>>>`, `^`, `\|`, `&` |
 | `X[expr2]`                    | `[]`                                                         |
 | `X[expr2] = expr3`            | `[]=`                                                        |
 | `X(args)`                     | `call`                                                       |


### PR DESCRIPTION
Not escaped `|` is treated as end of the column and it looks like

| Member invocation on target X | Corresponding member name                                    |
| :---------------------------- | :----------------------------------------------------------- |
| `X binop expr2`               | `+`, `-`, `*`, `/` , `~/`, `%`, `<`, `<=`, `>`, `>=`, `<<`, `>>`, `>>>`, `^`, `|`, `&` |


