### PR TITLE
Clarify the notion of being noSuchMethod forwarded

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -2404,16 +2404,18 @@ one of the following is true:
 \end{itemize}
 
 \LMHash{}%
+For a concrete class $C$, a
+\IndexCustom{noSuchMethod forwarder}{noSuchMethod forwarder}
+is implicitly induced for each member $m$ which is noSuchMethod forwarded.
+
+\LMHash{}%
 It is a compile-time error if a concrete class $C$ has
 an unimplemented member named $m$ with signature $S$,
 and a superclass of $C$ has an accessible concrete declaration of $m$
-which is not a \code{noSuchMethod} forwarder.
+which is not a noSuchMethod forwarder.
 
 \LMHash{}%
-For a concrete class $C$, a
-\IndexCustom{\code{noSuchMethod} forwarder}{noSuchMethod forwarder}
-is implicitly induced for each member $m$ which is noSuchMethod forwarded.
-This is a concrete member of $C$
+A noSuchMethod forwarder is a concrete member of $C$
 with the signature taken from the interface of $C$ respectively $D$ above,
 and with the same default value for each optional parameter.
 It can be invoked in an ordinary invocation and in a superinvocation,

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -31,6 +31,9 @@
 %   'class declaration' everywhere, so `<classDefinition>` is inconsistent).
 % - Clarify that <libraryDeclaration> and <partDeclaration> are the
 %   start symbols of the grammar.
+% - Clarify the notion of being 'noSuchMethod forwarded': `m` is indeed
+%   noSuchMethod forwarded if an implementation of `m` is inherited, but
+%   it does not have the required signature.
 %
 % 2.6
 % - Specify static analysis of a "callable object" invocation (where
@@ -2380,9 +2383,12 @@ one of the following is true:
 
 \begin{itemize}
 \item $C$ has a non-trivial \code{noSuchMethod},
-  the interface of $C$ contains $m$,
-  and $C$ has no concrete declaration of $m$
-  (\commentary{that is, no member $m$ is declared or inherited by $C$}).
+  the interface of $C$ contains a member signature $s$ named $m$,
+  and $C$ has no concrete declaration named $m$ that correctly overrides $s$
+  (\commentary{%
+    that is, no member named $m$ is declared or inherited by $C$,
+    or one is inherited, but it does not have the required signature%
+  }).
 \item
   % Inaccessible private methods are not present in the interface of a class,
   % so we need to find a class that can access $m$.
@@ -2450,8 +2456,8 @@ because compilers control the treatment of private names.
 
 \LMHash{}%
 It is a compile-time error if a concrete class $C$ has
-a \code{noSuchMethod} forwarded method signature $S$
-for a method named $m$,
+a \code{noSuchMethod} forwarded member signature $S$
+for a member named $m$,
 and a superclass of $C$ has an accessible concrete declaration of $m$
 which is not a \code{noSuchMethod} forwarder.
 

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -2392,6 +2392,7 @@ one of the following is true:
     that is, no member named $m$ is declared or inherited by $C$,
     or one is inherited, but it does not have the required signature%
   }).
+  In this case we also say that $S$ is noSuchMethod forwarded.
 \item
   \textbf{Forced by privacy:}
   There exists a direct or indirect superinterface
@@ -2401,16 +2402,18 @@ one of the following is true:
   and no superclass of $C$ has
   a concrete member named $m$ accessible to $L_2$
   that correctly overrides $S$.
+  In this case we also say that $S$ is noSuchMethod forwarded.
 \end{itemize}
 
 \LMHash{}%
 For a concrete class $C$, a
 \Index{noSuchMethod forwarder}
-is implicitly induced for each member $m$ which is noSuchMethod forwarded.
+is implicitly induced for each member signature
+which is noSuchMethod forwarded.
 
 \LMHash{}%
-It is a compile-time error if a concrete class $C$ has
-a noSuchMethod forwarded member named $m$ with signature $S$,
+It is a compile-time error if the name $m$ is noSuchMethod forwarded
+in a concrete class $C$,
 and a superclass of $C$ has an accessible concrete declaration of $m$
 which is not a noSuchMethod forwarder.
 
@@ -2442,7 +2445,7 @@ correctly override $S$. Consider the following example:%
 
 \CLASS{} C \EXTENDS{} A \IMPLEMENTS{} B \{
   noSuchMethod(Invocation i) => ...;
-  // Error: Forwarder would override `A.foo`.
+  // Error: noSuchMethod forwarder cannot override `A.foo`.
 \}
 \end{dartCode}
 

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -2391,8 +2391,6 @@ one of the following is true:
     or one is inherited, but it does not have the required signature%
   }).
 \item
-  % Inaccessible private methods are not present in the interface of a class,
-  % so we need to find a class that can access $m$.
   \textbf{Forced by privacy:}
   There exists a direct or indirect superinterface
   $D$ of $C$ which is declared in the library $L_2$,

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -2382,9 +2382,10 @@ The member $m$ is \Index{noSuchMethod forwarded} in $C$ if{}f
 one of the following is true:
 
 \begin{itemize}
-\item $C$ has a non-trivial \code{noSuchMethod},
-  the interface of $C$ contains a member signature $s$ named $m$,
-  and $C$ has no concrete declaration named $m$ that correctly overrides $s$
+\item \textbf{Requested in program:}
+  $C$ has a non-trivial \code{noSuchMethod},
+  the interface of $C$ contains a member signature $S$ named $m$,
+  and $C$ has no concrete member named $m$ that correctly overrides $S$
   (\commentary{%
     that is, no member named $m$ is declared or inherited by $C$,
     or one is inherited, but it does not have the required signature%
@@ -2392,20 +2393,26 @@ one of the following is true:
 \item
   % Inaccessible private methods are not present in the interface of a class,
   % so we need to find a class that can access $m$.
+  \textbf{Forced by privacy:}
   There exists a direct or indirect superinterface
   $D$ of $C$ which is declared in the library $L_2$,
   the interface of $D$ contains $m$
   (\commentary{which implies that $m$ is accessible to $L_2$}),
   $m$ is inaccessible to $L$,
   and no superclass of $C$ has
-  a concrete declaration of $m$ accessible to $L_2$.
+  a concrete member of $m$ accessible to $L_2$.
 \end{itemize}
+
+\LMHash{}%
+It is a compile-time error if a concrete class $C$ has
+an unimplemented member named $m$ with signature $S$,
+and a superclass of $C$ has an accessible concrete declaration of $m$
+which is not a \code{noSuchMethod} forwarder.
 
 \LMHash{}%
 For a concrete class $C$, a
 \IndexCustom{\code{noSuchMethod} forwarder}{noSuchMethod forwarder}
-is implicitly induced for each member $m$
-which is noSuchMethod forwarded.
+is implicitly induced for each member $m$ which is noSuchMethod forwarded.
 This is a concrete member of $C$
 with the signature taken from the interface of $C$ respectively $D$ above,
 and with the same default value for each optional parameter.
@@ -2415,55 +2422,11 @@ and when $m$ is a method it can be closurized
 using a property extraction
 (\ref{propertyExtraction}).
 
-\commentary{
-This implies that a \code{noSuchMethod} forwarder has the same
-properties as an explicitly declared concrete member,
-except of course that a \code{noSuchMethod} forwarder
-does not prevent itself from being induced.
-We do not specify the body of a \code{noSuchMethod} forwarder,
-but it will invoke \code{noSuchMethod},
-and we specify the dynamic semantics of executing it below.
-}
-
-\commentary{
-At the beginning of this section we mentioned that implicit invocations
-of \code{noSuchMethod} can only occur
-with a receiver of static type \DYNAMIC{}
-or a function of static type \DYNAMIC{} or \FUNCTION{}.
-With a \code{noSuchMethod} forwarder,
-\code{noSuchMethod} can also be invoked
-on a receiver whose static type is not \DYNAMIC{}.
-No similar situation exists for functions,
-because it is impossible to induce a \code{noSuchMethod} forwarder
-into the class of a function object.
-}
-
-\commentary{
-For a concrete class $C$,
-we may think of a non-trivial \code{noSuchMethod}
-(declared in or inherited by $C$)
-as a request for ``automatic implementation'' of all unimplemented members
-in the interface of $C$ as \code{noSuchMethod} forwarders.
-Similarly, there is an implicit request for
-automatic implementation of all unimplemented
-inaccessible members of any concrete class,
-whether or not there is a non-trivial \code{noSuchMethod}.
-Note that the latter cannot be written explicitly in Dart,
-because their names are inaccessible;
-but the language can still specify that they are induced implicitly,
-because compilers control the treatment of private names.
-}
-
-\LMHash{}%
-It is a compile-time error if a concrete class $C$ has
-a \code{noSuchMethod} forwarded member signature $S$
-for a member named $m$,
-and a superclass of $C$ has an accessible concrete declaration of $m$
-which is not a \code{noSuchMethod} forwarder.
-
-\commentary{
-This can only happen if that concrete declaration does not
-correctly override $S$. Consider the following example:
+\commentary{%
+The error concerned with an implictly induced forwarder
+that would override a human-written declaration
+can only occur if that concrete declaration does not
+correctly override $S$. Consider the following example:%
 }
 
 \begin{dartCode}
@@ -2506,6 +2469,45 @@ It is no problem, however,
 to let a \code{noSuchMethod} forwarder override
 another \code{noSuchMethod} forwarder,
 and hence there is no error in that situation.
+}
+
+\commentary{
+This implies that a \code{noSuchMethod} forwarder has the same
+properties as an explicitly declared concrete member,
+except of course that a \code{noSuchMethod} forwarder
+does not prevent itself from being induced.
+We do not specify the body of a \code{noSuchMethod} forwarder,
+but it will invoke \code{noSuchMethod},
+and we specify the dynamic semantics of executing it below.
+}
+
+\commentary{
+At the beginning of this section we mentioned that implicit invocations
+of \code{noSuchMethod} can only occur
+with a receiver of static type \DYNAMIC{}
+or a function of static type \DYNAMIC{} or \FUNCTION{}.
+With a \code{noSuchMethod} forwarder,
+\code{noSuchMethod} can also be invoked
+on a receiver whose static type is not \DYNAMIC{}.
+No similar situation exists for functions,
+because it is impossible to induce a \code{noSuchMethod} forwarder
+into the class of a function object.
+}
+
+\commentary{
+For a concrete class $C$,
+we may think of a non-trivial \code{noSuchMethod}
+(declared in or inherited by $C$)
+as a request for ``automatic implementation'' of all unimplemented members
+in the interface of $C$ as \code{noSuchMethod} forwarders.
+Similarly, there is an implicit request for
+automatic implementation of all unimplemented
+inaccessible members of any concrete class,
+whether or not there is a non-trivial \code{noSuchMethod}.
+Note that the latter cannot be written explicitly in Dart,
+because their names are inaccessible;
+but the language can still specify that they are induced implicitly,
+because compilers control the treatment of private names.
 }
 
 \LMHash{}%

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -2410,7 +2410,7 @@ is implicitly induced for each member $m$ which is noSuchMethod forwarded.
 
 \LMHash{}%
 It is a compile-time error if a concrete class $C$ has
-an unimplemented member named $m$ with signature $S$,
+an noSuchMethod forwarded member named $m$ with signature $S$,
 and a superclass of $C$ has an accessible concrete declaration of $m$
 which is not a noSuchMethod forwarder.
 

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -2376,9 +2376,10 @@ where only the null object is accepted:
 \end{dartCode}
 
 \LMHash{}%
-Let $C$ be a concrete class and
-let $L$ be the library that contains the declaration of $C$.
-The member $m$ is \Index{noSuchMethod forwarded} in $C$ if{}f
+Let $C$ be a concrete class,
+let $L$ be the library that contains the declaration of $C$,
+and let $m$ be a name.
+Then $m$ is \Index{noSuchMethod forwarded} in $C$ if{}f
 one of the following is true:
 
 \begin{itemize}
@@ -2393,22 +2394,22 @@ one of the following is true:
 \item
   \textbf{Forced by privacy:}
   There exists a direct or indirect superinterface
-  $D$ of $C$ which is declared in the library $L_2$,
-  the interface of $D$ contains $m$
-  (\commentary{which implies that $m$ is accessible to $L_2$}),
-  $m$ is inaccessible to $L$,
+  $D$ of $C$ which is declared in a library $L_2$ different from $L$,
+  the interface of $D$ contains a member signature $S$ named $m$,
+  $m$ is a private name,
   and no superclass of $C$ has
-  a concrete member of $m$ accessible to $L_2$.
+  a concrete member named $m$ accessible to $L_2$
+  that correctly overrides $S$.
 \end{itemize}
 
 \LMHash{}%
 For a concrete class $C$, a
-\IndexCustom{noSuchMethod forwarder}{noSuchMethod forwarder}
+\Index{noSuchMethod forwarder}
 is implicitly induced for each member $m$ which is noSuchMethod forwarded.
 
 \LMHash{}%
 It is a compile-time error if a concrete class $C$ has
-an noSuchMethod forwarded member named $m$ with signature $S$,
+a noSuchMethod forwarded member named $m$ with signature $S$,
 and a superclass of $C$ has an accessible concrete declaration of $m$
 which is not a noSuchMethod forwarder.
 

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -2418,8 +2418,11 @@ and a superclass of $C$ has an accessible concrete declaration of $m$
 which is not a noSuchMethod forwarder.
 
 \LMHash{}%
+%% TODO(eernst): We used to say 'the interface of $C$ or $D$'; but we
+%% need to change 'accessible' to a scheme similar to name-merging everywhere
+%% in order to be able to say this precisely.
 A noSuchMethod forwarder is a concrete member of $C$
-with the signature taken from the interface of $C$ respectively $D$ above,
+with the signature taken from the interface of $C$,
 and with the same default value for each optional parameter.
 It can be invoked in an ordinary invocation and in a superinvocation,
 and when $m$ is a method it can be closurized
@@ -2480,7 +2483,7 @@ and hence there is no error in that situation.
 This implies that a \code{noSuchMethod} forwarder has the same
 properties as an explicitly declared concrete member,
 except of course that a \code{noSuchMethod} forwarder
-does not prevent itself from being induced.
+does not prevent itself or another noSuchMethod forwarder from being induced.
 We do not specify the body of a \code{noSuchMethod} forwarder,
 but it will invoke \code{noSuchMethod},
 and we specify the dynamic semantics of executing it below.

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -2386,7 +2386,8 @@ one of the following is true:
 \item \textbf{Requested in program:}
   $C$ has a non-trivial \code{noSuchMethod},
   the interface of $C$ contains a member signature $S$ named $m$,
-  and $C$ has no concrete member named $m$ that correctly overrides $S$
+  and $C$ has no concrete member named $m$ and accessible to $L$
+  that correctly overrides $S$
   (\commentary{%
     that is, no member named $m$ is declared or inherited by $C$,
     or one is inherited, but it does not have the required signature%


### PR DESCRIPTION
The current language specification text about a noSuchMethod forwarded member seems to imply that `m` is _not_ nsm forwarded when an implementation named `m` is inherited. As is implied by the example a few lines later, this was never the intention: We must have an implementation named `m` which is a correct override of the member signature named `m` in the interface of the class, and if we don't have that then `m` is nsm forwarded.