### PR TITLE
Introduced static rules into section Asynchronous For-in

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -14793,6 +14793,12 @@ but $e$ evaluates to an instance of a type
 which is not a subtype of \code{Iterable<dynamic>}.
 }
 
+\LMHash{}%
+The scope introduced by \code{\{\,$S$\,\}} around $S$
+is known as the
+\IndexCustom{scope of the for-in statement $s$}{%
+  scope!for-in statement}.
+
 
 \subsubsection{Asynchronous For-in}
 \LMLabel{asynchronousFor-in}
@@ -14800,12 +14806,69 @@ which is not a subtype of \code{Iterable<dynamic>}.
 \LMHash{}%
 A for-in statement may be asynchronous.
 The asynchronous form is designed to iterate over streams.
-An asynchronous for loop is distinguished by the keyword \AWAIT{} immediately preceding the keyword \FOR.
+An asynchronous for loop is distinguished by
+the keyword \AWAIT{} immediately preceding the keyword \FOR.
+
+\LMHash{}%
+It is a compile-time error if an asynchronous for-in statement appears
+inside a synchronous function (\ref{functions}).
+It is a compile-time error if a traditional for loop
+(\ref{forLoop})
+is prefixed by the \AWAIT{} keyword.
+
+\rationale{%
+An asynchronous loop would make no sense within a synchronous function,
+for the same reasons that an await expression makes no sense in
+a synchronous function.%
+}
+
+\LMHash{}%
+Let $D$ be derived from \syntax{<finalConstVarOrType>?}\ and
+let $s$ be an asynchronous for-in statement of the form
+`\code{\AWAIT\,\,\FOR\,\,($D$\,\,\id\,\,\IN\,\,$e$)\,\,$s_b$}'.
+Let $T_e$ be the static type of $e$.
+A compile-time error occurs unless $T_e$ may be assigned to
+\code{Stream<\DYNAMIC>}.
+%% TODO(eernst): Come nnbd, `a top type` --> `\DYNAMIC{}`.
+If $T_e$ is a top type then let $T_{\metavar{elm}}$ be \DYNAMIC.
+Otherwise there exists a type $U$
+such that $T_e$ implements \code{Stream<$U$>},
+in which case $T_{\metavar{elm}}$ is $U$.
+
+\LMHash{}%
+If $D$ is empty:
+Assume that $v$ is a fresh variable with declared type $T_{\metavar{elm}}$.
+%% Several cases here: \id{} could denote a local variable, an instance or
+%% static setter, nothing, or a lot of things causing an error.
+A compile-time error occurs if replacing $s$ by
+the statement `\code{\id\,\,=\,\,$v$;}'
+would give rise to a compile-time error.
+
+\LMHash{}%
+Otherwise, $D$ is not empty:
+Let $V$ be the declared type of \id.
+\commentary{%
+Type inference is assumed to have taken place already
+(\ref{overview}),
+so $V$ may be present explicitly or it may have been inferred.%
+}
+A compile-time error occurs unless $T_{\metavar{elm}}$ may be assigned to $V$.
+
+\LMHash{}%
+In either case
+(\commentary{with an empty or non-empty $D$}),
+a fresh scope, the
+\IndexCustom{scope of the asynchronous for-in statement $s$}{%
+  scope!asynchronous for-in statement},
+is introduced which has the enclosing scope of $s$ as its enclosing scope,
+and which is the current scope for the body $s_b$.
+If $D$ is non-empty it introduces a local variable into
+the scope of $s$ with the name \id{} and the declared type $V$.
 
 \LMHash{}%
 Let $D$ be derived from \syntax{<finalConstVarOrType>?}.
-Execution of a for-in statement, $f$, of the form
-\code{\AWAIT{} \FOR{} ($D$ \id{} \IN{} $e$) $s$}
+Execution of a for-in statement, $s$, of the form
+`\code{\AWAIT\,\,\FOR\,\,($D$\,\,\id\,\,\IN\,\,$e$)\,\,$s_b$}'
 proceeds as follows:
 
 \LMHash{}%
@@ -14833,27 +14896,39 @@ The \code{pause} call can throw, although that should never happen for a correct
 
 \LMHash{}%
 For each \Index{data event} from $u$,
-the statement $s$ is executed with \id{} bound to the value of the current data event.
+the statement $s_b$ is executed with \id{} bound to
+the value of the current data event.
 
 \commentary{
-Either execution of $s$ is completely synchronous, or it contains an
+Either execution of $s_b$ is completely synchronous, or it contains an
 asynchronous construct (\AWAIT{}, \AWAIT{} \FOR{}, \YIELD{} or \YIELD*)
 which will pause the stream subscription of its surrounding asynchronous loop.
-This ensures that no other event of $u$ occurs before execution of $s$ is complete, if $o$ is a correctly implemented stream.
-If $o$ doesn't act as a valid stream, for example by not respecting pause requests, the behavior of the asynchronous loop may become unpredictable.
+This ensures that no other event of $u$ occurs
+before execution of $s_b$ is complete,
+if $o$ is a correctly implemented stream.
+If $o$ doesn't act as a valid stream,
+for example by not respecting pause requests,
+the behavior of the asynchronous loop may become unpredictable.
 }
 
 \LMHash{}%
-If execution of $s$ continues without a label, or to a label (\ref{labels}) that prefixes the asynchronous for statement (\ref{statementCompletion}), then the execution of $s$ is treated as if it had completed normally.
+If execution of $s_b$ continues without a label, or
+to a label (\ref{labels}) that prefixes the asynchronous for statement
+(\ref{statementCompletion}),
+then the execution of $s_b$ is treated as if it had completed normally.
 
-If execution of $s$ otherwise does not complete normally, the subscription $u$ is canceled by evaluating \code{\AWAIT{} $v$.cancel()} where $v$ is a fresh variable referencing the stream subscription $u$.
+If execution of $s_b$ otherwise does not complete normally,
+the subscription $u$ is canceled by evaluating \code{\AWAIT{} $v$.cancel()}
+where $v$ is a fresh variable referencing the stream subscription $u$.
 If that evaluation throws,
-execution of $f$ throws the same exception and stack trace.
-Otherwise execution of $f$ completes in the same way as the execution of $s$.
+execution of $s_b$ throws the same exception and stack trace.
+Otherwise execution of $s$ completes in the same way as the execution of $s_b$.
 % Notice: The previous specification was unclear about what happened when
 % a subscripton is canceled. This text is explicit, and existing
 % implementations may not properly await the cancel call.
-Otherwise the execution of $f$ is suspended again, waiting for the next stream subscription event, and $u$ is resumed if it has been paused.
+Otherwise the execution of $s_b$ is suspended again,
+waiting for the next stream subscription event,
+and $u$ is resumed if it has been paused.
 \commentary{
 The \code{resume} call can throw, in which case the asynchronous for
 loop also throws.
@@ -14866,19 +14941,12 @@ with error object $e$ and stack trace $st$,
 the subscription $u$ is canceled by evaluating \code{\AWAIT{} v.cancel()}
 where $v$ is a fresh variable referencing the stream subscription $u$.
 If that evaluation throws,
-execution of $f$ throws the same exception object and stack trace.
-Otherwise execution of $f$ throws with $e$ as exception object and $st$ as stack trace.
+execution of $s_b$ throws the same exception object and stack trace.
+Otherwise execution of $s_b$ throws
+with $e$ as exception object and $st$ as stack trace.
 
 \LMHash{}%
-When $u$ is done, execution of $f$ completes normally.
-
-\LMHash{}%
-It is a compile-time error if an asynchronous for-in statement appears inside a synchronous function (\ref{functions}).
-It is a compile-time error if a traditional for loop (\ref{forLoop}) is prefixed by the \AWAIT{} keyword.
-
-\rationale{
-An asynchronous loop would make no sense within a synchronous function, for the same reasons that an await expression makes no sense in a synchronous function.
-}
+When $u$ is done, execution of $s_b$ and $s$ completes normally.
 
 
 \subsection{While}

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -14939,11 +14939,11 @@ although that should never happen for a correctly implemented stream.%
 
 \LMHash{}%
 For each \Index{data event} from $u$,
-the statement $s_b$ is executed with a fresh variable named \id{} bound to
+the statement $s_b$ is executed in a fresh scope where \id{} is bound to
 the value of the current data event.
 
 \commentary{%
-The fact that each iteration uses a fresh variable ensures that
+The fact that each iteration uses a fresh scope ensures that
 the variable may be captured by referencing it in a function literal in $s_b$,
 and the captured variable will then retain the value from that iteration,
 rather than being updated in each subsequent iteration.%

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -487,12 +487,23 @@ and use a concise and clear notation across the specification.
 When the specification refers to the order given in the program, it means the order of the program source code text, scanning left-to-right and top-to-bottom.
 
 \LMHash{}%
+%% TODO(eernst): Come nnbd, specify that a fresh variable with a specific
+%% declared type is assumed to be definitely assigned, such that it is
+%% never an error to evaluate it.
 When the specification refers to a
 \IndexCustom{fresh variable}{variable!fresh},
 it means a local variable with a name that doesn't occur anywhere
 in the current program.
 When the specification introduces a fresh variable bound to an object,
 the fresh variable is implicitly bound in a surrounding scope.
+
+\commentary{%
+Note that a fresh variable $v$ is never promoted,
+because there are no references to it in the current program.
+So if $v$ is a fresh variable of type $T$,
+and $v$ is used as en expression,
+the static type of that expression is $T$.%
+}
 
 \LMHash{}%
 References to otherwise unspecified names of program entities
@@ -14842,8 +14853,8 @@ Assume that $v$ is a fresh variable with declared type $T_{\metavar{elm}}$.
 %% Several cases here: \id{} could denote a local variable, an instance or
 %% static setter, nothing, or a lot of things causing an error.
 A compile-time error occurs if replacing $s$ by
-the statement `\code{\id\,\,=\,\,$v$;}'
-would give rise to a compile-time error.
+the statement $s_1$ of the form `\code{\id\,\,=\,\,$v$;}'
+would make $s_1$ a compile-time error.
 
 \LMHash{}%
 Otherwise, $D$ is not empty:
@@ -14952,7 +14963,13 @@ Otherwise execution of $s_b$ throws
 with $e$ as exception object and $st$ as stack trace.
 
 \LMHash{}%
-When $u$ is done, execution of $s_b$ and $s$ completes normally.
+If $u$ emits an error event
+with error object \metavar{error} and associated stack trace \metavar{stack},
+then $u$ is cancelled and completed in the same way as if
+$s_b$ had completed by throwing \metavar{error} and \metavar{stack}.
+
+\LMHash{}%
+When $u$ emits a done event, execution of $s$ completes normally.
 
 
 \subsection{While}

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -14707,6 +14707,10 @@ The \Index{for statement} supports iteration.
 \subsubsection{For Loop}
 \LMLabel{forLoop}
 
+%% TODO(eernst): When updating this section to have static analysis,
+%% move the error from \ref{asynchronousFor-in} about traditional for loops
+%% to this section.
+
 \LMHash{}%
 Execution of a for statement of the form
 \code{\FOR{} (\VAR{} $v$ = $e_0$; $c$; $e$) $s$} proceeds as follows:
@@ -14777,7 +14781,7 @@ It is a compile-time error if the static type of $c$ may not be assigned to \cod
 
 \LMHash{}%
 Let $D$ be derived from \syntax{<finalConstVarOrType>?}.
-A for statement of the form \code{\FOR{} ($D$ \id{} \IN{} $e$)\,\,$S$}
+A for statement of the form \code{\FOR{} ($D$ \id{} \IN{} $e$)\,\,$s$}
 is then treated as the following code,
 where $\id_1$ and $\id_2$ are fresh identifiers:
 
@@ -14786,7 +14790,7 @@ $T$ $\id_1$ = $e$;
 \VAR{} $\id_2$ = $id_1$.iterator;
 \WHILE{} ($\id_2$.moveNext()) \{
 \ \ $D$ \id{} = $\id_2$.current;
-\ \ \{ $S$ \}
+\ \ \{ $s$ \}
 \}
 \end{normativeDartCode}
 
@@ -14795,7 +14799,8 @@ If the static type of $e$ is a top type
 (\ref{superBoundedTypes})
 then $T$ is \code{Iterable<\DYNAMIC>},
 otherwise $T$ is the static type of $e$.
-It is a compile-time error if $T$ is not assignable to \code{Iterable<\DYNAMIC>}.
+It is a compile-time error if $T$ is not assignable
+to \code{Iterable<\DYNAMIC>}.
 
 \commentary{
 It follows that it is a compile-time error
@@ -14806,10 +14811,10 @@ which is not a subtype of \code{Iterable<dynamic>}.
 }
 
 \LMHash{}%
-The scope introduced by \code{\{\,$S$\,\}} around $S$
+The scope introduced by \code{\{\,$s$\,\}} around $s$
 is known as the
-\IndexCustom{scope of the for-in statement $s$}{%
-  scope!for-in statement}.
+\IndexCustom{for-in scope}{scope!for-in statement},
+and it allows the body of the statement to access the iteration variable.
 
 
 \subsubsection{Asynchronous For-in}
@@ -14822,8 +14827,10 @@ An asynchronous for loop is distinguished by
 the keyword \AWAIT{} immediately preceding the keyword \FOR.
 
 \LMHash{}%
-It is a compile-time error if an asynchronous for-in statement appears
-inside a synchronous function (\ref{functions}).
+It is a compile-time error if an asynchronous for-in statement occurs,
+unless there is an innermost enclosing function which is asynchronous
+(\ref{functions}).
+%% TODO(eernst): Move this to \ref{forLoop} when that section is updated.
 It is a compile-time error if a traditional for loop
 (\ref{forLoop})
 is prefixed by the \AWAIT{} keyword.
@@ -14835,7 +14842,7 @@ a synchronous function.%
 }
 
 \LMHash{}%
-Let $D$ be derived from \syntax{<finalConstVarOrType>?}\ and
+Let $D$ be derived from \synt{finalConstVarOrType} and
 let $s$ be an asynchronous for-in statement of the form
 `\code{\AWAIT\,\,\FOR\,\,($D$\,\,\id\,\,\IN\,\,$e$)\,\,$s_b$}'.
 Let $T_e$ be the static type of $e$.
@@ -14848,16 +14855,6 @@ such that $T_e$ implements \code{Stream<$U$>},
 in which case $T_{\metavar{elm}}$ is $U$.
 
 \LMHash{}%
-If $D$ is empty:
-Assume that $v$ is a fresh variable with declared type $T_{\metavar{elm}}$.
-%% Several cases here: \id{} could denote a local variable, an instance or
-%% static setter, nothing, or a lot of things causing an error.
-A compile-time error occurs if replacing $s$ by
-the statement $s_1$ of the form `\code{\id\,\,=\,\,$v$;}'
-would make $s_1$ a compile-time error.
-
-\LMHash{}%
-Otherwise, $D$ is not empty:
 Let $V$ be the declared type of \id.
 \commentary{%
 Type inference is assumed to have taken place already
@@ -14867,27 +14864,56 @@ so $V$ may be present explicitly or it may have been inferred.%
 A compile-time error occurs unless $T_{\metavar{elm}}$ may be assigned to $V$.
 
 \LMHash{}%
-In either case
-(\commentary{with an empty or non-empty $D$}),
-a fresh scope, the
-\IndexCustom{scope of the asynchronous for-in statement $s$}{%
-  scope!asynchronous for-in statement},
-is introduced which has the enclosing scope of $s$ as its enclosing scope,
+A fresh scope is introduced, known as the
+\IndexCustom{for-in scope}{scope!asynchronous for-in statement},
+which has the current scope of $s$ as its enclosing scope,
 and which is the current scope for the body $s_b$.
-If $D$ is non-empty it introduces a local variable into
-the scope of $s$ with the name \id{} and the declared type $V$.
+A local variable is introduced into the scope of $s$
+with the name \id{} and the declared type $V$.
+
+\commentary{%
+An asynchronous for-in statement can use
+a name which is in scope rather than declaring a new variable.
+This occurs when the \synt{finalConstVarOrType} is omitted,
+as is allowed by the grammar.
+This is a shorthand for an additional variable:%
+}
 
 \LMHash{}%
-Let $D$ be derived from \syntax{<finalConstVarOrType>?}.
-Execution of a for-in statement, $s$, of the form
-`\code{\AWAIT\,\,\FOR\,\,($D$\,\,\id\,\,\IN\,\,$e$)\,\,$s_b$}'
-proceeds as follows:
+Let $s_{\metavar{novar}}$ of the form
+`\code{\AWAIT\,\,\FOR\,\,(\id\,\,\IN\,\,$e$)\,\,$s_b$}'
+be an asynchronous for-in statement, and $v$ a fresh name.
+Then $s_{\metavar{novar}}$ is treated as the following:
+
+\begin{normativeDartCode}
+\AWAIT{} \FOR{} ($T_{\metavar{elm}}$ $v$ \IN{} $e$) \{
+\ \ \id{} = $v$;
+\ \ \{ $s_b$ \}
+\}
+\end{normativeDartCode}
+
+\noindent
+where $T_{\metavar{elm}}$ is determined in the same way as above.
+
+\commentary{%
+Having desugared $s_{\metavar{novar}}$ to
+a form that declares an iteration variable,
+we can assume everywhere else that an asynchronous for-in statement
+declares an iteration variable.%
+}
+
+\LMHash{}%
+Execution proceeds as follows.
+Let $D$ be derived from \syntax{<finalConstVarOrType>}.
+Let $s$ be an asynchronous for-in statement of the form
+`\code{\AWAIT\,\,\FOR\,\,($D$\,\,\id\,\,\IN\,\,$e$)\,\,$s_b$}'.
 
 \LMHash{}%
 The expression $e$ is evaluated to an object $o$.
 % This error can occur due to implicit casts and null.
 It is a dynamic type error if $o$ is not an instance of
-a class that implements \code{Stream}.
+a class that implements \code{Stream<$U$>}
+for some type $U$ which is assignable to $T_{\metavar{elm}}$.
 
 \LMHash{}%
 The stream associated with the innermost enclosing asynchronous for loop,
@@ -14913,12 +14939,26 @@ although that should never happen for a correctly implemented stream.%
 
 \LMHash{}%
 For each \Index{data event} from $u$,
-the statement $s_b$ is executed with \id{} bound to
+the statement $s_b$ is executed with a fresh variable named \id{} bound to
 the value of the current data event.
 
 \commentary{%
-Either execution of $s_b$ is completely synchronous, or it contains an
-asynchronous construct (\AWAIT{}, \AWAIT{} \FOR{}, \YIELD{} or \YIELD*)
+The fact that each iteration uses a fresh variable ensures that
+the variable may be captured by referencing it in a function literal in $s_b$,
+and the captured variable will then retain the value from that iteration,
+rather than being updated in each subsequent iteration.%
+}
+
+\rationale{%
+This helps avoiding the common bug where such a captured variable ends up
+having the value from the very last iteration in all function objects
+obtained by evaluating that function literal.%
+}
+
+\commentary{%
+Execution of $s_b$ is either completely synchronous,
+or it contains an asynchronous construct
+(\AWAIT{}, \AWAIT{} \FOR{}, \YIELD{} or \YIELD*)
 which will pause the stream subscription of its surrounding asynchronous loop.
 This ensures that no other event of $u$ occurs
 before execution of $s_b$ is complete,
@@ -14934,18 +14974,20 @@ to a label (\ref{labels}) that prefixes the asynchronous for statement
 (\ref{statementCompletion}),
 then the execution of $s_b$ is treated as if it had completed normally.
 
+\LMHash{}%
 If execution of $s_b$ otherwise does not complete normally,
 the subscription $u$ is canceled by evaluating \code{\AWAIT{} $v$.cancel()}
 where $v$ is a fresh variable referencing the stream subscription $u$.
 If that evaluation throws,
-execution of $s_b$ throws the same exception and stack trace.
+execution of $s$ throws the same exception and stack trace.
 Otherwise execution of $s$ completes in the same way as the execution of $s_b$.
 % Notice: The previous specification was unclear about what happened when
 % a subscripton is canceled. This text is explicit, and existing
 % implementations may not properly await the cancel call.
-Otherwise the execution of $s_b$ is suspended again,
+Otherwise the execution of $s$ is suspended again,
 waiting for the next stream subscription event,
 and $u$ is resumed if it has been paused.
+
 \commentary{%
 The \code{resume} call can throw, in which case the asynchronous for
 loop also throws.
@@ -14958,15 +15000,9 @@ with error object $e$ and stack trace $st$,
 the subscription $u$ is canceled by evaluating \code{\AWAIT{} v.cancel()}
 where $v$ is a fresh variable referencing the stream subscription $u$.
 If that evaluation throws,
-execution of $s_b$ throws the same exception object and stack trace.
-Otherwise execution of $s_b$ throws
+execution of $s$ throws the same exception object and stack trace.
+Otherwise execution of $s$ throws
 with $e$ as exception object and $st$ as stack trace.
-
-\LMHash{}%
-If $u$ emits an error event
-with error object \metavar{error} and associated stack trace \metavar{stack},
-then $u$ is cancelled and completed in the same way as if
-$s_b$ had completed by throwing \metavar{error} and \metavar{stack}.
 
 \LMHash{}%
 When $u$ emits a done event, execution of $s$ completes normally.

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -40,6 +40,7 @@
 %   consistent with decision in SDK issue #33415.
 % - Re-adjust `yield*` rules: Per-element type checks are not supported,
 %   the given Iterable/Stream must have a safe element type.
+% - Specify static analysis of asynchronous for-in statements.
 %
 % 2.6
 % - Specify static analysis of a "callable object" invocation (where
@@ -14874,24 +14875,29 @@ proceeds as follows:
 \LMHash{}%
 The expression $e$ is evaluated to an object $o$.
 % This error can occur due to implicit casts and null.
-It is a dynamic type error if $o$ is not an instance of a class that implements \code{Stream}.
-It is a compile-time error if $D$ is empty and \id{} is a final variable.
+It is a dynamic type error if $o$ is not an instance of
+a class that implements \code{Stream}.
 
 \LMHash{}%
-The stream associated with the innermost enclosing asynchronous for loop, if any, is paused.
+The stream associated with the innermost enclosing asynchronous for loop,
+if any, is paused.
 The stream $o$ is listened to, producing a stream subscription $u$,
 and execution of the asynchronous for-in loop is suspended
 until a stream event is available.
-\commentary{
-This allows other asynchronous events to execute while this loop is waiting for stream events.
+\commentary{%
+This allows other asynchronous events to execute
+while this loop is waiting for stream events.%
 }
 
-Pausing an asynchronous for loop means pausing the associated stream subscription.
+Pausing an asynchronous for loop means
+pausing the associated stream subscription.
 A stream subscription is paused by calling its \code{pause} method.
-If the subscription is already paused, an implementation may omit further calls to \code{pause}.
+If the subscription is already paused,
+an implementation may omit further calls to \code{pause}.
 
-\commentary{
-The \code{pause} call can throw, although that should never happen for a correctly implemented stream.
+\commentary{%
+The \code{pause} call can throw,
+although that should never happen for a correctly implemented stream.%
 }
 
 \LMHash{}%
@@ -14899,7 +14905,7 @@ For each \Index{data event} from $u$,
 the statement $s_b$ is executed with \id{} bound to
 the value of the current data event.
 
-\commentary{
+\commentary{%
 Either execution of $s_b$ is completely synchronous, or it contains an
 asynchronous construct (\AWAIT{}, \AWAIT{} \FOR{}, \YIELD{} or \YIELD*)
 which will pause the stream subscription of its surrounding asynchronous loop.
@@ -14908,7 +14914,7 @@ before execution of $s_b$ is complete,
 if $o$ is a correctly implemented stream.
 If $o$ doesn't act as a valid stream,
 for example by not respecting pause requests,
-the behavior of the asynchronous loop may become unpredictable.
+the behavior of the asynchronous loop may become unpredictable.%
 }
 
 \LMHash{}%
@@ -14929,10 +14935,10 @@ Otherwise execution of $s$ completes in the same way as the execution of $s_b$.
 Otherwise the execution of $s_b$ is suspended again,
 waiting for the next stream subscription event,
 and $u$ is resumed if it has been paused.
-\commentary{
+\commentary{%
 The \code{resume} call can throw, in which case the asynchronous for
 loop also throws.
-That should never happen for a correctly implemented stream.
+That should never happen for a correctly implemented stream.%
 }
 
 \LMHash{}%


### PR DESCRIPTION
The language specification used to be near-silent on the static analysis of an asynchronous for-in statement. This PR adds rules about that topic.

Edit, Mar 03:

We need to achieve the outcome that a function literal capturing the iteration variable can be evaluated during any or all iterations of the loop body, which means that the iteration variable must be in a fresh scope (considered as a run-time entity) for each execution of the body. The previous text in this section did not specify this requirement at all.

With a synchronous for-in statement we rely on having a local variable in a block statement, which would then ensure that every execution of the body may capture a variable in a fresh run-time scope.

However, this only works because the specification allows us to assume that a local variable declared in a block will be a fresh run-time entity (section 'Blocks' only mentions scopes, no run-time properties). So we are already assuming that it is required that an implementation of Dart must ensure that a captured variable which is declared as a local variable in a block is allocated afresh for each execution of the block. In particular, it is _not_ allowed for an implementation to use the same storage location in the current activation record for state declared in a block that is executed more than once (of course, that's still allowed as an optimization, and a crucial one, whenever there is no observable difference).

This PR requires that the run-time scope is 'fresh' with each execution of the loop body, and supports the intention by commentary. I believe that this improves the level of precision and explicitness that we currently have in locations where the same property is required, and also that it has a sufficiently unambiguous semantics to be tolerable. So I'd recommend that we use this approach for section 'Blocks' as well.

One extra benefit is that it is very concise, and we may use the same approach, e.g., with `\ref{forLoop}`.

Alternatively, we could also extend the implicit reliance on the above mentioned property of blocks, and specify a desugaring step which will introduce an extra level of blocks, adding a local variable declaration (or just an assignment when `$D$` is empty). However, if we do this then we will have to desugar each asynchronous for-in statement _exactly once_ (because the desugaring step produces an output which matches the desugaring rule again), which is a new kind of constraint, or we need to introduce an `await while` statement, or in some other way ensure that this desugaring step will terminate.

We must of course still be able to desugar nested or enclosing loops, and null-shorting expressions in the iterable, and collection literals with `<element>`s, etc, so we will need to specify that this particular desugaring transformation can only be applied once to a given piece of code `$s$`, and then we need to avoid doing it again on any piece of code `$s_1$` which was produced by taking some other desugaring step on `$s$`. Sounds like we'll have to talk about abstract syntax tree nodes with identity in order to be able to say "don't do this twice".

Moreover, we still need to introduce exactly the notion of being a fresh scope at run time that we need for these for-in loops, in order to specify the dynamic semantics of blocks. So it seems reasonable to use it twice, rather than using it once and then introducing a complex desugaring rule just so we avoid using it a second time.