### PR TITLE
Clarify conflict merging

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -17010,8 +17010,8 @@ and one of the following conditions holds:
 \item Otherwise, there exists a $j \in 1 .. m$ and name $n'$ such that
   \NamespaceName{j} is defined at $n'$,
   $n$ and $n'$ have the same basename,
-  \Namespace{i}{n} and \Namespace{j}{n'} are declarations
-  that are not the same declaration
+  \Namespace{i}{n} and \Namespace{j}{n'} are not the same declaration
+  and not the same namespace
   and not a getter and a setter declared in the same library,
   and either none or both of
   \Namespace{i}{n} and \Namespace{j}{n'}
@@ -17032,17 +17032,6 @@ and one of the following conditions holds:
 \end{itemize}
 
 \commentary{%
-Note that the case where \NamespaceName{i} is a prefix namespace,
-that is, \Namespace{i}{n} is a namespace,
-never causes a conflict:
-If \Namespace{j}{n'} is a namespace then $n$ is equal to $n'$
-and the namespace \Namespace{i}{n} is equal to the namespace \Namespace{j}{n'},
-so there is no conflict.
-The case where \Namespace{i}{n} is a namespace
-and \Namespace{j}{n'} is a declaration cannot occur,
-because conflict merging is only used
-when imported declarations have already been shadowed by import prefixes.
-
 In short, conflict merging takes a list of namespaces and produces
 a namespace that is the union of several disjoint namespaces
 (because all name clashes have been eliminated):

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -17010,7 +17010,8 @@ and one of the following conditions holds:
 \item Otherwise, there exists a $j \in 1 .. m$ and name $n'$ such that
   \NamespaceName{j} is defined at $n'$,
   $n$ and $n'$ have the same basename,
-  \Namespace{i}{n} and \Namespace{j}{n'} are not the same declaration
+  \Namespace{i}{n} and \Namespace{j}{n'} are declarations
+  that are not the same declaration
   and not a getter and a setter declared in the same library,
   and either none or both of
   \Namespace{i}{n} and \Namespace{j}{n'}
@@ -17019,10 +17020,7 @@ and one of the following conditions holds:
   \commentary{%
     So with two distinct declarations with the same basename,
     both are eliminated,
-    except when it is a getter and a setter from the same library.
-    Note that \Namespace{i}{n} and \Namespace{j}{n'} must be declarations,
-    because conflict merging is never applied to namespaces
-    where a shared key is an import prefix.%
+    except when it is a getter and a setter from the same library.%
   }
 
   In this situation $n$ is mapped to \ConflictValue{}
@@ -17034,6 +17032,17 @@ and one of the following conditions holds:
 \end{itemize}
 
 \commentary{%
+Note that the case where \NamespaceName{i} is a prefix namespace,
+that is, \Namespace{i}{n} is a namespace,
+never causes a conflict:
+If \Namespace{j}{n'} is a namespace then $n$ is equal to $n'$
+and the namespace \Namespace{i}{n} is equal to the namespace \Namespace{j}{n'},
+so there is no conflict.
+The case where \Namespace{i}{n} is a namespace
+and \Namespace{j}{n'} is a declaration cannot occur,
+because conflict merging is only used
+when imported declarations have already been shadowed by import prefixes.
+
 In short, conflict merging takes a list of namespaces and produces
 a namespace that is the union of several disjoint namespaces
 (because all name clashes have been eliminated):

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -17025,7 +17025,9 @@ and one of the following conditions holds:
     must both be declarations or must both be namespaces,
     because conflict merging is applied to namespaces where
     imported declarations that conflict with an import prefix
-    have already been eliminated.%
+    have already been eliminated.
+    When they are both namespaces there is no conflict,
+    because it is then the same namespace.%
   }
 
   In this situation $n$ is mapped to \ConflictValue{}

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -16601,7 +16601,7 @@ as defined previously
 \NamespaceName{\metavar{deferred}} then has the following bindings:
 
 \begin{itemize}
-\item The name \code{loadLibrary} is bound to 
+\item The name \code{loadLibrary} is bound to
   a function with signature \code{Future<\VOID> loadLibrary()}.
   This function returns a future $f$.
   When called, the function causes
@@ -17020,7 +17020,12 @@ and one of the following conditions holds:
   \commentary{%
     So with two distinct declarations with the same basename,
     both are eliminated,
-    except when it is a getter and a setter from the same library.%
+    except when it is a getter and a setter from the same library.
+    Note that \Namespace{i}{n} and \Namespace{j}{n'}
+    must both be declarations or must both be namespaces,
+    because conflict merging is applied to namespaces where
+    imported declarations that conflict with an import prefix
+    have already been eliminated.%
   }
 
   In this situation $n$ is mapped to \ConflictValue{}


### PR DESCRIPTION
Thanks for all the hard work on 1161! Here's a follow-up, clarifying that conflict merging never considers import prefixes as conflicted.