### PR TITLE
Clarify rules about initializing formals

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -2984,9 +2984,8 @@ A \Index{formal constructor parameter} is a formal parameter
 (\ref{formalParameters}),
 which can be an initializing formal.
 An \Index{initializing formal} contains a term of the form \code{\THIS.\id},
-where \id{} is the name of an instance variable of
-the immediately enclosing class.
-It is a compile-time error if \id{} is not
+where \id{} is the name of the initializing formal.
+It is a compile-time error if \id{} is not also the name of
 an instance variable of the immediately enclosing class.
 It is a compile-time error if an initializing formal is declared in
 a function declaration which is not a non-redirecting generative constructor.

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -2978,16 +2978,27 @@ and either a redirect clause or an initializer list and an optional body.
 \end{grammar}
 
 \LMHash{}%
-A \Index{constructor parameter list} is a parenthesized, comma-separated list of formal constructor parameters.
-A \Index{formal constructor parameter} is either a formal parameter (\ref{formalParameters}) or an initializing formal.
-An \Index{initializing formal} has the form \code{\THIS{}.\id}, where \id{} is the name of an instance variable of the immediately enclosing class.
-It is a compile-time error if \id{} is not an instance variable of the immediately enclosing class.
-It is a compile-time error if an initializing formal is used by a function other than a non-redirecting generative constructor.
+A \Index{constructor parameter list} is
+a parenthesized, comma-separated list of formal constructor parameters.
+A \Index{formal constructor parameter} is a formal parameter
+(\ref{formalParameters}),
+which can be an initializing formal.
+An \Index{initializing formal} contains a term of the form \code{\THIS.\id},
+where \id{} is the name of an instance variable of
+the immediately enclosing class.
+It is a compile-time error if \id{} is not
+an instance variable of the immediately enclosing class.
+It is a compile-time error if an initializing formal is declared in
+a function declaration which is not a non-redirecting generative constructor.
 
 \LMHash{}%
-If an explicit type is attached to the initializing formal, that is its static type.
-Otherwise, the type of an initializing formal named \id{} is $T_{id}$, where $T_{id}$ is the type of the instance variable named \id{} in the immediately enclosing class.
-It is a compile-time error if the static type of \id{} is not a subtype of $T_{id}$.
+Assume that $p$ is a declaration of an initializing formal parameter named \id.
+Let $T_{id}$ be the type of the instance variable named \id{} in
+the immediately enclosing class.
+If $p$ has a type annotation $T$ then the declared type of $p$ is $T$.
+Otherwise, the declared type of $p$ is $T_{id}$.
+It is a compile-time error if the declared type of $p$
+is not a subtype of $T_{id}$.
 
 \LMHash{}%
 Initializing formals constitute an exception to the rule that

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -30,7 +30,8 @@
 % - Change several warnings to compile-time errors, matching the actual
 %   behavior of tools.
 % - Eliminate error for library name conflicts in imports and exports.
-% - Clarify the specification of initializing formals.
+% - Clarify the specification of initializing formals. Fix error: Add
+%   missing `?' at the end for function typed initializing formal.
 %
 % 2.7
 % - Rename non-terminals `<...Definition>` to `<...Declaration>` (e.g., it is

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -1574,6 +1574,16 @@ It is a compile-time error if \VAR{} occurs as
 the first token of a \synt{fieldFormalParameter}.
 
 \LMHash{}%
+It is a compile-time error if a parameter derived from
+\synt{fieldFormalParameter} occurs in a function declaration
+which is not a non-redirecting generative constructor.
+
+\commentary{%
+The \synt{fieldFormalParameter} construct is described elsewhere
+(\ref{generativeConstructors}).%
+}
+
+\LMHash{}%
 It is possible to include the modifier \COVARIANT{}
 in some forms of parameter declarations.
 The effect of doing this is described in a separate section
@@ -2968,8 +2978,13 @@ If{}f no constructor is specified for a class $C$, it implicitly has a default c
 
 \LMHash{}%
 A \IndexCustom{generative constructor}{constructor!generative}
-declaration consists of a constructor name, a constructor parameter list,
+declaration consists of a constructor name, a formal parameter list
+(\ref{formalParameters}),
 and either a redirect clause or an initializer list and an optional body.
+\commentary{%
+See \synt{declaration} and \synt{methodSignature}
+for grammar rules where these elements are included.%
+}
 
 \begin{grammar}
 <constructorSignature> ::= <constructorName> <formalParameterList>
@@ -2978,17 +2993,20 @@ and either a redirect clause or an initializer list and an optional body.
 \end{grammar}
 
 \LMHash{}%
-A \Index{constructor parameter list} is
-a parenthesized, comma-separated list of formal constructor parameters.
-A \Index{formal constructor parameter} is a formal parameter
-(\ref{formalParameters}),
-which can be an initializing formal.
-An \Index{initializing formal} contains a term of the form \code{\THIS.\id},
-where \id{} is the name of the initializing formal.
+If a formal parameter declaration $p$ is derived from
+\synt{fieldFormalParameter},
+it declares an \Index{initializing formal parameter}.
+A term of the form \code{\THIS.\id} is contained in $p$,
+and \id{} is the \NoIndex{name} of $p$.
 It is a compile-time error if \id{} is not also the name of
 an instance variable of the immediately enclosing class.
-It is a compile-time error if an initializing formal is declared in
-a function declaration which is not a non-redirecting generative constructor.
+
+\commentary{%
+Note that it is a compile-time error for an initializing formal
+to occur in any function which is not a non-redirecting generative constructor
+(\ref{requiredFormals}),
+so there is always an enclosing class.%
+}
 
 \LMHash{}%
 Assume that $p$ is a declaration of an initializing formal parameter named \id.

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -1577,7 +1577,7 @@ the first token of a \synt{fieldFormalParameter}.
 
 \LMHash{}%
 It is a compile-time error if a parameter derived from
-\synt{fieldFormalParameter} occurs in a function declaration
+\synt{fieldFormalParameter} occurs as a parameter of a function
 which is not a non-redirecting generative constructor.
 
 \commentary{%

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -1579,7 +1579,8 @@ It is a compile-time error if a parameter derived from
 which is not a non-redirecting generative constructor.
 
 \commentary{%
-The \synt{fieldFormalParameter} construct is described elsewhere
+A \synt{fieldFormalParameter} declares an initializing formal,
+which is described elsewhere
 (\ref{generativeConstructors}).%
 }
 
@@ -2981,16 +2982,17 @@ A \IndexCustom{generative constructor}{constructor!generative}
 declaration consists of a constructor name, a formal parameter list
 (\ref{formalParameters}),
 and either a redirect clause or an initializer list and an optional body.
-\commentary{%
-See \synt{declaration} and \synt{methodSignature}
-for grammar rules where these elements are included.%
-}
 
 \begin{grammar}
 <constructorSignature> ::= <constructorName> <formalParameterList>
 
 <constructorName> ::= <typeIdentifier> (`.' <identifier>)?
 \end{grammar}
+
+\commentary{%
+See \synt{declaration} and \synt{methodSignature} for grammar rules
+introducing a redirection or an initializer list and a body.%
+}
 
 \LMHash{}%
 If a formal parameter declaration $p$ is derived from

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -30,6 +30,7 @@
 % - Change several warnings to compile-time errors, matching the actual
 %   behavior of tools.
 % - Eliminate error for library name conflicts in imports and exports.
+% - Clarify the specification of initializing formals.
 %
 % 2.7
 % - Rename non-terminals `<...Definition>` to `<...Declaration>` (e.g., it is
@@ -1564,7 +1565,7 @@ It is a compile-time error if any default values are specified in the signature 
   \alt \COVARIANT{}? <identifier>
 
 <fieldFormalParameter> ::= \gnewline{}
-  <finalConstVarOrType>? \THIS{} `.' <identifier> <formalParameterPart>?
+  <finalConstVarOrType>? \THIS{} `.' <identifier> (<formalParameterPart> `?'?)?
 \end{grammar}
 
 \LMHash{}%


### PR DESCRIPTION
Issue https://github.com/dart-lang/language/issues/1108 reports that the rules about initializing formals use `$T_{id}$` in a location where it is undefined. This PR resolves that, and several other imprecision issues at that location in the specification.

Note that the syntax of `<fieldFormalParameter>` was changed to allow an old-style function type to be nullable, but that there is no corresponding implementation effort because the analyzer as well as the CFE already supports this syntax.

Resolves #1108.