### PR TITLE
Small-features-21Q1 fix: Allow generic functions as bounds

### DIFF
--- a/accepted/future-releases/triple-shift-operator/implementation-plan.md
+++ b/accepted/future-releases/triple-shift-operator/implementation-plan.md
@@ -28,9 +28,9 @@ The language specification is already updated with this feature.
 ### Phase 1 (Implementation)
 
 All tools implement syntactic support for the `>>>` operator.
-The syntax is guarded by the experiments flag `tripple-shift`,
+The syntax is guarded by the experiments flag `triple-shift`,
 so to enable the syntax, the tools need to be passed a flag
-like `--enable-experiments=tripple-shift`.
+like `--enable-experiments=triple-shift`.
 
 This also includes all derived syntax required by the specification, 
 including the `>>>=` assignment oprator and the `#>>>` symbol.


### PR DESCRIPTION
The small-features-21Q1 spec includes the feature described in #496, except that it does not mention generic function types used as bounds. I think we should include bounds: There is a need to specify a generic function type as a bound if a particular type variable is intended to have a value which is a generic function type, e.g., in order to know how many type arguments to pass in invocations.

```dart
class C<F extends void Function<X>(X)> {
  F f;
  C(this.f);
  void m() { f<int>(42); }
}

class D<F extends void Function<X>(X, [List<X>?]) extends C<X> {...}
```

Also, this PR fixes a typo `tripple-shift` --> `triple-shift`.
