### PR TITLE
Add nnbd warning for cases like `C?.staticMethod()`

### DIFF
--- a/accepted/future-releases/nnbd/feature-specification.md
+++ b/accepted/future-releases/nnbd/feature-specification.md
@@ -6,6 +6,10 @@ Status: Draft
 
 ## CHANGELOG
 
+2020.10.05
+  - Specify that a null-aware static member access (e.g., `C?.staticMethod()`)
+    is a warning.
+
 2020.09.21
   - Specify that when a variable inferred from an initializer with intersection
     type is immediately promoted, the intersection type is a type of interest.
@@ -626,8 +630,9 @@ does not occur in any of the ways specified in
 [this list](https://github.com/dart-lang/language/blob/780cd5a8be92e88e8c2c74ed282785a2e8eda393/specification/dartLangSpec.tex#L18238).
 *This implies that `void*` is treated the same as `void`.*
 
-It is a warning to use a null aware member access (`?.`, `?..`) whose receiver
-is a type literal. *E.g., `C?.staticMethod()` is a warning.*
+Let `C` be a type literal denoting a class, mixin, or extension. It is a warning
+to use a null aware member access with receiver `C`. *E.g., `C?.staticMethod()` 
+is a warning.*
 
 It is a warning to use a null aware operator (`?.`, `?[]`, `?..`, `??`, `??=`, or
 `...?`) on an expression of type `T` if `T` is **strictly non-nullable**.

--- a/accepted/future-releases/nnbd/feature-specification.md
+++ b/accepted/future-releases/nnbd/feature-specification.md
@@ -626,6 +626,9 @@ does not occur in any of the ways specified in
 [this list](https://github.com/dart-lang/language/blob/780cd5a8be92e88e8c2c74ed282785a2e8eda393/specification/dartLangSpec.tex#L18238).
 *This implies that `void*` is treated the same as `void`.*
 
+It is a warning to use a null aware member access (`?.`, `?..`) whose receiver
+is a type literal. *E.g., `C?.staticMethod()` is a warning.*
+
 It is a warning to use a null aware operator (`?.`, `?[]`, `?..`, `??`, `??=`, or
 `...?`) on an expression of type `T` if `T` is **strictly non-nullable**.
 


### PR DESCRIPTION
When `T` is a type literal denoting a class, mixin, or extension `C` (`T` could be `C` or `p.C`), `T.m()` will invoke the static method `m` declared by `C`. In that case `T?.m()` was previously equivalent to `T.m()` and caused no diagnostic messages. This PR changes it to be a warning.

This was discussed by mail in May-June ('ClassName?.foo diagnostics'), but apparently hasn't yet been specified.