### PR TITLE
Update to new number operation rules

### DIFF
--- a/accepted/future-releases/nnbd/number-operation-typing.md
+++ b/accepted/future-releases/nnbd/number-operation-typing.md
@@ -73,21 +73,21 @@ We extend the special-casing rules of `+`, `-`, `*` and `%` to also cover calls 
 Let `e` be an expression of one of the forms `e1 + e2`, `e1 - e2`, `e1 * e2`, `e1 % e2` or `e1.remainder(e2)`, where the static type of `e1` is a non-`Never` type *T* where *T* <: `num` and the static type of `e2` is *S*. Then:
 
 * If *T* <: `double` , then the static type of `e` is *T*.
-* Otherwise if *S* is a non-`Never` subtype of `double` then the static type of `e` is `double`.
+* Otherwise, if *S* is a non-`Never` subtype of `double` then the static type of `e` is `double`.
 * Otherwise, if *S* is a non-`Never` subtype of  `int` then the static type of `e` is *T*.
-* Otherwise if is a non-`Never` subtype of *T* , then the static type of `e` is *T*.
+* Otherwise, if *S* is a non-`Never` subtype of *T*  then the static type of `e` is *T*.
 * Otherwise the static type of *e* is `num`.
 
 We also special-case the `clamp` method.
 
-Let `e` be a normal invocation of the form `e1.clamp(e2, e3)`, where the static types of `e1`, `e2` and `e3` are *T*<sub>1</sub>, *T*<sub>2</sub> and *T*<sub>3</sub> respectively, and where  *T*<sub>1 is a non-`Never` subtype of `num`. Let *R* be LUB(*T*<sub>1</sub>, *T*<sub>2</sub>, *T*<sub>3</sub>). Then:
+Let `e` be a normal invocation of the form `e1.clamp(e2, e3)`, where the static types of `e1`, `e2` and `e3` are *T*<sub>1</sub>, *T*<sub>2</sub> and *T*<sub>3</sub> respectively, and where  *T*<sub>1</sub> is a non-`Never` subtype of `num`. Let *R* be LUB(*T*<sub>1</sub>, *T*<sub>2</sub>, *T*<sub>3</sub>). Then:
 
-* If *R* <: `num`, the static type of`e` as *R*.
+* If *R* <: `num`, the static type of `e` as *R*.
 * Otherwise the static type of `e` is `num`.
 
 With these typing rules, we cover all the instance members of `int` which has a return type of `num`, and we ensure that a using operands with the *same* type gives a result of that type, even if that type is a type variable (like `X extends int`) or promoted type variable (like `X & int`).
 
-There are no special rules for `/` and `~/` because their return type is not `num`, and the return value's type is independent of the argument types. A `/` operation always returns a `double` and a `~/` operation always returns an `int`.ma
+There are no special rules for `/` and `~/` because their return type is not `num`, and the return value's type is independent of the argument types. A `/` operation always returns a `double` and a `~/` operation always returns an `int`.
 
 The rules for the binary operators can be summarized (non-normatively) as:
 
@@ -112,15 +112,16 @@ If `e` is an expression of the form  `e1 + e2`, `e1 - e2`, `e1 * e2`, `e1 % e2` 
 
 * If *C* <: `int` and *T* <: `int`, then the context type of `e2` is `int`. 
 * If *C* <: `double` and *T* is not a subtype of `double`, then the context type of `e2` is `double`.
+* Otherwise, the context type of `e2` is `num`.
 
-It is a compile-time error if the static type of `e2` is not a subtype of `num`. *(It is not necessarily a compile-time error if the static type of `e2` is not a subtype of _C_.)*
+*(It is not necessarily a compile-time error if the static type of `e2` is not a subtype of _C_, but it is still a compile-time error if the static type of `e2` is not assignable to the actual parameter type,`num`.)*
 
 If `e` is an expression of the form `e1.clamp(e2, e3)` where *C* is the context type of `e` and *T* is the static type of `e1` where both *T* is a non-`Never` subtype of `num`, then:
 
 * If *C* is a non-`Never` subtype of `num` then  the context type of `e2` and `e3` is *C*.
 * Otherwise the context type of `e2` an `e3` is `num`
 
-It is a compile-time error if the static type of `e2` or `e3` is not a subtype of `num`.  *(It is not necessarily a compile-time error if the static type of `e2` or `e3` is not a subtype of _C_.)*
+*(It is not necessarily a compile-time error if the static type of `e2` or `e3` is not a subtype of _C_, but it is still a compile-time error if the static type of `e2` or `e3` is not assignable to the actual parameter type,`num`.)*
 
 (This does emphasize the inherent non-symmetry of Dart operators: The first operand is a receiver which is always evaluated with no type context, and is then used to resolve the operator method against, and the second operand is an argument to that method. We need to fully resolve the first operand and the operator before we can even begin with the second operand.)
 

--- a/accepted/future-releases/nnbd/number-operation-typing.md
+++ b/accepted/future-releases/nnbd/number-operation-typing.md
@@ -75,7 +75,7 @@ Let `e` be an expression of one of the forms `e1 + e2`, `e1 - e2`, `e1 * e2`, `e
 * If *T* <: `double` , then the static type of `e` is *T*.
 * Otherwise if *S* is a non-`Never` subtype of `double` then the static type of `e` is `double`.
 * Otherwise, if *S* is a non-`Never` subtype of  `int` then the static type of `e` is *T*.
-* Otherwise if *S* <: *T* and *T* <: *S*, then the static type of `e` is *T*.
+* Otherwise if is a non-`Never` subtype of *T* , then the static type of `e` is *T*.
 * Otherwise the static type of *e* is `num`.
 
 We also special-case the `clamp` method.
@@ -98,7 +98,7 @@ The rules for the binary operators can be summarized (non-normatively) as:
 | **<: double** | *T*    | *T*       | *T*     | *T*     |
 |  **<: num**   | *T*    | double    | num/*T* | num     |
 
-where `<: num` here represents a subtype of `num` which is *not* also a subtype of `int` or `double`, and "num/*T*" covers the case where the static type is *T* when *S* and *T* are mutual subtypes, and `num` when they are not.
+where `<: num` here represents a subtype of `num` which is *not* also a subtype of `int` or `double`, and "num/*T*" covers the case where the static type is *T* when *S* <: *T* , and `num` when they are not.
 
 The rules are *not symmetric*. When possible, the type of the expression is the type of the first operand (which can be a type variable, even a promoted one), and otherwise it's a plain `int`, `double` or `num` type. The typing prefers the type of the first operand because it allows operations like `x += 1`  to work seamlessly.
 


### PR DESCRIPTION
After writing tests, I gave the rules a serious look.

They were both too complex and too imprecise.

I changed them so that `x + y` will take the type of `x` where possible (not `int + double`, but `int + int`, `double + num` etc.)
This ensures that a variable which has a type variable (possibly promoted) as type will be safe to do `x += 1` and `x++` because such an operation *always* has the same type as `x` (as long as `x` is a non-`Never` subtype of `num`).

That makes the rules asymmetric, but I think most users will readily accept that the type of the LHS is more important than the RHS. It is a method call after all.
(Most users will also not have type variables that are subtypes of `num` or `int` at all).