### PR TITLE
Spec null-safety combined member signature and spread type

### DIFF
--- a/accepted/future-releases/nnbd/feature-specification.md
+++ b/accepted/future-releases/nnbd/feature-specification.md
@@ -687,9 +687,12 @@ Dart.
 
 In a collection literal in Dart before null-safety, the inferred element
 type of a spread element of the form `...?e` where `e` has static type
-`Null` is `Null`, and so are the inferred key type and value type. With
-null-safety, when the static type of `e` is `Null` or a subtype thereof, the
-inferred element, key, and value type is `Never`
+`Null` is `Null`, and so are the inferred key type and value type.
+
+With null-safety, when the static type of `e` is `Null` or a potentially
+nullable subtype thereof, the inferred element, key, and value type
+of `...?e` is `Never`, and so is the element, key, and value type of
+`...e` where the static type of `e` is a subtype of `Never`.
 (which corresponds to 6 changes in
 [this section](https://github.com/dart-lang/language/blob/9e12517922c1f0021aead2af163c3b502497f312/specification/dartLangSpec.tex#L8433)).
 

--- a/accepted/future-releases/nnbd/feature-specification.md
+++ b/accepted/future-releases/nnbd/feature-specification.md
@@ -688,7 +688,8 @@ Dart.
 In a collection literal in Dart before null-safety, the inferred element
 type of a spread element of the form `...?e` where `e` has static type
 `Null` is `Null`, and so are the inferred key type and value type. With
-null-safety, the inferred element, key, and value type is `Never`
+null-safety, when the static type of `e` is `Null` or a subtype thereof, the
+inferred element, key, and value type is `Never`
 (which corresponds to 6 changes in
 [this section](https://github.com/dart-lang/language/blob/9e12517922c1f0021aead2af163c3b502497f312/specification/dartLangSpec.tex#L8433)).
 

--- a/accepted/future-releases/nnbd/feature-specification.md
+++ b/accepted/future-releases/nnbd/feature-specification.md
@@ -691,10 +691,13 @@ type of a spread element of the form `...?e` where `e` has static type
 
 With null-safety, when the static type of `e` is `Null` or a potentially
 nullable subtype thereof, the inferred element, key, and value type
-of `...?e` is `Never`, and so is the element, key, and value type of
-`...e` where the static type of `e` is a subtype of `Never`.
-(which corresponds to 6 changes in
-[this section](https://github.com/dart-lang/language/blob/9e12517922c1f0021aead2af163c3b502497f312/specification/dartLangSpec.tex#L8433)).
+of `...?e` is `Never`.
+
+Similarly, when the static type of `e` is a subtype of `Never`,
+the element, key, and value type of `...e` and `...?e` is `Never`.
+
+*When the static type _S_ of `e` is strictly non-nullable, such as when _S_
+is `Never`, `...?e` is a warning, but it may still occur.*
 
 ### Instantiate to bounds
 

--- a/accepted/future-releases/nnbd/feature-specification.md
+++ b/accepted/future-releases/nnbd/feature-specification.md
@@ -6,7 +6,11 @@ Status: Draft
 
 ## CHANGELOG
 
-2020..06.02
+2020.07.09
+  - Specify combined member signature and spread element typing
+    with null-safety.
+
+2020.06.02
   - Fix the diff to the spec for potentially constant instance checks
   - Specify that extensions do not apply to values of type `Never`
   - Specify the treatment of typedefs from legacy libraries
@@ -679,6 +683,15 @@ If no type is specified in a catch clause, then the default type of the error
 variable is `Object`, instead of `dynamic` as was the case in pre-null safe
 Dart.
 
+#### Spread element typing
+
+In a collection literal in Dart before null-safety, the inferred element
+type of a spread element of the form `...?e` where `e` has static type
+`Null` is `Null`, and so are the inferred key type and value type. With
+null-safety, the inferred element, key, and value type is `Never`
+(which corresponds to 6 changes in
+[this section](https://github.com/dart-lang/language/blob/9e12517922c1f0021aead2af163c3b502497f312/specification/dartLangSpec.tex#L8433)).
+
 ### Instantiate to bounds
 
 The computation of instantiation to bounds is changed to substitute `Never` for
@@ -730,6 +743,25 @@ subtype of `S`.
 ### Generics
 
 The default bound of generic type parameters is treated as `Object?`.
+
+### Combined member signatures
+
+[This section](https://github.com/dart-lang/language/blob/9e12517922c1f0021aead2af163c3b502497f312/specification/dartLangSpec.tex#L4241)
+in the language specification defines the notion of a _combined member
+signature_. In Dart before null-safety it is based on the textually first
+superinterface that has a most specific signature. With null-safety it
+is changed such that the all the most specific signatures are merged.
+
+This is achieved by changing
+[this paragraph](https://github.com/dart-lang/language/blob/9e12517922c1f0021aead2af163c3b502497f312/specification/dartLangSpec.tex#L4373)
+to the following:
+
+"Let _m<sub>all</sub>_ be the result of applying `NNBD_TOP_MERGE` to
+the elements in _M<sub>all</sub>_, ordered according to the interface
+_I<sub>1</sub> .. I<sub>k</sub>_ that each signature came from."
+
+Moreover, the occurrence of _m<sub>i</sub>_ in the next paragraph is
+changed to _m<sub>all</sub>_.
 
 ### Implicit conversions
 


### PR DESCRIPTION
To maintain the result of discussions: This PR adds a specification of how to compute the combined member signature with null-safety, and how to compute various associated types for a `<spreadElement>` with null-safety.