### PR TITLE
Nullable definite assignment

### DIFF
--- a/accepted/future-releases/nnbd/feature-specification.md
+++ b/accepted/future-releases/nnbd/feature-specification.md
@@ -638,6 +638,10 @@ It is a compile time error to read a local variable when the variable is
 **definitely unassigned** unless the variable is non-final and has nullable
 type.  This includes variables marked `late` and/or `final`.
 
+It is a compile time error to read a local variable when the variable is not
+**definitely assigned** unless the variable is non-final and has nullable type
+or is `late`.
+
 The erors specified above are summarized in the following table (using `int` as
 an example non-nullable type).  A variable which has an initializer (explicit or
 implicit) is always considered definitely assigned, and is never considered

--- a/accepted/future-releases/nnbd/feature-specification.md
+++ b/accepted/future-releases/nnbd/feature-specification.md
@@ -762,8 +762,15 @@ join point, the variable is treated after the join point as having the
 **initialization inferred types** from the reachable paths into the join point.
 The **initialization inferred type** so computed is treated as a **type of
 interest** for the variable in question (including its non-nullable version if
-applicable).  The promoted type chains for the variable on the respective paths
-are intersected as usual.
+applicable).  If the newly computed **initialization inferred type** is not a
+subtype of the original **initialization inferred type** on a given path, the
+original **initialization inferred type** for that variable on that path shall
+be added to the head of the promoted type chain for that variable on the
+respective path before intersecting the promoted type chains.  The promoted type
+chains for the variable on the respective paths are then intersected as usual.
+*Adding the original inferred type to the head of promoted type chain allows a
+variable which has been promoted on one path to the inferred type of the other
+path to remain at the shared common type (see example below).*
 
 ```dart
 void test(bool b) {
@@ -788,12 +795,26 @@ void test(bool b) {
 
  var z; // z is an untyped variable
  if (b) {
-   x = 3; // x is promoted to int
+   z = 3; // z is promoted to int
  } else {
-   x = 3.0;
+   z = 3.0;
    return;
  }
- x.isEven; // No error, only one reachable path
+ z.isEven; // No error, only one reachable path
+
+ var u; // u is an untyped variable
+ if (b) {
+   u = 0 as num; // u is promoted to num
+   if (u is! int) u = 1;
+   // u has inferred type num, but is promoted to int
+ } else {
+   u = 3;
+ }
+ // At the join point, the initialization inferred type becomes
+ // UP(num, int) = num. However, int is added to the promotion
+ // chain on the second path before intersecting the promotion
+ // chains, and hence the promoted type of u becomes int
+ u.isEven; // No error.  u has inferred type num, promoted to int
 }
 ```
 
@@ -822,14 +843,14 @@ void test(bool b) {
   print(z); // Error, z has no initialization inferred type
 ```
 
-Note that as a consequence of the above it is impossible, in an error-free
-program, to observe the static type or contents of an untyped variable before it
-has been given an inferred type.  From this standpoint it may be thought of as
-having no type.  However, IDEs and tools may wish to report a static type for
-such a variable for the purposes of documentation and error reporting.  For such
+As a consequence of the above it is impossible, in an error-free program, to
+observe the static type or contents of an untyped variable before it has been
+given an inferred type.  From this standpoint it may be thought of as having no
+type.  However, IDEs and tools may wish to report a static type for such a
+variable for the purposes of documentation and error reporting.  For such
 purposes, tools shall treat an untyped variable as if it were declared with a
 type equal to the upper bound of all of the **initialization inferred types**
-that it is ascribed in the method, plus `Never`.  Note that as a consequence a
+that it is ascribed in the method, plus `Never`.  The latter implies that a
 variable which is ascribed no **initialization inferred types** on any path
 shall be treated as having declared type `Never`.
 

--- a/accepted/future-releases/nnbd/feature-specification.md
+++ b/accepted/future-releases/nnbd/feature-specification.md
@@ -757,20 +757,16 @@ void test(bool b) {
 
 At a join point in the program, if an **untyped variable** has been given an
 **initialization inferred type** on more than one of the reachable paths to the
-join point, the variable is treated after the join point as having the
-**initialization inferred type** equal to the upper bound of the
-**initialization inferred types** from the reachable paths into the join point.
-The **initialization inferred type** so computed is treated as a **type of
-interest** for the variable in question (including its non-nullable version if
-applicable).  If the newly computed **initialization inferred type** is not a
-subtype of the original **initialization inferred type** on a given path, the
-original **initialization inferred type** for that variable on that path shall
-be added to the head of the promoted type chain for that variable on the
-respective path before intersecting the promoted type chains.  The promoted type
-chains for the variable on the respective paths are then intersected as usual.
-*Adding the original inferred type to the head of promoted type chain allows a
-variable which has been promoted on one path to the inferred type of the other
-path to remain at the shared common type (see example below).*
+join point and all of such **initialization inferred types** are syntactically
+equal, the variable is treated after the join point as having that
+**initialization inferred type**.  The promoted type chains for the variable on
+the respective paths are then intersected as usual.
+
+At a join point in the program, if an **untyped variable** has been given an
+**initialization inferred type** on more than one of the reachable paths to the
+join point and any two such **initialization inferred types** are not
+syntactically equal, it is an error.
+
 
 ```dart
 void test(bool b) {
@@ -779,7 +775,7 @@ void test(bool b) {
     x = 3;
   } else {
     x = 3.0;
-  } // x is has type num = UP(int, double)
+  } // Error: x has two different types on different paths
 
   late var y; // y is a late untyped variable
   if (b) {
@@ -787,19 +783,16 @@ void test(bool b) {
       y = 3;
     } else {
       y = 3.0;
-    } // y has type num
-    y = 3.0; // y is promoted to double, since double is a type of interest
-    y = (3 as num); y is demoted to num.
-  } // y still has type num
-  y = "hello";  // Error, not an initializating write.
+    } // Error: y has two different types on different paths
+  }
 
  var z; // z is an untyped variable
  if (b) {
    z = 3; // z is promoted to int
  } else {
-   z = 3.0;
+   z = 3.0; // z is promoted to double
    return;
- }
+ } // No error.  z is inferred as int on the only reachable path
  z.isEven; // No error, only one reachable path
 
  var u; // u is an untyped variable
@@ -809,12 +802,7 @@ void test(bool b) {
    // u has inferred type num, but is promoted to int
  } else {
    u = 3;
- }
- // At the join point, the initialization inferred type becomes
- // UP(num, int) = num. However, int is added to the promotion
- // chain on the second path before intersecting the promotion
- // chains, and hence the promoted type of u becomes int
- u.isEven; // No error.  u has inferred type num, promoted to int
+ } // Error: u is inferred to different types on different paths
 }
 ```
 
@@ -852,7 +840,10 @@ purposes, tools shall treat an untyped variable as if it were declared with a
 type equal to the upper bound of all of the **initialization inferred types**
 that it is ascribed in the method, plus `Never`.  The latter implies that a
 variable which is ascribed no **initialization inferred types** on any path
-shall be treated as having declared type `Never`.
+shall be treated as having declared type `Never`.  Note that despite the
+requirement that the **initialization inferred types** be equal at join points,
+it is possible for a variable to take on different **initialization inferred
+types** on paths that never join before exiting.
 
 ```dart
 void test(b) {

--- a/accepted/future-releases/nnbd/feature-specification.md
+++ b/accepted/future-releases/nnbd/feature-specification.md
@@ -726,8 +726,11 @@ void test() {
 ```
 
 At a join point in the program, it is an error if an **untyped variable** has
-been given an **initialization inferred type** on one of the paths to the join
-point and not another, unless the variable is declared as `late`.
+been given an **initialization inferred type** on one of the reachable paths to
+the join point and not on another reachable path, unless the variable is
+declared as `late`.  Note that it is valid for a variable to have no
+**initialization inferred type** on a path into a join point which is known to
+be unreachable.
 
 ```dart
 void test(bool b) {
@@ -740,15 +743,22 @@ void test(bool b) {
   if (b) {
     y = 3;
   } // Ok, y has inferred type `int`
+
+  var z;
+  if (b) {
+     z = 3;
+  } else {
+    return;
+  }  // No error: z has been given a type on all reachable paths into the join
 }
 ```
 
 At a join point in the program, if an **untyped variable** has been given an
-**initialization inferred type** on more than one of the paths to the join
-point, the variable is treated after the join point as having the
+**initialization inferred type** on more than one of the reachable paths to the
+join point, the variable is treated after the join point as having the
 **initialization inferred type** equal to the upper bound of the
-**initialization inferred types** from the paths into the join point.  The
-**initialization inferred type** so computed is treated as a **type of
+**initialization inferred types** from the reachable paths into the join point.
+The **initialization inferred type** so computed is treated as a **type of
 interest** for the variable in question (including its non-nullable version if
 applicable).  The promoted type chains for the variable on the respective paths
 are intersected as usual.
@@ -773,6 +783,15 @@ void test(bool b) {
     y = (3 as num); y is demoted to num.
   } // y still has type num
   y = "hello";  // Error, not an initializating write.
+
+ var z; // z is an untyped variable
+ if (b) {
+   x = 3; // x is promoted to int
+ } else {
+   x = 3.0;
+   return;
+ }
+ x.isEven; // No error, only one reachable path
 }
 ```
 
@@ -798,7 +817,35 @@ void test(bool b) {
       z = 37;
     }
   } while (something);
-  print(z); // Error, z has not initialization inferred type
+  print(z); // Error, z has no initialization inferred type
+```
+
+Note that as a consequence of the above it is impossible, in an error-free
+program, to observe the static type or contents of an untyped variable before it
+has been initialized and given an inferred type.  From this standpoint it may be
+thought of as having no type.  However, IDEs and tools may wish to report a
+static type for such a variable for the purposes of documentation and error
+reporting.  For such purposes, tools shall treat an untyped variable as if it
+were declared with a type equal to the upper bound of all of the
+**initialization inferred types** that it is ascribed in the method, plus
+`Never`.  Note that as a consequence a variable which is ascribed no
+**initialization inferred types** on any path shall be treated as having
+declared type `Never`.
+
+```dart
+void test(b) {
+  var x; // x is an untyped variable, documented as having type num
+  var z; // z is an untyped variable, documented as having type Never
+  if (b) {
+    x = 3.0; // x is inferred to double
+    return;
+  } else if (b) {
+    return;  // Note, x is has inferred type
+  } else {
+    x = 3; // x is inferred to int
+  }
+  x.isEven; // x remains inferred to int, since only one path reaches here
+}
 ```
 
 ### Expression typing

--- a/accepted/future-releases/nnbd/feature-specification.md
+++ b/accepted/future-releases/nnbd/feature-specification.md
@@ -721,14 +721,16 @@ are those declared as `var x;`, `final x;`, `late var x;`, or `late final x;`.
 We refer to such variables as **untyped variables**.
 
 An **initializing assignment** is an assignment to an **untyped variable** when
-that variable is in the **definitely unassigned** state.  Such an assignment on
-a path shall cause the variable in question to be treated by the flow analysis
-on that path as if it were declared with the assigned expression as its
-initializing expression, up until the next join point in the program.  We refer
-to this inferred type as the **initialization inferred type** of the variable.
-The **initialization inferred type** of the variable is always treated as a
-**type of interest** for the purposes of promotion (including its non-nullable
-version if applicable).
+that variable is in the **definitely unassigned** state, and the variable would
+have been promoted if it had been declared with type `Object?` and the type of
+the assigned expression were a type of interest for the variable.  Such an
+assignment on a path shall cause the variable in question to be treated by the
+flow analysis on that path as if it were declared with the assigned expression
+as its initializing expression, up until the next join point in the program.  We
+refer to this inferred type as the **initialization inferred type** of the
+variable.  The **initialization inferred type** of the variable is always
+treated as a **type of interest** for the purposes of promotion (including its
+non-nullable version if applicable).
 
 ```dart
 void test() {

--- a/accepted/future-releases/nnbd/feature-specification.md
+++ b/accepted/future-releases/nnbd/feature-specification.md
@@ -613,7 +613,7 @@ It is a warning to use the null check operator (`!`) on an expression of type
 
 As part of the null safety release, errors for local variables are specified to
 take into account **definite assignment** and **definite unassignment** (see
-the secontion on Definite Assignment below).
+the section on Definite Assignment below).
 
 In all cases in this section, errors that are described as occurring on reads of
 a variable are intended to apply to all form of reads, including indirectly as

--- a/accepted/future-releases/nnbd/feature-specification.md
+++ b/accepted/future-releases/nnbd/feature-specification.md
@@ -487,8 +487,8 @@ fields on `Object`.
 It is an error to call an expression whose type is potentially nullable and not
 `dynamic`.
 
-It is an error if a top level variable or static variable with a non-nullable
-type has no initializer expression unless the variable is marked with the `late`
+It is an error if a top level variable or static variable has a non-nullable
+type and no initializer expression unless the variable is marked with the `late`
 modifier.
 
 It is an error if a class declaration declares an instance variable with a
@@ -621,15 +621,13 @@ part of composite assignment operators, as well as via pre and post-fix
 operators.  Similarly, errors that are described as occurring on writes of a
 variable are intended to apply to all form of writes.
 
-It is a compile time error to assign a value to a local variable marked `final`
-unless the variable is **definitely unassigned**, or the variable is marked
-`late`. Conversely, it is not a compile time error to write to a `final` local
-variable if that variable is **definitely unassigned**.
+It is a compile time error to assign a value to a `final`, non-`late` local
+variable which is not **definitely unassigned**.  Thus, it is *not* an error to
+assign to a **definitely unassigned** `final` local variable.
 
-It is a compile time error to assign a value to a local variable marked `final`
-and `late` if the variable is **definitely assigned**.  Conversely, it is not a
-compile time error to write to a `final` local variable if that variable is
-declared `late`, and is not **definitely assigned**.
+It is a compile time error to assign a value to a `final`, `late` local variable
+if it is **definitely assigned**. Thus, it is *not* an error to assign to a
+*not* **definitely assigned** `final`, `late` local variable.
 
 *Note that a variable is always considered definitely assigned and not
 definitely unassigned if it has an explicit initializer, or an implicit


### PR DESCRIPTION
This a variant of the simple definite assignment proposal which requires all initializing assignment to assign values of the same type except that `Null` is also allowed, in which case the variable is made nullable.  It also allows variables declared `var` to not be assigned on every path, in which case the type is also made nullable.

