### PR TITLE
Typo fix: Adjust variable/getter flow rule

### DIFF
--- a/resources/type-system/flow-analysis.md
+++ b/resources/type-system/flow-analysis.md
@@ -501,8 +501,8 @@ assigned to `after(N)`, but do not specify values for `true(N)`, `false(N)`,
     - Let `null(N) = before(N)`.
     - Let `notNull(N) = unreachable(before(N))`.
   - Otherwise if `T` is non-nullable then:
-    - Let `null(N) = before(N)`.
-    - Let `notNull(N) = unreachable(before(N))`.
+    - Let `null(N) = unreachable(before(N))`.
+    - Let `notNull(N) = before(N)`.
   - Otherwise:
     - Let `null(N) = promote(x, Null, before(N))`
     - Let `notNull(N) = promoteToNonNull(x, before(N))`

--- a/resources/type-system/flow-analysis.md
+++ b/resources/type-system/flow-analysis.md
@@ -255,8 +255,8 @@ We also make use of the following auxiliary functions:
 
   - We define `join(M1, M2)` to be `M3 = FlowModel(r3, VI3)` where:
     - `M1 = FlowModel(r1, VI1)`
-    - `M2 = FlowModel(r2, VI2))` 
-    - `pop(r1) = pop(r2) = r0` for some `r0` 
+    - `M2 = FlowModel(r2, VI2))`
+    - `pop(r1) = pop(r2) = r0` for some `r0`
     - `r3` is `push(r0, top(r1) || top(r2))`
     - `VI3` is the map which maps each variable `v` in the domain of `VI1` and
       `VI2` to `joinV(VI1(v), VI2(v))`.  Note that any variable which is in
@@ -492,7 +492,7 @@ assigned to `after(N)`, but do not specify values for `true(N)`, `false(N)`,
 `after(N)`.
 
 
-- **Variable or getter**: If `N` is an expression of the form `x` 
+- **Variable or getter**: If `N` is an expression of the form `x`
   where the type of `x` is `T` then:
   - If `T <: Never` then:
     - Let `null(N) = unreachable(before(N))`.


### PR DESCRIPTION
In the specification of the Dart [flow analysis rule about variable or getter evaluation](https://github.com/dart-lang/language/blob/master/resources/type-system/flow-analysis.md#expressions), we have this:

> Otherwise if T is non-nullable then:
> - Let null(N) = before(N).
> - Let notNull(N) = unreachable(before(N)).

This PR makes an adjustment such that this rule expects the null continuation to be unreachable, rather than the non-null continuation.