### PR TITLE
Clarify behavior of assignedIn() for initialized variables.

### DIFF
--- a/resources/type-system/flow-analysis.md
+++ b/resources/type-system/flow-analysis.md
@@ -203,14 +203,18 @@ The following functions associate flow models to nodes:
 
 - `assignedIn(S)`, where `S` is a `do`, `for`, `switch`, or `while` statement,
   or a `for` element in a collection, represents the set of variables assigned
-  to in the recurrent part of `S`, where the "recurrent" part of `S` is defined
-  as:
+  to in the recurrent part of `S`, not counting initializations of variables at
+  their declaration sites.  The "recurrent" part of `S` is defined as:
   - If `S` is a `do` or `while` statement, the entire statement `S`.
   - If `S` is a `for` statement or a `for` element in a collection, whose
     `forLoopParts` take the form of a traditional for loop, all of `S` except
     the `forInitializerStatement`.
   - If `S` is a `for` statement or a `for` element in a collection, whose
-    `forLoopParts` take the form of a for-in loop, the body of `S`.
+    `forLoopParts` take the form of a for-in loop, the body of `S`.  A loop of
+    the form `for (var x in ...) ...` is not considered to assign to `x`
+    (because `var x in ...` is considered an initialization of `x` at its
+    declaration site), but a loop of the form `for (x in ...) ...` (where `x` is
+    declared elsewhere in the function) *is* considered to assign to `x`.
   - If `S` is a `switch` statement, all of `S` except the switch `expression`.
 
 - `capturedIn(S)`, where `S` is a `do`, `for`, `switch`, or `while` statement,


### PR DESCRIPTION
This change, together with the corresponding implementation fix at
https://dart-review.googlesource.com/c/sdk/+/162581, fixes
https://github.com/dart-lang/sdk/issues/43136.