### PR TITLE
Clarify override checking

### DIFF
--- a/accepted/future-releases/nnbd/feature-specification.md
+++ b/accepted/future-releases/nnbd/feature-specification.md
@@ -846,10 +846,9 @@ class A {
 class B {
   int foo(int x) {}
 }
-opted_out.dart
 ```
 ```dart
-// opted out
+// opted_out.dart
 // @dart = 2.6
 import 'opted_in.dart';
 
@@ -919,13 +918,37 @@ than once as `I0, .., In`, and at least one of the `Ii` is not syntactically
 equal to the others, then it is an error if `NNBD_TOP_MERGE(S0, ..., Sn)` is not
 defined where `Si` is **NORM(`Ii`)**.  Otherwise, for the purposes of runtime
 subtyping checks, `C` is considered to implement the canonical interface given
-by `NNBD_TOP_MERGE(S0, ..., Sn)`.  
+by `NNBD_TOP_MERGE(S0, ..., Sn)`.
 
 If a class `C` in an opted-in library overrides a member, it is an error if its
 signature is not a subtype of the types of all overriden members from all
-super-interfaces (whether legacy or opted-in).  Members which are inherited from
-opted-in classes through legacy classes are still seen as having their opted-in
-signature.
+super-interfaces (whether legacy or opted-in).  For the purposes of override
+checking, members which are inherited from opted-in classes through legacy
+classes are still checked against each original declaration at its opted-in
+type.  For example, the following override is considered an error.
+
+```dart
+// opted_in.dart
+class A {
+  int foo(int? x) {}
+}
+```
+```dart
+// opted_out.dart
+// @dart = 2.6
+import 'opted_in.dart';
+
+class B extends A {}
+```
+
+```dart
+// opted_in.dart
+class C extends B {
+  // Override checking is done against the opted-in signature of A.foo
+  int? foo(int x) {}
+}
+```
+
 
 If a class `C` in an opted-in library inherits a member `m` with the same name
 from multiple super-interfaces (whether legacy or opted-in), let `T0, ..., Tn`


### PR DESCRIPTION
Eliminate incorrect language implying that opted in methods inherited through legacy classes preserved their opted-in types, but clarify that override checking is still done against the original declared type (whether inherited through legacy classes or not).