### PR TITLE
Added null-check selector to cascade grammar rules

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -11322,7 +11322,8 @@ In general, a cascade can be recognized by the use of exactly two periods,
 
 <cascadeSection> ::= <cascadeSelector> <cascadeSectionTail>
 
-<cascadeSelector> ::= `[' <expression> `]'
+<cascadeSelector> ::= `!'
+  \alt `[' <expression> `]'
   \alt <identifier>
 
 <cascadeSectionTail> ::= <cascadeAssignment>


### PR DESCRIPTION
Cf. https://dart-review.googlesource.com/c/sdk/+/124332 for Dart.g and a syntax test.