### PR TITLE
Specify null-safety `async` returns

### DIFF
--- a/accepted/future-releases/nnbd/feature-specification.md
+++ b/accepted/future-releases/nnbd/feature-specification.md
@@ -296,7 +296,7 @@ the last case will only be applied when `S` is a non-`void` top type._
 
 The static analysis of return statements is changed in the following
 way, where `$T$` is the declared return type and `$S$` is the static type of
-the expression `e`:
+the expression `e`.
 
 At [this location](https://github.com/dart-lang/language/blob/65b8267be0ebb9b3f0849e2061e6132021a4827d/specification/dartLangSpec.tex#L15477)
 about synchronous non-generator functions, the text is changed as follows:
@@ -338,8 +338,7 @@ to return a future when the future value type is a suitable future; for
 instance, we can have `return Future<int>.value(42)` in an `async` function
 with declared return type `Future<Future<int>>`. Conversely, it is no longer
 allowed to return a `Future<dynamic>` or `FutureOr<dynamic>` when the future
-value type is `Future<U>` for some `U` which is not a top type, because it is
-no longer enough that `dynamic` is assignable to `U`._
+value type is `Future<U>` for some `U` which is not a top type._
 
 The dynamic semantics specified at
 [this location](https://github.com/dart-lang/language/blob/65b8267be0ebb9b3f0849e2061e6132021a4827d/specification/dartLangSpec.tex#L15597)

--- a/accepted/future-releases/nnbd/feature-specification.md
+++ b/accepted/future-releases/nnbd/feature-specification.md
@@ -584,6 +584,11 @@ error. *This implies that
 [this](https://github.com/dart-lang/language/blob/780cd5a8be92e88e8c2c74ed282785a2e8eda393/specification/dartLangSpec.tex#L18281)
 list item will be removed from the language specification.*
 
+A compile-time error occurs if an expression has static type `void*`, and it
+does not occur in any of the ways specified in
+[this list](https://github.com/dart-lang/language/blob/780cd5a8be92e88e8c2c74ed282785a2e8eda393/specification/dartLangSpec.tex#L18238).
+*This implies that `void*` is treated the same as `void`.*
+
 It is a warning to use a null aware operator (`?.`, `?[]`, `?..`, `??`, `??=`, or
 `...?`) on an expression of type `T` if `T` is **strictly non-nullable**.
 

--- a/accepted/future-releases/nnbd/feature-specification.md
+++ b/accepted/future-releases/nnbd/feature-specification.md
@@ -10,7 +10,7 @@ Status: Draft
   - **CHANGE** (by overriding rules in the language specification): Change
     static rules for return statements, and dynamic semantics of return in
     asynchronous non-generators.
-  - Added rule that the use of expressions of type `void*` is restricted in
+  - Add rule that the use of expressions of type `void*` is restricted in
     the same way as expressions of type `void`.
 
 2020.04.30

--- a/accepted/future-releases/nnbd/feature-specification.md
+++ b/accepted/future-releases/nnbd/feature-specification.md
@@ -10,6 +10,8 @@ Status: Draft
   - **CHANGE** (by overriding rules in the language specification): Change
     static rules for return statements, and dynamic semantics of return in
     asynchronous non-generators.
+  - Added rule that the use of expressions of type `void*` is restricted in
+    the same way as expressions of type `void`.
 
 2020.04.30
   - Specify static analysis of `e1 == e2`.


### PR DESCRIPTION
This PR on the nnbd spec introduces the requirement "`S` assignable to `T_v` or` flatten(S) <: T_v`" (aka model 1) for a return statement in an `async` function, where `S` is the static type of the returned expression, and `T_v` is the future value type of the function.

This PR also specifies the dynamic semantics, using an approach where the presence/absence of an `await` step is statically determined whenever possible.

The new dynamic semantics is the same as the pre-null-safety dynamic semantics (that is, the one which is currently specified in `dartLangSpec.tex`), except for the case where the returned object dynamic type is a subtype of as well `T_v` as `Future<T_v>`, and the returned object static type is not `dynamic`, but it is a subtype of `T_v`. This case is expected to be very rare.

@lrhn, I made some changes to the rules that you proposed: (1) The case where `S` is `dynamic` is now first: This ensures that we _will_ await a `Future<T_v>`, even in the case where `T_v` is a top type. If we check `S <: T_v` first then that case will apply, and we wouldn't await the future. The typical case is `f() async => Future.value(1) as dynamic;`, and I think it is an unnecessary breaking change if `f` would stop awaiting the future and instead use it to complete the returned `Future<dynamic>`.

(2) I removed the case for `S implements Future<dynamic>`, because that is a compile-time error with model 1 (because otherwise an earlier case would apply). (3) I removed the case for `S is FutureOr<dynamic>` for the same reason.
