### PR TITLE
Add rule about static check on `e1 == e2`

### DIFF
--- a/accepted/future-releases/nnbd/feature-specification.md
+++ b/accepted/future-releases/nnbd/feature-specification.md
@@ -503,11 +503,13 @@ Consider an expression `e` of the form `e1 == e2` where the static type of
 formal parameter of `operator ==` in the interface of **NonNull**(`T1`).
 It is a compile-time error unless `T2` is assignable to `S?`.
 
-_In particular, even if the static type of `e1` is potentially nullable,
-the parameter type of the `operator ==` of the corresponding non-null type
-is taken into account. Similarly, it is not a compile-time error for the
-static type of `e2` to be potentially nullable, even when the parameter type
-of said `operator ==` is non-nullable (which is a very common case)._
+_Even if the static type of `e1` is potentially nullable, the parameter type
+of the `operator ==` of the corresponding non-null type is taken into account,
+because that instance method will not be invoked when `e1` is null. Similarly,
+it is not a compile-time error for the static type of `e2` to be potentially
+nullable, even when the parameter type of said `operator ==` is non-nullable.
+This is again safe, because the instance method will not be invoked when `e2`
+is null._
 
 In legacy mode, an override of `operator ==` with no explicit parameter type
 inherits the parameter type of the overridden method if any override of

--- a/accepted/future-releases/nnbd/feature-specification.md
+++ b/accepted/future-releases/nnbd/feature-specification.md
@@ -6,7 +6,7 @@ Status: Draft
 
 ## CHANGELOG
 
-2020.04.24
+2020.04.30
   - Specify static analysis of `e1 == e2`.
 
 2020.04.20
@@ -489,6 +489,10 @@ on `Object`, regardless of the type of the member as declared on `T` (note that
 the type as declared on `T` must be a subtype of the type on `Object`, and so
 choosing the `Object` type is a sound choice.  The opposite choice is not
 sound).
+
+_Note that evaluation of an expression `e` of the form `e1 == e2` is not an
+invocation of `operator ==`, it includes special treatment of null. The
+precise rules are specified later in this section._
 
 Calling a method (including an operator) or getter on a receiver of static type
 `Never` is treated by static analysis as producing a result of type `Never`.

--- a/accepted/future-releases/nnbd/feature-specification.md
+++ b/accepted/future-releases/nnbd/feature-specification.md
@@ -495,10 +495,16 @@ of a function call produces a result of type `Never`.
 
 The static type of a `throw e` expression is `Never`.
 
-In legacy mode, an override of operator== with no explicit parameter type
+An expression of the form `e1 == e2` where the static type of `e1` and `e2` is
+`T1` respectively `T2` is type checked as an invocation of the instance method
+`operator ==` on **NonNull**(`T1`) with an actual argument of type
+**NonNull**(`T2`).
+
+In legacy mode, an override of `operator ==` with no explicit parameter type
 inherits the parameter type of the overridden method if any override of
-operator== between the overriding method and Object.== has an explicit parameter
-type.  Otherwise, the parameter type of the overriding method is dynamic.
+`operator ==` between the overriding method and `Object.==` has an explicit
+parameter type.  Otherwise, the parameter type of the overriding method is
+`dynamic`.
 
 Top level variable and local function inference is performed
 as

--- a/accepted/future-releases/nnbd/feature-specification.md
+++ b/accepted/future-releases/nnbd/feature-specification.md
@@ -498,20 +498,16 @@ of a function call produces a result of type `Never`.
 
 The static type of a `throw e` expression is `Never`.
 
-An expression `e` of the form `e1 == e2` is treated as
-`let v1 = e1, v2 = e2 in v1 != null ? (v2 != null ? v1.==(v2) : false) : (v2 !=
-null ? false : true)`,
-where `v1.==(v2)` denotes an invocation of the instance method `operator ==`
-on `v1`, and the `let` construct is defined in the section 'Null aware
-operator'.
+Consider an expression `e` of the form `e1 == e2` where the static type of
+`e1` is `T1` and the static type of `e2` is `T2`. Let `S` be the type of the
+formal parameter of `operator ==` in the interface of **NonNull**(`T1`).
+It is a compile-time error unless `T2` is assignable to `S?`.
 
 _In particular, even if the static type of `e1` is potentially nullable,
 the parameter type of the `operator ==` of the corresponding non-null type
 is taken into account. Similarly, it is not a compile-time error for the
-static type of `e2` to be potentially nullable even when `operator ==` is
-statically known to have a parameter type which is non-nullable. Of course,
-implementations may eliminate the parts of this expression that are known to
-be unreachable, e.g., if the static type of `e1` is strictly non-nullable._
+static type of `e2` to be potentially nullable, even when the parameter type
+of said `operator ==` is non-nullable (which is a very common case)._
 
 In legacy mode, an override of `operator ==` with no explicit parameter type
 inherits the parameter type of the overridden method if any override of

--- a/accepted/future-releases/nnbd/feature-specification.md
+++ b/accepted/future-releases/nnbd/feature-specification.md
@@ -498,10 +498,20 @@ of a function call produces a result of type `Never`.
 
 The static type of a `throw e` expression is `Never`.
 
-An expression of the form `e1 == e2` where the static type of `e1` and `e2` is
-`T1` respectively `T2` is type checked as an invocation of the instance method
-`operator ==` on **NonNull**(`T1`) with an actual argument of type
-**NonNull**(`T2`).
+An expression `e` of the form `e1 == e2` is treated as
+`let v1 = e1, v2 = e2 in v1 != null ? (v2 != null ? v1.==(v2) : false) : (v2 !=
+null ? false : true)`,
+where `v1.==(v2)` denotes an invocation of the instance method `operator ==`
+on `v1`, and the `let` construct is defined in the section 'Null aware
+operator'.
+
+_In particular, even if the static type of `e1` is potentially nullable,
+the parameter type of the `operator ==` of the corresponding non-null type
+is taken into account. Similarly, it is not a compile-time error for the
+static type of `e2` to be potentially nullable even when `operator ==` is
+statically known to have a parameter type which is non-nullable. Of course,
+implementations may eliminate the parts of this expression that are known to
+be unreachable, e.g., if the static type of `e1` is strictly non-nullable._
 
 In legacy mode, an override of `operator ==` with no explicit parameter type
 inherits the parameter type of the overridden method if any override of

--- a/accepted/future-releases/nnbd/feature-specification.md
+++ b/accepted/future-releases/nnbd/feature-specification.md
@@ -6,6 +6,9 @@ Status: Draft
 
 ## CHANGELOG
 
+2020.04.24
+  - Specify static analysis of `e1 == e2`.
+
 2020.04.20
   - **CHANGE** (by adding a rule that overrides an existing rule in the language
     specification). Specify that it is a compile-time error to await an


### PR DESCRIPTION
Thanks to @johnniwinther for raising this. The null-safety specification does not seem to specify how to perform static checking of an expression of the form `e1 == e2`. This expression needs special attention because it amounts to some checks for null, possibly followed by an invocation of `operator ==`, and hence the static analysis needs to allow null as the value of `e1` as well as the value of `e2`.

It is possible to declare an overriding `operator ==` with a covariant parameter, and we should preserve the property that this gives rise to a stronger constraint on the expression. Both `e1` and `e2` can still be null, but when `e1` is not null and the operator will be invoked, `e2` should be assignable to `T?` where `T` is the (covariant) parameter type of `operator ==` in the interface of the receiver.

This PR adds a paragraph to section 'Expression Typing' to that effect.