### PR TITLE
Typo fix: Change `?` to `_`

### DIFF
--- a/resources/type-system/inference.md
+++ b/resources/type-system/inference.md
@@ -284,13 +284,8 @@ The function **futureValueTypeSchema** is defined as follows:
 - **futureValueTypeSchema**(`FutureOr<S>`) = `S`, for all `S`.
 - **futureValueTypeSchema**(`void`) = `void`.
 - **futureValueTypeSchema**(`dynamic`) = `dynamic`.
-- **futureValueTypeSchema**(`?`) = `?`.
+- **futureValueTypeSchema**(`_`) = `_`.
 - Otherwise, for all `S`, **futureValueTypeSchema**(`S`) = `Object?`.
-
-_In this definition, when `?` occurs as a type on its own, it is the type
-schema that imposes no constraints, cf. section 'Type Schemas'. Note that it
-has nothing to do with nullability, and in particular it does not stand for
-`T?` for any `T`._
 
 _Note that it is a compile-time error unless the return type of an asynchronous
 non-generator function is a supertype of `Future<Never>`, which means that


### PR DESCRIPTION
In #1102, Leaf said 'I have an open PR which is changing all uses of `?` to `_`, so let's keep this as `_`.' (click the only 'Show resolved' link on #1102 to see it).

This PR is a tiny fix that changes `?` back to `_` and deletes a commentary paragraph about `?`. It is needed because I forgot to upload a commit which did the same thing just before landing #1102.