### PR TITLE
Remove the error for library name conflicts in exports

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -16610,10 +16610,6 @@ When no confusion can arise, we may simply state
 that $L$ \NoIndex{re-exports} $L_i$, or
 that $L$ \NoIndex{re-exports} \Namespace{i}.
 
-\LMHash{}%
-It is a compile-time error to export two different libraries with the same name
-unless their name is the empty string.
-
 
 \subsection{Parts}
 \LMLabel{parts}


### PR DESCRIPTION
Following up on #1083, we need to remove the rule about library name clashes in exports as well. This PR does that.