### PR TITLE
Flow analysis: Fix promote()'s update of tested set.

### DIFF
--- a/resources/type-system/flow-analysis.md
+++ b/resources/type-system/flow-analysis.md
@@ -443,7 +443,7 @@ Definitions:
       - Else if `S` is `X extends R` then let `T1` = `X & T`
       - Else If `S` is `X & R` then let `T1` = `X & T`
       - Else `x` is not promotable (shouldn't happen since we checked above)
-      - Let `VM2 = VariableModel(declared, T1::promoted, T1::tested, assigned,
+      - Let `VM2 = VariableModel(declared, T1::promoted, T::tested, assigned,
       unassigned, captured)`
       - Let `M2 = FlowModel(r, VI[x -> VM2])`
       - If `T1 <: Never` then `M3` = `unreachable(M2)`, otherwise `M3` = `M2`


### PR DESCRIPTION
When promoting via a test on type T, the type that should be added to
the test set is T, even if the actual promoted type is different.
This brings the spec in line with the implementation.