### PR TITLE
Changed warnings to errors, cf. language issue #1012

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -29,6 +29,7 @@
 % 2.8
 % - Change several warnings to compile-time errors, matching the actual
 %   behavior of tools.
+% - Eliminate error for library name conflicts.
 %
 % 2.7
 % - Rename non-terminals `<...Definition>` to `<...Declaration>` (e.g., it is
@@ -16398,18 +16399,7 @@ The use of a class or interface, and of its members, is separate from its declar
 The usage and declaration may occur in widely separated places in the code, and may in fact be authored by different people or organizations.
 It is important that errors are given at the offending declaration so that the party that receives the error can respond to it a meaningful way.
 
-In contrast a library comprises both imports and their usage; the library is under the control of a single party and so any problem stemming from the import can be resolved even if it is reported at the use site.
-
-%On a related note, the provenance of the conflicting elements is not considered. An element that is imported via distinct paths may conflict with itself. This avoids variants of the well known "diamond" problem.
-}
-
-\LMHash{}%
-It is a compile-time error to import two different libraries with the same name
-unless their name is the empty string.
-
-\commentary{
-A widely disseminated library should be given a name that will not conflict with other such libraries.
-The preferred mechanism for this is using pub, the Dart package manager, which provides a global namespace for libraries, and conventions that leverage that namespace.
+In contrast a library comprises both imports and their usage; the library is under the control of a single party and so any problem stemming from the import can be resolved even if it is reported at the use site.%
 }
 
 \commentary{

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -26,6 +26,10 @@
 %
 % Significant changes to the specification.
 %
+% 2.8
+% - Change several warnings to compile-time errors, matching the actual
+%   behavior of tools.
+%
 % 2.7
 % - Rename non-terminals `<...Definition>` to `<...Declaration>` (e.g., it is
 %   'class declaration' everywhere, so `<classDefinition>` is inconsistent).
@@ -2317,7 +2321,7 @@ is not 0.
 It is a compile-time error to declare an optional parameter in an operator.
 
 \LMHash{}%
-It is a static warning if the return type of a user-declared operator
+It is a compile-time error if the return type of a user-declared operator
 \lit{[]=}
 is explicitly declared and not \VOID{}.
 
@@ -2786,8 +2790,8 @@ We could enforce this via the grammar, but we'd have to specify the evaluation r
 }
 
 \LMHash{}%
-It is a static warning if a setter declares a return type other than \VOID{}.
-It is a static warning if a class has
+It is a compile-time error if a setter declares a return type other than \VOID.
+It is a compile-time error if a class has
 a setter named \code{$v$=} with argument type $T$ and
 a getter named $v$ with return type $S$,
 and $S$ may not be assigned to $T$.
@@ -16401,7 +16405,8 @@ In contrast a library comprises both imports and their usage; the library is und
 }
 
 \LMHash{}%
-It is a static warning to import two different libraries with the same name unless their name is the empty string.
+It is a compile-time error to import two different libraries with the same name
+unless their name is the empty string.
 
 \commentary{
 A widely disseminated library should be given a name that will not conflict with other such libraries.

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -2321,9 +2321,8 @@ is not 0.
 It is a compile-time error to declare an optional parameter in an operator.
 
 \LMHash{}%
-It is a compile-time error if the return type of a user-declared operator
-\lit{[]=}
-is explicitly declared and not \VOID{}.
+It is a compile-time error if a user-declared operator \lit{[]=}
+declares a return type other than \VOID{}.
 
 \commentary{
 If no return type is specified for a user-declared operator


### PR DESCRIPTION
Addendum to #1012: It turns out that there is support in the language team for deleting the rule about `library` name clashes in imports, rather than changing it from a warning to an error. Hence, this PR deletes that rule.
