### PR TITLE
Make it explicit when inference rules are null-safety specific

### DIFF
--- a/resources/type-system/inference.md
+++ b/resources/type-system/inference.md
@@ -337,8 +337,8 @@ Let `T` be the **actual returned type** of a function literal as computed above.
 Let `R` be the greatest closure of the typing context `K` as computed above.
 
 With null safety: if `R` is `void`, or the function literal is marked `async`
-and `R` is `FutureOr<void>`, let `S` be `void`; without null-safety: no special
-treatment is applicable to `void`.
+and `R` is `FutureOr<void>`, let `S` be `void` (without null-safety: no special
+treatment is applicable to `void`).
 
 Otherwise, if `T <: R` then let `S` be `T`.  Otherwise, let `S` be `R`.  The
 inferred return type of the function literal is then defined as follows:


### PR DESCRIPTION
This PR adds phrases like 'Without null safety, ...' and 'with null safety, ...' in inference.md at locations where the rules differ for legacy code and opted-in code. The PR re-introduces the wording from before the change that added support for null safety where needed, such that we now specify both legacy code and code with null safety, and make the distinction explicit.

It also changes the definition of `futureValueTypeSchema` to use `?` to denote the type schema that imposes no constraints, because the rest of inference.md uses that notation.

(We could also change all these occurrences of `?` to `_`. But given that `_` is allowed as an identifier that denotes a type, we may need to choose some other notation which is syntactically not a type.)

Note that this PR has no associated implementation effort: It re-introduces legacy wording for the legacy case where needed, and it marks null-safety specific rules as such; it is not intended to change the meaning of the specification.
