### PR TITLE
Adjust futureValueType{,Schema} to propagate `dynamic`

### DIFF
--- a/accepted/future-releases/nnbd/feature-specification.md
+++ b/accepted/future-releases/nnbd/feature-specification.md
@@ -298,12 +298,12 @@ The function **futureValueType** is defined as follows:
 - **futureValueType**(`Future<S>`) = `S`, for all `S`.
 - **futureValueType**(`FutureOr<S>`) = `S`, for all `S`.
 - **futureValueType**(`void`) = `void`.
+- **futureValueType**(`dynamic`) = `dynamic`.
 - Otherwise, for all `S`, **futureValueType**(`S`) = `Object?`.
 
 _Note that it is a compile-time error unless the return type of an asynchronous
 non-generator function is a supertype of `Future<Never>`, which means that
-the last case will only be applied when `S` is `Object` or a non-`void` top
-type._
+the last case will only be applied when `S` is `Object` or a top type._
 
 ### Return statements
 

--- a/resources/type-system/inference.md
+++ b/resources/type-system/inference.md
@@ -240,13 +240,13 @@ The function **futureValueTypeSchema** is defined as follows:
 - **futureValueTypeSchema**(`Future<S>`) = `S`, for all `S`.
 - **futureValueTypeSchema**(`FutureOr<S>`) = `S`, for all `S`.
 - **futureValueTypeSchema**(`void`) = `void`.
+- **futureValueTypeSchema**(`dynamic`) = `dynamic`.
 - **futureValueTypeSchema**(`_`) = `_`.
 - Otherwise, for all `S`, **futureValueTypeSchema**(`S`) = `Object?`.
 
 _Note that it is a compile-time error unless the return type of an asynchronous
 non-generator function is a supertype of `Future<Never>`, which means that
-the last case will only be applied when `S` is `Object` or a non-`void` top
-type._
+the last case will only be applied when `S` is `Object` or a top type._
 
 In order to infer the return type of a function literal, we first infer the
 **actual returned type** of the function literal.


### PR DESCRIPTION
Here is yet another twist with the static checks on return statements: The new rules are treating the return type `dynamic` (along with `dynamic?` and `dynamic*`) the same as `Object?`, which causes a substantial amount of breakage. For instance:

```dart
f() async {
  return; // Error!
}
```

I think we do not want this breakage, so this PR adds one extra alternative to the definition of `futureValueType` and `futureValueTypeSchema` such that an `async` function returning `dynamic` (and its variants) will have future value type `dynamic`.

Konstantin has implemented this addition, and it removes the breakage as expected.

So do you agree that we should do this, @lrhn, @leafpetersen, @munificent?