### PR TITLE
Revise spec section imports (rebased PR)

### DIFF
--- a/specification/dart.sty
+++ b/specification/dart.sty
@@ -341,7 +341,18 @@
 
 % Namespaces, needed in the specification of imports and exports, and
 % also used when specifying lookups and scope rules.
-\newcommand{\Namespace}[1]{\ensuremath{\metavar{NS}_{#1}}}
+\newcommand{\NamespaceName}[1]{\ensuremath{\metavar{NS}_{#1}}}
+\newcommand{\Namespace}[2]{\ensuremath{\NamespaceName{#1}({#2})}}
+
+% Functions used in the specification of the namespace combinators
+% `show` and `hide`.
+\newcommand{\ShowName}{\metavar{show}}
+\newcommand{\HideName}{\metavar{hide}}
+\newcommand{\Show}[2]{\ensuremath{\ShowName({#1},{#2})}}
+\newcommand{\Hide}[2]{\ensuremath{\HideName({#1},{#2})}}
+
+% A special value in a namespace, used to indicate a conflict.
+\newcommand{\ConflictValue}{\mbox{NAME\_CONFLICT}}
 
 % Context types: Avoid the `?` because that is also concrete type
 % syntax.

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -752,6 +752,15 @@ which is declared in the same library.%
 }
 
 \LMHash{}%
+In order to specify a few properties of execution,
+we introduce the notion of a
+\Index{dynamic namespace}.
+This is a partial function from names to run-time entities,
+in particular objects and compiled code.
+Each dynamic namespace corresponds to a namespace with the same keys,
+but with values that correspond to the semantics of the namespace values.
+
+\LMHash{}%
 Dart is lexically scoped.
 Scopes may nest.
 A name or declaration $d$ is \Index{available in scope} $S$ if $d$ is in the namespace induced by $S$ or if $d$ is available in the lexically enclosing scope of $S$.
@@ -16680,7 +16689,7 @@ When $I_i$ is an immediate import that refers to a URI via the string $s_i$:
 
 \LMHash{}%
 Let \NamespaceName{\metavar{import}, i} be the namespace imported from $L_i$.
-The namespace \NamespaceName{i} will then have the following bindings:
+The dynamic namespace \NamespaceName{i} will then have the following bindings:
 
 \begin{itemize}
 \item
@@ -16696,26 +16705,26 @@ The namespace \NamespaceName{i} will then have the following bindings:
 
 \LMHash{}%
 If $I_i$ has prefix $p$,
-and the library namespace of the current library
+and the dynamic library namespace of the current library
 does not have a binding for $p$,
-then a mapping from $p$ to a non-deferred prefix namespace
+then a mapping from $p$ to a non-deferred dynamic prefix namespace
 with members determined by \NamespaceName{i} is introduced into the
-library namespace of the current library.
+dynamic library namespace of the current library.
 If $I_i$ has prefix $p$,
-and the library namespace of the current library
-binds $p$ to a non-deferred prefix namespace $o$,
+and the dynamic library namespace of the current library
+binds $p$ to a non-deferred dynamic prefix namespace $o$,
 then $o$ is extended with bindings as determined by \NamespaceName{i}.
 
 \LMHash{}%
 Otherwise, when $I_i$ does not have a prefix, each mapping in \NamespaceName{i}
-is introduced into the library namespace of the current library.
+is introduced into the dynamic library namespace of the current library.
 
 \commentary{%
-The dynamic construction of the library namespace
+The construction of the dynamic library namespace
 cannot encounter any name conflicts,
 because such conflicts would have caused a compile-time error.
 
-Library namespace construction can be completed at compile time,
+Dynamic library namespace construction can be completed at compile time,
 and any accesses, prefixed or not, can be resolved statically.
 So an implementation does not need to extend prefix namespaces dynamically,
 or even have a run-time representation of prefix namespaces at all,
@@ -16768,7 +16777,7 @@ in \NamespaceName{\metavar{public}}.%
 \LMHash{}%
 In the first step we compute the namespace provided by each exported library:
 For each $i \in 1 .. m$,
-\NamespaceName{\metavar{one},i} is
+\NamespaceName{\metavar{exported},i} is
 the namespace obtained from applying
 the namespace combinators of $E_i$ to
 the exported namespace of $L_i$
@@ -16781,7 +16790,7 @@ and $n$ and $n'$ have the same basename.
 \LMHash{}%
 The
 \IndexCustom{namespace re-exported from}{library!namespace re-exported from}
-$L_i$ is \NamespaceName{\metavar{one},i}.
+$L_i$ is \NamespaceName{\metavar{exported},i}.
 
 \LMHash{}%
 In the second step we compute the exported namespace of $L$.
@@ -16792,7 +16801,7 @@ to \List{\metavar{NS}}{\metavar{one},1}{\metavar{one},m}.
 A compile-time error occurs if any name in
 \NamespaceName{\metavar{merged}}
 is conflicted
-(\commentary{that is, the name is mapped to \ConflictValue}).
+(\ref{conflictMergingOfNamespaces}).
 
 \rationale{%
 This rule is more strict than the corresponding rule for imports:
@@ -16827,10 +16836,10 @@ we say that $L$
 \Index{re-exports library}
 $L_i$, and also that $L$
 \Index{re-exports namespace}
-\NamespaceName{\metavar{export},i}.
+\NamespaceName{\metavar{exported},i}.
 When no confusion can arise, we may simply state
 that $L$ \NoIndex{re-exports} $L_i$, or
-that $L$ \NoIndex{re-exports} \NamespaceName{\metavar{export},i}.
+that $L$ \NoIndex{re-exports} \NamespaceName{\metavar{exported},i}.
 
 
 \subsection{Namespace Combinators}
@@ -16963,8 +16972,8 @@ are specified as follows:
 \LMHash{}%
 \NamespaceName{\metavar{conflict}} is empty except for the
 bindings mentioned below.
-\NamespaceName{\metavar{narrowed},i} is identical to
-\NamespaceName{i}, $i \in 1 .. m$,
+For each $i \in 1 .. m$,
+\NamespaceName{\metavar{narrowed},i} is identical to \NamespaceName{i},
 except that the former is undefined at each name $n$ where
 the latter is defined,
 and one of the following conditions holds:
@@ -16979,7 +16988,7 @@ and one of the following conditions holds:
     So a declaration from a non-system library shadows
     declarations from system libraries.%
   }
-\item There exists a $j \in 1 .. m$ and name $n'$ such that
+\item Otherwise, there exists a $j \in 1 .. m$ and name $n'$ such that
   \NamespaceName{j} is defined at $n'$,
   $n$ and $n'$ have the same basename,
   \Namespace{i}{n} and \Namespace{j}{n'} are not the same declaration
@@ -17015,11 +17024,11 @@ over declarations from system libraries.%
 
 \LMHash{}%
 It is useful to be able to refer to the result of narrowing.
-Let \List{\metavar{NS}}{1}{m} be a list of namespaces, $j \in 1 .. m$,
+Let \List{\metavar{NS}}{1}{m} be a list of namespaces, $i \in 1 .. m$,
 and consider the conflict merging as specified above.
 The
 \IndexCustom{conflict narrowed namespace}{namespace!conflict narrowed}
-of \NamespaceName{j} is then \NamespaceName{\metavar{narrowed},j}.
+of \NamespaceName{i} is then \NamespaceName{\metavar{narrowed},i}.
 
 
 \subsection{Parts}

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -674,7 +674,12 @@ The method used to enable or disable assertions is implementation specific.
 \LMLabel{scoping}
 
 \LMHash{}%
-A \Index{namespace} is a partial function that maps names to namespace values.
+A \IndexCustom{compile-time namespace}{namespace!compile-time}
+is a partial function that maps names to namespace values.
+Compile-time namespaces are used much more frequently than run-time namespaces
+(\commentary{defined later in this section}),
+so when the word \Index{namespace} is used alone,
+it means compile-time namespace.
 A \Index{name} is a lexical token which is an \synt{IDENTIFIER},
 an \synt{IDENTIFIER} followed by \lit{=}, or
 an \synt{operator},
@@ -684,9 +689,7 @@ a declaration, a namespace, or the special value \ConflictValue{}
 (\ref{conflictMergingOfNamespaces}).
 
 \LMHash{}%
-The graph of a namespace \NamespaceName{} is the set
-$\{(n, V)\;|\;\Namespace{}{n} = V\}$,
-and for any $(n, V)$ in that set we say that \NamespaceName{}
+If $\Namespace{}{n} = V$ then we say that \NamespaceName{}
 \IndexCustom{maps}{namespace!maps a key to a value}
 the
 \IndexCustom{key}{namespace!key}
@@ -728,15 +731,16 @@ and the unary minus operator has the special name \code{unary-}.%
 }
 
 \commentary{%
-It is typically the case that $V$ is $D$,
-but there are exceptions:
-A variable declaration introduces an implicitly induced getter declaration,
+It is typically the case that $V$ is the declaration $D$ itself,
+but there are exceptions.
+For example,
+a variable declaration introduces an implicitly induced getter declaration,
 and in some cases also an implicitly induced setter declaration into the
 given scope.%
 }
 
 \commentary{%
-Note that labels are not included in the namespace of a scope.
+Note that labels (\ref{labels}) are not included in the namespace of a scope.
 They are resolved lexically rather then being looked up in a namespace.%
 }
 
@@ -756,7 +760,7 @@ which is declared in the same library.%
 We introduce the notion of a
 \Index{run-time namespace}.
 This is a partial function from names to run-time entities,
-in particular storage locations and compiled code.
+in particular storage locations and functions.
 Each run-time namespace corresponds to a namespace with the same keys,
 but with values that correspond to the semantics of the namespace values.
 
@@ -770,7 +774,8 @@ such that the dynamic semantics can access run-time entities
 like that storage location.
 The same code may be executed multiple times with the same run-time namespace,
 or with different run-time namespaces for each execution.
-E.g., local variables for a function invocation are specific to the invocation,
+E.g., local variables declared inside a function
+are specific to each invocation of the function,
 and instance variables are specific to an object.%
 }
 
@@ -16267,9 +16272,9 @@ Since top level privates are not imported, using the top level privates of anoth
 }
 
 \LMHash{}%
-The \Index{public namespace} of library $L$ is the mapping that maps
+The \Index{public namespace} of library $L$ is the namespace that maps
 the simple name of each public top-level member declaration $m$ of $L$ to $m$.
-The \Index{local namespace} of library $L$ is the mapping that maps
+The \Index{local namespace} of library $L$ is the namespace that maps
 the names introduced by each top-level declaration of $L$
 to the corresponding declaration.
 The \Index{library scope} of library $L$ is the outermost scope in $L$,
@@ -16282,7 +16287,7 @@ and its namespace is the library namespace of $L$
 
 \LMHash{}%
 An \Index{import} specifies a library whose exported namespace
-is made available in the current library.
+(or a subset of its mappings) is made available in the current library.
 
 \begin{grammar}
 <libraryImport> ::= <metadata> <importSpecification>
@@ -16331,8 +16336,8 @@ so we can refer to \emph{the} prefix clause of a deferred import.%
 \LMHash{}%
 It is a compile-time error if the prefix used in a deferred import
 is also used as the prefix of another import clause.
-It is a compile-time error if \id{} is an import prefix and
-the current library declares a top-level member named \id{}.
+It is a compile-time error if \id{} is an import prefix,
+and the current library declares a top-level member with basename \id{}.
 
 \LMHash{}%
 An import directive $I$ may optionally include namespace combinator clauses
@@ -16397,6 +16402,23 @@ conflicts with the system libraries are treated specially.%
 }
 
 \LMHash{}%
+Let $I$ be an import directive and let $L$ be the library imported by $I$.
+The
+\IndexCustom{namespace provided by}{%
+  namespace!provided by an import directive}
+by the import directive $I$ is the namespace obtained from applying
+the namespace combinators of $I$
+to the exported namespace of $L$
+(\ref{namespaceCombinators}).
+
+\commentary{%
+Note that the namespace provided by an import directive $I$ is not
+the same as the namespace imported from $I$.
+The latter includes conflict resolution,
+and is defined later in this section.%
+}
+
+\LMHash{}%
 Let \NamespaceName{\metavar{local}} be the local namespace of $L$
 (\ref{librariesAndScripts}).
 Let \List{I}{1}{m} be the import directives of $L$,
@@ -16411,22 +16433,22 @@ Let $i \in 1 .. m$.
 
 \LMHash{}%
 {\bf Step one.}
-In the first step we compute the namespace provided by each imported library,
+In the first step we compute the namespace obtained from each imported library,
 respectively by each group of libraries imported with the same prefix,
 \NamespaceName{\metavar{one},i}.
 
 \LMHash{}%
 \Case{Step one for imports without a prefix}
-When $I_i$ has no prefix, \NamespaceName{\metavar{one},i} is
-the namespace obtained from applying the namespace combinators of $I_i$ to
-the exported namespace of $L_i$
-(\ref{namespaceCombinators}),
-and eliminating every binding
-where the key is an import prefix declared in $L$.
+When $I_i$ has no prefix, \NamespaceName{\metavar{one},i} is obtained
+from the namespace provided by the import directive $I_i$
+by eliminating every binding for a name whose basename is
+the same as the basename of a top-level declaration in $L$,
+or whose basename is the prefix of an import directive in $L$.
 
 \commentary{%
-The former ensures that \HIDE{} and \SHOW{} directives are taken into account,
-and the latter ensures that an import prefix will shadow an imported name.%
+This step ensures that \SHOW{} and \HIDE{} directives are taken into account,
+and that an import prefix as well as a local declaration
+will shadow an imported name.%
 }
 \EndCase
 
@@ -16439,25 +16461,8 @@ let \List{I'}{1}{k} be the sublist of \List{I}{1}{m} that have prefix $p_i$,
 and let \List{L'}{1}{k} be the corresponding libraries
 (\commentary{which is a sublist of \List{L}{1}{m}}).
 Let \NamespaceName{\metavar{exported},j}, $j \in 1 .. k$,
-be the namespace obtained from applying the namespace combinators of $I'_j$ to
-the exported namespace of $L'_j$
-(\ref{namespaceCombinators}).
-
-\LMHash{}%
-For later reference, we need to introduce a way to refer to certain extensions:
-If \NamespaceName{\metavar{exported},j} contains an extension $E$
-(\ref{extensions})
-then we say that $E$ is
-\IndexCustom{exported to}{extension!exported to a prefix}
-$p_i$.
-\commentary{%
-Note that $E$ is `exported to $p_i$',
-even in the case where there is a name clash with a different import
-which makes it an error to access $E$ using its name
-because that name is conflicted.
-The point is that $E$ can still be used implicitly,
-based on its fresh name.%
-}
+be the namespace provided by the import directive $I'_j$
+(\commentary{which takes \SHOW{} and \HIDE{} into account}).
 
 \LMHash{}%
 When $I_i$ is a non-deferred import:
@@ -16508,33 +16513,21 @@ In the second step we resolve top level conflicts
 among the namespaces obtained in the first step.
 
 \LMHash{}%
-Let \NamespaceName{\metavar{merged}} be the result of applying
-conflict merging to the namespaces
+The \Index{imported namespace} of $L$, \NamespaceName{\metavar{import}},
+is then the result of applying conflict merging to the namespaces
 \List{\metavar{NS}}{\metavar{one},1}{\metavar{one},m}.
-Let \NamespaceName{\metavar{import}}
-be the namespace which is identical to \NamespaceName{\metavar{merged}},
-except that it is undefined at each name $n$ where
-\NamespaceName{\metavar{local}} is defined at $n'$
-such that $n$ and $n'$ have the same basename.
-
-\commentary{%
-In other words, a declaration in the current library shadows
-imported declarations.%
-}
-
-\LMHash{}%
-The \Index{imported namespace} of $L$ is then \NamespaceName{\metavar{import}}.
 
 \LMHash{}%
 Let $\cal E$ be a set of extension declarations
 (\ref{extensions})
 with the following members:
 An extension declaration $E$ is a member of $\cal E$
-if there is an $i \in 1 .. m$ and a name $n$
-such that $\Namespace{\metavar{one},i}{n} = E$,
-or if there is a prefix $p_i$ such that $E$ is exported to $p_i$
-(\commentary{as defined in step one}).
-%
+if there is an $i \in 1 .. m$ such that
+$E$ is in the namespace provided by the import directive $I_i$
+(\commentary{%
+note that this takes \SHOW{} and \HIDE{} into account,
+and it includes extensions imported both without and with a prefix%
+}).
 Let \NamespaceName{\metavar{extensions}} be a namespace that
 for each extension $E$ in $\cal E$ maps a fresh name to $E$.
 
@@ -16572,10 +16565,20 @@ and except the ones removed by conflict merging.%
 }
 
 \LMHash{}%
-We say that a name is \Index{imported by a library}
-if the name is in the library's imported namespace.
-We say that a declaration \Index{is imported by a library}
-if the declaration is in the library's imported namespace.
+Let $L$ be a library with imported namespace \NamespaceName.
+We say that a name is
+\IndexCustom{imported by $L$}{imported!name}
+if the name is a key of \NamespaceName.
+We say that a declaration is
+\IndexCustom{imported by $L$}{imported!declaration}
+if the declaration is a value of \NamespaceName.
+We say that a name is
+\IndexCustom{imported by $L$ with prefix $p$}{imported!name, with prefix}
+if the name is a key of \Namespace{}{p}.
+We say that a declaration is
+\IndexCustom{imported by $L$ with prefix $p$}{%
+  imported!declaration, with prefix}
+if the declaration is a value of \Namespace{}{p}.
 
 
 \subsubsection{Semantics of Imports}
@@ -16605,13 +16608,13 @@ as defined previously
   an immediate import $I'$ to be executed at some future time,
   where $I'$ is derived from $I_i$ by eliding the word \DEFERRED{}
   and adding a \HIDE{} \code{loadLibrary} combinator clause.
-  % Weasel wording here: We may not want to insist that it must be a
-  % a dynamic error if an implementation loads a library where a comment
-  % was changed, or anything else that doesn't matter, or even the exact
-  % same source code was obtained from a different file. Hence the error
-  % "may be raised".
-  A dynamic error may be raised if $I'$ imports a different library
-  than the one that the specified URI referred to at compile-time.
+  The execution of the immediate import may fail
+  for implementation specific reasons.
+  \commentary{%
+    For instance, $I'$ imports a different library than the one
+    that the specified URI referred to at compile-time;
+    or an OS level file read error occurs; etc.%
+  }
   We say that the invocation of \code{loadLibrary}
   \IndexCustom{succeeds}{loadLibrary!succeeds} if $f$ completes with a value,
   and that the invocation
@@ -16649,7 +16652,7 @@ The purpose of having members of the imported library in
 \NamespaceName{\metavar{deferred}}
 is to ensure that usages of members that have not yet been loaded
 can be resolved normally and has a well-defined behavior,
-but will raise errors.%
+which will raise errors.%
 }
 
 \LMHash{}%
@@ -16659,7 +16662,8 @@ the name $p$ is mapped to a non-deferred prefix run-time namespace
 with bindings as described below for immediate imports.
 In addition, \NamespaceName{\metavar{loaded}}
 maps \code{loadLibrary} to a function with the same signature as before,
-and so it is possible to invoke \code{$p$.loadLibrary()} again.
+and so it is possible to invoke \code{$p$.loadLibrary()} again,
+which will always succeed.
 If a call fails, the library has not been loaded,
 and one has the option to invoke \code{$p$.loadLibrary()} again.
 Whether a repeated call to \code{$p$.loadLibrary()} succeeds will vary,
@@ -16774,7 +16778,9 @@ It is a compile-time error if the specified URI
 does not refer to a library declaration.
 
 \LMHash{}%
-The exported namespace of a library is determined as follows, in two steps.
+The
+\Index{exported namespace}
+of a library is determined as follows, in two steps.
 Let $L$ be a library,
 let \List{E}{1}{m} be the export directives of $L$,
 and let \List{L}{1}{m} be libraries
@@ -16798,7 +16804,7 @@ the exported namespace of $L_i$
 and removing each binding of a name $n$ such that
 \NamespaceName{\metavar{public}} is defined at $n'$,
 and $n$ and $n'$ have the same basename.
-\commentary{So local declarations shadow re-exported ones.}
+\commentary{Because local declarations will shadow re-exported ones.}
 
 \LMHash{}%
 The
@@ -16818,9 +16824,9 @@ is conflicted
 
 \rationale{%
 This rule is more strict than the corresponding rule for imports:
-When two imported declarations have a name clash it is only an error to
+When two imported declarations have a name clash, it is only an error to
 \emph{use} the conflicted name, it is not an error that the name clash exists.
-With exported names it is an error that the name clash exists.
+With exported names, it is an error that the name clash exists.
 The reason for this difference is that
 the conflict could silently break importers of the current library $L$,
 if we were to use the same approach for exports as for imports:
@@ -17013,7 +17019,10 @@ and one of the following conditions holds:
   \commentary{%
     So with two distinct declarations with the same basename,
     both are eliminated,
-    except when it is a getter and a setter from the same library.%
+    except when it is a getter and a setter from the same library.
+    Note that \Namespace{i}{n} and \Namespace{j}{n'} must be declarations,
+    because conflict merging is never applied to namespaces
+    where a shared key is an import prefix.%
   }
 
   In this situation $n$ is mapped to \ConflictValue{}

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -16213,7 +16213,8 @@ as well as import prefixes
 and fresh names of extensions
 (\ref{extensions})
 to the corresponding declaration or import prefix.
-
+The \Index{library scope} of library $L$ is the outermost scope in $L$,
+and its namespace is the local namespace of $L$.
 
 \subsection{Imports}
 \LMLabel{imports}
@@ -16305,14 +16306,14 @@ by means of yet another special rule.%
 \LMLabel{conflictMergingOfNamespaces}
 
 \LMHash{}%
-In the following, we define an operation on namespaces
-which eliminates the binding of names in case of name clashes,
+In this section we define an operation on namespaces
+which eliminates certain bindings of names in case of name clashes,
 and keeps track of such name clashes using a special value,
 \Index{\ConflictValue}.
 
 \LMHash{}%
 When a name $n$ is mapped to \ConflictValue{} by a namespace,
-we say that the name is
+we say that $n$ is
 \IndexCustom{conflicted}{conflicted name}.
 A lookup for a conflicted name will succeed according to
 the normal rules for namespaces and lexical scoping,
@@ -16320,31 +16321,23 @@ but it is a compile-time error at the location where the name is used
 that this name is conflicted.
 
 \LMHash{}%
-Let \List{L}{1}{m} be a list of libraries
-(\commentary{the list may or may not contain duplicates}).
 Let \List{\metavar{NS}}{1}{m} be a list of namespaces
-(\commentary{again possibly with some duplicates}),
-such that \NamespaceName{j}
-is a subset of the namespace exported by $L_j$,
-for each $j \in 1 .. m$.
-
-\LMHash{}%
+(\commentary{the list may or may not contain duplicates}).
 The
 \IndexCustom{conflict merging}{namespace!conflict merging}
-of \List{\metavar{NS}}{1}{m}
-with associated libraries \List{L}{1}{m} is then
+of \List{\metavar{NS}}{1}{m} is then
 $\NamespaceName{\metavar{conflict}} \cup
 \NamespaceName{\metavar{narrowed},1} \cup\,
 \ldots\ \NamespaceName{\metavar{narrowed},m}$,
 where the namespaces \NamespaceName{\metavar{conflict}} and
-\List{\metavar{NS}}{\metavar{narrowed},1}{\metavar{narrowed},m}
-are specified below.
+\NamespaceName{\metavar{narrowed},i}, $i \in 1 .. m$,
+are specified as follows:
 
 \LMHash{}%
 \NamespaceName{\metavar{conflict}} is empty except for the
 bindings mentioned below.
 \NamespaceName{\metavar{narrowed},i} is identical to
-\NamespaceName{i}, for all $i \in 1 .. m$,
+\NamespaceName{i}, $i \in 1 .. m$,
 except that the former is undefined at each name $n$ where
 the latter is defined,
 and one of the following conditions holds:
@@ -16362,8 +16355,8 @@ and one of the following conditions holds:
 \item There exists a $j \in 1 .. m$ and name $n'$ such that
   \NamespaceName{j} is defined at $n'$,
   $n$ and $n'$ have the same basename,
-  \Namespace{i}{n} and \Namespace{j}{n'} are not the same declaration,
-  $L_i$ and $L_j$ are not the same library,
+  \Namespace{i}{n} and \Namespace{j}{n'} are not the same declaration
+  and not a getter and a setter declared in the same library,
   and either none or both of
   \Namespace{i}{n} and \Namespace{j}{n'}
   are declarations in a system library.
@@ -16373,23 +16366,16 @@ and one of the following conditions holds:
     both are eliminated,
     except when it is a getter and a setter from the same library.%
   }
-  % We need the 'not the same library' requirement (i != j is not enough),
-  % because otherwise we could have two imports of the same library,
-  % and we could focus on a getter `x` from one import of a library
-  % Lx, and on a setter `x=` from the other import of Lx, and then we would
-  % eliminate both.
-  % Conversely, when $L_i$ and $L_j$ are not the same library then it could
-  % not possibly be a getter/setter pair from the same library: Such a pair
-  % would be exported together, and they would be re-exported each time
-  % together (hide/show cannot distinguish).
 
   In this situation $n$ is mapped to \ConflictValue{}
   by \NamespaceName{\metavar{conflict}}.
+  \commentary{By symmetry, $n'$ is also conflicted.}
 \end{itemize}
 
 \commentary{%
 In summary, conflict merging takes a list of namespaces and produces
-a namespace that is the union of several disjoint namespaces:
+a namespace that is the union of several disjoint namespaces
+(because all name clashes have been eliminated):
 A conflict namespace that records all unresolved name clashes,
 and a list of namespaces where clashing names have been removed.
 Some name clashes have been resolved by preferring
@@ -16469,7 +16455,6 @@ the exported namespace of $L'_j$
 Let \NamespaceName{\metavar{prefix},i} be the namespace obtained from applying
 conflict merging to
 \List{\metavar{NS}}{\metavar{exported},1}{\metavar{exported},k}
-and the associated libraries \List{L'}{1}{k}
 (\ref{conflictMergingOfNamespaces}).
 Then \NamespaceName{\metavar{one},i} is a namespace that has
 a single binding that maps $p_i$ to \NamespaceName{\metavar{prefix},i}.
@@ -16504,10 +16489,7 @@ among the namespaces obtained in the first step.
 \LMHash{}%
 Let \NamespaceName{\metavar{merged}} be the result of applying
 conflict merging to the namespaces
-\List{\metavar{NS}}{\metavar{one},1}{\metavar{one},m}
-with associated libraries \List{L}{1}{m}.
-
-\LMHash{}%
+\List{\metavar{NS}}{\metavar{one},1}{\metavar{one},m}.
 Let \NamespaceName{\metavar{import}}
 be the namespace which is identical to \NamespaceName{\metavar{merged}},
 except that it is undefined at each name $n$ where

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -16612,10 +16612,10 @@ as defined previously
   % "may be raised".
   A dynamic error may be raised if $I'$ imports a different library
   than the one that the specified URI referred to at compile-time.
-  When $I'$ is loaded without error, $f$ completes successfully.
-  If $I'$ is loaded without error,
-  we say that the call to \code{loadLibrary} has succeeded,
-  otherwise we say the call has failed.
+  We say that the invocation of \code{loadLibrary}
+  \IndexCustom{succeeds}{loadLibrary!succeeds} if $f$ completes with a value,
+  and that the invocation
+  \IndexCustom{fails}{loadLibrary!fails} if $f$ completes with an error.
 \item
   For every top level function $f$ named \id{} in
   \NamespaceName{\metavar{import},i},
@@ -16653,7 +16653,7 @@ but will raise errors.%
 }
 
 \LMHash{}%
-After an invocation of \code{$p$.loadLibrary()} succeeds,
+When an invocation of \code{$p$.loadLibrary()} succeeds,
 the name $p$ is mapped to a non-deferred prefix run-time namespace
 \NamespaceName{\metavar{loaded}},
 with bindings as described below for immediate imports.
@@ -16725,8 +16725,7 @@ The run-time namespace \NamespaceName{i} will then have the following bindings:
   For every name \id{} in \NamespaceName{\metavar{import}, i}
   that is bound to a class, mixin, or type alias declaration
   introducing a type $T$,
-  a binding from \id{} to a compiled getter with return type \code{Type}
-  that, when invoked, returns the type object for $T$.
+  a binding from \id{} to the compiled representation of $T$.
 \end{itemize}
 
 \LMHash{}%
@@ -16822,7 +16821,7 @@ is conflicted
 This rule is more strict than the corresponding rule for imports:
 When two imported declarations have a name clash it is only an error to
 \emph{use} the conflicted name, it is not an error that the name clash exists.
-But with exported names it is an error that the name clash exists.
+With exported names it is an error that the name clash exists.
 The reason for this difference is that
 the conflict could silently break importers of the current library $L$,
 if we were to use the same approach for exports as for imports:

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -16701,15 +16701,15 @@ We do not specify which object the returned future resolves to.%
 
 \LMHash{}%
 \Case{Semantics of immediate imports}
-When $I_i$ is an immediate import that refers to a URI via the string $s_i$:
-Let $\ell_i$ denote the run-time entity that corresponds to the result of
-compiling the library $L_i$ denoted by $s_i$.
-
-\LMHash{}%
-$\ell_i$ is accessible in the current isolate at run time
-due to an implementation specific mechanism,
-and it provides access to the result of compiling functions,
-as well as other resources needed for the execution of code in $L_i$.
+When $I_i$ is an immediate import with a library URI, $u_i$,
+represented by the string $s_i$:
+Let $L_i$ be the library obtained from the source code denoted by $s_i$,
+and let $\ell_i$ be the result of compiling $L_i$.
+We then say that the URI $u_i$ denotes the library $L_i$
+(which also determines $\ell_i$).
+All imports and exports of the same URI in a Dart program denotes
+the same library,
+and imports or exports of different URIs denote distinct libraries.
 
 \LMHash{}%
 Let \NamespaceName{\metavar{import}, i} be the namespace imported from $L_i$.
@@ -16730,7 +16730,7 @@ The run-time namespace \NamespaceName{i} will then have the following bindings:
 
 \LMHash{}%
 If $I_i$ has prefix $p$,
-the run-time library namespace of the current library
+the run-time namespace of the current library
 maps $p$ to a non-deferred prefix run-time namespace \NamespaceName{p}
 containing the mappings of \NamespaceName{i}.
 

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -16301,6 +16301,102 @@ essentially canceling \code{dart:core}'s special treatment
 by means of yet another special rule.%
 }
 
+\subsubsection{Conflict Merging of Namespaces}
+\LMLabel{conflictMergingOfNamespaces}
+
+\LMHash{}%
+In the following, we define an operation on namespaces
+which eliminates the binding of names in case of name clashes,
+and keeps track of such name clashes using a special value,
+\Index{\ConflictValue}.
+
+\LMHash{}%
+When a name $n$ is mapped to \ConflictValue{} by a namespace,
+we say that the name is
+\IndexCustom{conflicted}{conflicted name}.
+A lookup for a conflicted name will succeed according to
+the normal rules for namespaces and lexical scoping,
+but it is a compile-time error at the location where the name is used
+that this name is conflicted.
+
+\LMHash{}%
+Let \List{L}{1}{m} be a list of libraries
+(\commentary{the list may or may not contain duplicates}).
+Let \List{\metavar{NS}}{1}{m} be a list of namespaces
+(\commentary{again possibly with some duplicates}),
+such that \NamespaceName{j}
+is a subset of the namespace exported by $L_j$,
+for each $j \in 1 .. m$.
+
+\LMHash{}%
+The
+\IndexCustom{conflict merging}{namespace!conflict merging}
+of \List{\metavar{NS}}{1}{m}
+with associated libraries \List{L}{1}{m} is then
+$\NamespaceName{\metavar{conflict}} \cup
+\NamespaceName{\metavar{narrowed},1} \cup\,
+\ldots\ \NamespaceName{\metavar{narrowed},m}$,
+where the namespaces \NamespaceName{\metavar{conflict}} and
+\List{\metavar{NS}}{\metavar{narrowed},1}{\metavar{narrowed},m}
+are specified below.
+
+\LMHash{}%
+\NamespaceName{\metavar{conflict}} is empty except for the
+bindings mentioned below.
+\NamespaceName{\metavar{narrowed},i} is identical to
+\NamespaceName{i}, for all $i \in 1 .. m$,
+except that the former is undefined at each name $n$ where
+the latter is defined,
+and one of the following conditions holds:
+
+\begin{itemize}
+\item There exists a $j \in 1 .. m$ and name $n'$ such that
+  \NamespaceName{j} is defined at $n'$,
+  $n$ and $n'$ have the same basename,
+  \Namespace{i}{n} is a declaration in a system library,
+  and \Namespace{j}{n'} is a declaration in a non-system library.
+  \commentary{%
+    So an imported declaration from a non-system library shadows
+    imported declarations from system libraries.%
+  }
+\item There exists a $j \in 1 .. m$ and name $n'$ such that
+  \NamespaceName{j} is defined at $n'$,
+  $n$ and $n'$ have the same basename,
+  \Namespace{i}{n} and \Namespace{j}{n'} are not the same declaration,
+  $L_i$ and $L_j$ are not the same library,
+  and either none or both of
+  \Namespace{i}{n} and \Namespace{j}{n'}
+  are declarations in a system library.
+  %
+  \commentary{%
+    So with two distinct imported declarations with the same basename,
+    both are eliminated,
+    except when it is a getter and a setter from the same library.%
+  }
+  % We need the 'not the same library' requirement (i != j is not enough),
+  % because otherwise we could have two imports of the same library,
+  % and we could focus on a getter `x` from one import of a library
+  % Lx, and on a setter `x=` from the other import of Lx, and then we would
+  % eliminate both.
+  % Conversely, when $L_i$ and $L_j$ are not the same library then it could
+  % not possibly be a getter/setter pair from the same library: Such a pair
+  % would be exported together, and they would be re-exported each time
+  % together (hide/show cannot distinguish).
+
+  In this situation $n$ is mapped to \ConflictValue{}
+  by \NamespaceName{\metavar{conflict}}.
+\end{itemize}
+
+\commentary{%
+In summary, conflict merging takes a list of namespaces and produces
+a namespace that is the union of several disjoint namespaces:
+A conflict namespace that records all unresolved name clashes,
+and a list of namespaces where clashing names have been removed.
+Some name clashes have been resolved by preferring
+declarations from non-system libraries
+over declarations from system libraries.%
+}
+
 
 \subsubsection{The Imported Namespace}
 \LMLabel{theImportedNamespace}
@@ -16341,7 +16437,6 @@ and it causes $p$ to be mapped to a prefix namespace as described below.
 Let \List{I}{1}{m} be the import directives of $L$,
 and let \List{L}{1}{m} be libraries
 such that $I_i$ refers to $L_i$ for all $i \in 1 .. m$.
-
 \commentary{%
 It is not an error to have multiple imports of the same library.%
 }
@@ -16371,74 +16466,18 @@ the exported namespace of $L'_j$
 (\ref{namespaceCombinators}).
 
 \LMHash{}%
-Let \NamespaceName{\metavar{narrowed},j} be the namespace which is identical to
-\NamespaceName{\metavar{exported},j} except that it is undefined at
-each name $n$ where \NamespaceName{\metavar{exported},j} is defined and
-one of the following conditions holds:
-
-\begin{itemize}
-\item There exists an $l \in 1 .. k$ and name $n'$ such that
-  \NamespaceName{\metavar{exported},l} is defined at $n'$,
-  $n$ and $n'$ have the same basename,
-  \Namespace{\metavar{exported},j}{n}
-  is a declaration in a system library,
-  and \Namespace{\metavar{exported},l}{n'}
-  is a declaration in a non-system library.
-  \commentary{%
-    So an imported declaration from a non-system library shadows
-    imported declarations from system libraries.%
-  }
-\item There exists an $l \in 1 .. k$ and name $n'$ such that
-  \NamespaceName{\metavar{exported},l} is defined at $n'$,
-  $n$ and $n'$ have the same basename,
-  \Namespace{\metavar{exported},j}{n}
-  and \Namespace{\metavar{exported},l}{n'}
-  are not the same declaration,
-  $L'_j$ and $L'_l$ are not the same library,
-  and either none or both of
-  \Namespace{\metavar{exported},j}{n} and
-  \Namespace{\metavar{exported},l}{n'}
-  are declarations in a system library.
-  \commentary{%
-    So with two distinct imported declarations with the same basename,
-    both are eliminated,
-    except when it is a getter and a setter from the same library.
-    When a name $n$ has been eliminated for this reason and a usage
-    \code{$p_i$.$n$} is encountered in $L$,
-    it is recommended that the error message mentions the conflict,
-    rather than just reporting that $n$ does not exist.%
-  }
-  % We need 'not the same library', l != j is not enough: See comment on the
-  % corresponding case for step two below (search 'not the same library').
-\end{itemize}
+Let \NamespaceName{\metavar{prefix},i} be the namespace obtained from applying
+conflict merging to
+\List{\metavar{NS}}{\metavar{exported},1}{\metavar{exported},k}
+and the associated libraries \List{L'}{1}{k}
+(\ref{conflictMergingOfNamespaces}).
+Then \NamespaceName{\metavar{one},i} is a namespace that has
+a single binding that maps $p_i$ to \NamespaceName{\metavar{prefix},i}.
 
 \LMHash{}%
-Let \NamespaceName{\metavar{prefix},i} be the namespace
-$\NamespaceName{\metavar{narrowed},1} \cup \ldots
-\NamespaceName{\metavar{narrowed},k}$.
-Then \NamespaceName{\metavar{one},i} is a namespace that has
-a single binding that maps $p_i$ to a \Index{prefix namespace},
-which is a mapping that associates names with entities declared in
-\List{L'}{1}{k} as follows:
-
-\begin{itemize}
-\item
-  For every top level function $f$ named \id{} in
-  \NamespaceName{\metavar{prefix}, i},
-  \id{} is mapped to a function with the same name and signature as $f$.
-\item
-  For every top level getter $g$ named \id{} in
-  \NamespaceName{\metavar{prefix}, i},
-  \id{} is mapped to a getter with the same return type as $g$.
-\item
-  For every top level setter $s$ named \code{\id=} in
-  \NamespaceName{\metavar{prefix}, i},
-  \code{\id=} is mapped to a setter with the same parameter type as $s$.
-\item
-  For every type $T$ named \id{} in
-  \NamespaceName{\metavar{prefix}, i},
-  \id{} is mapped to the type $T$.
-\end{itemize}
+In this situation we say that \NamespaceName{\metavar{one},i} is a
+\Index{prefix namespace},
+because it maps a library prefix to a namespace.
 
 \commentary{%
 A prefix namespace is not a Dart object, it is merely a device which is
@@ -16463,130 +16502,50 @@ In the second step we resolve conflicts
 among the namespaces obtained in the first step.
 
 \LMHash{}%
-For each $i \in 1 .. m$, the
-\Index{namespace imported from}
-$L_i$, \NamespaceName{\metavar{import},i},
-is identical to \NamespaceName{\metavar{one},i},
+Let \NamespaceName{\metavar{merged}} be the result of applying
+conflict merging to the namespaces
+\List{\metavar{NS}}{\metavar{one},1}{\metavar{one},m}
+with associated libraries \List{L}{1}{m}.
+
+\LMHash{}%
+Let \NamespaceName{\metavar{import}}
+be the namespace which is identical to \NamespaceName{\metavar{merged}},
 except that it is undefined at each name $n$ where
-\NamespaceName{\metavar{one},i} is defined
-and one of the following conditions holds:
-
-\begin{itemize}
-\item \NamespaceName{\metavar{local}} is defined at $n'$
-  such that $n$ and $n'$ have the same basename.
-  \commentary{%
-    In other words, a declaration in the current library shadows
-    imported declarations.
-    Note that the prefix of an import also introduces a binding
-    into \NamespaceName{\metavar{local}},
-    so a prefix can also shadow an imported declaration.%
-  }
-\item The first case does not apply,
-  there exists a $j \in 1 .. m$ and name $n'$ such that
-  \NamespaceName{\metavar{one},j} is defined at $n'$,
-  $n$ and $n'$ have the same basename,
-  \Namespace{\metavar{one},i}{n}
-  is a declaration in a system library,
-  and \Namespace{\metavar{one},j}{n'}
-  is a declaration in a non-system library.
-  \commentary{%
-    So an imported declaration from a non-system library shadows
-    imported declarations from system libraries.%
-  }
-\item The first case does not apply,
-  there exists a $j \in 1 .. m$ and name $n'$ such that
-  \NamespaceName{\metavar{one},j} is defined at $n'$,
-  $n$ and $n'$ have the same basename,
-  \Namespace{\metavar{one},i}{n} and
-  \Namespace{\metavar{one},j}{n'}
-  are not the same declaration,
-  $L_i$ and $L_j$ are not the same library,
-  and either none or both of
-  \Namespace{\metavar{one},i}{n} and
-  \Namespace{\metavar{one},j}{n'}
-  are declarations in a system library.
-  %
-  \commentary{%
-    So with two distinct imported declarations with the same basename,
-    both are eliminated,
-    except when it is a getter and a setter from the same library.%
-  }
-  % We need the 'not the same library' requirement (i != j is not enough),
-  % because otherwise we could have two imports of the same library (without
-  % a prefix here, but it works the same for two imports with the same
-  % prefix), and we could focus on a getter `x` from one import of a library
-  % Lx, and on a setter `x=` from the other import of Lx, and then we would
-  % eliminate both.
-  % Conversely, when $L_i$ and $L_j$ are not the same library then it could
-  % not possibly be a getter/setter pair from the same library: Such a pair
-  % would be exported from NS_local together, and they would be re-exported
-  % each time together (hide/show cannot distinguish).
-
-  In this situation we say that $n$ is a
-  \IndexCustom{conflicted imported name}{import!conflicted name}%
-  \index{conflicted imported name}.
-\end{itemize}
-
-\LMHash{}%
-Let \NamespaceName{\metavar{conflict}} be the namespace
-that maps each conflicted imported name to
-the special value \ConflictValue.
-A lookup for a conflicted imported name will succeed according to
-the normal rules for namespaces and lexical scoping,
-but it is a compile-time error at the location where the name is used
-that this name is mapped to \ConflictValue.
+\NamespaceName{\metavar{local}} is defined at $n'$
+such that $n$ and $n'$ have the same basename.
 
 \commentary{%
-The removal of these bindings from
-\NamespaceName{\metavar{one},i}
-yields the namespace imported from $L_i$,
-\NamespaceName{\metavar{import},i},
-and ensures that each imported namespace has a
-key set which is disjoint with that of
-\NamespaceName{\metavar{local}},
-and where two imported namespaces only share a key $n$ when
-they both map $n$ to the same value.%
-}
-
-\commentary{%
-Note that it is not an error if a name $n$ is introduced by two or more imports
-but is never used.
-It is recommended that error messages about usages of conflicted imported names
-include a reference to all the declarations that caused the conflict.%
-}
-
-\rationale{%
-The policy above makes libraries more robust
-in the face of additions made to their imports.
-
-A clear distinction needs to be made between this approach,
-and seemingly similar policies with respect to classes or interfaces.
-The use of a class or interface, and of its members,
-is separate from its declaration.
-The usage and declaration may occur in widely separated places in the code,
-and may in fact be authored by different people or organizations.
-It is important that errors are given at the offending declaration
-so that the party that receives the error can respond to it a meaningful way.
-
-In contrast, a library comprises both imports and their usage;
-the library is under the control of a single party and so
-any problem stemming from the import can be resolved
-even if it is reported at the use site.%
+In other words, a declaration in the current library shadows
+imported declarations.
+Note that the prefix of an import also introduces a binding
+into \NamespaceName{\metavar{local}},
+so a prefix can also shadow an imported declaration.%
 }
 
 \LMHash{}%
-The
+The namespace \NamespaceName{\metavar{import}} is known as the
 \Index{imported namespace}
-of $L$ is then
-$\NamespaceName{\metavar{import}} =
-\NamespaceName{\metavar{import},1} \cup
-\ldots \NamespaceName{\metavar{import},m}$,
-and the
-\Index{library namespace}
-of $L$ is
-$\NamespaceName{\metavar{local}} \cup
-\NamespaceName{\metavar{import}} \cup
-\NamespaceName{\metavar{conflict}}$.
+of $L$.
+The \Index{library namespace} of $L$ is
+$\NamespaceName{\metavar{local}} \cup \NamespaceName{\metavar{import}}$.
+
+\LMHash{}%
+Let $i \in 1 .. m$ and let
+\NamespaceName{\metavar{import},i} be
+the intersection of \NamespaceName{\metavar{one},i}
+and \NamespaceName{\metavar{import}}.
+If $L_i$ is imported without a prefix, the
+\IndexCustom{namespace imported from}{library!namespace imported from}
+$L_i$ is \NamespaceName{\metavar{import},i}.
+Otherwise $L_i$ is imported with a prefix $p$,
+in which case the namespace imported from $L_i$
+is \Namespace{\metavar{import},i}{p}.
+
+\commentary{%
+So the namespace imported by $L_i$ contains the bindings exported by $L_i$,
+except the ones removed by namespace combinators,
+and except the ones removed by conflict merging.%
+}
 
 \LMHash{}%
 We say that a name is \Index{imported by a library}
@@ -16601,6 +16560,8 @@ if the declaration is in the library's imported namespace.
 
 \subsubsection{Evaluation of Imports}
 \LMLabel{evaluationOfImports}
+
+!!!TODO!!!
 
 \LMHash{}%
 Let $I_i$ be an import directive that refers to a URI via the string $s_i$.

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -16219,7 +16219,7 @@ the scope of another library.
 
 <importSpecification> ::= \gnewline{}
   \IMPORT{} <configurableUri> (\AS{} <identifier>)? <combinator>* `;'
-  \alt \IMPORT{} <uri> \DEFERRED{} \AS{} <identifier> <combinator>* `;'
+  \alt \IMPORT{} <configurableUri> \DEFERRED{} \AS{} <identifier> <combinator>* `;'
 \end{grammar}
 
 \LMHash{}%
@@ -16227,8 +16227,14 @@ Syntactically, an import specifies a URI $s$
 where the declaration of an imported library is to be found.
 The interpretation of URIs is described elsewhere
 (\ref{uris}).
-It is a compile-time error if the specified URI
+It is a compile-time error if the specified URI of an import
 does not refer to a library declaration.
+
+\LMHash{}%
+The \Index{current library} is the library currently being compiled.
+The import modifies the namespace of the current library
+in a manner that is determined by the imported library and
+by the optional elements of the import.
 
 \LMHash{}%
 Imports may be deferred or immediate.
@@ -16261,19 +16267,6 @@ used to restrict the set of names imported by $I$.
 Their syntax, usage, and effect on namespaces is described elsewhere
 (\ref{namespaceCombinators}, \ref{theImportedNamespace},
 \ref{exports}).
-
-\LMHash{}%
-It is a static warning to import two different libraries with the same name,
-unless their name is the empty string.
-
-\rationale{%
-If two different URIs are inadvertently used to access the same library $L$,
-say, because of a symbolic link in the underlying file system,
-this may help explaining why there are two incompatible copies of
-the types declared in $L$.
-Developers may also choose to omit library names entirely,
-which motivates the exception for the empty name.%
-}
 
 \LMHash{}%
 The dart core library \code{dart:core}
@@ -16922,19 +16915,6 @@ $L_i$, and also that $L$
 When no confusion can arise, we may simply state
 that $L$ \NoIndex{re-exports} $L_i$, or
 that $L$ \NoIndex{re-exports} \NamespaceName{\metavar{export},i}.
-
-\LMHash{}%
-It is a static warning to export two different libraries with the same name,
-unless their name is the empty string.
-
-\rationale{%
-If two different URIs are inadvertently used to access the same library $L$,
-say, because of a symbolic link in the underlying file system,
-this may help explaining why there are two incompatible copies of
-the types declared in $L$.
-Developers may also choose to omit library names entirely,
-which motivates the exception for the empty name.%
-}
 
 
 \subsection{Namespace Combinators}

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -16578,23 +16578,24 @@ We say that a declaration \Index{is imported by a library}
 if the declaration is in the library's imported namespace.
 
 
-\subsubsection{Evaluation of Imports}
-\LMLabel{evaluationOfImports}
+\subsubsection{Semantics of Imports}
+\LMLabel{semanticsOfImports}
 
 \LMHash{}%
 Let $I_i$ be an import directive that refers to a URI via the string $s_i$.
-Evaluation of $I_i$ proceeds as follows:
+The semantics of $I_i$ is specified as follows:
 
 \LMHash{}%
-\Case{Evaluation of deferred imports}
-If $I_i$ is a deferred import with prefix $p$, a mapping of $p$ to a
-\Index{deferred prefix namespace} is added to
-the scope of the current library $L$.
+\Case{Semantics of deferred imports}
+If $I_i$ is a deferred import with prefix $p$, a binding of $p$ to a
+\Index{deferred prefix run-time namespace}
+\NamespaceName{\metavar{deferred}} is
+present in the library namespace of the current library $L$.
 Let \NamespaceName{\metavar{import},i} be
 the namespace imported from the library specified by $I_i$,
 as defined previously
 (\ref{theImportedNamespace}).
-The deferred prefix namespace has the following bindings:
+\NamespaceName{\metavar{deferred}} then has the following bindings:
 
 \begin{itemize}
 \item The name \code{loadLibrary} is bound to 
@@ -16611,8 +16612,8 @@ The deferred prefix namespace has the following bindings:
   % "may be raised".
   A dynamic error may be raised if $I'$ imports a different library
   than the one that the specified URI referred to at compile-time.
-  When $I'$ executes without error, $f$ completes successfully.
-  If $I'$ executes without error,
+  When $I'$ is loaded without error, $f$ completes successfully.
+  If $I'$ is loaded without error,
   we say that the call to \code{loadLibrary} has succeeded,
   otherwise we say the call has failed.
 \item
@@ -16644,7 +16645,8 @@ The deferred prefix namespace has the following bindings:
 \end{itemize}
 
 \rationale{%
-The purpose of adding members of the imported library to $p$
+The purpose of having members of the imported library in
+\NamespaceName{\metavar{deferred}}
 is to ensure that usages of members that have not yet been loaded
 can be resolved normally and has a well-defined behavior,
 but will raise errors.%
@@ -16652,14 +16654,23 @@ but will raise errors.%
 
 \LMHash{}%
 After an invocation of \code{$p$.loadLibrary()} succeeds,
-the name $p$ is mapped to a non-deferred prefix namespace,
-as described below.
-In addition, the prefix namespace also supports the \code{loadLibrary} function,
+the name $p$ is mapped to a non-deferred prefix run-time namespace
+\NamespaceName{\metavar{loaded}},
+with bindings as described below for immediate imports.
+In addition, \NamespaceName{\metavar{loaded}}
+maps \code{loadLibrary} to a function with the same signature as before,
 and so it is possible to invoke \code{$p$.loadLibrary()} again.
 If a call fails, the library has not been loaded,
 and one has the option to invoke \code{$p$.loadLibrary()} again.
 Whether a repeated call to \code{$p$.loadLibrary()} succeeds will vary,
 as described below.
+
+\commentary{%
+Note that it is a compile-time error for a deferred prefix
+to be used in more than one import,
+which means that the update of the binding of $p$
+does not interfere with other imports.%
+}
 
 \LMHash{}%
 The effect of a repeated invocation of \code{$p$.loadLibrary()} is as follows:
@@ -16689,22 +16700,16 @@ We do not specify which object the returned future resolves to.%
 \EndCase
 
 \LMHash{}%
-\Case{Evaluation of immediate imports}
+\Case{Semantics of immediate imports}
 When $I_i$ is an immediate import that refers to a URI via the string $s_i$:
+Let $\ell_i$ denote the run-time entity that corresponds to the result of
+compiling the library $L_i$ denoted by $s_i$.
 
-\begin{itemize}
-\item
-  If the URI that is the value of $s_i$ has not yet been accessed by
-  an import or export (\ref{exports}) directive in the current isolate
-  then the contents of the URI are compiled to yield a library $L_i$.
-  \commentary{%
-    Because libraries may have mutually recursive imports,
-    care must be taken to avoid an infinite regress.%
-  }
-\item
-  Otherwise, the contents of the URI denoted by $s_i$ has been compiled into
-  a library $L_i$ within the current isolate.
-\end{itemize}
+\LMHash{}%
+$\ell_i$ is accessible in the current isolate at run time
+due to an implementation specific mechanism,
+and it provides access to the result of compiling functions,
+as well as other resources needed for the execution of code in $L_i$.
 
 \LMHash{}%
 Let \NamespaceName{\metavar{import}, i} be the namespace imported from $L_i$.
@@ -16714,41 +16719,32 @@ The run-time namespace \NamespaceName{i} will then have the following bindings:
 \item
   For every top level function, getter, or setter $m$ named $n$ in
   \NamespaceName{\metavar{import}, i},
-  a binding from $n$ to the result of compiling $m$.
+  a binding from $n$ to the result of compiling $m$,
+  obtained from $\ell_i$.
 \item
-  For every type $T$ named \id{} in
-  \NamespaceName{\metavar{import}, i},
+  For every name \id{} in \NamespaceName{\metavar{import}, i}
+  that is bound to a class, mixin, or type alias declaration
+  introducing a type $T$,
   a binding from \id{} to a compiled getter with return type \code{Type}
   that, when invoked, returns the type object for $T$.
 \end{itemize}
 
 \LMHash{}%
 If $I_i$ has prefix $p$,
-and the dynamic library namespace of the current library
-does not have a binding for $p$,
-then a mapping from $p$ to a non-deferred dynamic prefix namespace
-with members determined by \NamespaceName{i} is introduced into the
-dynamic library namespace of the current library.
-If $I_i$ has prefix $p$,
-and the dynamic library namespace of the current library
-binds $p$ to a non-deferred dynamic prefix namespace $o$,
-then $o$ is extended with bindings as determined by \NamespaceName{i}.
-
-\LMHash{}%
-Otherwise, when $I_i$ does not have a prefix, each mapping in \NamespaceName{i}
-is introduced into the dynamic library namespace of the current library.
+the run-time library namespace of the current library
+maps $p$ to a non-deferred prefix run-time namespace \NamespaceName{p}
+containing the mappings of \NamespaceName{i}.
 
 \commentary{%
-The construction of the dynamic library namespace
-cannot encounter any name conflicts,
-because such conflicts would have caused a compile-time error.
-
-Dynamic library namespace construction can be completed at compile time,
-and any accesses, prefixed or not, can be resolved statically.
-So an implementation does not need to extend prefix namespaces dynamically,
-or even have a run-time representation of prefix namespaces at all,
-as long as the observable behavior is preserved.%
+\NamespaceName{p} may have additional mappings
+because there can be several imports with the same prefix
+as long as they are all immediate.%
 }
+
+\LMHash{}%
+Otherwise, when $I_i$ does not have a prefix,
+the run-time library namespace of the current library
+contains each mapping in \NamespaceName{i}.
 \EndCase
 
 

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -673,26 +673,48 @@ The method used to enable or disable assertions is implementation specific.
 \LMLabel{scoping}
 
 \LMHash{}%
-A \Index{namespace} is a mapping of names denoting declarations to actual declarations.
-Let $NS$ be a namespace.
-We say that a name $n$ \Index{is in} $NS$ if $n$ is a key of $NS$.
-We say a declaration $d$ \NoIndex{is in} $NS$ if a key of $NS$ maps to $d$.
+A \Index{namespace} is a mapping from names to declarations.
+It may be considered as a partial function.
+It may also be seen as a set of bindings from a name to a declaration,
+$n\mapsto{}D$,
+with the constraint that if a namespace has both
+$n\mapsto{}D_1$ and $n\mapsto{}D_2$
+then $D_1$ and $D_2$ is the same declaration.
+When a namespace is seen as a set of mappings we may also refer
+to each binding as having a \NoIndex{key}
+which is mapped to a \NoIndex{value}.
 
 \LMHash{}%
-A scope $S_0$ induces a namespace $NS_0$ that maps the simple name of each variable, type or function declaration $d$ declared in $S_0$ to $d$.
-Labels are not included in the induced namespace of a scope; instead they have their own dedicated namespace.
+Let \NamespaceName{} be a namespace.
+We say that a name $n$ \Index{is in} \NamespaceName{}
+if $n$ is a key of \NamespaceName{}.
+We say a declaration $d$ \NoIndex{is in} \NamespaceName{}
+if a key of \NamespaceName{} is mapped to $d$.
 
-\commentary{
-It is therefore impossible, e.g., to define a class that declares a method and a getter with the same name in Dart.
-Similarly one cannot declare a top-level function with the same name as a library variable or a class.
+\LMHash{}%
+A scope $S_0$ induces a namespace \NamespaceName{0} that maps
+the simple name of each variable, type or function declaration $d$
+declared in $S_0$ to $d$.
+Labels are not included in the induced namespace of a scope;
+instead they have their own dedicated namespace.
+
+\commentary{%
+It is therefore impossible, e.g., to define a class that declares
+a method and a getter with the same name in Dart.
+Similarly one cannot declare a top-level function with
+the same name as a library variable or a class.%
 }
 
 \LMHash{}%
-It is a compile-time error if there is more than one entity with the same name declared in the same scope.
+It is a compile-time error if there is more than one entity with the same name
+declared in the same scope.
 
-\commentary{
-In some cases, the name of the declaration differs from the identifier used to declare it.
-Setters have names that are distinct from the corresponding getters because they always have an = automatically added at the end, and unary minus has the special name unary-.
+\commentary{%
+In some cases, the name of the declaration differs from
+the identifier used to declare it.
+Setters have names that are distinct from the corresponding getters
+because they always have an \lit{=} automatically added at the end,
+and unary minus has the special name unary-.%
 }
 
 \LMHash{}%
@@ -1220,7 +1242,7 @@ Functions abstract over executable actions.
 
 \begin{grammar}
 <functionSignature> ::= \gnewline{}
-  <metadata> <type>? <identifier> <formalParameterPart>
+  <type>? <identifier> <formalParameterPart>
 
 <formalParameterPart> ::= <typeParameters>? <formalParameterList>
 
@@ -1960,7 +1982,7 @@ Classes may be defined by class declarations as described below, or via mixin ap
   \ABSTRACT{}? \CLASS{} <identifier> <typeParameters>?
   \gnewline{} <superclass>? <interfaces>?
   \gnewline{} `{' (<metadata> <classMemberDeclaration>)* `}'
-  \alt <metadata> \ABSTRACT{}? \CLASS{} <mixinApplicationClass>
+  \alt \ABSTRACT{}? \CLASS{} <mixinApplicationClass>
 
 <typeNotVoidList> ::= <typeNotVoid> (`,' <typeNotVoid>)*
 
@@ -16189,279 +16211,558 @@ The scope of a library $L$ consists of the names introduced by all top-level dec
 \LMLabel{imports}
 
 \LMHash{}%
-An \Index{import} specifies a library to be used in the scope of another library.
+An \Index{import} specifies a library to be used in
+the scope of another library.
+
 \begin{grammar}
 <libraryImport> ::= <metadata> <importSpecification>
 
 <importSpecification> ::= \gnewline{}
   \IMPORT{} <configurableUri> (\AS{} <identifier>)? <combinator>* `;'
-  \alt \IMPORT{} <configurableUri> \DEFERRED{} \AS{} <identifier> <combinator>* `;'
-
-<combinator> ::= \SHOW{} <identifierList>
-  \alt \HIDE{} <identifierList>
-
-<identifierList> ::= <identifier> (, <identifier>)*
+  \alt \IMPORT{} <uri> \DEFERRED{} \AS{} <identifier> <combinator>* `;'
 \end{grammar}
 
 \LMHash{}%
-An import specifies a URI $x$ where the declaration of an imported library is to be found.
+Syntactically, an import specifies a URI $s$
+where the declaration of an imported library is to be found.
+The interpretation of URIs is described elsewhere
+(\ref{uris}).
+It is a compile-time error if the specified URI
+does not refer to a library declaration.
 
 \LMHash{}%
-Imports may be
-\IndexCustom{deferred}{import!deferred} or
-\IndexCustom{immediate}{import!immediate}.
-A deferred import is distinguished by the appearance of the built-in identifier \DEFERRED{} after the URI.
-Any import that is not deferred is immediate.
-
-\LMHash{}%
-It is a compile-time error if the specified URI of an import does not
-refer to a library declaration.
-The interpretation of URIs is described in section \ref{uris} below.
-
-\LMHash{}%
-It is a dynamic error if
-the execution of \code{loadLibrary} that loads a deferred import
-does not load the library that
-the specified URI referred to at compile-time.
-
-\LMHash{}%
-The \Index{current library} is the library currently being compiled.
-The import modifies the namespace of the current library
-in a manner that is determined by the imported library and
-by the optional elements of the import.
+Imports may be deferred or immediate.
+A
+\IndexCustom{deferred import}{import!deferred}
+is distinguished by the appearance of
+the built-in identifier \DEFERRED{} after the URI.
+An
+\IndexCustom{immediate import}{import!immediate}
+is an import that is not deferred.
 
 \LMHash{}%
 An immediate import directive $I$ may optionally include
-a prefix clause of the form \code{\AS{} \id}
-used to prefix names imported by $I$.
-A deferred import must include a prefix clause or a compile-time error occurs.
+a \Index{prefix clause} of the form `\code{\AS{}\,\,\id}' used to prefix
+names imported by $I$.
+In this case we say that \id{} is an \Index{import prefix},
+or simply a \Index{prefix}.
+
+\LMHash{}%
+A deferred import must include a prefix clause,
+or a compile-time error occurs.
 It is a compile-time error if a prefix used in a deferred import
-is used in another import clause.
+is also used as the prefix of another import clause.
+It is a compile-time error if \id{} is an import prefix and
+the current library declares a top-level member named \id{}.
 
 \LMHash{}%
 An import directive $I$ may optionally include namespace combinator clauses
 used to restrict the set of names imported by $I$.
-Currently, two namespace combinators are supported: \HIDE{} and \SHOW{}.
+Their syntax, usage, and effect on namespaces is described elsewhere
+(\ref{namespaceCombinators}, \ref{theImportedNamespace},
+\ref{exports}).
 
 \LMHash{}%
-Let $I$ be an import directive that refers to a URI via the string $s_1$.
-Evaluation of $I$ proceeds as follows:
+It is a static warning to import two different libraries with the same name,
+unless their name is the empty string.
+
+\rationale{%
+If two different URIs are inadvertently used to access the same library $L$,
+say, because of a symbolic link in the underlying file system,
+this may help explaining why there are two incompatible copies of
+the types declared in $L$.
+Developers may also choose to omit library names entirely,
+which motivates the exception for the empty name.%
+}
 
 \LMHash{}%
-If $I$ is a deferred import, no evaluation takes place.
-Instead, a mapping of the name of the prefix, $p$ to a
-\Index{deferred prefix object} is added to
-the scope of the current library $L$.
-The deferred prefix object has the following methods:
+The dart core library \code{dart:core}
+is implicitly imported into every dart library other than itself
+via an import clause of the form
+\code{\IMPORT{} 'dart:core';}
+unless the importing library explicitly imports \code{dart:core}.
+Any import of \code{dart:core},
+even if restricted via \SHOW{}, \HIDE{} or \AS{},
+preempts the automatic import.
+
+\rationale{%
+It would be nice if there was nothing special about \code{dart:core}.
+However, its use is pervasive,
+which leads to the decision to import it automatically.
+However, some library $L$ may wish to define entities
+with names used by \code{dart:core}
+(which it can easily do, as the names declared by a library take precedence).
+Other libraries may wish to use $L$,
+and may want to use members of $L$ that conflict with the core library
+without having to use a prefix and without encountering errors.
+The above rule makes this possible,
+essentially canceling \code{dart:core}'s special treatment
+by means of yet another special rule.%
+}
+
+
+\subsubsection{The Imported Namespace}
+\LMLabel{theImportedNamespace}
+
+\LMHash{}%
+In the following, we specify the imported namespace of a library $L$,
+\NamespaceName{\metavar{import}},
+in two steps.
+
+\LMHash{}%
+We need to introduce system libraries because they have special rules.
+A \Index{system library} is a library that is part of the Dart implementation.
+Any other library is a \Index{non-system library}.
+
+\commentary{%
+A system library can generally be recognized by having
+a URI that starts with `\code{dart:}'.
+An exception is `\code{dart:ui}' which is not a system library.%
+}
+
+\rationale{%
+The special rules for system libraries exist for the following reason.
+Normal conflicts are resolved at deployment time,
+but the functionality of a system library is
+injected into an application at run time,
+and may vary over time as the platform is upgraded.
+Thus, conflicts with a system library can arise
+outside the developer's control.
+To avoid breaking deployed applications in this way,
+conflicts with the system libraries are treated specially.%
+}
+
+\LMHash{}%
+Let \NamespaceName{\metavar{local}} be the namespace that
+for each top-level declaration $D$ with name $n$ in $L$ maps $n$ to $D$.
+An import with a prefix $p$ is included among these top-level declarations,
+and it causes $p$ to be mapped to a prefix object as described below.
+Let \List{I}{1}{m} be the import directives of $L$,
+and let \List{L}{1}{m} be libraries
+such that $I_i$ refers to $L_i$ for all $i \in 1 .. m$.
+
+\LMHash{}%
+Let $i \in 1 .. m$.
+In the first step we compute the namespace provided by each imported library,
+\NamespaceName{\metavar{one},i}.
+
+\LMHash{}%
+\Case{Step one for imports without a prefix}
+When $I_i$ has no prefix, \NamespaceName{\metavar{one},i} is
+the namespace obtained from applying the namespace combinators of $I_i$ to
+the exported namespace of $L_i$
+(\ref{namespaceCombinators}).
+\EndCase
+
+\LMHash{}%
+\Case{Step one for prefixed imports}
+When $I_i$ has prefix $p_i$,
+let \List{I'}{1}{k} be the subset of \List{I}{1}{m} that have prefix $p_i$,
+and let \List{L'}{1}{k} be the corresponding libraries
+(\commentary{which is a subset of \List{L}{1}{m}}).
+Let \NamespaceName{\metavar{exported},j}, $j \in 1 .. k$,
+be the namespace obtained from applying the namespace combinators of $I'_j$ to
+the exported namespace of $L'_j$
+(\ref{namespaceCombinators}).
+
+\LMHash{}%
+Let \NamespaceName{\metavar{narrowed},j} be the namespace which is identical to
+\NamespaceName{\metavar{exported},j} except that it is undefined at
+each name $n$ where \NamespaceName{\metavar{exported},j} is defined and
+one of the following conditions holds:
 
 \begin{itemize}
-\item \code{loadLibrary}.
-This method returns a future $f$.
-When called, the method causes an immediate import $I'$ to be executed at some future time, where $I'$ is derived from $I$ by eliding the word \DEFERRED{} and adding a \HIDE{} \code{loadLibrary} combinator clause.
-When $I'$ executes without error, $f$ completes successfully.
-If $I'$ executes without error, we say that the call to \code{loadLibrary} has succeeded, otherwise we say the call has failed.
+\item There exists an $l \in 1 .. k$ and name $n'$ such that
+  \NamespaceName{\metavar{exported},l} is defined at $n'$,
+  $n$ and $n'$ have the same basename,
+  \Namespace{\metavar{exported},j}{n}
+  is a declaration in a system library,
+  and \Namespace{\metavar{exported},l}{n'}
+  is a declaration in a non-system library.
+  \commentary{%
+    So an imported declaration from a non-system library shadows
+    imported declarations from system libraries.%
+  }
+\item There exists an $l \in 1 .. k$ and name $n'$ such that
+  \NamespaceName{\metavar{exported},l} is defined at $n'$,
+  $n$ and $n'$ have the same basename,
+  \Namespace{\metavar{exported},j}{n}
+  and \Namespace{\metavar{exported},l}{n'}
+  are not the same declaration,
+  $L'_j$ and $L'_l$ are not the same library,
+  and either none or both of
+  \Namespace{\metavar{exported},j}{n} and
+  \Namespace{\metavar{exported},l}{n'}
+  are declarations in a system library.
+  \commentary{%
+    So with two distinct imported declarations with the same basename,
+    both are eliminated,
+    except when it is a getter and a setter from the same library.
+    When a name $n$ has been eliminated for this reason and a usage
+    \code{$p_i$.$n$} is encountered in $L$,
+    it is recommended that the error message mentions the conflict,
+    rather than just reporting that $n$ does not exist.%
+  }
+  % We need 'not the same library', l != j is not enough: See comment on the
+  % corresponding case for step two below (search 'not the same library').
+\end{itemize}
+
+\LMHash{}%
+Let \NamespaceName{\metavar{prefix},i} be the namespace
+$\NamespaceName{\metavar{narrowed},1} \cup \ldots
+\NamespaceName{\metavar{narrowed},k}$.
+Then \NamespaceName{\metavar{one},i} is the namespace that
+maps $p_i$ to a \Index{prefix object},
+which is a mapping that associates names with entities declared in
+\List{L'}{1}{k} as follows:
+
+\begin{itemize}
 \item
-  For every top level function $f$ named \id{} in the imported library $B$,
+  For every top level function $f$ named \id{} in
+  \NamespaceName{\metavar{prefix}, i},
+  \id{} is mapped to a function with the same name and signature as $f$.
+\item
+  For every top level getter $g$ named \id{} in
+  \NamespaceName{\metavar{prefix}, i},
+  \id{} is mapped to a getter with the same return type as $g$.
+\item
+  For every top level setter $s$ named \code{\id=} in
+  \NamespaceName{\metavar{prefix}, i},
+  \code{\id=} is mapped to a setter with the same parameter type as $s$.
+\item
+  For every type $T$ named \id{} in
+  \NamespaceName{\metavar{prefix}, i},
+  \id{} is mapped to the type $T$.
+\end{itemize}
+
+\commentary{%
+A prefix object is not a Dart object, it is merely a device which is
+used to manage names of the form \synt{qualified} and their types
+during static analysis,
+and a mapping that is used to access the corresponding entities
+at run time.
+Consequently, any attempt to use a prefix object on its own
+is a compile-time error.
+
+Note that if $l$ and $q$ are such that
+$I_l$ and $I_q$ both have the same prefix $p$
+then
+$\NamespaceName{\metavar{one},l} = \NamespaceName{\metavar{one},q} =
+\NamespaceName{\metavar{one},l} \cup \NamespaceName{\metavar{one},q}$.%
+}
+\EndCase
+
+\LMHash{}%
+{\bf Step two.}
+In the second step we resolve conflicts
+among the namespaces obtained in the first step.
+
+\LMHash{}%
+For each $i \in 1 .. m$, the
+\Index{namespace imported from}
+$L_i$, \NamespaceName{\metavar{import},i},
+is identical to \NamespaceName{\metavar{one},i},
+except that it is undefined at each name $n$ where
+\NamespaceName{\metavar{one},i} is defined
+and one of the following conditions holds:
+
+\begin{itemize}
+\item \NamespaceName{\metavar{local}} is defined at $n'$
+  such that $n$ and $n'$ have the same basename.
+  \commentary{%
+    In other words, a declaration in the current library shadows
+    imported declarations.
+    Note that the prefix of an import also introduces a binding
+    into \NamespaceName{\metavar{local}},
+    so a prefix can also shadow an imported declaration.%
+  }
+\item The first case does not apply,
+  there exists a $j \in 1 .. m$ and name $n'$ such that
+  \NamespaceName{\metavar{one},j} is defined at $n'$,
+  $n$ and $n'$ have the same basename,
+  \Namespace{\metavar{one},i}{n}
+  is a declaration in a system library,
+  and \Namespace{\metavar{one},j}{n'}
+  is a declaration in a non-system library.
+  \commentary{%
+    So an imported declaration from a non-system library shadows
+    imported declarations from system libraries.%
+  }
+\item The first case does not apply,
+  there exists a $j \in 1 .. m$ and name $n'$ such that
+  \NamespaceName{\metavar{one},j} is defined at $n'$,
+  $n$ and $n'$ have the same basename,
+  \Namespace{\metavar{one},i}{n} and
+  \Namespace{\metavar{one},j}{n'}
+  are not the same declaration,
+  $L_i$ and $L_j$ are not the same library,
+  and either none or both of
+  \Namespace{\metavar{one},i}{n} and
+  \Namespace{\metavar{one},j}{n'}
+  are declarations in a system library.
+  %
+  \commentary{%
+    So with two distinct imported declarations with the same basename,
+    both are eliminated,
+    except when it is a getter and a setter from the same library.%
+  }
+  % We need the 'not the same library' requirement (i != j is not enough),
+  % because otherwise we could have two imports of the same library (without
+  % a prefix here, but it works the same for two imports with the same
+  % prefix), and we could focus on a getter `x` from one import of a library
+  % Lx, and on a setter `x=` from the other import of Lx, and then we would
+  % eliminate both.
+  % Conversely, when $L_i$ and $L_j$ are not the same library then it could
+  % not possibly be a getter/setter pair from the same library: Such a pair
+  % would be exported from NS_local together, and they would be re-exported
+  % each time together (hide/show cannot distinguish).
+
+  In this situation we say that $n$ is a
+  \IndexCustom{conflicted imported name}{import!conflicted name}%
+  \index{conflicted imported name}.
+\end{itemize}
+
+\LMHash{}%
+Let \NamespaceName{\metavar{conflict}} be the namespace
+that maps each conflicted imported name to
+the special value \ConflictValue.
+A lookup for a conflicted imported name will succeed according to
+the normal rules for namespaces and lexical scoping,
+but it is a compile-time error at the location where the name is used
+that this name is mapped to \ConflictValue.
+
+\commentary{%
+The removal of these bindings from
+\NamespaceName{\metavar{one},i}
+yields the namespace imported from $L_i$,
+\NamespaceName{\metavar{import},i},
+and ensures that each imported namespace has a
+key set which is disjoint with that of
+\NamespaceName{\metavar{local}},
+and where two imported namespaces only share a key $n$ when
+they both map $n$ to the same value.%
+}
+
+\commentary{%
+Note that it is not an error if a name $n$ is introduced by two or more imports
+but is never used.
+It is recommended that error messages about usages of conflicted imported names
+include a reference to all the declarations that caused the conflict.%
+}
+
+\rationale{%
+The policy above makes libraries more robust
+in the face of additions made to their imports.
+
+A clear distinction needs to be made between this approach,
+and seemingly similar policies with respect to classes or interfaces.
+The use of a class or interface, and of its members,
+is separate from its declaration.
+The usage and declaration may occur in widely separated places in the code,
+and may in fact be authored by different people or organizations.
+It is important that errors are given at the offending declaration
+so that the party that receives the error can respond to it a meaningful way.
+
+In contrast, a library comprises both imports and their usage;
+the library is under the control of a single party and so
+any problem stemming from the import can be resolved
+even if it is reported at the use site.%
+}
+
+\LMHash{}%
+The
+\Index{imported namespace}
+of $L$ is then
+$\NamespaceName{\metavar{import}} =
+\NamespaceName{\metavar{import},1} \cup
+\ldots \NamespaceName{\metavar{import},m}$,
+and the
+\Index{library namespace}
+of $L$ is
+$\NamespaceName{\metavar{local}} \cup
+\NamespaceName{\metavar{import}} \cup
+\NamespaceName{\metavar{conflict}}$.
+
+\LMHash{}%
+We say that a name is \Index{imported by a library}
+(or equivalently, that a library
+\IndexCustom{imports a name}{imports!name})
+if the name is in the library's imported namespace.
+We say that a declaration \Index{is imported by a library}
+(or equivalently, that a library
+\IndexCustom{imports a declaration}{imports!declaration})
+if the declaration is in the library's imported namespace.
+
+
+\subsubsection{Evaluation of Imports}
+\LMLabel{evaluationOfImports}
+
+\LMHash{}%
+Let $I_i$ be an import directive that refers to a URI via the string $s_i$.
+Evaluation of $I_i$ proceeds as follows:
+
+\LMHash{}%
+\Case{Evaluation of deferred imports}
+If $I_i$ is a deferred import with prefix $p$, a mapping of $p$ to a
+\Index{deferred prefix object} is added to
+the scope of the current library $L$.
+Let \NamespaceName{\metavar{import},i} be
+the namespace imported from the library specified by $I_i$,
+as defined previously
+(\ref{theImportedNamespace}).
+The deferred prefix object has the following members:
+
+\begin{itemize}
+\item \code{loadLibrary()}.
+  This method returns a future $f$.
+  When called, the method causes
+  an immediate import $I'$ to be executed at some future time,
+  where $I'$ is derived from $I_i$ by eliding the word \DEFERRED{}
+  and adding a \HIDE{} \code{loadLibrary} combinator clause.
+  % Weasel wording here: We may not want to insist that it must be a
+  % a dynamic error if an implementation loads a library where a comment
+  % was changed, or anything else that doesn't matter, or even the exact
+  % same source code was obtained from a different file. Hence the error
+  % "may be raised".
+  A dynamic error may be raised if $I'$ imports a different library
+  than the one that the specified URI referred to at compile-time.
+  When $I'$ executes without error, $f$ completes successfully.
+  If $I'$ executes without error,
+  we say that the call to \code{loadLibrary} has succeeded,
+  otherwise we say the call has failed.
+\item
+  For every top level function $f$ named \id{} in
+  \NamespaceName{\metavar{import},i},
   a corresponding method named \id{} with the same signature as $f$.
   % This error can occur because being-loaded is a dynamic property.
   Calling the method results in a dynamic error.
 \item
-  For every top level getter $g$ named \id{} in $B$,
+  For every top level getter $g$ named \id{} in
+  \NamespaceName{\metavar{import},i},
   a corresponding getter named \id{} with the same signature as $g$.
   % This error can occur because being-loaded is a dynamic property.
-  Calling the method results in a dynamic error.
+  Calling the getter results in a dynamic error.
 \item
-  For every top level setter $s$ named \id{} in $B$,
-  a corresponding setter named \id{} with the same signature as $s$.
+  For every top level setter $s$ named \code{\id=} in
+  \NamespaceName{\metavar{import},i},
+  a corresponding setter named \code{\id=} with the same signature as $s$.
   % This error can occur because being-loaded is a dynamic property.
-  Calling the method results in a dynamic error.
+  Calling the setter results in a dynamic error.
 \item
-  For every type $T$ named \id{} in $B$,
+  For every type $T$ named \id{} in
+  \NamespaceName{\metavar{import},i},
   a corresponding getter named \id{} with return type \code{Type}.
   % This error can occur because being-loaded is a dynamic property.
-  Calling the method results in a dynamic error.
+  Calling the getter results in a dynamic error.
 \end{itemize}
 
-\rationale{
-The purpose of adding members of $B$ to $p$ is to ensure that any errors raised when using $p$ are correct, and no spurious errors are generated.
-In fact, at run time we cannot add these members until $B$ is loaded; but any such invocations will fail at run time as specified by virtue of being completely absent.
+\rationale{%
+The purpose of adding members of the imported library to $p$
+is to ensure that usages of members that have not yet been loaded
+can be resolved normally and has a well-defined behavior,
+but will raise errors.%
 }
-%But this is still a lie detectable by reflection. Probably revise so the type of p has these members but p does not.
-
-The static type of the prefix object $p$ is a unique interface type that has those members whose names and signatures are listed above.
 
 \LMHash{}%
-After a call succeeds, the name $p$ is mapped to a non-deferred prefix object as described below.
-In addition, the prefix object also supports the \code{loadLibrary} method, and so it is possible to call \code{loadLibrary} again.
-If a call fails, nothing happens, and one again has the option to call \code{loadLibrary} again.
-Whether a repeated call to \code{loadLibrary} succeeds will vary as described below.
+After an invocation of \code{$p$.loadLibrary} succeeds,
+the name $p$ is mapped to a non-deferred prefix object,
+as described below.
+In addition, the prefix object also supports the \code{loadLibrary()} method,
+and so it is possible to call \code{$p$.loadLibrary} again.
+If a call fails, nothing happens,
+and one has the option to call \code{$p$.loadLibrary} again.
+Whether a repeated call to \code{$p$.loadLibrary} succeeds will vary,
+as described below.
 
 \LMHash{}%
 The effect of a repeated call to \code{$p$.loadLibrary} is as follows:
 \begin{itemize}
 \item
-If another call to \code{$p$.loadLibrary} has already succeeded, the repeated call also succeeds.
-Otherwise,
+  If another call to \code{$p$.loadLibrary} has already succeeded,
+  the repeated call also succeeds.
+  Otherwise,
 \item
-If another call to \code{$p$.loadLibrary} has failed:
-\begin{itemize}
-\item
-If the failure is due to a compilation error, the repeated call fails for the same reason.
-\item
-If the failure is due to other causes, the repeated call behaves as if no previous call had been made.
-\end{itemize}
+  If another call to \code{$p$.loadLibrary} has failed:
+  \begin{itemize}
+  \item
+    If the failure is due to a compilation error,
+    the repeated call fails for the same reason.
+  \item
+    If the failure is due to other causes,
+    the repeated call behaves as if no previous call had been made.
+  \end{itemize}
 \end{itemize}
 
-\commentary{
+\commentary{%
 In other words, one can retry a deferred load after a network failure
 or because a file is absent,
 but once one finds some content and loads it, one can no longer reload.
-
 We do not specify which object the future returned resolves to.
 }
+\EndCase
 
 \LMHash{}%
-If $I$ is an immediate import then, first
+\Case{Evaluation of immediate imports}
+When $I_i$ is an immediate import that refers to a URI via the string $s_i$:
 
 \begin{itemize}
 \item
-If the URI that is the value of $s_1$ has not yet been accessed by an import or export (\ref{exports}) directive in the current isolate then the contents of the URI are compiled to yield a library $B$.
-\commentary{
-Because libraries may have mutually recursive imports, care must be taken to avoid an infinite regress.
-}
-\item Otherwise, the contents of the URI denoted by $s_1$ have been compiled into a library $B$ within the current isolate.
+  If the URI that is the value of $s_i$ has not yet been accessed by
+  an import or export (\ref{exports}) directive in the current isolate
+  then the contents of the URI are compiled to yield a library $L_i$.
+  \commentary{%
+    Because libraries may have mutually recursive imports,
+    care must be taken to avoid an infinite regress.%
+  }
+\item
+  Otherwise, the contents of the URI denoted by $s_i$ has been compiled into
+  a library $L_i$ within the current isolate.
 \end{itemize}
 
 \LMHash{}%
-Let $NS_0$ be the exported namespace (\ref{exports}) of $B$.
-Then, for each combinator clause $C_i, i \in 1 .. n$ in $I$:
-\begin{itemize}
-\item If $C_i$ is of the form
+Let \NamespaceName{\metavar{import}, i} be the namespace imported from $L_i$.
+The namespace \NamespaceName{i} will then have the following bindings:
 
-\code{\SHOW{} $\id_1, \ldots,\ \id_k$}
-
-then let $NS_i = \SHOW{}([\id_1, \ldots,\ \id_k], NS_{i-1}$)
-
-where $show(l,n)$ takes a list of identifiers $l$ and a namespace $n$, and produces a namespace that maps each name in $l$ to the same element that $n$ does.
-Furthermore, for each name $x$ in $l$, if $n$ defines the name \code{$x$=} then the new namespace maps \code{$x$=} to the same element that $n$ does.
-Otherwise the resulting mapping is undefined.
-
-\item If $C_i$ is of the form
-
-\code{\HIDE{} $\id_1, \ldots,\ \id_k$}
-
-then let $NS_i = \HIDE{}([\id_1, \ldots,\ \id_k], NS_{i-1}$)
-
-where $hide(l, n)$ takes a list of identifiers $l$ and a namespace $n$, and produces a namespace that is identical to $n$ except that for each name $k$ in $l$, $k$ and \code{$k$=} are undefined.
-\end{itemize}
-
-\LMHash{}%
-If $I$ includes a prefix clause of the form \AS{} $p$,
-let $NS = \{p: prefixObject(NS_n)\}$,
-where $prefixObject(NS_n)$ is a \Index{prefix object} for the namespace $NS_n$,
-which is an object that has the following members:
-
-\begin{itemize}
-\item For every top level function $f$ named \id{} in $NS_n$, a corresponding method with the same name and signature as $f$ that forwards (\ref{functionDeclarations}) to $f$.
-\item For every top level getter with the same name and signature as $g$ named \id{} in $NS_n$, a corresponding getter that forwards to $g$.
-\item For every top level setter $s$ with the same name and signature as named \id{} in $NS_n$, a corresponding setter that forwards to $s$.
-\item For every type $T$ named \id{} in $NS_n$, a corresponding getter named \id{} with return type \code{Type}, that, when invoked, returns the type object for $T$.
-\end{itemize}
-
-\LMHash{}%
-It is a compile-time error if the current library declares a top-level member named $p$.
-
-The static type of the prefix object $p$ is a unique interface type that has those members whose names and signatures are listed above.
-% What is the static type of a prefix object. Need to state that is a(n anonymous) type that has members with the same names as signatures as above.
-
-% This is problematic, because it implies that p.T would be available even in a scope that declared p. We really need to think of p as a single object with properties p.T etc., except it isn't really that
-% either. After all, p isn't actually available as a stand alone name.
-
-\LMHash{}%
-Otherwise (\commentary{when the import is not prefixed}), let $NS = NS_n$.
-
-\LMHash{}%
-Then, for each entry mapping key $k$ to declaration $d$ in $NS$, $d$ is made available in the top level scope of $L$ under the name $k$ unless either:
 \begin{itemize}
 \item
-a top-level declaration with the name $k$ exists in $L$, OR
-\item a prefix clause of the form \AS{} $k$ is used in $L$.
+  For every top level function, getter, or setter $m$ named $n$ in
+  \NamespaceName{\metavar{import}, i},
+  a binding from $n$ to the result of compiling $m$.
+\item
+  For every type $T$ named \id{} in
+  \NamespaceName{\metavar{import}, i},
+  a binding from \id{} to a compiled getter with return type \code{Type}
+  that, when invoked, returns the type object for $T$.
 \end{itemize}
 
-\rationale{
-The greatly increases the chance that a member can be added to a library without breaking its importers.
-}
+\LMHash{}%
+If $I_i$ has prefix $p$,
+and the library namespace of the current library
+does not have a binding for $p$,
+then a mapping from $p$ to a non-deferred prefix object
+with members determined by \NamespaceName{i} is introduced into the
+library namespace of the current library.
+If $I_i$ has prefix $p$,
+and the library namespace of the current library
+binds $p$ to a non-deferred prefix object $o$,
+then $o$ is extended with members as determined by \NamespaceName{i}.
 
 \LMHash{}%
-A \Index{system library} is a library that is part of the Dart implementation.
-Any other library is a \Index{non-system library}.
+Otherwise, when $I_i$ does not have a prefix, each mapping in \NamespaceName{i}
+is introduced into the library namespace of the current library.
 
-If a name $N$ is referenced by a library $L$
-and $N$ would be introduced into the top level scope of $L$
-by imports of two libraries, $L_1$ and $L_2$,
-the exported namespace of $L_1$ binds $N$
-to a declaration originating in a system library,
-and the exported namespace of $L_2$ binds $N$ to a declaration
-that does not originate in a system library,
-then the import of $L_1$ is implicitly extended by a \code{\HIDE{} $N$} clause.
+\commentary{%
+The dynamic construction of the library namespace
+cannot encounter any name conflicts,
+because such conflicts would have caused a compile-time error.
 
-\rationale{
-Whereas normal conflicts are resolved at deployment time, the functionality of \code{dart:} libraries is injected into an application at run time, and may vary over time as browsers are upgraded.
-Thus, conflicts with \code{dart:} libraries can arise at run time, outside the developer's control.
-To avoid breaking deployed applications in this way, conflicts with the \code{dart:} libraries are treated specially.
-
-It is recommended that tools that deploy Dart code produce output in which all imports use show clauses to ensure that additions to the namespace of a library never impact deployed code.
+Library namespace construction can be completed at compile time,
+and any accesses, prefixed or not, can be resolved statically.
+So an implementation does not need to extend prefix objects dynamically,
+or even have a run-time representation of prefix objects at all,
+as long as the observable behavior is preserved.%
 }
-
-\LMHash{}%
-If a name $N$ is referenced by a library $L$ and $N$ is introduced into the top level scope of $L$ by more than one import
-and not all the imports denote the same declaration,
-a compile-time error occurs.
-
-\LMHash{}%
-We say that the namespace $NS$
-\IndexCustom{has been imported into}{namespace!imported} $L$.
-
-\commentary{
-It is not an error if $N$ is introduced by two or more imports but never referred to.
-}
-
-\rationale{
-The policy above makes libraries more robust in the face of additions made to their imports.
-
-A clear distinction needs to be made between this approach, and seemingly similar policies with respect to classes or interfaces.
-The use of a class or interface, and of its members, is separate from its declaration.
-The usage and declaration may occur in widely separated places in the code, and may in fact be authored by different people or organizations.
-It is important that errors are given at the offending declaration so that the party that receives the error can respond to it a meaningful way.
-
-In contrast a library comprises both imports and their usage; the library is under the control of a single party and so any problem stemming from the import can be resolved even if it is reported at the use site.%
-}
-
-\commentary{
-Note that no errors are raised if one hides or shows a name that is not in a namespace.
-}
-\rationale{
-This prevents situations where removing a name from a library would cause breakage of a client library.
-}
-
-\LMHash{}%
-The dart core library \code{dart:core} is implicitly imported into every dart library other than itself via an import clause of the form
-
-\code{\IMPORT{} `dart:core';}
-
-unless the importing library explicitly imports \code{dart:core}.
-
-\commentary{
-Any import of \code{dart:core}, even if restricted via \SHOW{}, \HIDE{} or \AS{}, preempts the automatic import.
-}
-
-\rationale{
-It would be nice if there was nothing special about \code{dart:core}.
-However, its use is pervasive, which leads to the decision to import it automatically.
-However, some library $L$ may wish to define entities with names used by \code{dart:core} (which it can easily do, as the names declared by a library take precedence).
-Other libraries may wish to use $L$ and may want to use members of $L$ that conflict with the core library without having to use a prefix and without encountering errors.
-The above rule makes this possible, essentially canceling \code{dart:core}'s special treatment by means of yet another special rule.
-}
+\EndCase
 
 
 \subsection{Exports}
@@ -16484,9 +16785,10 @@ via \Index{export directives}, often referred to simply as \Index{exports}:
 \end{grammar}
 
 \LMHash{}%
-An export specifies a URI $x$
+An export specifies a URI $s$
 where the declaration of an exported library is to be found.
-The interpretation of URIs is described in section \ref{uris} below.
+The interpretation of URIs is described elsewhere
+(\ref{uris}).
 It is a compile-time error if the specified URI
 does not refer to a library declaration.
 
@@ -16500,144 +16802,235 @@ We say that a declaration \Index{is exported by a library}
 \IndexCustom{exports a declaration}{exports!declaration})
 if the declaration is in the library's exported namespace.
 
-%% TODO(eernst): Move this to `Imports` when that section gets update: Seems
-%% natural to define it at the first usage in terms of the page number.
 \LMHash{}%
-We define an operation for
-combining namespaces with disjoint sets of keys as follows.
-The
-\IndexCustom{union of two namespaces}{namespace!union},
-\IndexCustom{$\Namespace{a}\cup\Namespace{b}$}{%
-  $\cup$@$\Namespace{a} \cup \Namespace{b}$},
-is the namespace that maps
-each key $n$ of \Namespace{a}
-to the corresponding value $\Namespace{a}(n)$,
-and each key $n$ of \Namespace{b}
-to $\Namespace{b}(n)$.
-
-\commentary{%
-Note that this is well-defined because the union does not exist
-in the case where the sets of keys of the two namespaces overlap.%
-}
-
-\LMHash{}%
-The exported namespace of a library is then determined as follows.
+The exported namespace of a library is then determined as follows, in two steps.
 Let $L$ be a library,
 let \List{E}{1}{m} be the export directives of $L$,
 and let \List{L}{1}{m} be libraries
 such that $E_i$ refers to $L_i$ for all $i \in 1 .. m$.
-
-\LMHash{}%
-Let \Namespace{L} be the namespace that
+Let \NamespaceName{\metavar{local}} be the namespace that
 for each public top-level declaration $D$ with name $n$ in $L$ maps $n$ to $D$.
+An import prefix
+(\ref{imports})
+does not introduce a binding in
+\NamespaceName{\metavar{local}}.
+
+\LMHash{}%
+In the first step we compute the namespace provided by each exported library:
 For each $i \in 1 .. m$,
-let $\Namespace{\metavar{export}, i}$ be the exported namespace of $L_i$,
-and let \Namespace{i} be a namespace obtained from
-$\Namespace{\metavar{export}, i}$ by the narrowing process described below.
+\NamespaceName{\metavar{one},i} is
+the namespace obtained from applying
+the namespace combinators of $E_i$ to
+the exported namespace of $L_i$
+(\ref{namespaceCombinators}).
 
 \LMHash{}%
-The narrowing process that yields
-\Namespace{i} from $\Namespace{\metavar{export}, i}$
-consists of two steps.
-Each of them restricts the domain of the namespace to a subset
-(\commentary{%
-that is, it deletes the binding from a key to a value,
-for certain keys%
-}).
-
-{ %% Local scope: abbreviate narrowing namespaces.
-
-% The sequence of narrowed name spaces of export i.
-\def\NSNi#1{\Namespace{\metavar{narrowing},i,{#1}}}
-
-% The final narrowed name space of a given export. We don't want to
-% mention the number of hide/show clauses when the export varies.
-\def\NSN#1{\Namespace{\metavar{narrowing},{#1}}}
-
-\LMHash{}%
-Let \NSNi{0} be \Namespace{\metavar{export}, i}.
-Then, for each combinator clause $C_j$, $j \in 1 .. l$ in $E_i$
-(where \SHOW($\ldots$) and \HIDE($\ldots$) are defined in~\ref{imports}):
+In the second step we compute the
+\Index{namespace exported from}
+$L_i$, \NamespaceName{\metavar{export},i}.
+For each $i \in 1 .. m$,
+\NamespaceName{\metavar{export},i}
+is identical to \NamespaceName{\metavar{one},i},
+except that it is undefined at each name $n$ where
+\NamespaceName{\metavar{one},i} is defined
+and one of the following conditions hold:
 
 \begin{itemize}
-\item If $C_j$ is of the form \code{\SHOW{} $\id_1, \ldots,\ \id_k$} then let
-
-$\NSNi{j} = \SHOW([\id_1, \ldots,\ \id_k], \NSNi{j-1})$.
-\item If $C_i$ is of the form \code{\HIDE{} $\id_1, \ldots,\ \id_k$}
-
-then let $\NSNi{j} = \HIDE([\id_1, \ldots,\ \id_k], \NSNi{j-1})$.
-\end{itemize}
-
-\LMHash{}%
-Let \NSN{i} be \NSNi{l}.
-
-\commentary{%
-This first step of narrowing performs the actions requested
-by \SHOW{} and \HIDE{} clauses in the export $E_i$
-and yields the result \NSN{i}.
-The second step deals with conflicts.%
-}
-
-\LMHash{}%
-The second step starts from \NSN{i}
-and obtains the final result, \Namespace{i},
-by eliminating each key $n$, bound to declaration $D$,
-where one of the following conditions hold:
-
-\begin{itemize}
-\item \Namespace{L} maps $n$ to a declaration.
+\item \NamespaceName{\metavar{local}} is defined at $n'$
+  such that $n$ and $n'$ have the same basename.
   \commentary{%
-    In other words, a declaration in $L$ shadows
-    re-exported declarations with the same name.%
+    In other words, a declaration in $L$ shadows re-exported declarations.
+    Import prefixes of $L$ are not exported, and do not shadow anything.%
   }
 \item The first case does not apply,
-  $L_i$ is a system library,
-  there exists a $j \not= i$ in $1 .. m$ such that
-  $L_j$ is not a system library,
-  and \NSN{j} maps $n$ to a declaration.
+  there exists a $j \in 1 .. m$ and name $n'$ such that
+  \NamespaceName{\metavar{one},j} is defined at $n'$,
+  $n$ and $n'$ have the same basename,
+  \Namespace{\metavar{one},i}{n}
+  is a declaration in a system library,
+  and \Namespace{\metavar{one},j}{n'}
+  is a declaration in a non-system library.
   \commentary{%
     So a re-exported declaration from a non-system library shadows
     re-exported declarations from system libraries.%
   }
   \rationale{%
-    See the discussion in section \ref{imports} for
+    See the discussion in section \ref{theImportedNamespace} for
     the reasoning behind this rule.%
   }
 \end{itemize}
 
-\LMHash{}%
-The removal of these bindings from \NSN{i} yields the
-final, narrowed namespace \Namespace{i}.
-
-\LMHash{}%
-Assume that $i$ and $j$ are distinct numbers in $1 .. m$.
-It is a compile-time error if there exist a key $n$ such that
-\Namespace{i} maps $n$ to a declaration $D_i$,
-and \Namespace{j} maps $n$ to a declaration $D_j$,
-and $D_i$ and $D_j$ are not the same declaration.
+\commentary{%
+The removal of these bindings ensures that each exported namespace has a
+key set which is disjoint with that of \NamespaceName{\metavar{local}}.%
 }
 
+\LMHash{}%
+Assume that $i$ and $j$ are numbers in $1 .. m$ and $n$ and $n'$ are names.
+It is a compile-time error if
+\NamespaceName{\metavar{export},i} is defined at $n$,
+\NamespaceName{\metavar{export},j} is defined at $n'$,
+$n$ and $n'$ have the same basename,
+\Namespace{\metavar{export},i}{n} and
+\Namespace{\metavar{export},j}{n'}
+are not the same declaration,
+and $L_i$ and $L_j$ are not the same library.
+% We need 'not the same library', i != j is not enough: See comment on the
+% corresponding case for step two above (search 'not the same library').
+
 \commentary{%
-It is possible for $D_i$ and $D_j$ to be the same declaration,
-e.g., due to multiple re-exports.%
+This means that it is an error when two distinct exported declarations have
+the same basename,
+except when it is a getter and a setter from the same library.%
+}
+
+\rationale{%
+This rule is more strict than the corresponding rule for imports:
+When two imported declarations have a name clash it is only an error to
+\emph{use} the conflicted name, it is not an error that the name clash exists.
+But with exported names it is an error that the name clash exists.
+The reason for this difference is that
+the conflict could silently break importers of the current library $L$,
+if we were to use the same approach for exports as for imports:
+If a library $L'$ imports $L$
+and uses a name $n$ which is re-exported by $L$ from $L_n$
+then the addition of a declaration named $n$ to some other re-exported library
+will make the use of $n$ in $L'$ an error,
+and the maintainers of $L'$ may not be in a position to change $L$.%
 }
 
 \LMHash{}%
 Finally, the \Index{exported namespace} of $L$ is
-$\Namespace{L} \cup \Namespace{1} \cup \ldots \Namespace{m}$.
+$\NamespaceName{\metavar{local}} \cup
+\NamespaceName{\metavar{export},1} \cup
+\ldots \NamespaceName{\metavar{export},m}$.
 
 \commentary{%
-This union is well-defined because all these namespaces have
-pairwise disjoint sets of keys.%
+Unions of namespaces are defined elsewhere
+(\ref{namespaceCombinators}).
+This union is well-defined because all these namespaces only share
+keys where they have the same value.%
 }
 
 \LMHash{}%
 For a given $i$,
-we say that $L$ \Index{re-exports library} $L_i$,
-and also that $L$ \Index{re-exports namespace} \Namespace{i}.
+we say that $L$
+\Index{re-exports library}
+$L_i$, and also that $L$
+\Index{re-exports namespace}
+\NamespaceName{\metavar{export},i}.
 When no confusion can arise, we may simply state
 that $L$ \NoIndex{re-exports} $L_i$, or
-that $L$ \NoIndex{re-exports} \Namespace{i}.
+that $L$ \NoIndex{re-exports} \NamespaceName{\metavar{export},i}.
+
+\LMHash{}%
+It is a static warning to export two different libraries with the same name,
+unless their name is the empty string.
+
+\rationale{%
+If two different URIs are inadvertently used to access the same library $L$,
+say, because of a symbolic link in the underlying file system,
+this may help explaining why there are two incompatible copies of
+the types declared in $L$.
+Developers may also choose to omit library names entirely,
+which motivates the exception for the empty name.%
+}
+
+
+\subsection{Namespace Combinators}
+\LMLabel{namespaceCombinators}
+
+\LMHash{}%
+Imports (\ref{imports}) and exports (\ref{exports}) rely on
+\Index{namespace combinators}
+in order to adjust namespaces
+(\ref{scoping})
+and manage name clashes.
+The supported namespace combinators are \SHOW{} and \HIDE{}.
+
+\begin{grammar}
+<combinator> ::= \SHOW{} <identifierList> | \HIDE{} <identifierList>
+
+<identifierList> ::= <identifier> (`,' <identifier>)*
+\end{grammar}
+
+\LMHash{}%
+We define several operations that compute namespaces.
+The
+\IndexCustom{union of two namespaces}{namespace!union},
+\IndexCustom{$\NamespaceName{a}\cup\NamespaceName{b}$}{%
+  $\cup$@$\NamespaceName{a} \cup \NamespaceName{b}$},
+is defined when every key where both are defined is mapped to the same value.
+This union is the namespace that maps
+each key $n$ of \NamespaceName{a}
+to the corresponding value \Namespace{a}{n},
+and each key $n$ of \NamespaceName{b}
+to \Namespace{b}{n}.
+
+\commentary{%
+Note that this \emph{is} a namespace because the union is only defined
+when the mapping of any given key is unambiguous.%
+}
+
+\LMHash{}%
+The function
+\IndexCustom{\Hide{l}{\NamespaceName{a}}}{%
+  hide(l,NSa)@\Hide{l}{\NamespaceName{}}}
+takes a list of identifiers $l$ and a namespace \NamespaceName{a},
+and produces a namespace \NamespaceName{b} that is
+identical to \NamespaceName{a} except that for each identifier \id{} in $l$,
+\NamespaceName{b} is undefined at \id{} and at \code{\id=}.
+
+\LMHash{}%
+The function
+\IndexCustom{\Show{l}{\NamespaceName{a}}}{%
+  show(l,NSa)@\Show{l}{\NamespaceName{}}}
+takes a list of identifiers $l$ and a namespace \NamespaceName{a},
+and produces a namespace \NamespaceName{b} that
+maps each identifier \id{} in $l$
+where \NamespaceName{a} is defined
+to \Namespace{a}{n}.
+Furthermore, for each identifier \id{} in $l$
+where \NamespaceName{a} is defined at \code{\id=},
+\NamespaceName{b} maps \code{\id=} to \Namespace{a}{\code{\id=}}.
+Finally, \NamespaceName{b} is undefined at all other names.
+
+\LMHash{}%
+Let \List{C}{1}{n} be a sequence of combinator clauses.
+\commentary{They would come from an import or export directive.}
+The result of
+\IndexCustom{applying the combinator clauses}{%
+  combinator clauses!application to namespace}
+to a given namespace \NamespaceName{\metavar{start}}
+is a namespace \NamespaceName{\metavar{end}},
+which is computed as follows.
+
+\LMHash{}%
+Let \NamespaceName{0} be \NamespaceName{\metavar{start}}.
+For each combinator clause $C_j$, $j \in 1 .. n$:
+If $C_j$ is of the form \code{\SHOW{} $\id_1, \ldots,\ \id_k$} then let
+$\NamespaceName{j} = \Show{[\List{\id}{1}{k}]}{\NamespaceName{j-1}}$.
+If $C_i$ is of the form \code{\HIDE{} $\id_1, \ldots,\ \id_k$} then let
+$\NamespaceName{j} = \Hide{[\List{id}{1}{k}]}{\NamespaceName{j-1}}$.
+Then \NamespaceName{\metavar{end}} is \NamespaceName{n}.
+
+\commentary{%
+\NamespaceName{\metavar{end}} will always agree with
+\NamespaceName{\metavar{start}} wherever both are defined,
+and the set of names where \NamespaceName{\metavar{end}} is defined
+is always a subset of that of \NamespaceName{\metavar{start}}.
+In that sense, this is a \emph{narrowing} procedure.%
+}
+
+\commentary{%
+Note that it is possible to use \HIDE{} or \SHOW{} on an identifier
+which is not in the given namespace.%
+}
+\rationale{%
+Allowing this prevents situations where, e.g.,
+removing a declaration from a library $L$ would cause
+breakage in a library that imports $L$.%
+}
 
 
 \subsection{Parts}

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -677,7 +677,8 @@ The method used to enable or disable assertions is implementation specific.
 A \Index{namespace} is a partial function that maps names to namespace values.
 A \Index{name} is a lexical token which is an \synt{IDENTIFIER},
 an \synt{IDENTIFIER} followed by \lit{=}, or
-an \synt{operator};
+an \synt{operator},
+or \code{unary-};
 and a \Index{namespace value} is
 a declaration, a namespace, or the special value \ConflictValue{}
 (\ref{conflictMergingOfNamespaces}).
@@ -723,7 +724,7 @@ In some cases, the name of the declaration differs from
 the identifier that occurs in the declaration syntax used to declare it.
 Setters have names that are distinct from the corresponding getters
 because they always have an \lit{=} automatically added at the end,
-and the unary minus operator has the special name unary-.%
+and the unary minus operator has the special name \code{unary-}.%
 }
 
 \commentary{%
@@ -752,13 +753,26 @@ which is declared in the same library.%
 }
 
 \LMHash{}%
-In order to specify a few properties of execution,
-we introduce the notion of a
-\Index{dynamic namespace}.
+We introduce the notion of a
+\Index{run-time namespace}.
 This is a partial function from names to run-time entities,
-in particular objects and compiled code.
-Each dynamic namespace corresponds to a namespace with the same keys,
+in particular storage locations and compiled code.
+Each run-time namespace corresponds to a namespace with the same keys,
 but with values that correspond to the semantics of the namespace values.
+
+\rationale{%
+A namespace typically maps a name to a declaration,
+and it can be used statically to figure out what that name refers to.
+For example,
+a variable is associated with an actual storage location at run time.
+We introduce the notion of a run-time namespace based on a namespace,
+such that the dynamic semantics can access run-time entities
+like that storage location.
+The same code may be executed multiple times with the same run-time namespace,
+or with different run-time namespaces for each execution.
+E.g., local variables for a function invocation are specific to the invocation,
+and instance variables are specific to an object.%
+}
 
 \LMHash{}%
 Dart is lexically scoped.
@@ -855,23 +869,28 @@ This means private declarations may only be accessed within
 the library in which they are declared.%
 }
 
-\LMHash{}%
+\rationale{%
 Privacy applies only to declarations within a library,
 not to the library declaration as a whole.
-
-\rationale{
-Libraries do not reference each other by name and so the idea of a private library is meaningless.
-Thus, if the name of a library begins with an underscore, it has no effect on the accessibility of the library or its members.
+This is because libraries do not reference each other by name,
+and so the idea of a private library is meaningless
+(\ref{imports}).
+Thus, if the name of a library begins with an underscore,
+it has no effect on the accessibility of the library or its members.%
 }
 
-\rationale{
-Privacy is, at this point, a static notion tied to a particular piece of code (a library).
-It is designed to support software engineering concerns rather than security concerns.
+\rationale{%
+Privacy is, at this point, a static notion tied to
+a particular piece of code (a library).
+It is designed to support software engineering concerns
+rather than security concerns.
 Untrusted code should always run in an another isolate.
-It is possible that libraries will become first class objects and privacy will be a dynamic notion tied to a library instance.
 
-Privacy is indicated by the name of a declaration - hence privacy and naming are not orthogonal.
-This has the advantage that both humans and machines can recognize access to private declarations at the point of use without knowledge of the context from which the declaration is derived.
+Privacy is indicated by the name of a declaration---hence
+privacy and naming are not orthogonal.
+This has the advantage that both humans and machines
+can recognize access to private declarations at the point of use
+without knowledge of the context from which the declaration is derived.%
 }
 
 
@@ -11917,7 +11936,7 @@ Consider an unconditional property extraction $i$
 (\ref{propertyExtraction})
 of the form \code{$e$.\id}.
 It is a compile-time error if \id{} is the name of
-a member of the built-in class \code{Object}
+an instance member of the built-in class \code{Object}
 and $e$ is a type literal.
 
 \commentary{
@@ -16689,7 +16708,7 @@ When $I_i$ is an immediate import that refers to a URI via the string $s_i$:
 
 \LMHash{}%
 Let \NamespaceName{\metavar{import}, i} be the namespace imported from $L_i$.
-The dynamic namespace \NamespaceName{i} will then have the following bindings:
+The run-time namespace \NamespaceName{i} will then have the following bindings:
 
 \begin{itemize}
 \item

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -16692,9 +16692,11 @@ The effect of a repeated invocation of \code{$p$.loadLibrary()} is as follows:
 \end{itemize}
 
 \commentary{%
-In other words, one can retry a deferred load after a network failure
-or because a file is absent,
-but once one finds some content and loads it, one can no longer reload.
+In other words, a successful \code{loadLibrary()} guarantees that
+the import can be successfully accessed through the import prefix.
+If an invocation of \code{loadLibrary()} is initiated after
+another invocation has completed successfully,
+it is guaranteed to also complete successfully (success is idempotent).
 We do not specify which object the returned future resolves to.%
 }
 \EndCase
@@ -16703,10 +16705,8 @@ We do not specify which object the returned future resolves to.%
 \Case{Semantics of immediate imports}
 When $I_i$ is an immediate import with a library URI, $u_i$,
 represented by the string $s_i$:
-Let $L_i$ be the library obtained from the source code denoted by $s_i$,
-and let $\ell_i$ be the result of compiling $L_i$.
-We then say that the URI $u_i$ denotes the library $L_i$
-(which also determines $\ell_i$).
+Let $L_i$ be the library obtained from the source code denoted by $s_i$.
+We then say that the URI $u_i$ denotes the library $L_i$.
 All imports and exports of the same URI in a Dart program denotes
 the same library,
 and imports or exports of different URIs denote distinct libraries.
@@ -16719,8 +16719,7 @@ The run-time namespace \NamespaceName{i} will then have the following bindings:
 \item
   For every top level function, getter, or setter $m$ named $n$ in
   \NamespaceName{\metavar{import}, i},
-  a binding from $n$ to the result of compiling $m$,
-  obtained from $\ell_i$.
+  a binding from $n$ to said function, getter, or setter.
 \item
   For every name \id{} in \NamespaceName{\metavar{import}, i}
   that is bound to a class, mixin, or type alias declaration

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -32,6 +32,7 @@
 % - Eliminate error for library name conflicts in imports and exports.
 % - Clarify the specification of initializing formals. Fix error: Add
 %   missing `?' at the end for function typed initializing formal.
+% - Revise and clarify the sections Imports and Exports.
 %
 % 2.7
 % - Rename non-terminals `<...Definition>` to `<...Declaration>` (e.g., it is
@@ -673,16 +674,34 @@ The method used to enable or disable assertions is implementation specific.
 \LMLabel{scoping}
 
 \LMHash{}%
-A \Index{namespace} is a mapping from names to declarations.
-It may be considered as a partial function.
-It may also be seen as a set of bindings from a name to a declaration,
-$n\mapsto{}D$,
-with the constraint that if a namespace has both
-$n\mapsto{}D_1$ and $n\mapsto{}D_2$
-then $D_1$ and $D_2$ is the same declaration.
-When a namespace is seen as a set of mappings we may also refer
-to each binding as having a \NoIndex{key}
-which is mapped to a \NoIndex{value}.
+A \Index{namespace} is a partial function that maps names to namespace values.
+A \Index{name} is a lexical token which is an \synt{IDENTIFIER},
+an \synt{IDENTIFIER} followed by \lit{=}, or
+an \synt{operator};
+and a \Index{namespace value} is
+a declaration, a namespace, or the special value \ConflictValue{}
+(\ref{conflictMergingOfNamespaces}).
+
+\LMHash{}%
+The graph of a namespace \NamespaceName{} is the set
+$\{(n, V)\;|\;\Namespace{}{n} = V\}$,
+and for any $(n, V)$ in that set we say that \NamespaceName{}
+\IndexCustom{maps}{namespace!maps a key to a value}
+the
+\IndexCustom{key}{namespace!key}
+$n$ to the
+\IndexCustom{value}{namespace!value}
+$V$,
+and that \NamespaceName{}
+\IndexCustom{has the binding}{namespace!has a binding}
+$n\mapsto{}V$.
+\commentary{%
+The fact that \NamespaceName{} is a partial function just means that
+each name is mapped to at most one namespace value.
+That is, if \NamespaceName{} has the bindings
+$n\mapsto{}V_1$ and $n\mapsto{}V_2$
+then $V_1 = V_2$.%
+}
 
 \LMHash{}%
 Let \NamespaceName{} be a namespace.
@@ -692,18 +711,32 @@ We say a declaration $d$ \NoIndex{is in} \NamespaceName{}
 if a key of \NamespaceName{} is mapped to $d$.
 
 \LMHash{}%
-A scope $S_0$ induces a namespace \NamespaceName{0} that maps
-the simple name of each variable, type or function declaration $d$
-declared in $S_0$ to $d$.
-Labels are not included in the induced namespace of a scope;
-instead they have their own dedicated namespace.
+A scope $S_0$ has an associated namespace \NamespaceName{0}.
+The bindings of \NamespaceName{0} is specified in this document by saying that
+a given declaration $D$ named $n$
+\IndexCustom{introduces}{declaration!introduces an entity into a scope}
+a specific entity $V$ into $S_0$,
+which means that the binding $n\mapsto{}V$ is added to \NamespaceName{0}.
 
 \commentary{%
-It is therefore impossible, e.g., to define a class that declares
-a method and a getter with the same name in Dart.
-Similarly one cannot declare a top-level function with
-the same name as a library variable or a class
-which is declared in the same library.%
+In some cases, the name of the declaration differs from
+the identifier that occurs in the declaration syntax used to declare it.
+Setters have names that are distinct from the corresponding getters
+because they always have an \lit{=} automatically added at the end,
+and the unary minus operator has the special name unary-.%
+}
+
+\commentary{%
+It is typically the case that $V$ is $D$,
+but there are exceptions:
+A variable declaration introduces an implicitly induced getter declaration,
+and in some cases also an implicitly induced setter declaration into the
+given scope.%
+}
+
+\commentary{%
+Note that labels are not included in the namespace of a scope.
+They are resolved lexically rather then being looked up in a namespace.%
 }
 
 \LMHash{}%
@@ -711,11 +744,11 @@ It is a compile-time error if there is more than one entity with the same name
 declared in the same scope.
 
 \commentary{%
-In some cases, the name of the declaration differs from
-the identifier that occurs in the declaration syntax used to declare it.
-Setters have names that are distinct from the corresponding getters
-because they always have an \lit{=} automatically added at the end,
-and unary minus has the special name unary-.%
+It is therefore impossible, e.g., to define a class that declares
+a method and a getter with the same name in Dart.
+Similarly one cannot declare a top-level function with
+the same name as a library variable or a class
+which is declared in the same library.%
 }
 
 \LMHash{}%
@@ -808,12 +841,14 @@ otherwise it is \IndexCustom{public}{public!identifier}.
 A declaration $m$ is \Index{accessible to a library} $L$
 if $m$ is declared in $L$ or if $m$ is public.
 
-\commentary{
-This means private declarations may only be accessed within the library in which they are declared.
+\commentary{%
+This means private declarations may only be accessed within
+the library in which they are declared.%
 }
 
 \LMHash{}%
-Privacy applies only to declarations within a library, not to library declarations themselves.
+Privacy applies only to declarations within a library,
+not to the library declaration as a whole.
 
 \rationale{
 Libraries do not reference each other by name and so the idea of a private library is meaningless.
@@ -7462,8 +7497,12 @@ All occurrences of \code{\#$\id.\id_2\ldots\id_n$} with the same sequence of ide
 evaluate to the same instance,
 and no other symbol literals evaluate to that \code{Symbol} instance
 or to a \code{Symbol} instance that is \lit{==} to that instance.
-\commentary{This kind of symbol literal denotes the name of a library declaration. Library names are not subject to library privacy, even
-if some of its identifiers begin with an underscore.}
+\commentary{%
+This kind of symbol literal denotes the name of a library declaration,
+as specified in a \synt{libraryName}.
+Library names are not subject to library privacy, even
+if some of its identifiers begin with an underscore.%
+}
 
 \LMHash{}%
 A symbol literal \code{\#\metavar{operator}} evaluates to an instance of \code{Symbol}
@@ -11485,9 +11524,7 @@ and the static type of $i$ is as specified there.
 
 \LMHash{}%
 It is a compile-time error to invoke any of the methods of class \code{Object}
-on a prefix namespace
-(\ref{imports})
-or on a constant type literal that is immediately followed by the token `.'\,.
+on a constant type literal that is immediately followed by the token `.'\,.
 
 \rationale{%
 The reason for the latter is that this syntax is reserved for
@@ -11870,14 +11907,12 @@ or of the form \code{\SUPER.\id}
 Consider an unconditional property extraction $i$
 (\ref{propertyExtraction})
 of the form \code{$e$.\id}.
-It is a compile-time error if \id{} is a member of class \code{Object}
-and $e$ is either a prefix namespace (\ref{imports})
-or a type literal.
+It is a compile-time error if \id{} is the name of
+a member of the built-in class \code{Object}
+and $e$ is a type literal.
 
 \commentary{
-It may seem obvious that it is an error to use prefix namespace,
-but more surprising that it also applies to a type literal.
-In particular, we cannot use \code{int.toString}
+This means that we cannot use \code{int.toString}
 to obtain a function object for the \code{toString} method of the
 \code{Type} object for \code{int}.
 But we can use \code{(int).toString}:
@@ -16207,14 +16242,12 @@ Since top level privates are not imported, using the top level privates of anoth
 The \Index{public namespace} of library $L$ is the mapping that maps
 the simple name of each public top-level member declaration $m$ of $L$ to $m$.
 The \Index{local namespace} of library $L$ is the mapping that maps
-the names introduced by each top-level member declaration of $L$
-as well as import prefixes
-(\ref{imports})
-and fresh names of extensions
-(\ref{extensions})
-to the corresponding declaration or import prefix.
+the names introduced by each top-level declaration of $L$
+to the corresponding declaration.
 The \Index{library scope} of library $L$ is the outermost scope in $L$,
-and its namespace is the local namespace of $L$.
+and its namespace is the library namespace of $L$
+(\ref{theImportedNamespace}).
+
 
 \subsection{Imports}
 \LMLabel{imports}
@@ -16227,8 +16260,7 @@ is made available in the current library.
 <libraryImport> ::= <metadata> <importSpecification>
 
 <importSpecification> ::= \gnewline{}
-  \IMPORT{} <configurableUri> (\AS{} <identifier>)? <combinator>* `;'
-  \alt \IMPORT{} <configurableUri> \DEFERRED{} \AS{} <identifier> <combinator>* `;'
+  \IMPORT{} <configurableUri> (\DEFERRED? \AS{} <identifier>)? <combinator>* `;'
 \end{grammar}
 
 \LMHash{}%
@@ -16262,10 +16294,14 @@ names imported by $I$.
 In this case we say that \id{} is an \Index{import prefix},
 or simply a \Index{prefix}.
 
+\commentary{%
+Note that the grammar enforces that a deferred import
+includes a prefix clause,
+so we can refer to \emph{the} prefix clause of a deferred import.%
+}
+
 \LMHash{}%
-It is a compile-time error if a deferred import does not include
-a prefix clause.
-It is a compile-time error if a prefix used in a deferred import
+It is a compile-time error if the prefix used in a deferred import
 is also used as the prefix of another import clause.
 It is a compile-time error if \id{} is an import prefix and
 the current library declares a top-level member named \id{}.
@@ -16308,7 +16344,7 @@ by means of yet another special rule.%
 \LMHash{}%
 In the following, we specify the imported namespace of a library $L$,
 \NamespaceName{\metavar{import}},
-in two steps.
+and use that to define the namespace that defines the library scope of $L$.
 
 \LMHash{}%
 We need to introduce system libraries because they have special rules.
@@ -16317,8 +16353,7 @@ Any other library is a \Index{non-system library}.
 
 \commentary{%
 A system library can generally be recognized by having
-a URI that starts with `\code{dart:}'.
-An exception is `\code{dart:ui}' which is not a system library.%
+a URI that starts with `\code{dart:}'.%
 }
 
 \rationale{%
@@ -16336,8 +16371,6 @@ conflicts with the system libraries are treated specially.%
 \LMHash{}%
 Let \NamespaceName{\metavar{local}} be the local namespace of $L$
 (\ref{librariesAndScripts}).
-An import with a prefix $p$ is included among these top-level declarations,
-and it causes $p$ to be mapped to a prefix namespace as described below.
 Let \List{I}{1}{m} be the import directives of $L$,
 and let \List{L}{1}{m} be libraries
 such that $I_i$ refers to $L_i$ for all $i \in 1 .. m$.
@@ -16347,7 +16380,11 @@ It is not an error to have multiple imports of the same library.%
 
 \LMHash{}%
 Let $i \in 1 .. m$.
+
+\LMHash{}%
+{\bf Step one.}
 In the first step we compute the namespace provided by each imported library,
+respectively by each group of libraries imported with the same prefix,
 \NamespaceName{\metavar{one},i}.
 
 \LMHash{}%
@@ -16355,11 +16392,20 @@ In the first step we compute the namespace provided by each imported library,
 When $I_i$ has no prefix, \NamespaceName{\metavar{one},i} is
 the namespace obtained from applying the namespace combinators of $I_i$ to
 the exported namespace of $L_i$
-(\ref{namespaceCombinators}).
+(\ref{namespaceCombinators}),
+and eliminating every binding
+where the key is an import prefix declared in $L$.
+
+\commentary{%
+The former ensures that \HIDE{} and \SHOW{} directives are taken into account,
+and the latter ensures that an import prefix will shadow an imported name.%
+}
 \EndCase
 
 \LMHash{}%
 \Case{Step one for prefixed imports}
+In this step we resolve name conflicts
+among names imported with the same prefix.
 When $I_i$ has prefix $p_i$,
 let \List{I'}{1}{k} be the sublist of \List{I}{1}{m} that have prefix $p_i$,
 and let \List{L'}{1}{k} be the corresponding libraries
@@ -16370,10 +16416,39 @@ the exported namespace of $L'_j$
 (\ref{namespaceCombinators}).
 
 \LMHash{}%
+For later reference, we need to introduce a way to refer to certain extensions:
+If \NamespaceName{\metavar{exported},j} contains an extension $E$
+(\ref{extensions})
+then we say that $E$ is
+\IndexCustom{exported to}{extension!exported to a prefix}
+$p_i$.
+\commentary{%
+Note that $E$ is `exported to $p_i$',
+even in the case where there is a name clash with a different import
+which makes it an error to access $E$ using its name
+because that name is conflicted.
+The point is that $E$ can still be used implicitly,
+based on its fresh name.%
+}
+
+\LMHash{}%
+When $I_i$ is a non-deferred import:
 Let \NamespaceName{\metavar{prefix},i} be the namespace obtained from applying
 conflict merging to
 \List{\metavar{NS}}{\metavar{exported},1}{\metavar{exported},k}
 (\ref{conflictMergingOfNamespaces}).
+
+\LMHash{}%
+When $I_i$ is a deferred import:
+In this case $k$ is 1
+(\commentary{otherwise a compile-time error would occur}),
+and \NamespaceName{\metavar{prefix},i} is the namespace obtained by
+adding a binding of the name \code{loadLibrary}
+to an implicitly induced declaration of a function with signature
+\code{Future<\VOID> loadLibrary()}
+to \NamespaceName{\metavar{exported},1}.
+
+\LMHash{}%
 Then \NamespaceName{\metavar{one},i} is a namespace that has
 a single binding that maps $p_i$ to \NamespaceName{\metavar{prefix},i}.
 
@@ -16383,13 +16458,13 @@ In this situation we say that \NamespaceName{\metavar{one},i} is a
 because it maps a library prefix to a namespace.
 
 \commentary{%
-A prefix namespace is not a Dart object, it is merely a device which is
-used to manage names of the form \synt{qualified} and their types
-during static analysis,
-and a mapping that is used to access the corresponding entities
-at run time.
+A prefix namespace is not a Dart object,
+it is merely a device which is used to manage
+expressions of the form \synt{qualifiedName} and what they refer to
+during static analysis.
 Consequently, any attempt to use a prefix namespace as an object
-is a compile-time error.
+is a compile-time error, e.g.,
+it cannot be the result of an expression evaluation.
 
 Note that if $l$ and $q$ are such that
 $I_l$ and $I_q$ both have the same prefix $p$
@@ -16401,7 +16476,7 @@ $\NamespaceName{\metavar{one},l} = \NamespaceName{\metavar{one},q} =
 
 \LMHash{}%
 {\bf Step two.}
-In the second step we resolve conflicts
+In the second step we resolve top level conflicts
 among the namespaces obtained in the first step.
 
 \LMHash{}%
@@ -16416,18 +16491,38 @@ such that $n$ and $n'$ have the same basename.
 
 \commentary{%
 In other words, a declaration in the current library shadows
-imported declarations.
-Note that the prefix of an import also introduces a binding
-into \NamespaceName{\metavar{local}},
-so a prefix can also shadow an imported declaration.%
+imported declarations.%
 }
 
 \LMHash{}%
-The namespace \NamespaceName{\metavar{import}} is known as the
-\Index{imported namespace}
-of $L$.
-The \Index{library namespace} of $L$ is
-$\NamespaceName{\metavar{local}} \cup \NamespaceName{\metavar{import}}$.
+The \Index{imported namespace} of $L$ is then \NamespaceName{\metavar{import}}.
+
+\LMHash{}%
+Let $\cal E$ be a set of extension declarations
+(\ref{extensions})
+with the following members:
+An extension declaration $E$ is a member of $\cal E$
+if there is an $i \in 1 .. m$ and a name $n$
+such that $\Namespace{\metavar{one},i}{n} = E$,
+or if there is a prefix $p_i$ such that $E$ is exported to $p_i$
+(\commentary{as defined in step one}).
+%
+Let \NamespaceName{\metavar{extensions}} be a namespace that
+for each extension $E$ in $\cal E$ maps a fresh name to $E$.
+
+\commentary{%
+\NamespaceName{\metavar{extensions}} provides a fresh name
+allowing implicit access to each extension exported by an imported library
+and not removed by \HIDE{} or \SHOW{},
+even the ones that cannot be accessed using their declared name,
+because of a name clash.%
+}
+
+\LMHash{}%
+The \Index{library namespace} of $L$ is then
+$\NamespaceName{\metavar{local}} \cup
+\NamespaceName{\metavar{import}} \cup
+\NamespaceName{\metavar{extensions}}$.
 
 \LMHash{}%
 Let $i \in 1 .. m$.
@@ -16495,9 +16590,11 @@ The deferred prefix namespace has the following bindings:
 \item
   For every top level function $f$ named \id{} in
   \NamespaceName{\metavar{import},i},
-  a corresponding method named \id{} with the same signature as $f$.
+  a corresponding function named \id{} with the same signature as $f$.
   % This error can occur because being-loaded is a dynamic property.
-  Calling the method results in a dynamic error.
+  Calling the function results in a dynamic error,
+  and so does closurizing it
+  (\ref{functionClosurization}).
 \item
   For every top level getter $g$ named \id{} in
   \NamespaceName{\metavar{import},i},
@@ -16511,7 +16608,7 @@ The deferred prefix namespace has the following bindings:
   % This error can occur because being-loaded is a dynamic property.
   Calling the setter results in a dynamic error.
 \item
-  For every type $T$ named \id{} in
+  For every class, mixin and type alias declaration named \id{} in
   \NamespaceName{\metavar{import},i},
   a corresponding getter named \id{} with return type \code{Type}.
   % This error can occur because being-loaded is a dynamic property.
@@ -16531,7 +16628,7 @@ the name $p$ is mapped to a non-deferred prefix namespace,
 as described below.
 In addition, the prefix namespace also supports the \code{loadLibrary} function,
 and so it is possible to invoke \code{$p$.loadLibrary()} again.
-If a call fails, nothing happens,
+If a call fails, the library has not been loaded,
 and one has the option to invoke \code{$p$.loadLibrary()} again.
 Whether a repeated call to \code{$p$.loadLibrary()} succeeds will vary,
 as described below.
@@ -16559,7 +16656,7 @@ The effect of a repeated invocation of \code{$p$.loadLibrary()} is as follows:
 In other words, one can retry a deferred load after a network failure
 or because a file is absent,
 but once one finds some content and loads it, one can no longer reload.
-We do not specify which object the future returned resolves to.%
+We do not specify which object the returned future resolves to.%
 }
 \EndCase
 

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -702,7 +702,8 @@ instead they have their own dedicated namespace.
 It is therefore impossible, e.g., to define a class that declares
 a method and a getter with the same name in Dart.
 Similarly one cannot declare a top-level function with
-the same name as a library variable or a class.%
+the same name as a library variable or a class
+which is declared in the same library.%
 }
 
 \LMHash{}%
@@ -711,7 +712,7 @@ declared in the same scope.
 
 \commentary{%
 In some cases, the name of the declaration differs from
-the identifier used to declare it.
+the identifier that occurs in the declaration syntax used to declare it.
 Setters have names that are distinct from the corresponding getters
 because they always have an \lit{=} automatically added at the end,
 and unary minus has the special name unary-.%
@@ -11484,7 +11485,7 @@ and the static type of $i$ is as specified there.
 
 \LMHash{}%
 It is a compile-time error to invoke any of the methods of class \code{Object}
-on a prefix object
+on a prefix namespace
 (\ref{imports})
 or on a constant type literal that is immediately followed by the token `.'\,.
 
@@ -11870,11 +11871,11 @@ Consider an unconditional property extraction $i$
 (\ref{propertyExtraction})
 of the form \code{$e$.\id}.
 It is a compile-time error if \id{} is a member of class \code{Object}
-and $e$ is either a prefix object (\ref{imports})
+and $e$ is either a prefix namespace (\ref{imports})
 or a type literal.
 
 \commentary{
-It may seem obvious that it is an error to use prefix object,
+It may seem obvious that it is an error to use prefix namespace,
 but more surprising that it also applies to a type literal.
 In particular, we cannot use \code{int.toString}
 to obtain a function object for the \code{toString} method of the
@@ -16204,22 +16205,22 @@ Since top level privates are not imported, using the top level privates of anoth
 
 \LMHash{}%
 The \Index{public namespace} of library $L$ is the mapping that maps
-the simple name of each public top-level member $m$ of $L$ to $m$.
+the simple name of each public top-level member declaration $m$ of $L$ to $m$.
 The \Index{local namespace} of library $L$ is the mapping that maps
-the names introduced by each top-level member of $L$
+the names introduced by each top-level member declaration of $L$
 as well as import prefixes
 (\ref{imports})
 and fresh names of extensions
 (\ref{extensions})
-to the corresponding declaration.
+to the corresponding declaration or import prefix.
 
 
 \subsection{Imports}
 \LMLabel{imports}
 
 \LMHash{}%
-An \Index{import} specifies a library to be used in
-the scope of another library.
+An \Index{import} specifies a library whose exported namespace
+is made available in the current library.
 
 \begin{grammar}
 <libraryImport> ::= <metadata> <importSpecification>
@@ -16261,8 +16262,8 @@ In this case we say that \id{} is an \Index{import prefix},
 or simply a \Index{prefix}.
 
 \LMHash{}%
-A deferred import must include a prefix clause,
-or a compile-time error occurs.
+It is a compile-time error if a deferred import does not include
+a prefix clause.
 It is a compile-time error if a prefix used in a deferred import
 is also used as the prefix of another import clause.
 It is a compile-time error if \id{} is an import prefix and
@@ -16289,7 +16290,7 @@ preempts the automatic import.
 It would be nice if there was nothing special about \code{dart:core}.
 However, its use is pervasive,
 which leads to the decision to import it automatically.
-However, some library $L$ may wish to define entities
+On the other hand, some library $L$ may wish to define entities
 with names used by \code{dart:core}
 (which it can easily do, as the names declared by a library take precedence).
 Other libraries may wish to use $L$,
@@ -16336,10 +16337,14 @@ conflicts with the system libraries are treated specially.%
 Let \NamespaceName{\metavar{local}} be the local namespace of $L$
 (\ref{librariesAndScripts}).
 An import with a prefix $p$ is included among these top-level declarations,
-and it causes $p$ to be mapped to a prefix object as described below.
+and it causes $p$ to be mapped to a prefix namespace as described below.
 Let \List{I}{1}{m} be the import directives of $L$,
 and let \List{L}{1}{m} be libraries
 such that $I_i$ refers to $L_i$ for all $i \in 1 .. m$.
+
+\commentary{%
+It is not an error to have multiple imports of the same library.%
+}
 
 \LMHash{}%
 Let $i \in 1 .. m$.
@@ -16357,9 +16362,9 @@ the exported namespace of $L_i$
 \LMHash{}%
 \Case{Step one for prefixed imports}
 When $I_i$ has prefix $p_i$,
-let \List{I'}{1}{k} be the subset of \List{I}{1}{m} that have prefix $p_i$,
+let \List{I'}{1}{k} be the sublist of \List{I}{1}{m} that have prefix $p_i$,
 and let \List{L'}{1}{k} be the corresponding libraries
-(\commentary{which is a subset of \List{L}{1}{m}}).
+(\commentary{which is a sublist of \List{L}{1}{m}}).
 Let \NamespaceName{\metavar{exported},j}, $j \in 1 .. k$,
 be the namespace obtained from applying the namespace combinators of $I'_j$ to
 the exported namespace of $L'_j$
@@ -16411,8 +16416,8 @@ one of the following conditions holds:
 Let \NamespaceName{\metavar{prefix},i} be the namespace
 $\NamespaceName{\metavar{narrowed},1} \cup \ldots
 \NamespaceName{\metavar{narrowed},k}$.
-Then \NamespaceName{\metavar{one},i} is the namespace that
-maps $p_i$ to a \Index{prefix object},
+Then \NamespaceName{\metavar{one},i} is a namespace that has
+a single binding that maps $p_i$ to a \Index{prefix namespace},
 which is a mapping that associates names with entities declared in
 \List{L'}{1}{k} as follows:
 
@@ -16436,12 +16441,12 @@ which is a mapping that associates names with entities declared in
 \end{itemize}
 
 \commentary{%
-A prefix object is not a Dart object, it is merely a device which is
+A prefix namespace is not a Dart object, it is merely a device which is
 used to manage names of the form \synt{qualified} and their types
 during static analysis,
 and a mapping that is used to access the corresponding entities
 at run time.
-Consequently, any attempt to use a prefix object on its own
+Consequently, any attempt to use a prefix namespace as an object
 is a compile-time error.
 
 Note that if $l$ and $q$ are such that
@@ -16604,13 +16609,13 @@ Evaluation of $I_i$ proceeds as follows:
 \LMHash{}%
 \Case{Evaluation of deferred imports}
 If $I_i$ is a deferred import with prefix $p$, a mapping of $p$ to a
-\Index{deferred prefix object} is added to
+\Index{deferred prefix namespace} is added to
 the scope of the current library $L$.
 Let \NamespaceName{\metavar{import},i} be
 the namespace imported from the library specified by $I_i$,
 as defined previously
 (\ref{theImportedNamespace}).
-The deferred prefix object has the following members:
+The deferred prefix namespace has the following bindings:
 
 \begin{itemize}
 \item \code{loadLibrary()}.
@@ -16665,9 +16670,9 @@ but will raise errors.%
 
 \LMHash{}%
 After an invocation of \code{$p$.loadLibrary} succeeds,
-the name $p$ is mapped to a non-deferred prefix object,
+the name $p$ is mapped to a non-deferred prefix namespace,
 as described below.
-In addition, the prefix object also supports the \code{loadLibrary()} method,
+In addition, the prefix namespace also supports the \code{loadLibrary()} method,
 and so it is possible to call \code{$p$.loadLibrary} again.
 If a call fails, nothing happens,
 and one has the option to call \code{$p$.loadLibrary} again.
@@ -16739,13 +16744,13 @@ The namespace \NamespaceName{i} will then have the following bindings:
 If $I_i$ has prefix $p$,
 and the library namespace of the current library
 does not have a binding for $p$,
-then a mapping from $p$ to a non-deferred prefix object
+then a mapping from $p$ to a non-deferred prefix namespace
 with members determined by \NamespaceName{i} is introduced into the
 library namespace of the current library.
 If $I_i$ has prefix $p$,
 and the library namespace of the current library
-binds $p$ to a non-deferred prefix object $o$,
-then $o$ is extended with members as determined by \NamespaceName{i}.
+binds $p$ to a non-deferred prefix namespace $o$,
+then $o$ is extended with bindings as determined by \NamespaceName{i}.
 
 \LMHash{}%
 Otherwise, when $I_i$ does not have a prefix, each mapping in \NamespaceName{i}
@@ -16758,8 +16763,8 @@ because such conflicts would have caused a compile-time error.
 
 Library namespace construction can be completed at compile time,
 and any accesses, prefixed or not, can be resolved statically.
-So an implementation does not need to extend prefix objects dynamically,
-or even have a run-time representation of prefix objects at all,
+So an implementation does not need to extend prefix namespaces dynamically,
+or even have a run-time representation of prefix namespaces at all,
 as long as the observable behavior is preserved.%
 }
 \EndCase

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -16302,88 +16302,6 @@ essentially canceling \code{dart:core}'s special treatment
 by means of yet another special rule.%
 }
 
-\subsubsection{Conflict Merging of Namespaces}
-\LMLabel{conflictMergingOfNamespaces}
-
-\LMHash{}%
-In this section we define an operation on namespaces
-which eliminates certain bindings of names in case of name clashes,
-and keeps track of such name clashes using a special value,
-\Index{\ConflictValue}.
-
-\LMHash{}%
-When a name $n$ is mapped to \ConflictValue{} by a namespace,
-we say that $n$ is
-\IndexCustom{conflicted}{conflicted name}.
-A lookup for a conflicted name will succeed according to
-the normal rules for namespaces and lexical scoping,
-but it is a compile-time error at the location where the name is used
-that this name is conflicted.
-
-\LMHash{}%
-Let \List{\metavar{NS}}{1}{m} be a list of namespaces
-(\commentary{the list may or may not contain duplicates}).
-The
-\IndexCustom{conflict merging}{namespace!conflict merging}
-of \List{\metavar{NS}}{1}{m} is then
-$\NamespaceName{\metavar{conflict}} \cup
-\NamespaceName{\metavar{narrowed},1} \cup\,
-\ldots\ \NamespaceName{\metavar{narrowed},m}$,
-where the namespaces \NamespaceName{\metavar{conflict}} and
-\NamespaceName{\metavar{narrowed},i}, $i \in 1 .. m$,
-are specified as follows:
-
-\LMHash{}%
-\NamespaceName{\metavar{conflict}} is empty except for the
-bindings mentioned below.
-\NamespaceName{\metavar{narrowed},i} is identical to
-\NamespaceName{i}, $i \in 1 .. m$,
-except that the former is undefined at each name $n$ where
-the latter is defined,
-and one of the following conditions holds:
-
-\begin{itemize}
-\item There exists a $j \in 1 .. m$ and name $n'$ such that
-  \NamespaceName{j} is defined at $n'$,
-  $n$ and $n'$ have the same basename,
-  \Namespace{i}{n} is a declaration in a system library,
-  and \Namespace{j}{n'} is a declaration in a non-system library.
-  \commentary{%
-    So an imported declaration from a non-system library shadows
-    imported declarations from system libraries.%
-  }
-\item There exists a $j \in 1 .. m$ and name $n'$ such that
-  \NamespaceName{j} is defined at $n'$,
-  $n$ and $n'$ have the same basename,
-  \Namespace{i}{n} and \Namespace{j}{n'} are not the same declaration
-  and not a getter and a setter declared in the same library,
-  and either none or both of
-  \Namespace{i}{n} and \Namespace{j}{n'}
-  are declarations in a system library.
-  %
-  \commentary{%
-    So with two distinct imported declarations with the same basename,
-    both are eliminated,
-    except when it is a getter and a setter from the same library.%
-  }
-
-  In this situation $n$ is mapped to \ConflictValue{}
-  by \NamespaceName{\metavar{conflict}}.
-  \commentary{By symmetry, $n'$ is also conflicted.}
-\end{itemize}
-
-\commentary{%
-In summary, conflict merging takes a list of namespaces and produces
-a namespace that is the union of several disjoint namespaces
-(because all name clashes have been eliminated):
-A conflict namespace that records all unresolved name clashes,
-and a list of namespaces where clashing names have been removed.
-Some name clashes have been resolved by preferring
-declarations from non-system libraries
-over declarations from system libraries.%
-}
-
-
 \subsubsection{The Imported Namespace}
 \LMLabel{theImportedNamespace}
 
@@ -16512,16 +16430,17 @@ The \Index{library namespace} of $L$ is
 $\NamespaceName{\metavar{local}} \cup \NamespaceName{\metavar{import}}$.
 
 \LMHash{}%
-Let $i \in 1 .. m$ and let
-\NamespaceName{\metavar{import},i} be
-the intersection of \NamespaceName{\metavar{one},i}
-and \NamespaceName{\metavar{import}}.
+Let $i \in 1 .. m$.
 If $L_i$ is imported without a prefix, the
 \IndexCustom{namespace imported from}{library!namespace imported from}
-$L_i$ is \NamespaceName{\metavar{import},i}.
+$L_i$ is the conflict narrowed namespace
+(\ref{conflictMergingOfNamespaces})
+of \NamespaceName{\metavar{one},i}.
+%
 Otherwise $L_i$ is imported with a prefix $p$,
-in which case the namespace imported from $L_i$
-is \Namespace{\metavar{import},i}{p}.
+in which case the \NoIndex{namespace imported from} $L_i$
+is the conflict narrowed namespace
+of \NamespaceName{\metavar{exported},i}.
 
 \commentary{%
 So the namespace imported by $L_i$ contains the bindings exported by $L_i$,
@@ -16531,19 +16450,13 @@ and except the ones removed by conflict merging.%
 
 \LMHash{}%
 We say that a name is \Index{imported by a library}
-(or equivalently, that a library
-\IndexCustom{imports a name}{imports!name})
 if the name is in the library's imported namespace.
 We say that a declaration \Index{is imported by a library}
-(or equivalently, that a library
-\IndexCustom{imports a declaration}{imports!declaration})
 if the declaration is in the library's imported namespace.
 
 
 \subsubsection{Evaluation of Imports}
 \LMLabel{evaluationOfImports}
-
-!!!TODO!!!
 
 \LMHash{}%
 Let $I_i$ be an import directive that refers to a URI via the string $s_i$.
@@ -16561,9 +16474,10 @@ as defined previously
 The deferred prefix namespace has the following bindings:
 
 \begin{itemize}
-\item \code{loadLibrary()}.
-  This method returns a future $f$.
-  When called, the method causes
+\item The name \code{loadLibrary} is bound to 
+  a function with signature \code{Future<\VOID> loadLibrary()}.
+  This function returns a future $f$.
+  When called, the function causes
   an immediate import $I'$ to be executed at some future time,
   where $I'$ is derived from $I_i$ by eliding the word \DEFERRED{}
   and adding a \HIDE{} \code{loadLibrary} combinator clause.
@@ -16612,32 +16526,32 @@ but will raise errors.%
 }
 
 \LMHash{}%
-After an invocation of \code{$p$.loadLibrary} succeeds,
+After an invocation of \code{$p$.loadLibrary()} succeeds,
 the name $p$ is mapped to a non-deferred prefix namespace,
 as described below.
-In addition, the prefix namespace also supports the \code{loadLibrary()} method,
-and so it is possible to call \code{$p$.loadLibrary} again.
+In addition, the prefix namespace also supports the \code{loadLibrary} function,
+and so it is possible to invoke \code{$p$.loadLibrary()} again.
 If a call fails, nothing happens,
-and one has the option to call \code{$p$.loadLibrary} again.
-Whether a repeated call to \code{$p$.loadLibrary} succeeds will vary,
+and one has the option to invoke \code{$p$.loadLibrary()} again.
+Whether a repeated call to \code{$p$.loadLibrary()} succeeds will vary,
 as described below.
 
 \LMHash{}%
-The effect of a repeated call to \code{$p$.loadLibrary} is as follows:
+The effect of a repeated invocation of \code{$p$.loadLibrary()} is as follows:
 \begin{itemize}
 \item
-  If another call to \code{$p$.loadLibrary} has already succeeded,
-  the repeated call also succeeds.
+  If another invocation of \code{$p$.loadLibrary()} has already succeeded,
+  the repeated invocation also succeeds.
   Otherwise,
 \item
-  If another call to \code{$p$.loadLibrary} has failed:
+  If another invocation of \code{$p$.loadLibrary()} has failed:
   \begin{itemize}
   \item
     If the failure is due to a compilation error,
-    the repeated call fails for the same reason.
+    the repeated invocation fails for the same reason.
   \item
     If the failure is due to other causes,
-    the repeated call behaves as if no previous call had been made.
+    the repeated invocation behaves as if no previous call had been made.
   \end{itemize}
 \end{itemize}
 
@@ -16645,7 +16559,7 @@ The effect of a repeated call to \code{$p$.loadLibrary} is as follows:
 In other words, one can retry a deferred load after a network failure
 or because a file is absent,
 but once one finds some content and loads it, one can no longer reload.
-We do not specify which object the future returned resolves to.
+We do not specify which object the future returned resolves to.%
 }
 \EndCase
 
@@ -16721,7 +16635,7 @@ A library $L$ exports a namespace (\ref{scoping}), meaning that
 the declarations in the namespace are made available to other libraries
 if they choose to import $L$ (\ref{imports}).
 The namespace that $L$ exports is known as its
-\IndexCustom{exported namespace}{namespace!exported}.
+\IndexCustom{exported namespace}{library!exported namespace of}.
 
 \LMHash{}%
 A library always exports all names and all declarations in its public namespace.
@@ -16741,17 +16655,7 @@ It is a compile-time error if the specified URI
 does not refer to a library declaration.
 
 \LMHash{}%
-We say that a name is \Index{exported by a library}
-(or equivalently, that a library
-\IndexCustom{exports a name}{exports!name})
-if the name is in the library's exported namespace.
-We say that a declaration \Index{is exported by a library}
-(or equivalently, that a library
-\IndexCustom{exports a declaration}{exports!declaration})
-if the declaration is in the library's exported namespace.
-
-\LMHash{}%
-The exported namespace of a library is then determined as follows, in two steps.
+The exported namespace of a library is determined as follows, in two steps.
 Let $L$ be a library,
 let \List{E}{1}{m} be the export directives of $L$,
 and let \List{L}{1}{m} be libraries
@@ -16771,67 +16675,27 @@ For each $i \in 1 .. m$,
 the namespace obtained from applying
 the namespace combinators of $E_i$ to
 the exported namespace of $L_i$
-(\ref{namespaceCombinators}).
+(\ref{namespaceCombinators}),
+and removing each binding of a name $n$ such that
+\NamespaceName{\metavar{public}} is defined at $n'$,
+and $n$ and $n'$ have the same basename.
+\commentary{So local declarations shadow re-exported ones.}
 
 \LMHash{}%
-In the second step we compute the
-\Index{namespace exported from}
-$L_i$, \NamespaceName{\metavar{export},i}.
-For each $i \in 1 .. m$,
-\NamespaceName{\metavar{export},i}
-is identical to \NamespaceName{\metavar{one},i},
-except that it is undefined at each name $n$ where
-\NamespaceName{\metavar{one},i} is defined
-and one of the following conditions hold:
-
-\begin{itemize}
-\item \NamespaceName{\metavar{public}} is defined at $n'$
-  such that $n$ and $n'$ have the same basename.
-  \commentary{%
-    In other words, a declaration in $L$ shadows re-exported declarations.
-    Import prefixes of $L$ are not exported, and do not shadow anything.%
-  }
-\item The first case does not apply,
-  there exists a $j \in 1 .. m$ and name $n'$ such that
-  \NamespaceName{\metavar{one},j} is defined at $n'$,
-  $n$ and $n'$ have the same basename,
-  \Namespace{\metavar{one},i}{n}
-  is a declaration in a system library,
-  and \Namespace{\metavar{one},j}{n'}
-  is a declaration in a non-system library.
-  \commentary{%
-    So a re-exported declaration from a non-system library shadows
-    re-exported declarations from system libraries.%
-  }
-  \rationale{%
-    See the discussion in section \ref{theImportedNamespace} for
-    the reasoning behind this rule.%
-  }
-\end{itemize}
-
-\commentary{%
-The removal of these bindings ensures that each exported namespace has a
-key set which is disjoint with that of \NamespaceName{\metavar{public}}.%
-}
+The
+\IndexCustom{namespace re-exported from}{library!namespace re-exported from}
+$L_i$ is \NamespaceName{\metavar{one},i}.
 
 \LMHash{}%
-Assume that $i$ and $j$ are numbers in $1 .. m$ and $n$ and $n'$ are names.
-It is a compile-time error if
-\NamespaceName{\metavar{export},i} is defined at $n$,
-\NamespaceName{\metavar{export},j} is defined at $n'$,
-$n$ and $n'$ have the same basename,
-\Namespace{\metavar{export},i}{n} and
-\Namespace{\metavar{export},j}{n'}
-are not the same declaration,
-and $L_i$ and $L_j$ are not the same library.
-% We need 'not the same library', i != j is not enough: See comment on the
-% corresponding case for step two above (search 'not the same library').
-
-\commentary{%
-This means that it is an error when two distinct exported declarations have
-the same basename,
-except when it is a getter and a setter from the same library.%
-}
+In the second step we compute the exported namespace of $L$.
+Let \NamespaceName{\metavar{merged}} be the result of applying
+conflict merging
+(\ref{conflictMergingOfNamespaces})
+to \List{\metavar{NS}}{\metavar{one},1}{\metavar{one},m}.
+A compile-time error occurs if any name in
+\NamespaceName{\metavar{merged}}
+is conflicted
+(\commentary{that is, the name is mapped to \ConflictValue}).
 
 \rationale{%
 This rule is more strict than the corresponding rule for imports:
@@ -16849,17 +16713,16 @@ and the maintainers of $L'$ may not be in a position to change $L$.%
 }
 
 \LMHash{}%
-Finally, the \Index{exported namespace} of $L$ is
-$\NamespaceName{\metavar{public}} \cup
-\NamespaceName{\metavar{export},1} \cup
-\ldots \NamespaceName{\metavar{export},m}$.
+The
+\IndexCustom{exported namespace}{library!exported namespace of}
+of $L$ is
+$\NamespaceName{\metavar{public}} \cup \NamespaceName{\metavar{merged}}$.
 
-\commentary{%
-Unions of namespaces are defined elsewhere
-(\ref{namespaceCombinators}).
-This union is well-defined because all these namespaces only share
-keys where they have the same value.%
-}
+\LMHash{}%
+We say that a name is \Index{exported by a library}
+if the name is in the library's exported namespace.
+We say that a declaration \Index{is exported by a library}
+if the declaration is in the library's exported namespace.
 
 \LMHash{}%
 For a given $i$,
@@ -16967,6 +16830,99 @@ Allowing this prevents situations where, e.g.,
 removing a declaration from a library $L$ would cause
 breakage in a library that imports $L$.%
 }
+
+
+\subsection{Conflict Merging of Namespaces}
+\LMLabel{conflictMergingOfNamespaces}
+
+\LMHash{}%
+In this section we define an operation on namespaces
+which eliminates certain bindings of names in case of name clashes,
+and keeps track of such name clashes using a special value,
+\Index{\ConflictValue}.
+
+\LMHash{}%
+When a name $n$ is mapped to \ConflictValue{} by a namespace,
+we say that $n$ is
+\IndexCustom{conflicted}{conflicted name}.
+A lookup for a conflicted name will succeed according to
+the normal rules for namespaces and lexical scoping,
+but it is a compile-time error at the location where the name is used
+that this name is conflicted.
+
+\LMHash{}%
+Let \List{\metavar{NS}}{1}{m} be a list of namespaces
+(\commentary{the list may or may not contain duplicates}).
+The
+\IndexCustom{conflict merging}{namespace!conflict merging}
+of \List{\metavar{NS}}{1}{m} is then
+$\NamespaceName{\metavar{conflict}} \cup
+\NamespaceName{\metavar{narrowed},1} \cup\,
+\ldots\ \NamespaceName{\metavar{narrowed},m}$,
+where the namespaces \NamespaceName{\metavar{conflict}} and
+\NamespaceName{\metavar{narrowed},i}, $i \in 1 .. m$,
+are specified as follows:
+
+\LMHash{}%
+\NamespaceName{\metavar{conflict}} is empty except for the
+bindings mentioned below.
+\NamespaceName{\metavar{narrowed},i} is identical to
+\NamespaceName{i}, $i \in 1 .. m$,
+except that the former is undefined at each name $n$ where
+the latter is defined,
+and one of the following conditions holds:
+
+\begin{itemize}
+\item There exists a $j \in 1 .. m$ and name $n'$ such that
+  \NamespaceName{j} is defined at $n'$,
+  $n$ and $n'$ have the same basename,
+  \Namespace{i}{n} is a declaration in a system library,
+  and \Namespace{j}{n'} is a declaration in a non-system library.
+  \commentary{%
+    So a declaration from a non-system library shadows
+    declarations from system libraries.%
+  }
+\item There exists a $j \in 1 .. m$ and name $n'$ such that
+  \NamespaceName{j} is defined at $n'$,
+  $n$ and $n'$ have the same basename,
+  \Namespace{i}{n} and \Namespace{j}{n'} are not the same declaration
+  and not a getter and a setter declared in the same library,
+  and either none or both of
+  \Namespace{i}{n} and \Namespace{j}{n'}
+  are declarations in a system library.
+  %
+  \commentary{%
+    So with two distinct declarations with the same basename,
+    both are eliminated,
+    except when it is a getter and a setter from the same library.%
+  }
+
+  In this situation $n$ is mapped to \ConflictValue{}
+  by \NamespaceName{\metavar{conflict}}.
+  \commentary{%
+    We can swap all names and use the rule again,
+    so $n'$ is also conflicted.%
+  }
+\end{itemize}
+
+\commentary{%
+In short, conflict merging takes a list of namespaces and produces
+a namespace that is the union of several disjoint namespaces
+(because all name clashes have been eliminated):
+A conflict namespace that records all unresolved name clashes,
+and a list of namespaces where clashing names have been removed.
+Some name clashes have been resolved by preferring
+declarations from non-system libraries
+over declarations from system libraries.%
+}
+
+\LMHash{}%
+It is useful to be able to refer to the result of narrowing.
+Let \List{\metavar{NS}}{1}{m} be a list of namespaces, $j \in 1 .. m$,
+and consider the conflict merging as specified above.
+The
+\IndexCustom{conflict narrowed namespace}{namespace!conflict narrowed}
+of \NamespaceName{j} is then \NamespaceName{\metavar{narrowed},j}.
 
 
 \subsection{Parts}

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -16203,8 +16203,15 @@ Since top level privates are not imported, using the top level privates of anoth
 }
 
 \LMHash{}%
-The \Index{public namespace} of library $L$ is the mapping that maps the simple name of each public top-level member $m$ of $L$ to $m$.
-The scope of a library $L$ consists of the names introduced by all top-level declarations declared in $L$, and the names added by $L$'s imports (\ref{imports}).
+The \Index{public namespace} of library $L$ is the mapping that maps
+the simple name of each public top-level member $m$ of $L$ to $m$.
+The \Index{local namespace} of library $L$ is the mapping that maps
+the names introduced by each top-level member of $L$
+as well as import prefixes
+(\ref{imports})
+and fresh names of extensions
+(\ref{extensions})
+to the corresponding declaration.
 
 
 \subsection{Imports}
@@ -16223,10 +16230,10 @@ the scope of another library.
 \end{grammar}
 
 \LMHash{}%
-Syntactically, an import specifies a URI $s$
-where the declaration of an imported library is to be found.
-The interpretation of URIs is described elsewhere
+The interpretation of configurable URIs is described elsewhere
 (\ref{uris}).
+An import specifies a URI $s$
+where the declaration of an imported library is to be found.
 It is a compile-time error if the specified URI of an import
 does not refer to a library declaration.
 
@@ -16240,7 +16247,7 @@ by the optional elements of the import.
 Imports may be deferred or immediate.
 A
 \IndexCustom{deferred import}{import!deferred}
-is distinguished by the appearance of
+is distinguished by the occurrence of
 the built-in identifier \DEFERRED{} after the URI.
 An
 \IndexCustom{immediate import}{import!immediate}
@@ -16326,8 +16333,8 @@ conflicts with the system libraries are treated specially.%
 }
 
 \LMHash{}%
-Let \NamespaceName{\metavar{local}} be the namespace that
-for each top-level declaration $D$ with name $n$ in $L$ maps $n$ to $D$.
+Let \NamespaceName{\metavar{local}} be the local namespace of $L$
+(\ref{librariesAndScripts}).
 An import with a prefix $p$ is included among these top-level declarations,
 and it causes $p$ to be mapped to a prefix object as described below.
 Let \List{I}{1}{m} be the import directives of $L$,
@@ -16778,10 +16785,10 @@ via \Index{export directives}, often referred to simply as \Index{exports}:
 \end{grammar}
 
 \LMHash{}%
+The interpretation of configurable URIs is described elsewhere
+(\ref{uris}).
 An export specifies a URI $s$
 where the declaration of an exported library is to be found.
-The interpretation of URIs is described elsewhere
-(\ref{uris}).
 It is a compile-time error if the specified URI
 does not refer to a library declaration.
 
@@ -16801,12 +16808,13 @@ Let $L$ be a library,
 let \List{E}{1}{m} be the export directives of $L$,
 and let \List{L}{1}{m} be libraries
 such that $E_i$ refers to $L_i$ for all $i \in 1 .. m$.
-Let \NamespaceName{\metavar{local}} be the namespace that
-for each public top-level declaration $D$ with name $n$ in $L$ maps $n$ to $D$.
-An import prefix
-(\ref{imports})
-does not introduce a binding in
-\NamespaceName{\metavar{local}}.
+Let \NamespaceName{\metavar{public}} be the public namespace of $L$
+(\ref{librariesAndScripts}).
+
+\commentary{%
+Note that private names and import prefixes are not present
+in \NamespaceName{\metavar{public}}.%
+}
 
 \LMHash{}%
 In the first step we compute the namespace provided by each exported library:
@@ -16829,7 +16837,7 @@ except that it is undefined at each name $n$ where
 and one of the following conditions hold:
 
 \begin{itemize}
-\item \NamespaceName{\metavar{local}} is defined at $n'$
+\item \NamespaceName{\metavar{public}} is defined at $n'$
   such that $n$ and $n'$ have the same basename.
   \commentary{%
     In other words, a declaration in $L$ shadows re-exported declarations.
@@ -16855,7 +16863,7 @@ and one of the following conditions hold:
 
 \commentary{%
 The removal of these bindings ensures that each exported namespace has a
-key set which is disjoint with that of \NamespaceName{\metavar{local}}.%
+key set which is disjoint with that of \NamespaceName{\metavar{public}}.%
 }
 
 \LMHash{}%
@@ -16894,7 +16902,7 @@ and the maintainers of $L'$ may not be in a position to change $L$.%
 
 \LMHash{}%
 Finally, the \Index{exported namespace} of $L$ is
-$\NamespaceName{\metavar{local}} \cup
+$\NamespaceName{\metavar{public}} \cup
 \NamespaceName{\metavar{export},1} \cup
 \ldots \NamespaceName{\metavar{export},m}$.
 


### PR DESCRIPTION
The PR #534 was blocked for a long time because of the worries about a breaking change. This PR is a manually rebased version of the same update, that is, it integrates the changes that were made to the updated sections (esp. 'Imports' and 'Exports') after #534 was created. (An actual `git rebase` was not helpful, because of all the conflicts).

The first version of this PR contains the manually rebased PR #534. The last commit includes responses to the partial review which was added to PR #534.