### PR TITLE
Adjust mixed mode rules

### DIFF
--- a/accepted/future-releases/nnbd/feature-specification.md
+++ b/accepted/future-releases/nnbd/feature-specification.md
@@ -6,6 +6,10 @@ Status: Draft
 
 ## CHANGELOG
 
+2020.03.26
+  - Adjust mixed-mode inheritance rules to express a consolidated model
+    where legacy types prevail in some additional cases.
+
 2020.03.05
   - Update grammar for null aware subscript.
   - Fix reversed subtype order in assignability.
@@ -1177,6 +1181,9 @@ class C extends B {
 }
 ```
 
+It is difficult to predict the outcome of migrating `B` in such situations, but
+lints or hints may be used by tools to communicate to developers that `C` may
+need to be changed again when `B` is migrated.
 
 If a class `C` in an opted-in library inherits a member `m` with the same name
 from multiple direct super-interfaces (whether legacy or opted-in), let `T0,

--- a/accepted/future-releases/nnbd/feature-specification.md
+++ b/accepted/future-releases/nnbd/feature-specification.md
@@ -1144,13 +1144,10 @@ arguments) marked as nullable or non-nullable as written.
 If a class `C` in an opted-in library implements the same generic class `I` more
 than once as `I0, .., In`, and at least one of the `Ii` is not syntactically
 equal to the others, then it is an error if `NNBD_TOP_MERGE(S0, ..., Sn)` is not
-defined where `Si` is **NORM(`Ii`)**.
-
-If `C` implements `I` once, or `C` implements `I` multiple times without error,
-`C` is considered to implement the canonical interface given by
-`NNBD_TOP_MERGE(S0, ..., Sn)`. This determines the outcome of dynamic instance
-checks applied to instances of `C`, as well as static subtype checks on
-expressions of type `C`.
+defined where `Si` is **NORM(`Ii`)**.  Otherwise, `C` is considered to
+implement the canonical interface given by `NNBD_TOP_MERGE(S0, ..., Sn)`.  This
+determines the outcome of dynamic instance checks applied to instances of `C`,
+as well as static subtype checks on expressions of type `C`.
 
 If a class `C` in an opted-in library overrides a member, it is an error if its
 signature is not a subtype of the types of all overriden members from all

--- a/accepted/future-releases/nnbd/feature-specification.md
+++ b/accepted/future-releases/nnbd/feature-specification.md
@@ -12,11 +12,11 @@ Status: Draft
   - Fix inconsistent uses of `null` and `Null` in instance checks.
 
 2020.02.28
-  - Specify that a `covariant late final x;` is an allowed instance variable which 
+  - Specify that a `covariant late final x;` is an allowed instance variable which
     introduces a setter.
 
 2020.01.31
-  - Specify that mixins must not have uninitialized potentially non-nullable 
+  - Specify that mixins must not have uninitialized potentially non-nullable
     non-late fields, and nor must classes with no generative constructors.
   - Remove reference to `CastError`. A failed `!` check is just a
     "dynamic type error" like the `as` check in the current language specification.
@@ -214,7 +214,7 @@ previous paragraph.
 We modify the upper and lower bound rules to account for nullability and legacy
 types as
 specified
-[here](https://github.com/dart-lang/language/blob/master/resources/type-system/upper-lower-bounds.md).  
+[here](https://github.com/dart-lang/language/blob/master/resources/type-system/upper-lower-bounds.md).
 
 ### Type normalization
 
@@ -323,19 +323,19 @@ fields on `Object`.
 It is an error to call an expression whose type is potentially nullable and not
 `dynamic`.
 
-It is an error if a top level variable or static variable with a non-nullable type 
+It is an error if a top level variable or static variable with a non-nullable type
 has no initializer expression unless the variable is marked with the `late` modifier.
 
-It is an error if a class declaration declares an instance variable with a potentially 
-non-nullable type and no initializer expression, and the class has a generative constructor 
-where the variable is not initialized via an initializing formal or an initializer list entry, 
+It is an error if a class declaration declares an instance variable with a potentially
+non-nullable type and no initializer expression, and the class has a generative constructor
+where the variable is not initialized via an initializing formal or an initializer list entry,
 unless the variable is marked with the `late` modifier.
 
 It is an error if a mixin declaration or a class declaration with no generative constructors
-declares an instance variable with a potentially non-nullable type and no initializer expression 
+declares an instance variable with a potentially non-nullable type and no initializer expression
 unless the variable is marked with the `late` modifier.
 
-It is an error to derive a mixin from a class declaration which contains 
+It is an error to derive a mixin from a class declaration which contains
 an instance variable with a potentially non-nullable type and no initializer expression
 unless the variable is marked with the `late` modifier.
 
@@ -509,7 +509,7 @@ class G<T> {
 
 For the purposes of extension method resolution, there is no special treatment
 of nullable types with respect to what members are considered accessible.  That
-is, the only members of a nullable tyhpe that are considered accessible 
+is, the only members of a nullable tyhpe that are considered accessible
 (and hence which take precedence over extensions) are the members on `Object`.
 
 ### Assignability
@@ -686,9 +686,9 @@ semantics are obeyed.
 
 ### Null check operator
 
-When evaluating an expression of the form `e!`, 
-where `e` evaluates to a value `v`, 
-a dynamic type error occurs if `v` is `null`, 
+When evaluating an expression of the form `e!`,
+where `e` evaluates to a value `v`,
+a dynamic type error occurs if `v` is `null`,
 and otherwise the expression evaluates to `v`.
 
 ### Null aware operator

--- a/accepted/future-releases/nnbd/feature-specification.md
+++ b/accepted/future-releases/nnbd/feature-specification.md
@@ -999,9 +999,10 @@ than once, it is an error if the `LEGACY_ERASURE` of all such super-interfaces
 are not all syntactically equal.
 
 When `C` implements `I` once, and also when `C` implements `I` more than once
-without error, `C` is considered to implement the canonical `LEGACY_ERASURE` of
-`I`. This determines the outcome of dynamic instance checks applied to instances
-of `C`, as well as static subtype checks on expressions of type `C`.
+without error, `C` is considered to implement the canonical signature given by
+`LEGACY_ERASURE` of the super-interfaces in question. This determines the
+outcome of dynamic instance checks applied to instances of `C`, as well as
+static subtype checks on expressions of type `C`.
 
 A member which is defined in a class in a legacy library (whether concrete or
 abstract), is given a signature in which every type is a legacy type.  It is an


### PR DESCRIPTION
Complementing https://dart-review.googlesource.com/c/sdk/+/139817, this PR proposes a few adjustments to the nnbd spec in locations where the description of mixed-mode inheritance differs from recent discussions about the approach and the implementation.