### PR TITLE
Adjust `<type> implements` to include type variables

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -4427,7 +4427,10 @@ or $J$ is a superinterface of a direct superinterface of $I$.
 When we say that a type $S$
 \IndexCustom{implements}{type!implements a type}
 another type $T$,
-this means that $T$ is a superinterface of $S$.
+this means that $T$ is a superinterface of $S$,
+or $S$ is $S_0$ bounded for some type $S_0$
+(\ref{bindingActualsToFormals}),
+and $T$ is a superinterface of $S_0$.
 Assume that $G$ is a raw type
 (\ref{instantiationToBound})
 whose declaration declares $s$ type parameters.
@@ -4435,7 +4438,7 @@ When we say that a type $S$
 \IndexCustom{implements}{type!implements a raw type}
 $G$,
 this means that there exist types \List{U}{1}{s}
-such that \code{$G$<\List{U}{1}{s}>} is a superinterface of $S$.
+such that $S$ implements \code{$G$<\List{U}{1}{s}>}.
 
 \commentary{%
 Note that this is not the same as being a subtype.
@@ -4449,8 +4452,8 @@ $S$ cannot be a subtype of \code{Null}.%
 
 \LMHash{}%
 Assume that $S$ is a type and $G$ is a raw type such that $S$ implements $G$.
-Per definition there exist types \List{U}{1}{s} such that
-\code{$G$<\List{U}{1}{s}>} is a superinterface of $S$.
+Then there exist unique types \List{U}{1}{s} such that
+$S$ implements \code{$G$<\List{U}{1}{s}>}.
 We then say that \List{U}{1}{s} are the
 \IndexCustom{actual type arguments of $S$ at $G$}{%
   type arguments!of a type at a raw type},


### PR DESCRIPTION
This PR changes the language specification such that `$S$ implements $T$` is generalized to allow `$S$` to be a type variable whose nearest non-type-variable bound is an interface type that has `$T$` as a superinterface. This means that we are relying on the interface associated with `$S$` rather than `$S$` itself. In particular, `X extends C` is treated the same as `C`, which is also what is needed for meaningful and useful behavior of the rules.

For example, the current definition makes this an error, and that is neither intended nor helpful:

```dart
void f<X extends Iterable<int>>(X x) {
  var v = [...x]; // Error!
}
```

The error occurs because the static type of `a` is required to be a type that "implements `Iterable<T>`" for some `T`. We already have special cases for the situation where `a` has a bottom-ish type (`Null`, `Never`, `X extends Null` and so on), but the case where we have a type variable like `X extends Iterable<int>` doesn't match any of the cases, and ends up being an error. I've checked all usages of `<type> implements` in the language specification, and they all justify this change.

This change is also consistent with the previously added text [here](https://github.com/dart-lang/language/blob/b196daf6bdeb6e591fd90a3a683d736365cb8526/specification/dartLangSpec.tex#L4176), which provides the same effect for ordinary method invocations and property extractions. (That part can't use the new meaning of `<type> implements ...` for simplification, because it is only concerned with the the interface associated with a type, not with the relationship to a different type which is found in the superinterface hierarchy).
