### PR TITLE
Fix flow analysis handling of write-captured variables in loops and try-blocks.

### DIFF
--- a/resources/type-system/flow-analysis.md
+++ b/resources/type-system/flow-analysis.md
@@ -347,7 +347,7 @@ We also make use of the following auxiliary functions:
     - `VI0` maps `v` to `VM0 = VariableModel(d0, p0, s0, a0, u0, c0)`
     - If `captured` contains `v` then `VI1` maps `v` to
       `VariableModel(d0, [], s0, a0, u0, true)`
-    - Otherwise if `written` contains `v` then `VI1` maps `c` to
+    - Otherwise if `written` contains `v` then `VI1` maps `v` to
       `VariableModel(d0, [], s0, a0, u0, c0)`
     - Otherwise `VI1` maps `v` to `VM0`
 


### PR DESCRIPTION
This change ensures that we properly reject the following unsound program:

```dart
f(Object x) {
  void Function()? g;
  while (true) {
    if (x is int) {
      g?.call();
      print(x.isEven); // UNSOUND
    }
    g = () {
      x = 'bad';
    }
  }
}
```

(The program is unsound because the second time through the loop, a
closure exists that writes to `x`, therefore after (A) there is no
guarantee that `x` is still an `int`.)

Note that this bug has already been fixed in the implementation (see
https://github.com/dart-lang/sdk/commit/88b76997c49b6a86bec2ef5afc6e97b329e5a2eb).