### PR TITLE
Clarify legacy override check

### DIFF
--- a/accepted/future-releases/nnbd/feature-specification.md
+++ b/accepted/future-releases/nnbd/feature-specification.md
@@ -1008,8 +1008,8 @@ static subtype checks on expressions of type `C`.
 A member which is defined in a class in a legacy library (whether concrete or
 abstract), is given a signature in which every type is a legacy type.  It is an
 error if the signature of a member is not a correct override of all members of
-the same name in super-interfaces of the class, using the legacy subtyping
-rules.
+the same name in the direct super-interfaces of the class, using the legacy
+subtyping rules.
 
 Using the legacy erasure for checking super-interfaces accounts for opted-out
 classes which depend on both opted-in and opted-out versions of the same generic

--- a/accepted/future-releases/nnbd/feature-specification.md
+++ b/accepted/future-releases/nnbd/feature-specification.md
@@ -6,6 +6,10 @@ Status: Draft
 
 ## CHANGELOG
 
+2020.04.02
+  - Clarify that legacy class override checks are done with respect to the
+    direct super-interfaces.
+
 2020.04.01
   - Adjust mixed-mode inheritance rules to express a consolidated model
     where legacy types prevail in some additional cases; also state


### PR DESCRIPTION
This PR makes it explicit that override checks in a legacy class are performed relative to the direct superinterfaces (rather than just 'the superinterfaces'). I believe it makes no difference, because the legacy subtype relationship ignores the differences that could occur, but it seems reasonable to reinforce the general rule that all relevant properties of a class (member signatures, implemented superinterfaces) are available on the class itself, and it is never necessary to search the entire superinterface graph.

(PS: We still need to search the entire superinterface graph when checking the correctness of the declared type of a covariant formal parameter relative to the overridden declarations of the same parameter, but that step is separate from regular override checks, and there are no changes in that area.)