### PR TITLE
Fix LaTeX issue that has emerged recently

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -7850,7 +7850,9 @@ also called an \NoIndex{object sequence} when no ambiguity can arise.
 
 \LMHash{}%
 We use the notation
-\IndexCustom{\LiteralSequence{\ldots}}{[[...]]@\LiteralSequence{\ldots}}
+% `\LiteralSequence` cannot be used after `@`, so we use an approximation.
+\IndexCustom{\LiteralSequence{\ldots}}{[[...]]@%
+  \ensuremath{[\hspace{-0.6mm}[\ldots]\hspace{-0.6mm}]}}
 to denote an object sequence with explicitly listed elements,
 and we use `$+$' to compute the concatenation of object sequences
 (\commentary{as in $s_1 + s_2$}),


### PR DESCRIPTION
Generation of a PDF from dartLangSpec.tex fails today, and it fails for earlier versions of dartLangSpec.tex a long way back (at least a year). The failure is a low-level TeX failure, and it seems likely that it has emerged because the underlying LaTeX source was updated.

It couldn't possibly have occurred for all those versions of dartLangSpec.tex during this year, because we have been able to fetch a PDF from https://dart.dev/guides/language/spec all the time, and we've also been able to generate the PDF locally.

The problem is that we can't use `\LiteralSequence{...}` in a `\IndexCustom` after a `@`, apparently because it uses `\!`. This CL changes the offending occurrence of `\IndexCustom` to achieve almost the same thing as `\LiteralSequence{...}` using an `\hspace{}`.

I think it's better to fix the single occurrence in the index (which is at a specific font size), and keep using `\!` in `\LiteralSequence`. We could also change `\LiteralSequence` to use `\hspace` rather than `\!`, such that we use `\hspace` everywhere for a literal sequence. However, I think this would be rather brittle because it is difficult to make a `\hspace` of the proper size in math mode in different contexts.
