### PR TITLE
Propose rules about `main` for null-safety

### DIFF
--- a/accepted/future-releases/nnbd/feature-specification.md
+++ b/accepted/future-releases/nnbd/feature-specification.md
@@ -910,11 +910,12 @@ The section 'Scripts' in the language specification is replaced by the
 following:
 
 Let _L_ be a library that exports a declaration _D_ named `main`.  It is a
-compile-time error unless _D_ is a function.  It is a compile-time error if
-_D_ declares more than two required positional parameters, or if there are
-any required named parameters.  It is a compile-time error if _D_ declares
-at least one positional parameter, and the first positional parameter has a
-type which is not a supertype of `List<String>`.
+compile-time error unless _D_ is a function declaration.  It is a
+compile-time error if _D_ declares more than two required positional
+parameters, or if there are any required named parameters.  It is a
+compile-time error if _D_ declares at least one positional parameter, and
+the first positional parameter has a type which is not a supertype of
+`List<String>`.
 
 Implementations are free to impose any additional restrictions on the
 signature of `main`.
@@ -933,7 +934,7 @@ it is invoked with the following two actual arguments:
 - An object specified when the current isolate _i_ was created,
   for example through the invocation of `Isolate.spawnUri` that spawned _i_,
   or the null object if no such object was supplied.
-  A dynamic error occurs unless the run-time type of this object is a
+  A dynamic error occurs if the run-time type of this object is not a
   subtype of the declared type of the corresponding parameter of `main`.
 
 If `main` cannot be called with two positional arguments, but it can be
@@ -944,12 +945,14 @@ If `main` cannot be called with one or two positional arguments, it is
 invoked with no arguments.
 
 In each of the above three cases, an implementation is free to provide
-additional arguments allowed by the signature of `main`, but must ensure
-that a dynamic error occurs if an actual argument does not have a run-time
-type which is a subtype of the declared type of the parameter.
+additional arguments allowed by the signature of `main` (*the above rules
+ensure that the corresponding parameters are optional*).  But the
+implementation must ensure that a dynamic error occurs if an actual
+argument does not have a run-time type which is a subtype of the declared
+type of the parameter.
 
-A Dart program will typically be executed by executing a script.
-The procedure whereby this script is chosen is implementation specific.
+A Dart program will typically be executed by executing a script.  The
+procedure whereby this script is chosen is implementation specific.
 
 ## Runtime semantics
 

--- a/accepted/future-releases/nnbd/feature-specification.md
+++ b/accepted/future-releases/nnbd/feature-specification.md
@@ -6,6 +6,9 @@ Status: Draft
 
 ## CHANGELOG
 
+2020.08.12
+  - Specify constraints on the `main` function.
+
 2020.08.06
   - Specify error for uninitialized final instance variable in class
     with no generative constructors.
@@ -900,6 +903,53 @@ defined as follows.
 These are extended as
 per
 [separate proposal](https://github.com/dart-lang/language/blob/master/resources/type-system/flow-analysis.md).
+
+### The main function
+
+The section 'Scripts' in the language specification is replaced by the
+following:
+
+Let _L_ be a library that exports a declaration _D_ named `main`.  It is a
+compile-time error unless _D_ is a function.  It is a compile-time error if
+_D_ declares more than two required positional parameters, or if there are
+any required named parameters.  It is a compile-time error if _D_ declares
+at least one positional parameter, and the first positional parameter has a
+type which is not a supertype of `List<String>`.
+
+Implementations are free to impose any additional restrictions on the
+signature of `main`.
+
+A _script_ is a library that exports a declaration named `main`.
+A script _L_ is executed as follows:
+
+First, _L_ is compiled as a library as specified above.
+Then, the top-level function defined by `main`
+in the exported namespace of _L_ is invoked as follows:
+
+If `main` can be called with with two positional arguments,
+it is invoked with the following two actual arguments:
+
+- An object whose run-time type implements `List<String>`.
+- An object specified when the current isolate _i_ was created,
+  for example through the invocation of `Isolate.spawnUri` that spawned _i_,
+  or the null object if no such object was supplied.
+  A dynamic error occurs unless the run-time type of this object is a
+  subtype of the declared type of the corresponding parameter of `main`.
+
+If `main` cannot be called with two positional arguments, but it can be
+called with one positional argument, it is invoked with an object whose
+run-time type implements `List<String>` as the only argument.
+
+If `main` cannot be called with one or two positional arguments, it is
+invoked with no arguments.
+
+In each of the above three cases, an implementation is free to provide
+additional arguments allowed by the signature of `main`, but must ensure
+that a dynamic error occurs if an actual argument does not have a run-time
+type which is a subtype of the declared type of the parameter.
+
+A Dart program will typically be executed by executing a script.
+The procedure whereby this script is chosen is implementation specific.
 
 ## Runtime semantics
 


### PR DESCRIPTION
This is a proposal for new rules about `main`, adding a new section in the null safety spec (which will replace the section 'Scripts' in the language specification in the future).

Potentially noteworthy aspects (compared to [this](https://github.com/dart-lang/language/issues/1120#issuecomment-670097180)):

This proposal maintains that the initial function has the name `main`. I think it's helpful for developers to know for sure that the initial function has this name, so that they don't suddenly have to use some other name, just because they have switched to use a different compiler.

This proposal still defines the term _script_; however, it is now a very straightforward concept. If we think the word 'script' sounds too "PHP-ish" then we can rename it (here, and later in the language specification in general), but it seems reasonable to be able to talk about the ability to be the provider of the function that defines what it means to run a program (the "initial function").

I have preserved the specification of how to invoke `main` (with 2, 1, or 0 arguments), but broadened it to allow implementations to pass additional arguments. This means that an embedder can allow or require `main` to have additional optional parameters (positional or named), and it can pass whatever actual arguments it wants to those additional parameters.

But we do maintain that `T main()` for any `T`, `T main(U u)` where `List<String> <: U`, and `T main(U u, V v)` _must_ work (except for the catchall clause that "implementations can have arbitrary extra constraints on the signature of `main`"). Also, all invocations must enforce the declared types, and we do statically prevent weird signatures like `void main(int i)` and `void main(arg1, arg2, arg3)`.
