### PR TITLE
Clarify mixed mode inheritance of conflicting signatures

### DIFF
--- a/accepted/future-releases/nnbd/feature-specification.md
+++ b/accepted/future-releases/nnbd/feature-specification.md
@@ -6,6 +6,10 @@ Status: Draft
 
 ## CHANGELOG
 
+2019.01.21
+  - Clarify that method inheritance checking is done relative to the
+    consolidated super-interface signature.
+
 2019.12.27
   - Update errors for switch statements.
   - Make it an error entirely to use the default `List` constructor in opted-in
@@ -1047,13 +1051,46 @@ class C extends B {
 
 
 If a class `C` in an opted-in library inherits a member `m` with the same name
-from multiple super-interfaces (whether legacy or opted-in), let `T0, ..., Tn`
-be the signatures of the inherited members.  If there is exactly one `Ti` such
-that `NNBD_SUBTYPE(Ti, Tk)` for all `k` in `0...n`, then the signature of `m` is
-considered to be `Ti`.  If there are more than one such `Ti`, then it is an
-error if the `NNBD_TOP_MERGE` of `S0, ..., Sn` does not exist, where `Si` is
-**NORM(`Ti`)**.  Otherwise, the signature of `m` for the purposes of member
+from multiple direct super-interfaces (whether legacy or opted-in), let `T0,
+..., Tn` be the signatures of the inherited members.  If there is exactly one
+`Ti` such that `NNBD_SUBTYPE(Ti, Tk)` for all `k` in `0...n`, then the signature
+of `m` is considered to be `Ti`.  If there are more than one such `Ti`, then it
+is an error if the `NNBD_TOP_MERGE` of `S0, ..., Sn` does not exist, where `Si`
+is **NORM(`Ti`)**.  Otherwise, the signature of `m` for the purposes of member
 lookup is the `NNBD_TOP_MERGE` of the `Si`.
+
+Note that when a member `m` is inherited from multiple indirect super-interfaces
+**via** a single direct super-interface, override checking is only performed
+against the signature of the direct super-interface which mediates the
+inheritance as described above.  Hence the following example is not an error,
+since the direct super-interface `C` of `D` mediates the conflicting inherited
+signatures of `foo` as `C.foo` with signature `int* Function(int*)`.
+
+```dart
+// opted_in.dart
+class A {
+  int? foo(int? x) {}
+}
+class B {
+  int foo(int x) {}
+}
+```
+```dart
+// opted_out.dart
+// @dart = 2.6
+import 'opted_in.dart';
+
+class C extends A implements B {}
+
+```
+```
+//opted in
+import 'opted_out.dart';
+class D extends C {}
+void test() {
+  new D().foo(null).isEven;
+}
+```
 
 
 ### Type reification

--- a/accepted/future-releases/nnbd/feature-specification.md
+++ b/accepted/future-releases/nnbd/feature-specification.md
@@ -1083,7 +1083,7 @@ import 'opted_in.dart';
 class C extends A implements B {}
 
 ```
-```
+```dart
 //opted in
 import 'opted_out.dart';
 class D extends C {}


### PR DESCRIPTION
cc @lrhn @munificent @scheglov @stereotype441 

Per discussion, this specifies that inherited signatures that are mediated by an intervening class use the consolidated signature from the intervening class.