### PR TITLE
Adjust definitions of the `assigned` and `unassigned` bits

### DIFF
--- a/resources/type-system/flow-analysis.md
+++ b/resources/type-system/flow-analysis.md
@@ -132,13 +132,15 @@ source code.
   of promotion, generally because the variable in question has been tested
   against the type on some path in some way.
 
-- `assigned` is a boolean value indicating whether the variable is known to
-  have been definitely assigned at the given point in the source code.
+- `assigned` is a boolean value indicating whether the variable has definitely
+  been assigned at the given point in the source code.  When `assigned` is
+  true, we say that the variable is _definitely assigned_ at that point.
 
-- `unassigned` is a boolean value indicating whether the variable is known not
-  to have been definitely assigned at the given point in the source code.  (Note
-  that a variable may not be both definitely assigned and definitely
-  unassigned).
+- `unassigned` is a boolean value indicating whether the variable has
+  definitely not been assigned at the given point in the source code.  When
+  `unassigned` is true, we say that the variable is _definitely unassigned_ at
+  that point.  (Note that a variable cannot be both definitely assigned and
+  definitely unassigned at any location).
 
 - `writeCaptured` is a boolean value indicating whether a closure might exist at
   the given point in the source code, which could potentially write to the


### PR DESCRIPTION
The existing definition of `unassigned` in flow-analysis.md had 'is known not to have been definitely assigned at the given point in the source code', which is confusing (or even misleading) because it is identical to the wording about `assigned` except for including 'not', which makes it difficult to interpret `unassigned` as anything other than the negation of `assigned` (which would of course be useless).

My interpretation of '`v` is definitely assigned at _N_' is that every path in the flow graph from the root to _N_ contains a node which is an assignment to `v`, and there is at least one such path; and '`v` is definitely unassigned at _N_' means that no path in the flow graph from the root to _N_ contains any node which is an assignment to `v`.

The new text explicitly defines 'definitely assigned' and 'definitely unassigned' as separate concepts based on `assigned` and `unassigned`, and specifies `assigned` and `unassigned` to fit the above interpretation (with no reference to 'definitely assigned' or 'definitely unassigned', that is, relying on graph properties alone&mdash;though in a language that doesn't make that fact very explicit, in order to match the style used elsewhere in this document).
