### PR TITLE
Fix conservativeJoin's handling of unassigned.

### DIFF
--- a/resources/type-system/flow-analysis.md
+++ b/resources/type-system/flow-analysis.md
@@ -348,9 +348,9 @@ We also make use of the following auxiliary functions:
   such that:
     - `VI0` maps `v` to `VM0 = VariableModel(d0, p0, s0, a0, u0, c0)`
     - If `captured` contains `v` then `VI1` maps `v` to
-      `VariableModel(d0, [], s0, a0, u0, true)`
+      `VariableModel(d0, [], s0, a0, false, true)`
     - Otherwise if `written` contains `v` then `VI1` maps `v` to
-      `VariableModel(d0, [], s0, a0, u0, c0)`
+      `VariableModel(d0, [], s0, a0, false, c0)`
     - Otherwise `VI1` maps `v` to `VM0`
 
 


### PR DESCRIPTION
When the `conservativeJoin` function makes a conservative
approximation of the result of a join (e.g. at the top of a loop, when
accounting for incoming control flow from the bottom of the loop),
possibly-assigned variables need to have their `unassigned` flag set
to false, otherwise we would emit a bogus error for code like this:

```dart
f() {
  late int x;
  for (int i = 0; i < 2; i++) {
    if (i == 1) {
      print(x); // Bogus error: late variable definitely unassigned
    }
    if (i == 0) {
      x = 10;
    }
  }
}
```

This is already handled correctly in the implementation (see
`VariableModel.discardPromotionsAndMarkNotUnassigned`), and several
test cases would be broken if it weren't:
- language/nnbd/flow_analysis/late_var_assigned_in_try_test
- language/nnbd/flow_analysis/late_var_used_before_assignment_in_local_function_ok_test
- language/nnbd/flow_analysis/late_var_used_before_assignment_in_loop_test
- language/nnbd/flow_analysis/late_var_used_before_assignment_in_switch_test