### PR TITLE
Clarify that `main` cannot be a getter

### DIFF
--- a/accepted/future-releases/nnbd/feature-specification.md
+++ b/accepted/future-releases/nnbd/feature-specification.md
@@ -6,6 +6,9 @@ Status: Draft
 
 ## CHANGELOG
 
+2020.10.05
+  - Clarify that `main` cannot be a getter.
+
 2020.09.10
   - Specify updates to super-bounded type rules for null safety.
 
@@ -1112,7 +1115,7 @@ The section 'Scripts' in the language specification is replaced by the
 following:
 
 Let _L_ be a library that exports a declaration _D_ named `main`.  It is a
-compile-time error unless _D_ is a function declaration.  It is a
+compile-time error unless _D_ is a non-getter function declaration.  It is a
 compile-time error if _D_ declares more than two required positional
 parameters, or if there are any required named parameters.  It is a
 compile-time error if _D_ declares at least one positional parameter, and


### PR DESCRIPTION
@johnniwinther just noted that the wording about errors on `main` introduced by https://github.com/dart-lang/language/pull/1146 needs to be clarified: It is not the intention that `main` can be a getter (and the old text says so explicitly in commentary), but the word `function` in the spec refers to "functions" (with a `<formalParameterPart>`) as well as setters, getters, and constructors.

In the context we already know that `main` is a top-level declaration, so it can't be a constructor. It can't be a setter because a setter name ends in `=`. So we just need to specify that it can't be a getter. This PR does that.