### PR TITLE
Little script to extract the spec's grammar as plaintext.

### DIFF
--- a/tools/plaintext_grammar.dart
+++ b/tools/plaintext_grammar.dart
@@ -1,0 +1,68 @@
+import 'dart:io';
+
+/// Reads the "dartLangSpec.tex" and prints out all of the grammar rules it
+/// contains as plaintext.
+
+/// Matches Tex keyword references like:
+///
+///     \LATE
+///     \FINAL{}
+final keywordRegExp = RegExp(r'\\([A-Z]+)(\{\})?');
+
+/// Matches non-terminals like:
+///
+///     <declaredIdentifier>
+final ruleRegExp = RegExp(r'<(\w+)>');
+
+void main(List<String> arguments) {
+  if (arguments.isEmpty) {
+    print("Usage: dart plaintext_grammar.dart <path to dartLangSpec.tex>");
+    exit(1);
+  }
+
+  var specFile = File(arguments[0]);
+
+  var inGrammar = false;
+  for (var line in specFile.readAsLinesSync()) {
+    line = line.trimRight();
+
+    if (line == r'\begin{grammar}') {
+      inGrammar = true;
+    } else if (line == r'\end{grammar}') {
+      print('');
+      inGrammar = false;
+    } else if (inGrammar) {
+      line = line
+          .replaceAll('`', "'")
+          .replaceAll(r'\alt', '|')
+          .replaceAll(r' \gnewline{}', '')
+          .replaceAll(r'\gtilde{}', '~')
+          .replaceAll(r'\_', '_')
+          .replaceAll(r'\{', '{')
+          .replaceAll(r'\}', '}')
+          .replaceAll(r'\&', '&')
+          .replaceAll(r'\%', '%')
+          .replaceAll(r'\gtgtgt', '>>>')
+          .replaceAll(r'\gtgt', '>>')
+          .replaceAll(r'\ltltlt', '<<<')
+          .replaceAll(r'\ltlt', '<<')
+          .replaceAll(r'\\b', r'\b')
+          .replaceAll(r'\\f', r'\f')
+          .replaceAll(r'\\n', r'\n')
+          .replaceAll(r'\\r', r'\r')
+          .replaceAll(r'\\t', r'\t')
+          .replaceAll(r'\\u', r'\u')
+          .replaceAll(r'\\v', r'\v')
+          .replaceAll(r'\\x', r'\x')
+          .replaceAll(r'\sqsqsq', r"\'\'\'")
+          .replaceAll(r'\sqsq', r"\'\'")
+          .replaceAll(r'\sq', r"\'")
+          .replaceAll(r'\\', r'\')
+          .replaceAll('<NEWLINE>', "'\\n'")
+          .replaceAllMapped(
+              keywordRegExp, (match) => "'${match[1]!.toLowerCase()}'")
+          .replaceAllMapped(ruleRegExp, (match) => match[1]!);
+      print(line);
+    }
+  }
+}

--- a/tools/plaintext_grammar.dart
+++ b/tools/plaintext_grammar.dart
@@ -58,7 +58,7 @@ void main(List<String> arguments) {
           .replaceAll(r'\sqsq', r"\'\'")
           .replaceAll(r'\sq', r"\'")
           .replaceAll(r'\\', r'\')
-          .replaceAll('<NEWLINE>', "'\\n'")
+          .replaceAll(r'\FUNCTION{}', "'Function'")
           .replaceAllMapped(
               keywordRegExp, (match) => "'${match[1]!.toLowerCase()}'")
           .replaceAllMapped(ruleRegExp, (match) => match[1]!);


### PR DESCRIPTION
When working on Markdown feature specs, I end up copying pieces of the grammar out of the spec. In Chrome, it ends up putting `h` before and after every grammar rule and does some other weird stuff. I got tired of fixing that up manually every time, so this little script extracts all of the grammar rules from the spec, cleans them up, and prints them out.

Kind of hacky, but it seems to work. :)

cc @leafpetersen @lrhn 