### PR TITLE
Specify error for a function returning Never which may return

### DIFF
--- a/accepted/future-releases/nnbd/feature-specification.md
+++ b/accepted/future-releases/nnbd/feature-specification.md
@@ -352,6 +352,9 @@ assigned (see Definite Assignment below).
 It is an error if the body of a method, function, getter, or function expression
 with a potentially non-nullable return type **may complete normally**.
 
+It is an error if the body of a method, function, getter, or function expression
+with return type `Never` **returns with or without an object**.
+
 It is an error if an optional parameter (named or otherwise) with no default
 value has a potentially non-nullable type **except** in the parameter list of an
 abstract method declaration.

--- a/accepted/future-releases/nnbd/feature-specification.md
+++ b/accepted/future-releases/nnbd/feature-specification.md
@@ -350,10 +350,11 @@ initializer expression and is not marked `late` is used before it is definitely
 assigned (see Definite Assignment below).
 
 It is an error if the body of a method, function, getter, or function expression
-with a potentially non-nullable return type **may complete normally**.
+with a potentially non-nullable return type **may complete normally** or may
+return without an object.
 
 It is an error if the body of a method, function, getter, or function expression
-with return type `Never` **returns with or without an object**.
+with return type `Never` may return with an object.
 
 It is an error if an optional parameter (named or otherwise) with no default
 value has a potentially non-nullable type **except** in the parameter list of an


### PR DESCRIPTION
[Edit, eernstg: I'm closing this PR because one change is already subsumed by existing rules in the language specification, and I'd prefer to avoid the other change (and allow certain programs), and this PR only contained those two changes.]

It seems reasonable to flag a function that may return (like `return;` or `return d;` where `d` has type `dynamic`) if it has return type `Never`. I put this error into and just after the error that catches the situation where these functions (along with other functions whose return type is potentially non-nullable) may complete normally.

Cf. https://github.com/dart-lang/language/issues/914 as well.