### PR TITLE
Add rule about generators and return type void

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -1362,9 +1362,17 @@ This situation is very unusual so it is not worth making an exception to the gen
 }
 
 \LMHash{}%
-It is a compile-time error if the declared return type of a function marked \ASYNC{} is not a supertype of \code{Future<$T$>} for some type $T$.
-It is a compile-time error if the declared return type of a function marked \code{\SYNC*} is not a supertype of \code{Iterable<$T$>} for some type $T$.
-It is a compile-time error if the declared return type of a function marked \code{\ASYNC*} is not a supertype of \code{Stream<$T$>} for some type $T$.
+It is a compile-time error if the declared return type of
+a function marked \ASYNC{} is not
+a supertype of \code{Future<$T$>} for some type $T$.
+It is a compile-time error if the declared return type of
+a function marked \code{\SYNC*} is not
+a supertype of \code{Iterable<$T$>} for some type $T$.
+It is a compile-time error if the declared return type of
+a function marked \code{\ASYNC*} is not
+a supertype of \code{Stream<$T$>} for some type $T$.
+It is a compile-time error if the declared return type of
+a function marked \code{\SYNC*} or \code{\ASYNC*} is \VOID.
 
 \LMHash{}%
 We define the notion of the


### PR DESCRIPTION
Cf. https://github.com/dart-lang/language/issues/1059, this PR adds the rule that it is a compile-time error for a generator function to have return type `void`.

If and when this lands, update https://github.com/dart-lang/sdk/issues/32192.