### PR TITLE
Add missing word

### DIFF
--- a/working/0546-patterns/patterns.md
+++ b/working/0546-patterns/patterns.md
@@ -351,7 +351,7 @@ printGeometry(Geometry geometry) {
 
 Here, the outer `Point(...)` pattern is a matcher that does a type test to see
 if `geometry` is a Point. If it is not, it simply proceeds to the next case. If
-`geometry` is a point, the `Point(...)` patterns destructures the value and
+`geometry` is a point, the inner `Point(...)` patterns destructures the value and
 evaluates its two subpatterns. The `var x` and `var y` patterns are *bind
 matchers* that hop over to the bind category to bind variables. A bind matcher
 is a special kind of matcher that contains a binder as a subpattern. This lets


### PR DESCRIPTION
@munificent This paragraph starts out confusing to me, since you use `Point(...)` in 2 places, but I think you're trying to differentiate them by using the word `outer` for the matcher, but maybe you missed `inner` for the binder?