### PR TITLE
Specify that null shorting does not include operators

### DIFF
--- a/accepted/future-releases/nnbd/feature-specification.md
+++ b/accepted/future-releases/nnbd/feature-specification.md
@@ -1362,6 +1362,24 @@ continuation.
   - A list literal `[e1, ..., en]` translates to `TERM[ [EXP(e1), ..., EXP(en)] ]`
   - A parenthesized expression `(e)` translates to `TERM[(EXP(e))]`
 
+The language specification specifies that an invocation of any of several
+operators is considered equivalent to a member access (this applies to
+relational expressions, bitwise expressions, shift expressions, additive
+expressions, multiplicative expressions, and unary expressions).
+
+*For example, `a + b` is specified as equivalent to `a.plus(b)`,
+where `plus` is assumed to be a method with the same behavior as `+`.
+Similarly, `-e` is equivalent to `e.unaryMinus()`.*
+
+This equivalence is not applicable in the above rules, so operators not
+mentioned specifically in a rule are handled in the case for 'other'
+expressions, not in the case for `e.m(args)`.
+
+*This means that null-shorting stops at operators. For instance, `e?.f + b`
+is a compile-time error because `e?.f` can be null, it is not an expression
+where both `.f` and `+ b` will be skipped if `e` is null.  Similarly, both
+`-a?.f` and `~a?.f` is an error, it does not null-short like `a?.f.op()`.*
+
 ### Late fields and variables
 
 A non-local `late` variable declaration _D_ implicitly induces a getter

--- a/accepted/future-releases/nnbd/feature-specification.md
+++ b/accepted/future-releases/nnbd/feature-specification.md
@@ -6,6 +6,10 @@ Status: Draft
 
 ## CHANGELOG
 
+2020.10.09
+  - Clarify that operators not mentioned explicitly in the rules
+    do not participate in the null-shorting transformation.
+
 2020.10.05
   - Specify that a null-aware static member access (e.g., `C?.staticMethod()`)
     is a warning.
@@ -1375,10 +1379,11 @@ This equivalence is not applicable in the above rules, so operators not
 mentioned specifically in a rule are handled in the case for 'other'
 expressions, not in the case for `e.m(args)`.
 
-*This means that null-shorting stops at operators. For instance, `e?.f + b`
-is a compile-time error because `e?.f` can be null, it is not an expression
-where both `.f` and `+ b` will be skipped if `e` is null.  Similarly, both
-`-a?.f` and `~a?.f` is an error, it does not null-short like `a?.f.op()`.*
+*This means that the null-shorting transformation stops at operators. For
+instance, `e?.f + b` is a compile-time error because `e?.f` can be null, it is
+not an expression where both `.f` and `+ b` will be skipped if `e` is null.
+Similarly, both `-a?.f` and `~a?.f` is an error, it does not null-short like
+`a?.f.op()`.*
 
 ### Late fields and variables
 

--- a/accepted/future-releases/nnbd/feature-specification.md
+++ b/accepted/future-releases/nnbd/feature-specification.md
@@ -1382,7 +1382,7 @@ expressions, not in the case for `e.m(args)`.
 *This means that the null-shorting transformation stops at operators. For
 instance, `e?.f + b` is a compile-time error because `e?.f` can be null, it is
 not an expression where both `.f` and `+ b` will be skipped if `e` is null.
-Similarly, both `-a?.f` and `~a?.f` is an error, it does not null-short like
+Similarly, both `-a?.f` and `~a?.f` are errors, and do not null-short like
 `a?.f.op()`.*
 
 ### Late fields and variables


### PR DESCRIPTION
Cf. #1081, this PR updates the null-safety spec of null shorting to say that it does _not_ use the equivalence between operator invocations and method invocations that the language specification specifies.

For instance `-e` is specified as equivalent to `e.unaryMinus()` (for a suitable declaration of method `unaryMinus`), and similarly for `e1 + e2` respectively `e1.plus(e2)`.

The tools already treat operators in this manner, so there are no implementation issues.