### PR TITLE
Resource: use-site widening function

### DIFF
--- a/resources/variance/showWidening.sml
+++ b/resources/variance/showWidening.sml
@@ -1,3 +1,16 @@
+(* Run this using `sml showWidening.sml` to get a printout of the systematic
+ * iteration over all combinations of a small set of cases: Declare a class
+ * `C` with a single type argument and a single member which is a getter `g`
+ * or a method `m` (thus covering a covariant and a contravariant placement
+ * of a type in a member signature). Next, declare a variable `c` whose type
+ * annotation is `C<... T>` where `T` is a type which is not modeled in more
+ * detail (any type would do), and `...` stands for a use-site variance
+ * modifier (absent, `out`, `inout`, or `in`). Finally, the printout shows
+ * the return type of the getter respectively the parameter type of the
+ * method, indicating how the declaration-site and use-site variance
+ * annotations give rise to an 'effective' member signature.
+ *)
+
 use "typeModel.sml";
 use "widen.sml";
 open List;

--- a/resources/variance/testWiden.sml
+++ b/resources/variance/testWiden.sml
@@ -1,0 +1,105 @@
+use "typeModel.sml";
+use "widen.sml";
+open List;
+
+(* ---------- Validation *)
+
+fun checkConfig (D_LEGACY, _, U_IN, _, _) = false
+  | checkConfig (D_OUT, _, U_IN, _, _) = false
+  | checkConfig (D_IN, _, U_OUT, _, _) = false
+  | checkConfig (_, _, _, _, _) = true;
+
+fun checkCovariantConfig c =
+    let fun f (D_LEGACY, _, _, _, _) = true
+          | f (D_OUT, X, _, _, T) = occursOnlyCovariantly X T
+          | f (D_INOUT, _, _, _, _) = true
+          | f (D_IN, X, _, _, T) = occursOnlyContravariantly X T
+    in  checkConfig c andalso f c
+    end;
+
+fun checkContravariantConfig c =
+    let fun f (D_LEGACY, _, _, _, _) = true
+          | f (D_OUT, X, _, _, T) = occursOnlyContravariantly X T
+          | f (D_INOUT, _, _, _, _) = true
+          | f (D_IN, X, _, _, T) = occursOnlyCovariantly X T
+    in  checkConfig c andalso f c
+    end;
+
+(* ---------- Auxiliary testing functions *)
+
+val concat = String.concat;
+
+fun resultToString NONE = "-"
+  | resultToString (SOME true) = "true"
+  | resultToString (SOME false) = "false";
+
+fun boolToString true = "true"
+  | boolToString false = "false";
+
+fun classOfConfig c member comment =
+    let val (d, X, u, T, _) = c
+        val receiverClassString =
+            case d of D_LEGACY => "Cl"
+                    | D_OUT => "Co"
+                    | D_INOUT => "Ci"
+                    | D_IN => "Con"
+        val typeParametersString =
+            case d of D_LEGACY => concat ["<", X, ">"]
+                    | D_OUT => concat ["<out ", X, ">"]
+                    | D_INOUT => concat ["<inout ", X, ">"]
+                    | D_IN => concat ["<in ", X, ">"]
+        val typeArgumentsString =
+            case u of U_NONE => "<T>"
+                    | U_OUT => "<out T>"
+                    | U_INOUT => "<inout T>"
+                    | U_IN => "<in T>"
+                    | U_STAR => "<*>"
+    in  concat [
+            "class ", receiverClassString, typeParametersString,
+            " {\n  ", member, "\n}\n",
+            receiverClassString,
+            typeArgumentsString,
+            " c; // ", comment, "\n\n"
+        ]
+    end;
+
+(* ---------- Look at the outcome from `widen`, `narrow` *)
+
+fun showGetter (c as (d, X, u, T, S)) =
+    let val ok = checkCovariantConfig c
+        val resultString =
+            if ok then
+                let val (widenResult, widened) = widen c
+                in  concat [
+                        "c.g ",
+                        if widened then "widened" else "ok",
+                        ": ",
+                        typeToString widenResult
+                    ]
+                end
+            else "Impossible"
+        val (_, _, _, _, t) = c
+        val member = concat [typeToString t, " get g => ...;"]
+    in  print (classOfConfig c member resultString)
+    end;
+
+fun showMethod (c as (d, X, u, T, S)) =
+    let val ok = checkContravariantConfig c
+        val resultString =
+            if ok then
+                let val (narrowResult, narrowed) = narrow c
+                in  concat ["c.m(_) ",
+                            if narrowed then "narrowed" else "ok",
+                            ": ",
+                            typeToString narrowResult
+                           ]
+                end
+            else "Impossible"
+        val (_, _, _, _, t) = c
+        val member = concat ["void m(", typeToString t, " arg) {}"]
+    in  print (classOfConfig c member resultString)
+    end;
+
+val _ = print "---------- Show code plus {widen,narrow} outcome.\n";
+val _ = map showGetter allConfigs;
+val _ = map showMethod allConfigs;

--- a/resources/variance/typeModel.sml
+++ b/resources/variance/typeModel.sml
@@ -1,0 +1,221 @@
+exception NotYet;
+
+datatype DeclarationVariance
+  = D_LEGACY | D_OUT | D_INOUT | D_IN;
+datatype UseVariance
+  = U_NONE | U_OUT | U_INOUT | U_IN | U_STAR;
+datatype Type
+  = T_Var of string (* A type variable *)
+  | T_Cl of Type (* A class whose single type argument is legacy *)
+  | T_Co of Type (* A class whose single type argument is `out` *)
+  | T_Ci of Type (* A class whose single type argument is `inout` *)
+  | T_Con of Type (* A class whose single type argument is `in` *)
+  | T_CiOut of Type (* T_Ci with use-site modifier `out` *)
+  | T_CiIn of Type (* T_Ci with use-site modifier `in` *)
+  | T_CoInout of Type (* T_Co with use-site modifier `inout` *)
+  | T_ConInout of Type (* T_Con with use-site modifier `inout` *)
+  | T_Other; (* Any type that does not contain any type variables *)
+
+(* ---------- Substitution; ignores capture *)
+
+fun subst X T (S as T_Var Y) = if X = Y then T else S
+  | subst X T (T_Cl t) = T_Cl (subst X T t)
+  | subst X T (T_Co t) = T_Co (subst X T t)
+  | subst X T (T_Ci t) = T_Ci (subst X T t)
+  | subst X T (T_Con t) = T_Con (subst X T t)
+  | subst X T (T_CiOut t) = T_CiOut (subst X T t)
+  | subst X T (T_CiIn t) = T_CiIn (subst X T t)
+  | subst X T (T_CoInout t) = T_CoInout (subst X T t)
+  | subst X T (T_ConInout t) = T_ConInout (subst X T t)
+  | subst X T T_Other = T_Other;
+
+(* ---------- Queries about the occurrences of a type variable in a type *)
+
+fun occurs X (T_Var Z) = X = Z
+  | occurs X (T_Cl t) = occurs X t
+  | occurs X (T_Co t) = occurs X t
+  | occurs X (T_Ci t) = occurs X t
+  | occurs X (T_Con t) = occurs X t
+  | occurs X (T_CiOut t) = occurs X t
+  | occurs X (T_CiIn t) = occurs X t
+  | occurs X (T_CoInout t) = occurs X t
+  | occurs X (T_ConInout t) = occurs X t
+  | occurs X T_Other = false;
+
+fun occursOnlyCovariantly X (T_Var _) = true
+  | occursOnlyCovariantly X (T_Cl t) = occursOnlyCovariantly X t
+  | occursOnlyCovariantly X (T_Co t) = occursOnlyCovariantly X t
+  | occursOnlyCovariantly X (T_Ci t) = not (occurs X t)
+  | occursOnlyCovariantly X (T_Con t) = occursOnlyContravariantly X t
+  | occursOnlyCovariantly X (T_CiOut t) = occursOnlyCovariantly X t
+  | occursOnlyCovariantly X (T_CiIn t) = occursOnlyContravariantly X t
+  | occursOnlyCovariantly X (T_CoInout t) = not (occurs X t)
+  | occursOnlyCovariantly X (T_ConInout t) = not (occurs X t)
+  | occursOnlyCovariantly X T_Other = true
+
+and occursOnlyContravariantly X (T_Var Z) = X <> Z
+  | occursOnlyContravariantly X (T_Cl t) = occursOnlyContravariantly X t
+  | occursOnlyContravariantly X (T_Co t) = occursOnlyContravariantly X t
+  | occursOnlyContravariantly X (T_Ci t) = not (occurs X t)
+  | occursOnlyContravariantly X (T_Con t) = occursOnlyCovariantly X t
+  | occursOnlyContravariantly X (T_CiOut t) = occursOnlyContravariantly X t
+  | occursOnlyContravariantly X (T_CiIn t) = occursOnlyCovariantly X t
+  | occursOnlyContravariantly X (T_CoInout t) = not (occurs X t)
+  | occursOnlyContravariantly X (T_ConInout t) = not (occurs X t)
+  | occursOnlyContravariantly X T_Other = true;
+
+(* ---------- Pretty-printing *)
+
+fun typeToString (T_Var Z) = Z
+  | typeToString (T_Cl T) =
+    String.concat ["Cl<", typeToString T, ">"]
+  | typeToString (T_Co T) =
+    String.concat ["Co<", typeToString T, ">"]
+  | typeToString (T_Ci T) =
+    String.concat ["Ci<", typeToString T, ">"]
+  | typeToString (T_Con T) =
+    String.concat ["Con<", typeToString T, ">"]
+  | typeToString (T_CiOut T) =
+    String.concat ["Ci<out ", typeToString T, ">"]
+  | typeToString (T_CiIn T) =
+    String.concat ["Ci<in ", typeToString T, ">"]
+  | typeToString (T_CoInout T) =
+    String.concat ["Co<inout ", typeToString T, ">"]
+  | typeToString (T_ConInout T) =
+    String.concat ["Con<inout ", typeToString T, ">"]
+  | typeToString  T_Other = "Other";
+
+fun declarationVarianceToString D_LEGACY = ""
+  | declarationVarianceToString D_OUT = "out "
+  | declarationVarianceToString D_INOUT = "inout "
+  | declarationVarianceToString D_IN = "in ";
+
+fun useVarianceToTypeArgumentString U_NONE T = T
+  | useVarianceToTypeArgumentString U_OUT T = String.concat ["out ", T]
+  | useVarianceToTypeArgumentString U_INOUT T = String.concat ["inout ", T]
+  | useVarianceToTypeArgumentString U_IN T = String.concat ["in ", T]
+  | useVarianceToTypeArgumentString U_STAR _ = "*";
+
+(* Assuming that the actual type argument to the receiver is shown as "T" *)
+fun configToString (d, X, u, T, t) =
+    String.concat [
+        "(",
+        declarationVarianceToString d,
+        X, ": ",
+        useVarianceToTypeArgumentString u (typeToString T),
+        ", ",
+        typeToString t,
+        ")"];
+
+(* ---------- List all configurations *)
+
+val allConfigs =
+    let val X = "X"
+        val T = T_Var "T"
+        val dVariances = [D_LEGACY, D_OUT, D_INOUT, D_IN]
+        val uVariances = [U_NONE, U_OUT, U_INOUT, U_IN, U_STAR]
+        val types = [
+            T_Var X,
+            T_Cl (T_Var X),
+            T_Co (T_Var X),
+            T_Ci (T_Var X),
+            T_Con (T_Var X),
+            T_CiOut (T_Var X),
+            T_CiIn (T_Var X),
+            T_CoInout (T_Var X),
+            T_ConInout (T_Var X),
+
+            T_Cl (T_Cl (T_Var X)),
+            T_Cl (T_Co (T_Var X)),
+            T_Cl (T_Ci (T_Var X)),
+            T_Cl (T_Con (T_Var X)),
+            T_Cl (T_CiOut (T_Var X)),
+            T_Cl (T_CiIn (T_Var X)),
+            T_Cl (T_CoInout (T_Var X)),
+            T_Cl (T_ConInout (T_Var X)),
+
+            T_Co (T_Cl (T_Var X)),
+            T_Co (T_Co (T_Var X)),
+            T_Co (T_Ci (T_Var X)),
+            T_Co (T_Con (T_Var X)),
+            T_Co (T_CiOut (T_Var X)),
+            T_Co (T_CiIn (T_Var X)),
+            T_Co (T_CoInout (T_Var X)),
+            T_Co (T_ConInout (T_Var X)),
+
+            T_Ci (T_Cl (T_Var X)),
+            T_Ci (T_Co (T_Var X)),
+            T_Ci (T_Ci (T_Var X)),
+            T_Ci (T_Con (T_Var X)),
+            T_Ci (T_CiOut (T_Var X)),
+            T_Ci (T_CiIn (T_Var X)),
+            T_Ci (T_CoInout (T_Var X)),
+            T_Ci (T_ConInout (T_Var X)),
+
+            T_Con (T_Cl (T_Var X)),
+            T_Con (T_Co (T_Var X)),
+            T_Con (T_Ci (T_Var X)),
+            T_Con (T_Con (T_Var X)),
+            T_Con (T_CiOut (T_Var X)),
+            T_Con (T_CiIn (T_Var X)),
+            T_Con (T_CoInout (T_Var X)),
+            T_Con (T_ConInout (T_Var X)),
+
+            T_CiOut (T_Cl (T_Var X)),
+            T_CiOut (T_Co (T_Var X)),
+            T_CiOut (T_Ci (T_Var X)),
+            T_CiOut (T_Con (T_Var X)),
+            T_CiOut (T_CiOut (T_Var X)),
+            T_CiOut (T_CiIn (T_Var X)),
+            T_CiOut (T_CoInout (T_Var X)),
+            T_CiOut (T_ConInout (T_Var X)),
+
+            T_CiIn (T_Cl (T_Var X)),
+            T_CiIn (T_Co (T_Var X)),
+            T_CiIn (T_Ci (T_Var X)),
+            T_CiIn (T_Con (T_Var X)),
+            T_CiIn (T_CiOut (T_Var X)),
+            T_CiIn (T_CiIn (T_Var X)),
+            T_CiIn (T_CoInout (T_Var X)),
+            T_CiIn (T_ConInout (T_Var X)),
+
+            T_CoInout (T_Cl (T_Var X)),
+            T_CoInout (T_Co (T_Var X)),
+            T_CoInout (T_Ci (T_Var X)),
+            T_CoInout (T_Con (T_Var X)),
+            T_CoInout (T_CiOut (T_Var X)),
+            T_CoInout (T_CiIn (T_Var X)),
+            T_CoInout (T_CoInout (T_Var X)),
+            T_CoInout (T_ConInout (T_Var X)),
+
+            T_ConInout (T_Cl (T_Var X)),
+            T_ConInout (T_Co (T_Var X)),
+            T_ConInout (T_Ci (T_Var X)),
+            T_ConInout (T_Con (T_Var X)),
+            T_ConInout (T_CiOut (T_Var X)),
+            T_ConInout (T_CiIn (T_Var X)),
+            T_ConInout (T_CoInout (T_Var X)),
+            T_ConInout (T_ConInout (T_Var X)),
+
+            T_Other,
+            T_Cl T_Other,
+            T_Co T_Other,
+            T_Ci T_Other,
+            T_Con T_Other,
+            T_CiOut T_Other,
+            T_CiIn T_Other,
+            T_CoInout T_Other,
+            T_ConInout T_Other
+        ]
+    in  List.concat
+            (List.map
+                 (fn typ =>
+                     List.concat
+                         (List.map
+                              (fn uVar =>
+                                  List.map
+                                      (fn dVar => (dVar, X, uVar, T, typ))
+                                      dVariances)
+                              uVariances))
+                 types)
+    end;

--- a/resources/variance/widen.sml
+++ b/resources/variance/widen.sml
@@ -1,3 +1,29 @@
+(* Compute the effective signature of a member, based on the declaration-site
+ * variance modifiers in the receiver class declaration, and the use-site
+ * variance annotations in the receiver type, plus in the member signature
+ * itself. The model considers only classes with exactly one type parameter.
+ * The main functions are `widen` and `narrow`.
+ *
+ * `widen` receives an argument which is a configuration `(d, X, u, T, S)`;
+ * `d` is the declaration-site variance, `X` is the name of the type variable
+ * of the receiver class, `u` is the use-site variance in the receiver type,
+ * `T` is the actual type argument in the receiver type, and `S` is the type
+ * from the member signature. See the comments in `typeModel.sml` for more
+ * details about the modeling of `d` (with constructors of the form D_..) 
+ * and `u` (with constructors of the form U_..).
+ *
+ * `widen` will then compute a type which is a supertype of `[T/X]S` as
+ * well as a supertype of `[T1/X]S` where `T1` is any possible dynamic
+ * value of the type argument corresponding to `T`. The relationship between
+ * the type argument `T` and the possible dynamic values corresponding to
+ * `T` is determined by the given variances (declaration-site and use-site).
+ *
+ * For instance, if the receiver type is `Ci<out T>` where the type argument
+ * of `Ci` is is `inout` then the receiver will be of type `Ci<inout T1>` 
+ * at run-time, such that `T1 <: T`. Similarly, for `Ci<in T>` the known
+ * relationship is `T <: T1`, and for `Ci<T>` it is known that `T1 == T`.
+ *)
+
 (* Raised when the given configuration is an error *)
 exception Impossible;
 

--- a/resources/variance/widen.sml
+++ b/resources/variance/widen.sml
@@ -1,0 +1,232 @@
+(* Raised when the given configuration is an error *)
+exception Impossible;
+
+fun boundOf X = T_Var (String.concat [X, ".bound"]);
+val Never = T_Var "Never";
+
+fun needsRecursion (T_Var _) = false
+  | needsRecursion (T_Cl (T_Var _)) = false
+  | needsRecursion (T_Co (T_Var _)) = false
+  | needsRecursion (T_Ci (T_Var _)) = false
+  | needsRecursion (T_Con (T_Var _)) = false
+  | needsRecursion (T_CiOut (T_Var _)) = false
+  | needsRecursion (T_CiIn (T_Var _)) = false
+  | needsRecursion (T_CoInout (T_Var _)) = false
+  | needsRecursion (T_ConInout (T_Var _)) = false
+  | needsRecursion T_Other = false
+  | needsRecursion _ = true;
+
+local fun ws X Y T newT S = if X = Y then (T, newT) else (S, false) in
+fun widenSubst X T newT (S as T_Var Y) = ws X Y T newT S
+  | widenSubst X T newT (S as T_Cl (T_Var Y)) = ws X Y (T_Cl T) newT S
+  | widenSubst X T newT (S as T_Co (T_Var Y)) = ws X Y (T_Co T) newT S
+  | widenSubst X T newT (S as T_Ci (T_Var Y)) = ws X Y (T_CiOut T) true S
+  | widenSubst X T newT (S as T_Con (T_Var Y)) = ws X Y (T_Con T) newT S
+  | widenSubst X T newT (S as T_CiOut (T_Var Y)) = ws X Y (T_CiOut T) newT S
+  | widenSubst X T newT (S as T_CiIn (T_Var Y)) = ws X Y (T_CiIn T) newT S
+  | widenSubst X T newT (S as T_CoInout (T_Var Y)) = ws X Y (T_Co T) true S
+  | widenSubst X T newT (S as T_ConInout (T_Var Y)) = ws X Y (T_Con T) true S
+  | widenSubst _ _ _ _ = raise Impossible
+end
+
+local fun ns X Y T S = if X = Y then (T, true) else (S, false) in
+fun narrowSubst X (S as T_Var Y) = ns X Y Never S
+  | narrowSubst X (S as T_Cl (T_Var Y)) = ns X Y (T_Cl Never) S
+  | narrowSubst X (S as T_Co (T_Var Y)) = ns X Y (T_Co Never) S
+  | narrowSubst X (S as T_Ci (T_Var Y)) = ns X Y Never S
+  | narrowSubst X (S as T_Con (T_Var Y)) = ns X Y (T_Con (boundOf X)) S
+  | narrowSubst X (S as T_CiOut (T_Var Y)) = ns X Y (T_CiOut Never) S
+  | narrowSubst X (S as T_CiIn (T_Var Y)) = ns X Y (T_CiIn (boundOf X)) S
+  | narrowSubst X (S as T_CoInout (T_Var Y)) = ns X Y Never S
+  | narrowSubst X (S as T_ConInout (T_Var Y)) = ns X Y Never S
+  | narrowSubst _ _ = raise Impossible
+end
+
+fun eliminateRedundancy (D_OUT, X, U_OUT, T, S) = (D_OUT, X, U_NONE, T, S)
+  | eliminateRedundancy (D_INOUT, X, U_INOUT, T, S) = (D_INOUT, X, U_NONE, T, S)
+  | eliminateRedundancy (D_IN, X, U_IN, T, S) = (D_IN, X, U_NONE, T, S)
+  | eliminateRedundancy c = c;
+
+fun contradiction (D_LEGACY, U_IN) = true
+  | contradiction (D_OUT, U_IN) = true
+  | contradiction (D_IN, U_OUT) = true
+  | contradiction _ = false;
+
+fun widen c =
+    let val (d, X, u, T, S) = eliminateRedundancy c
+        val _ = if contradiction (d, u) then raise Impossible else ()
+        fun wrongPosition (D_OUT, S as T_Ci (T_Var Y)) = true
+          | wrongPosition (D_OUT, S as T_Con (T_Var Y)) = true
+          | wrongPosition (D_OUT, S as T_CiIn (T_Var Y)) = true
+          | wrongPosition (D_OUT, S as T_CoInout (T_Var Y)) = true
+          | wrongPosition (D_OUT, S as T_ConInout (T_Var Y)) = true
+          | wrongPosition (D_IN, S as T_Var Y) = true
+          | wrongPosition (D_IN, S as T_Cl (T_Var Y)) = true
+          | wrongPosition (D_IN, S as T_Co (T_Var Y)) = true
+          | wrongPosition (D_IN, S as T_Ci (T_Var Y)) = true
+          | wrongPosition (D_IN, S as T_CiOut (T_Var Y)) = true
+          | wrongPosition (D_IN, S as T_CoInout (T_Var Y)) = true
+          | wrongPosition (D_IN, S as T_ConInout (T_Var Y)) = true
+          | wrongPosition (d, S) = false
+        val _ = if wrongPosition (d, S) then raise Impossible else ()
+        fun doWidenToBound (D_INOUT, U_IN, T_Var _) = true
+          | doWidenToBound (D_INOUT, U_IN, T_Cl (T_Var _)) = true
+          | doWidenToBound (D_INOUT, U_IN, T_Co (T_Var _)) = true
+          | doWidenToBound (D_INOUT, U_IN, T_Ci (T_Var _)) = true
+          | doWidenToBound (D_INOUT, U_IN, T_CiOut (T_Var _)) = true
+          | doWidenToBound (D_INOUT, U_IN, T_CoInout (T_Var _)) = true
+          | doWidenToBound (_, U_STAR, T_Var _) = true
+          | doWidenToBound (_, U_STAR, T_Cl (T_Var _)) = true
+          | doWidenToBound (_, U_STAR, T_Co (T_Var _)) = true
+          | doWidenToBound (_, U_STAR, T_Ci (T_Var _)) = true
+          | doWidenToBound (_, U_STAR, T_CiOut (T_Var _)) = true
+          | doWidenToBound (_, U_STAR, T_CoInout (T_Var _)) = true
+          | doWidenToBound _ = false
+        fun doWidenToT (D_LEGACY, U_NONE, T_Ci (T_Var Y)) = true
+          | doWidenToT (D_LEGACY, U_NONE, T_CoInout (T_Var Y)) = true
+          | doWidenToT (D_LEGACY, U_OUT, T_Ci (T_Var Y)) = true
+          | doWidenToT (D_LEGACY, U_OUT, T_CoInout (T_Var Y)) = true
+          | doWidenToT (D_INOUT, U_OUT, T_Ci (T_Var Y)) = true
+          | doWidenToT (D_INOUT, U_OUT, T_CoInout (T_Var Y)) = true
+          | doWidenToT (D_INOUT, U_IN, T_ConInout (T_Var Y)) = true
+          | doWidenToT _ = false
+        fun doWidenToNever (D_LEGACY, U_NONE, T_Con (T_Var Y)) = true
+          | doWidenToNever (D_LEGACY, U_NONE, T_CiIn (T_Var Y)) = true
+          | doWidenToNever (D_LEGACY, U_NONE, T_ConInout (T_Var Y)) = true
+          | doWidenToNever (D_LEGACY, U_OUT, T_Con (T_Var Y)) = true
+          | doWidenToNever (D_LEGACY, U_OUT, T_CiIn (T_Var Y)) = true
+          | doWidenToNever (D_LEGACY, U_OUT, T_ConInout (T_Var Y)) = true
+          | doWidenToNever (D_INOUT, U_OUT, T_Con (T_Var Y)) = true
+          | doWidenToNever (D_INOUT, U_OUT, T_CiIn (T_Var Y)) = true
+          | doWidenToNever (D_INOUT, U_OUT, T_ConInout (T_Var Y)) = true
+          | doWidenToNever (_, U_STAR, T_Con (T_Var Y)) = true
+          | doWidenToNever (_, U_STAR, T_CiIn (T_Var Y)) = true
+          | doWidenToNever (_, U_STAR, T_ConInout (T_Var Y)) = true
+          | doWidenToNever _ = false
+        fun wrap (d, u, U) transform wrapper =
+            let val (U1, transformed) = transform (d, X, u, T, U)
+            in  (wrapper (U1, transformed), transformed)
+            end
+        fun recur (d, u, T_Cl U) =
+            wrap (d, u, U) widen (fn (U1, _) => T_Cl U1)
+          | recur (d, u, T_Co U) =
+            wrap (d, u, U) widen (fn (U1, _) => T_Co U1)
+          | recur (d, u, T_Ci U) =
+            let fun wrapper (U1, widened) =
+                    if widened then T_CiOut U1 else T_Ci U1
+            in  wrap (d, u, U) widen wrapper
+            end
+          | recur (d, u, T_Con U) =
+            wrap (d, u, U) narrow (fn (U1, _) => T_Con U1)
+          | recur (d, u, T_CiOut U) =
+            wrap (d, u, U) widen (fn (U1, _) => T_CiOut U1)
+          | recur (d, u, T_CiIn U) =
+            wrap (d, u, U) narrow (fn (U1, _) => T_CiIn U1)
+          | recur (d, u, T_CoInout U) =
+            let fun wrapper (U1, widened) = if widened
+                                            then T_Co U1
+                                            else T_CoInout U1
+            in  wrap (d, u, U) widen wrapper
+            end
+          | recur (d, u, T_ConInout U) =
+            let fun wrapper (U1, narrowed) = if narrowed
+                                             then T_Con U1
+                                             else T_ConInout U1
+            in  wrap (d, u, U) narrow wrapper
+            end
+    in  if needsRecursion S then recur (d, u, S) else
+        if doWidenToBound (d, u, S) then widenSubst X (boundOf X) true S else
+        if doWidenToT (d, u, S) then widenSubst X T false S else
+        if doWidenToNever (d, u, S) then widenSubst X Never true S else
+        (subst X T S, false)
+    end
+
+and narrow c =
+    let val (d, X, u, T, S) = eliminateRedundancy c
+        val _ = if contradiction (d, u) then raise Impossible else ()
+        fun wrongPosition (D_IN, S as T_Ci (T_Var Y)) = true
+          | wrongPosition (D_IN, S as T_Con (T_Var Y)) = true
+          | wrongPosition (D_IN, S as T_CiIn (T_Var Y)) = true
+          | wrongPosition (D_IN, S as T_CoInout (T_Var Y)) = true
+          | wrongPosition (D_IN, S as T_ConInout (T_Var Y)) = true
+          | wrongPosition (D_OUT, S as T_Var Y) = true
+          | wrongPosition (D_OUT, S as T_Cl (T_Var Y)) = true
+          | wrongPosition (D_OUT, S as T_Co (T_Var Y)) = true
+          | wrongPosition (D_OUT, S as T_Ci (T_Var Y)) = true
+          | wrongPosition (D_OUT, S as T_CiOut (T_Var Y)) = true
+          | wrongPosition (D_OUT, S as T_CoInout (T_Var Y)) = true
+          | wrongPosition (D_OUT, S as T_ConInout (T_Var Y)) = true
+          | wrongPosition _ = false
+        val _ = if wrongPosition (d, S) then raise Impossible else ()
+        fun doNarrow (D_LEGACY, U_NONE, T_Ci (T_Var Y)) = true
+          | doNarrow (D_LEGACY, U_NONE, T_CiOut (T_Var Y)) = true
+          | doNarrow (D_LEGACY, U_NONE, T_Cl (T_Var Y)) = true
+          | doNarrow (D_LEGACY, U_NONE, T_Co (T_Var Y)) = true
+          | doNarrow (D_LEGACY, U_NONE, T_CoInout (T_Var Y)) = true
+          | doNarrow (D_LEGACY, U_NONE, T_ConInout (T_Var Y)) = true
+          | doNarrow (D_LEGACY, U_NONE, T_Var Y) = true
+          | doNarrow (D_LEGACY, U_OUT, T_Ci (T_Var Y)) = true
+          | doNarrow (D_LEGACY, U_OUT, T_CiOut (T_Var Y)) = true
+          | doNarrow (D_LEGACY, U_OUT, T_Cl (T_Var Y)) = true
+          | doNarrow (D_LEGACY, U_OUT, T_Co (T_Var Y)) = true
+          | doNarrow (D_LEGACY, U_OUT, T_CoInout (T_Var Y)) = true
+          | doNarrow (D_LEGACY, U_OUT, T_ConInout (T_Var Y)) = true
+          | doNarrow (D_LEGACY, U_OUT, T_Var Y) = true
+          | doNarrow (D_INOUT, U_OUT, T_Ci (T_Var Y)) = true
+          | doNarrow (D_INOUT, U_OUT, T_CiOut (T_Var Y)) = true
+          | doNarrow (D_INOUT, U_OUT, T_Cl (T_Var Y)) = true
+          | doNarrow (D_INOUT, U_OUT, T_Co (T_Var Y)) = true
+          | doNarrow (D_INOUT, U_OUT, T_CoInout (T_Var Y)) = true
+          | doNarrow (D_INOUT, U_OUT, T_ConInout (T_Var Y)) = true
+          | doNarrow (D_INOUT, U_OUT, T_Var Y) = true
+          | doNarrow (D_INOUT, U_IN, T_Ci (T_Var Y)) = true
+          | doNarrow (D_INOUT, U_IN, T_CiIn (T_Var Y)) = true
+          | doNarrow (D_INOUT, U_IN, T_CoInout (T_Var Y)) = true
+          | doNarrow (D_INOUT, U_IN, T_Con (T_Var Y)) = true
+          | doNarrow (D_INOUT, U_IN, T_ConInout (T_Var Y)) = true
+          | doNarrow (_, U_STAR, T_Ci (T_Var Y)) = true
+          | doNarrow (_, U_STAR, T_CiIn (T_Var Y)) = true
+          | doNarrow (_, U_STAR, T_CiOut (T_Var Y)) = true
+          | doNarrow (_, U_STAR, T_Cl (T_Var Y)) = true
+          | doNarrow (_, U_STAR, T_Co (T_Var Y)) = true
+          | doNarrow (_, U_STAR, T_CoInout (T_Var Y)) = true
+          | doNarrow (_, U_STAR, T_Con (T_Var Y)) = true
+          | doNarrow (_, U_STAR, T_ConInout (T_Var Y)) = true
+          | doNarrow (_, U_STAR, T_Var Y) = true
+          | doNarrow _ = false
+        fun wrap (d, u, U) transform wrapper =
+            let val (U1, transformed) = transform (d, X, u, T, U)
+            in  (wrapper (U1, transformed), transformed)
+            end
+        fun recur (d, u, T_Cl U) =
+            wrap (d, u, U) narrow (fn (U1, _) => T_Cl U1)
+          | recur (d, u, T_Co U) =
+            wrap (d, u, U) narrow (fn (U1, _) => T_Co U1)
+          | recur (d, u, T_Ci U) =
+            let fun wrapper (U1, narrowed) = if narrowed
+                                             then Never
+                                             else T_Ci U1
+            in  wrap (d, u, U) narrow wrapper
+            end
+          | recur (d, u, T_Con U) =
+            wrap (d, u, U) widen (fn (U1, _) => T_Con U1)
+          | recur (d, u, T_CiOut U) =
+            wrap (d, u, U) narrow (fn (U1, _) => T_CiOut U1)
+          | recur (d, u, T_CiIn U) =
+            wrap (d, u, U) widen (fn (U1, _) => T_CiIn U1)
+          | recur (d, u, T_CoInout U) =
+            let fun wrapper (U1, narrowed) = if narrowed
+                                             then Never
+                                             else T_CoInout U1
+            in  wrap (d, u, U) narrow wrapper
+            end
+          | recur (d, u, T_ConInout U) =
+            let fun wrapper (U1, narrowed) = if narrowed
+                                             then Never
+                                             else T_ConInout U1
+            in  wrap (d, u, U) widen wrapper
+            end
+    in  if needsRecursion S then recur (d, u, S) else
+        if doNarrow (d, u, S) then narrowSubst X S else
+        (subst X T S, false)
+    end;


### PR DESCRIPTION
This adds some SML source code to `resources/variance`, modeling the computation of effective member signatures for member accesses where the receiver class may have declaration-site variance modifiers on its type parameters, and the receiver type may have use-site variance modifiers on its actual type arguments, and the member signature itself may also have use-site variance modifiers.

Running `sml showWidening.sml` yields a long list of cases, systematically iterating over all combinations of a small number of types. Here is one of the examples:

```dart
class Cl<X> {
  Ci<Ci<X>> get g => ...;
}
Cl<out T> c; // c.g widened: Ci<out Ci<out T>>
```

This says that with a class `Cl` whose type argument is legacy, with a getter `g` with return type `Ci<Ci<X>>` where `Ci` has a type argument which is invariant (we always have `Cl`: legacy, `Co`: covariant, `Ci`: invariant, `Con`: contravariant), and with a variable `c` of type `Cl<out T>`, the return type of the getter `c.g` is `Ci<out Ci<out T>>`.

To unfold this, assume that `T` is `num` and the run-time value of `c` has type `Cl<int>`. The actual return type of the getter is then `Ci<Ci<int>>`, and this is safely approximated by the widened result:

```dart
Ci<Ci<int>>  <:  Ci<out Ci<int>>  <:  Ci<out Ci<out int>>  <:  Ci<out Ci<out num>>
```

The subtype relation is needed for soundness. The intention is that the effective type is never widened unless necessary, and when it is widened it should be as tight as possible, i.e., it should be the most special type which can be expressed and which is guaranteed to be a supertype of the actual run-time type.

The function `narrow` is the dual of `widen`, and it is used to find a safe approximation of the actual run-time type from below. For example:

```dart
class Ci<inout X> {
  void m(Con<inout X> arg) {}
}
Ci<out T> c; // c.m(_) narrowed: Never
```

In this case, the safe approximation to the parameter type of `c.m(_)` is `Never`. Consider the case where `T` is `num` and the run-time value of `c` has type `Ci<int>` in that case the parameter type of `m` is actually `Con<inout int>`. There is no type which is a subtype of that which preserves the reference to the class `Con` (`Con<inout int>` is a subtype of `Con<int>`, but it isn't a supertype of any type `Con<v S>` for any variance modifier `v` (including no modifier) and type `S`), so the only safe approximation from below is `Never`. In other words, we cannot call `m` when the receiver has type `Ci<out T>`.