### PR TITLE
Add/clarify type alias errors in specification

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -19654,7 +19654,7 @@ otherwise $T_j$ is $T_j?$.
 This means that the older forms allow for a parameter type to be omitted,
 in which case it is taken to be \DYNAMIC,
 but the parameter name cannot be omitted.
-This rule is error prone,
+This behavior is error prone,
 and hence the newer form (with \lit{=}) is recommended.
 For instance, the declaration \code{\TYPEDEF{} $F$(int);}
 specifies that $F$ denotes the type
@@ -19677,35 +19677,6 @@ When such a type alias has type parameters,
 it always expresses a family of non-generic function types.
 These restrictions exist because that syntax was defined
 before generic functions were added to Dart.%
-}
-
-\LMHash{}%
-A type alias $F$ can be used to invoke static methods of the denoted class.
-
-\begin{dartCode}
-\CLASS{} C<X> \{
-  static void staticMethod() \{\}
-\}
-\\
-\TYPEDEF{} F = C<int>;
-\\
-\VOID{} main() \{
-  F.staticMethod(); // \comment{OK.}
-\}
-\end{dartCode}
-
-\rationale{%
-This indirectly allows an invocation of a static method to pass
-a list of actual type arguments to the class.
-This is currently an error when it occurs directly
-(e.g., \code{List<int>.castFrom(xs)}).
-But it may be part of a future language extension to allow
-static methods to use the type parameters declared by the enclosing class,
-in which case both the direct and indirect approach will be allowed.
-At that time,
-existing invocations where type arguments are passed indirectly will not break,
-because it is currently an error for a static method to depend on the value
-of a formal type parameter of the enclosing class.%
 }
 
 \LMHash{}%
@@ -19779,22 +19750,91 @@ of $U$.
 \commentary{%
 Note that the transitive alias expansion exists,
 because it is an error for a type alias declaration
-to depend on itself.%
+to depend on itself.
+However, it may be large.
+For instance, \code{\TYPEDEF{} $F$<$X$> = Map<$X$, $X$>;} yields
+an exponential size increase for \code{$F$<$F$<\ldots$F$<int>\ldots{}>{}>}.%
 }
 
 \LMHash{}%
+\BlindDefineSymbol{D, F, T}%
 Let $D$ be a type alias declaration of the form
 
 \noindent
 \code{\TYPEDEF{} $F$<\TypeParametersStd> = $T$;}
 
 \noindent
-We say that $D$
-\NoIndex{expands to a type variable}
-if the transitive alias expansion of $T$ is $X_j$ for some $j \in 1 .. s$.
+and let \DefineSymbol{U} be a parameterized type of the form
+\code{$F$<\List{U}{1}{s}>}
+in a scope where $F$ denotes $D$.
+Assume that the transitive alias expansion of $U$ is
+a type of the form $C$ or \code{$p$.$C$}
+where $C$ is an identifier denoting a class or mixin,
+and $p$ is an identifier denoting an import prefix,
+optionally followed by \synt{typeArguments}.
+Assume that $U$ occurs in an expression $e$ of the form
+`\code{$U$.\id\;\metavar{args}}'
+where \metavar{args} is derived from \syntax{<argumentPart>?},
+such that \id{} is the name of
+a static member of $C$ respectively \code{$p$.$C$}.
+The expression $e$ is then treated as
+`\code{$C$.\id\;\metavar{args}}'
+respectively
+`\code{$p$.$C$.\id\;\metavar{args}}'.
+
+\commentary{%
+This means that it is possible to use a type alias
+to invoke a static member of a class or a mixin.
+For example:%
+}
+
+\begin{dartCode}
+\CLASS{} C<X> \{
+  static void staticMethod() \{\}
+\}
+\\
+\TYPEDEF{} F = C<int>;
+\\
+\VOID{} main() \{
+  F.staticMethod(); // \comment{OK.}
+\}
+\end{dartCode}
+
+\rationale{%
+Note that the type arguments passed to $C$ respectively \code{$p$.$C$}
+are erased,
+such that the resulting expression can be a correct static member invocation.
+If a future version of Dart allows type arguments to be passed via the class
+in an invocation of a static member,
+it may be preferable to preserve these type arguments.
+At that time,
+existing invocations where type arguments are passed in this manner
+will not break,
+because it is currently an error for a static member to depend on the value
+of a formal type parameter of the enclosing class.%
+}
 
 \LMHash{}%
+\BlindDefineSymbol{D, F, X_j, B_j}%
+Let $D$ be a type alias declaration of the form
+
+\noindent
+\code{\TYPEDEF{} $F$<\TypeParametersStd> = $T$;}
+
+\noindent
+\BlindDefineSymbol{Y_j}%
+Let \List{Y}{1}{s} be fresh type variables,
+assumed to satisfy the bounds of $D$.
+We say that $D$
+\NoIndex{expands to a type variable}
+if the transitive alias expansion of
+\code{$F$<\List{Y}{1}{s}>}
+is $Y_j$ for some $j \in 1 .. s$.
+
+\LMHash{}%
+\BlindDefineSymbol{T, F, D}%
 Let $T$ be a parameterized type \code{$F$<\List{T}{1}{s}>}
+(where $s$ can be zero)
 in a scope where $F$ denotes a type alias declaration $D$.
 We say that $T$
 \IndexCustom{uses $D$ as a class}{type alias!used as a class}
@@ -19803,11 +19843,17 @@ when $T$ occurs in one of the following ways:
 \begin{itemize}
 \item
   $T$ occurs in an instance creation expression of the form
-  \code{$T$(\ldots)} or the form \code{$T$.\id(\ldots)}
-  (\ref{instanceCreation}), or of the same forms with \NEW{} or
-  \CONST{} prepended.
+  \code{$nc$ $T$(\ldots)} or the form \code{$nc$ $T$.\id(\ldots)},
+  where $nc$ is either \NEW{} or \CONST{}
+  (\ref{instanceCreation}).
+  \commentary{%
+    Note that, e.g., \code{$T$(42)} may be an instance creation,
+    but it is then treated as \code{\NEW{} $T$(42)} or \code{\CONST{} $T$(42)},
+    which means that it is included here
+    (\ref{unqualifiedInvocation}).%
+  }
 \item
-  $T$ or \code{$T$.\id} is the redirectee in a redirecting factory constructor
+  $T$ or \code{$T$.\id} is the redirectee in a redirecting factory constructor,
   (\ref{redirectingFactoryConstructors}).
 \item
   $T$ is used as a superclass, a mixin, or a superinterface
@@ -19818,17 +19864,12 @@ when $T$ occurs in one of the following ways:
   % It is OK to use it as the \ON{} type of an extension declaration:
   % In that position it is used as a type, not as a class.
 \item
-  $T$ is used in an expression of the form `\code{$T$.\id\;\metavar{args}}'
-  where \metavar{args} is derived from \syntax{<argumentPart>?}.
-
-  \commentary{%
-    This is the situation where the type alias is used to invoke
-    a static getter or a static method.%
-  }
+  $T$ is used to invoke a static member of a class or mixin,
+  as described above.
 \end{itemize}
 
 \LMHash{}%
-A compile-time error occurs if $D$ expands to a type variable
+A compile-time error occurs if $D$ expands to a type variable,
 and $T$ uses $D$ as a class.
 A compile-time error occurs if $T$ uses $D$ as a class,
 and $T$ is not regular-bounded.
@@ -19837,11 +19878,13 @@ and $T$ is not regular-bounded.
 \begin{dartCode}
 \CLASS{} C<X extends num> \{\}
 \TYPEDEF{} F<Y extends int> = C<Y>;
+\TYPEDEF{} G<Z> = Z;
 \\
 \VOID{} main() \{
   F<int>(); // \comment{OK.}
   C<num>(); // \comment{OK.}
   F<num>(); // \comment{Error.}
+  G<C<int>{}>(); // \comment{Error.}
 \}
 \end{dartCode}
 

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -6619,111 +6619,14 @@ Otherwise, said parameterized type \code{$C$<$T_1, \ldots,\ T_m$>} denotes an ap
 This yields a class $C'$ whose members are equivalent to those of a class declaration which is obtained from the declaration $G$ by replacing each occurrence of $X_j$ by $T_j$.
 
 \commentary{%
-% TODO(eernst): make sure this list of properties is complete.
 Other properties of $C'$ such as the subtype relationships
 are specified elsewhere
 (\ref{subtypes}).%
 }
 
-\LMHash{}%
-A \IndexCustom{generic type alias}{type alias!generic}
-is a declaration $D$ of one of the following forms:
-
-\begin{itemize}
-\item \code{$m$ \TYPEDEF{} \id<\TypeParametersStd> = $T$;}
-\item \code{$m$ \TYPEDEF{} $S$?\ \id<\TypeParametersStd>(\\
-  \mbox\quad\PairList{T}{p}{1}{n},\ [\PairList{T}{p}{n+1}{n+k}]);}
-\item \code{$m$ \TYPEDEF{} $S$?\ \id<\TypeParametersStd>(\\
-  \mbox\quad\PairList{T}{p}{1}{n},\ \{\PairList{T}{p}{n+1}{n+k}\});}
-\end{itemize}
-
-\noindent
-where $m$ is derived from \synt{metadata},
-$T$ is a type,
-and \code{$S$?} is a type or the empty string.
-Let $S'$ be \code{$S$?} if it is a type, otherwise let $S'$ be \DYNAMIC.
-The associated type of $D$, call it $F$, is, respectively:
-
-\begin{itemize}
-\item $T$
-\item \FunctionTypeSimple{S'}{\FunctionTypePositionalArgumentsStd}
-\item \FunctionTypeSimple{S'}{\FunctionTypeNamedArgumentsStd}
-\end{itemize}
-
-\LMHash{}%
-$D$ introduces a mapping from actual type argument lists to types.
-Under the assumption that \List{X}{1}{s} are types such that
-$X_j <: B_j$, for all $j \in 1 .. s$,
-it is a compile-time error if $T$ is not regular-bounded,
-and it is a compile-time error if any type occurring in $T$ is not well-bounded.
-
 \commentary{%
-This means that the bounds declared for
-the formal type parameters of a generic type alias
-must be such that when they are satisfied,
-the bounds that pertain to the body are also satisfied,
-and a type occurring as a subterm of the body can violate its bounds,
-but only if it is a correct super-bounded type.%
-}
-
-\LMHash{}%
-Moreover,
-let $T_1,\ \ldots,\ T_l$ be types
-and let $U$ be the parameterized type \code{\id<$T_1, \ldots,\ T_l$>}
-in a location where \id{} denotes $D$.
-It is a compile-time error if $l \not= s$.
-It is a compile-time error if $U$ is not well-bounded
-(\ref{superBoundedTypes}).
-
-\LMHash{}%
-Otherwise,
-$U$ denotes an application of the mapping denoted by $D$ to the type arguments
-$T_1, \ldots, T_s$,
-yielding the type
-$[T_1/X_1, \ldots, T_s/X_s]F$.
-
-\commentary{%
-Note that the type alias syntax without \lit{=}
-can only express function types,
-and it cannot express the type of a generic function.
-When such a type alias is generic,
-it always expresses a family of non-generic function types.
-These restrictions exist because that syntax was defined
-before generic functions were added to Dart.%
-}
-
-\rationale{%
-The requirement that satisfaction of the bounds on
-the formal type parameters of a generic type alias $D$
-must imply satisfaction of all bounds pertaining to
-every type that occurs in the body of $D$
-limits the expressive power of generic type aliases.
-However, it would require the constraints on formal type parameters
-to be expressed in a much more powerful language
-if we were to allow a significantly larger set of types
-to be expressed using a generic type alias.%
-}
-
-\commentary{%
-For example, consider the following code:%
-}
-
-\begin{dartCode}
-\CLASS{} A<X \EXTENDS{} \VOID{} \FUNCTION(num)> \{\}
-\TYPEDEF{} F<Y> = A<\VOID{} \FUNCTION(Y)> \FUNCTION(); // \comment{compile-time error}
-\end{dartCode}
-
-\commentary{%
-There is no way to specify a bound on \code{Y} in the declaration of \code{F}
-which will ensure that all bounds on the right hand side are respected.
-This is because the actual requirement is that \code{Y} must be
-a \emph{supertype} of \code{num},
-but Dart does not support lower bounds for type parameters.
-The type \code{A<\VOID{} \FUNCTION(U)> \FUNCTION()}
-can still be specified explicitly
-for every \code{U} which satisfies the bounds declared by \code{A}.
-So the types can be expressed,
-they just cannot be abbreviated using a generic type alias.%
+Generic type aliases are specified elsewhere
+(\ref{typedef}).%
 }
 
 \LMHash{}%
@@ -19631,19 +19534,15 @@ A constant type literal is a constant expression (\ref{constants}).%
 \LMLabel{typedef}
 
 \LMHash{}%
-A \Index{type alias} declares a name for a type expression.
+A \Index{type alias} declares a name for a type,
+or for a mapping from type arguments to types.
 
 \commentary{%
 It is common to use the phrase ``a typedef'' for such a declaration,
 because of the prominent occurrence of the token \TYPEDEF.%
 }
 
-% TODO(eernst): We include <metadata> in <typeAlias> even though it is not
-% there in Dart.g, because <libraryDeclaration> in Dart.g allows metadata
-% before every <topLevelDeclaration>, but that's not yet been transferred to
-% this document. So we'll need to remove the <metadata> below _when_ it is
-% made redundant by changing <libraryDeclaration> to be like in Dart.g.
-
+%%TODO(eernst): With null safety, change <functionType> to <type>.
 \begin{grammar}
 <typeAlias> ::= \gnewline{}
   \TYPEDEF{} <typeIdentifier> <typeParameters>? `=' <functionType> `;'
@@ -19655,42 +19554,131 @@ because of the prominent occurrence of the token \TYPEDEF.%
 \end{grammar}
 
 \LMHash{}%
-The effect of a type alias of the form
-\code{\TYPEDEF{} \id{} = $T$;}
-declared in a library $L$ is to introduce the name \id{} into the scope of $L$,
-bound to the type $T$.
-
-\LMHash{}%
-The effect of a type alias of the form
+Consider a type alias declaration $D$ of the form
 
 \noindent
-\code{\TYPEDEF{} $T$ \id($T_1\ p_1, \ldots,\ T_n\ p_n,\ [T_{n+1}\ p_{n+1}, \ldots,\ T_{n+k}\ p_{n+k}]$);}
+\code{\TYPEDEF{} \id<\TypeParametersStd> = $T$;}
 
 \noindent
-declared in a library $L$ is to introduce the name \id{} into the scope of $L$, bound to the function type
-\FunctionTypeSimple{T}{\List{T}{1}{n},\ [\List{T}{n+1}{n+k}]}.
+declared in a library $L$.
+The effect of $D$ is to introduce \id{} into the library scope of $L$.
+When $s = 0$
+(\commentary{where the type alias is non-generic})
+\id{} is bound to $T$.
+When $s > 0$
+(\commentary{where the type alias is generic})
+\id{} is bound to a mapping from a type argument list
+\List{U}{1}{s}
+to the type
+$[U_1/X_1, \ldots, U_s/X_s]T$.
 
 \LMHash{}%
-The effect of a type alias of the form
+Under the assumption that \List{X}{1}{s} are types such that
+$X_j <: B_j$, for all $j \in 1 .. s$,
+it is a compile-time error if $T$ is not regular-bounded,
+and it is a compile-time error if any type occurring in $T$ is not well-bounded.
+
+\commentary{
+This means that the bounds declared for
+the formal type parameters of a generic type alias
+must be such that when they are satisfied,
+the bounds that pertain to the body are also satisfied,
+and a type occurring as a subterm of the body can violate its bounds,
+but only if it is a correct super-bounded type.
+}
+
+\LMHash{}%
+Moreover,
+let $T_1,\ \ldots,\ T_l$ be types
+and let $U$ be the parameterized type \code{\id<$T_1, \ldots,\ T_l$>}
+in a location where \id{} denotes $D$.
+It is a compile-time error if $l \not= s$.
+It is a compile-time error if $U$ is not well-bounded
+(\ref{superBoundedTypes}).
+
+\LMHash{}%
+For historic reasons, a type alias can have two more forms.
+Let $S?$ be a term which is empty or derived from \synt{type}.
+The two older forms are then as follows:
+
+\LMHash{}%
+A type alias of the form
 
 \noindent
-\code{\TYPEDEF{} $T$ \id($T_1\ p_1, \ldots,\ T_n\ p_n,\ \{T_{n+1}\ p_{n+1}, \ldots,\ T_{n+k}\ p_{n+k}\}$);}
+\code{\TYPEDEF{} $S?$ \id<\TypeParametersStd>(}
 
 \noindent
-declared in a library $L$ is to introduce the name \id{} into the scope of $L$, bound to the function type
-\FunctionTypeSimple{T}{\List{T}{1}{n},\ \{\PairList{T}{p}{n+1}{n+k}\}}.
+\code{\quad$T_1\ p_1, \ldots,\ T_n\ p_n,\ [T_{n+1}\ p_{n+1}, \ldots,\ T_{n+k}\ p_{n+k}]$);}
+
+\noindent
+is treated as
+
+\noindent
+\code{\TYPEDEF{} \id<\TypeParametersStd> =}
+
+\noindent
+\code{\quad$S?$ \FUNCTION($T_1\ p_1, \ldots,\ T_n\ p_n,\ [T_{n+1}\ p_{n+1}, \ldots,\ T_{n+k}\ p_{n+k}]$);}
 
 \LMHash{}%
-In either case, if{}f no return type is specified, it is taken to be \DYNAMIC{}.
-Likewise, if a type annotation is omitted on a formal parameter, it is taken to be \DYNAMIC{}.
+A type alias of the form
+
+\noindent
+\code{\TYPEDEF{} $S?$ \id<\TypeParametersStd>(}
+
+\noindent
+\code{\quad$T_1\ p_1, \ldots,\ T_n\ p_n,\ \{T_{n+1}\ p_{n+1}, \ldots,\ T_{n+k}\ p_{n+k}\}$);}
+
+\noindent
+is treated as
+
+\noindent
+\code{\TYPEDEF{} \id<\TypeParametersStd> =}
+
+\noindent
+\code{\quad$S?$ \FUNCTION($T_1\ p_1, \ldots,\ T_n\ p_n,\ \{T_{n+1}\ p_{n+1}, \ldots,\ T_{n+k}\ p_{n+k}\}$);}
 
 \LMHash{}%
-It is a compile-time error if any default values are specified
-in the signature of a function type in a type alias.
-%A typedef may only refer to itself via the bounds of its generic parameters.
-Any self reference in a type alias,
-either directly or recursively via another type declaration,
-is a compile-time error.
+It is a compile-time error if a default value is specified for
+a formal parameter in these older forms.
+
+\commentary{%
+Note that the old forms can only define function types,
+and they cannot denote the type of a generic function.
+When such a type alias has type parameters,
+it always expresses a family of non-generic function types.
+These restrictions exist because that syntax was defined
+before generic functions were added to Dart.%
+}
+
+\LMHash{}%
+Let $D_F$ be a type alias declaration of the form
+
+\noindent
+\code{\TYPEDEF{} $F$<\TypeParametersStd> = $T$;}
+
+\noindent
+If $T$ or $B_j$ for some $j \in 1 .. s$ is or contains
+an identifier or qualified identifier $G$ denoting
+a type alias declaration $D_G$,
+then we say that
+\IndexCustom{$D_F$ depends on $D_G$}{type alias!dependency}.
+
+%%TODO(eernst): The relaxation where a type alias dependency arises
+%% via $T$, but not via $B_j$, is more permissive and allows for some
+%% type aliases to be declared that will be an error withthe above rule.
+%% It is very likely that the more relaxed rule can be used. This is a
+%% possible enhancement for the future, and a non breaking change.
+
+\LMHash{}%
+Let $D$ be a type alias delaration,
+and let $M$ be the transitive closure of
+the type alias declarations that $D$ depends on.
+A compile-time error occurs if $D \in M$.
+
+\commentary{%
+In other words, it is an error for a type alias declaration
+to depend on itself, directly or indirectly.%
+}
 
 \commentary{%
 This kind of error may also arise when type arguments have been
@@ -19702,7 +19690,7 @@ which will be specified later
 (\ref{overview}).%
 }
 
-\commentary{%
+\LMHash{}%
 A type alias can be used as a type annotation,
 as a return type or parameter type in a function declaration,
 in a function type,
@@ -19711,21 +19699,43 @@ in a type test,
 in a type cast,
 and in an \ON{} clause of a \TRY{} statement.
 
-Consider the case where the body of a given type alias $F$
-is a \synt{typeName} that denotes a non-generic class,
-or it is a parameterized type that starts with
-a \synt{typeName} that denotes a generic class,
-or one of these cases occur indirectly via another type alias.
-In this case $F$ or a parameterized type that starts with $F$,
-whichever is not an error,
-can also be used to name a constructor in an instance creation expression
+\LMHash{}%
+Consider a type alias declaration of the form
+
+\noindent
+\code{\TYPEDEF{} $F$<\TypeParametersStd> = $X_j$;}
+
+\noindent
+for some $j \in 1 .. s$.
+In this case we say that $F$
+\IndexCustom{expands to a type variable}{%
+  type alias!expands to a type variable}.
+Similarly, with a type alias of the form
+
+\noindent
+\code{\TYPEDEF{} $G$<\TypeParametersStd> = $H$<$T_1, \ldots\ T_k$>;}
+
+\noindent
+where $H$ denotes a type alias declaration that expands to a type variable,
+we also say that \NoIndex{$G$ expands to a type variable}.
+
+\LMHash{}%
+Consider a type alias $F$ that does not expand to a type variable.
+$F$, and a parameterized type that starts with $F$, if not an error,
+can be used
+to denote a constructor in an instance creation expression
 (\ref{instanceCreation}),
+it can be used as a redirectee constructor
+in a redirecting factory constructor
+(\ref{redirectingFactoryConstructors}),
 and it can be used as a superclass, mixin, or superinterface
-(\ref{superclasses}, \ref{superinterfaces}, \ref{mixinApplication}).
-Moreover, $F$ or a parameterized type that starts with $F$,
-whichever is not an error,
-can be used to invoke static methods of the denoted class.%
-}
+(\ref{superclasses}, \ref{mixinApplication}, \ref{superinterfaces}).
+A compile-time error occurs at each of these usages,
+if $F$ does expand to a type variable.
+
+\LMHash{}%
+Finally, $F$
+can be used to invoke static methods of the denoted class.
 
 \rationale{%
 This indirectly allows an invocation of a static method to pass
@@ -19739,14 +19749,6 @@ At that time,
 existing invocations where type arguments are passed indirectly will not break,
 because it is currently an error for a static method to depend on the value
 of a formal type parameter of the enclosing class.%
-}
-
-%% TODO(eernst): Move specification of generic type aliases to this
-%% section, change the non-generic case to a special case.
-\commentary{%
-The generic variants of type alias declarations are specified
-in the section about generics
-(\ref{generics}).%
 }
 
 

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -19680,6 +19680,35 @@ before generic functions were added to Dart.%
 }
 
 \LMHash{}%
+A type alias $F$ can be used to invoke static methods of the denoted class.
+
+\begin{dartCode}
+\CLASS{} C<X> \{
+  static void staticMethod() \{\}
+\}
+\\
+\TYPEDEF{} F = C<int>;
+\\
+\VOID{} main() \{
+  F.staticMethod(); // \comment{OK.}
+\}
+\end{dartCode}
+
+\rationale{%
+This indirectly allows an invocation of a static method to pass
+a list of actual type arguments to the class.
+This is currently an error when it occurs directly
+(e.g., \code{List<int>.castFrom(xs)}).
+But it may be part of a future language extension to allow
+static methods to use the type parameters declared by the enclosing class,
+in which case both the direct and indirect approach will be allowed.
+At that time,
+existing invocations where type arguments are passed indirectly will not break,
+because it is currently an error for a static method to depend on the value
+of a formal type parameter of the enclosing class.%
+}
+
+\LMHash{}%
 Let $D_F$ be a type alias declaration of the form
 
 \noindent
@@ -19728,8 +19757,8 @@ When $D$ is a type alias declaration of the form
 we say that the parameterized type $U$ of the form
 \code{$F$<\List{U}{1}{s}>}
 in a scope where $F$ resolves to $D$
-\IndexCustom{alias-expands in one step to}{
-  type alias!alias-expands in one step}
+\IndexCustom{alias expands in one step to}{
+  type alias!alias expands in one step}
 $[U_1/X_1, \ldots, U_s/X_s]T$.
 
 \commentary{%
@@ -19740,15 +19769,15 @@ and we are just replacing the type alias name by its body.%
 \LMHash{}%
 If $U$ is a type we may repeatedly replace each subterm of $U$
 which is a parameterized type applying a type alias to some type arguments
-by its expansion in one step
+by its alias expansion in one step
 (\commentary{including the non-generic case where there are no type arguments}).
 When no further steps are possible we say that the resulting type is the
-\IndexCustom{transitive alias-expansion}{
-  type alias!transitive alias-expansion}
+\IndexCustom{transitive alias expansion}{
+  type alias!transitive alias expansion}
 of $U$.
 
 \commentary{%
-Note that the transitive alias-expansion exists,
+Note that the transitive alias expansion exists,
 because it is an error for a type alias declaration
 to depend on itself.%
 }
@@ -19762,7 +19791,7 @@ Let $D$ be a type alias declaration of the form
 \noindent
 We say that $D$
 \NoIndex{expands to a type variable}
-if the transitive alias-expansion of $T$ is $X_j$ for some $j \in 1 .. s$.
+if the transitive alias expansion of $T$ is $X_j$ for some $j \in 1 .. s$.
 
 \LMHash{}%
 Let $T$ be a parameterized type \code{$F$<\List{T}{1}{s}>}
@@ -19815,36 +19844,6 @@ and $T$ is not regular-bounded.
   F<num>(); // \comment{Error.}
 \}
 \end{dartCode}
-
-\LMHash{}%
-Finally, $F$
-can be used to invoke static methods of the denoted class.
-
-\begin{dartCode}
-\CLASS{} C<X> \{
-  static void staticMethod() \{\}
-\}
-\\
-\TYPEDEF{} F = C<int>;
-\\
-\VOID{} main() \{
-  F.staticMethod(); // \comment{OK.}
-\}
-\end{dartCode}
-
-\rationale{%
-This indirectly allows an invocation of a static method to pass
-a list of actual type arguments to the class.
-This is currently an error when it occurs directly
-(e.g., \code{List<int>.castFrom(xs)}).
-But it may be part of a future language extension to allow
-static methods to use the type parameters declared by the enclosing class,
-in which case both the direct and indirect approach will be allowed.
-At that time,
-existing invocations where type arguments are passed indirectly will not break,
-because it is currently an error for a static method to depend on the value
-of a formal type parameter of the enclosing class.%
-}
 
 
 \subsection{Subtypes}

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -44,6 +44,12 @@
 % - Specify identifier references denoting extension members.
 % - Remove a few null safety features, to enable publishing a stable
 %   version of the specification which is purely about Dart 2.11.
+% - Reorganize specification of type aliases to be in section 'Type Aliases'
+%   (this used to be both there, and in 'Generics').
+% - Clarify the cyclicity error for type aliases ("F is not allowed to depend
+%   on itself).
+% - Add the error for a type alias $F$ used in an instance creation etc., when
+%   $F$ expands to a type variable.
 %
 % 2.7
 % - Rename non-terminals `<...Definition>` to `<...Declaration>` (e.g., it is
@@ -19720,7 +19726,7 @@ where $H$ denotes a type alias declaration that expands to a type variable,
 we also say that \NoIndex{$G$ expands to a type variable}.
 
 \LMHash{}%
-Consider a type alias $F$ that does not expand to a type variable.
+Consider a type alias $F$.
 $F$, and a parameterized type that starts with $F$, if not an error,
 can be used
 to denote a constructor in an instance creation expression
@@ -19730,8 +19736,23 @@ in a redirecting factory constructor
 (\ref{redirectingFactoryConstructors}),
 and it can be used as a superclass, mixin, or superinterface
 (\ref{superclasses}, \ref{mixinApplication}, \ref{superinterfaces}).
-A compile-time error occurs at each of these usages,
-if $F$ does expand to a type variable.
+
+\LMHash{}%
+In each of these cases,
+a compile-time error occurs if $F$ expands to a type variable,
+or if the usage is a parameterized type which is not regular-bounded.
+\commentary{For example:}
+
+\begin{dartCode}
+\CLASS{} C<X extends num> \{\}
+\TYPEDEF{} F<Y extends int> = C<Y>;
+\\
+\VOID{} main() \{
+  F<int>(); // \comment{OK.}
+  C<num>(); // \comment{OK.}
+  F<num>(); // \comment{Error.}
+\}
+\end{dartCode}
 
 \LMHash{}%
 Finally, $F$

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -19548,7 +19548,7 @@ It is common to use the phrase ``a typedef'' for such a declaration,
 because of the prominent occurrence of the token \TYPEDEF.%
 }
 
-%%TODO(eernst): With null safety, change <functionType> to <type>.
+%%TODO(eernst): With non-function type aliases, change <functionType> to <type>.
 \begin{grammar}
 <typeAlias> ::= \gnewline{}
   \TYPEDEF{} <typeIdentifier> <typeParameters>? `=' <functionType> `;'
@@ -19603,9 +19603,11 @@ It is a compile-time error if $U$ is not well-bounded
 (\ref{superBoundedTypes}).
 
 \LMHash{}%
-For historic reasons, a type alias can have two more forms.
-Let $S?$ be a term which is empty or derived from \synt{type}.
-The two older forms are then as follows:
+For historic reasons, a type alias can have two more forms,
+derived using \synt{functionTypeAlias}.
+Let \DefineSymbol{S?} be a term which is empty or derived from \synt{type},
+and similarly for \DefineSymbol{T_j?} for any $j$.
+The two older forms are then defined as follows:
 
 \LMHash{}%
 A type alias of the form
@@ -19614,7 +19616,7 @@ A type alias of the form
 \code{\TYPEDEF{} $S?$ \id<\TypeParametersStd>(}
 
 \noindent
-\code{\quad$T_1\ p_1, \ldots,\ T_n\ p_n,\ [T_{n+1}\ p_{n+1}, \ldots,\ T_{n+k}\ p_{n+k}]$);}
+\code{\quad$T_1?\ p_1, \ldots,\ T_n?\ p_n,\ [T_{n+1}?\ p_{n+1}, \ldots,\ T_{n+k}?\ p_{n+k}]$);}
 
 \noindent
 is treated as
@@ -19632,7 +19634,7 @@ A type alias of the form
 \code{\TYPEDEF{} $S?$ \id<\TypeParametersStd>(}
 
 \noindent
-\code{\quad$T_1\ p_1, \ldots,\ T_n\ p_n,\ \{T_{n+1}\ p_{n+1}, \ldots,\ T_{n+k}\ p_{n+k}\}$);}
+\code{\quad$T_1?\ p_1, \ldots,\ T_n?\ p_n,\ \{T_{n+1}?\ p_{n+1}, \ldots,\ T_{n+k}?\ p_{n+k}\}$);}
 
 \noindent
 is treated as
@@ -19644,8 +19646,29 @@ is treated as
 \code{\quad$S?$ \FUNCTION($T_1\ p_1, \ldots,\ T_n\ p_n,\ \{T_{n+1}\ p_{n+1}, \ldots,\ T_{n+k}\ p_{n+k}\}$);}
 
 \LMHash{}%
+In these rules, for each $j$, if $T_j?$ is empty
+then \DefineSymbol{T_j} is \DYNAMIC,
+otherwise $T_j$ is $T_j?$.
+
+\commentary{%
+This means that the older forms allow for a parameter type to be omitted,
+in which case it is taken to be \DYNAMIC,
+but the parameter name cannot be omitted.
+This rule is error prone,
+and hence the newer form (with \lit{=}) is recommended.
+For instance, the declaration \code{\TYPEDEF{} $F$(int);}
+specifies that $F$ denotes the type
+\code{\DYNAMIC{} \FUNCTION(\DYNAMIC)},
+and it is documented, but technically ignored,
+that the parameter has the name \code{int}.
+It is extremely likely that a reader will misread this,
+and assume that \code{int} is the parameter type.%
+}
+
+\LMHash{}%
 It is a compile-time error if a default value is specified for
-a formal parameter in these older forms.
+a formal parameter in these older forms,
+or if a formal parameter has the modifier \COVARIANT.
 
 \commentary{%
 Note that the old forms can only define function types,
@@ -19670,7 +19693,7 @@ then we say that
 
 %%TODO(eernst): The relaxation where a type alias dependency arises
 %% via $T$, but not via $B_j$, is more permissive and allows for some
-%% type aliases to be declared that will be an error withthe above rule.
+%% type aliases to be declared that will be an error with the above rule.
 %% It is very likely that the more relaxed rule can be used. This is a
 %% possible enhancement for the future, and a non breaking change.
 
@@ -19733,13 +19756,19 @@ We say that $T$
 when $T$ occurs in one of the following ways:
 
 \begin{itemize}
-\item $T$ denotes a constructor in an instance creation expression
-  (\ref{instanceCreation}).
+\item $T$ occurs in an instance creation expression
+  of the form \code{$T$(\ldots)} or the form \code{$T$.\id(\ldots)}
+  (\ref{instanceCreation}),
+  or of the same forms with \NEW{} or \CONST{} prepended.
 \item $T$ is the redirectee in a redirecting factory constructor
   (\ref{redirectingFactoryConstructors}).
 \item $T$ is used as a superclass, a mixin, or a superinterface
   in a class declaration
-  (\ref{superclasses}, \ref{mixinApplication}, \ref{superinterfaces}).
+  (\ref{superclasses}, \ref{mixinApplication}, \ref{superinterfaces}),
+  or as an \ON{} type or a superinterface in a mixin declaration
+  (\ref{mixinDeclaration}).
+  % It is OK to use it as the \ON{} type of an extension declaration:
+  % In that position it is used as a type, not as a class.
 \end{itemize}
 
 \LMHash{}%

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -19719,56 +19719,83 @@ which will be specified later
 }
 
 \LMHash{}%
-We define the notion that a type alias declaration
-\NoIndex{expands to a type variable}
-inductively as follows:
-When $j \in 1 .. s$, we say that a type alias declaration of the form
-\code{\TYPEDEF{} $F$<\TypeParametersStd> = $X_j$;}
-\NoIndex{expands to a type variable at position} $j$.
-Similarly, if $H$ denotes a type alias declaration
-that declares $k$ type parameters and
-expands to a type variable at position $i \in 1 .. k$,
-we say that the type alias declaration
+When $D$ is a type alias declaration of the form
 
 \noindent
-\code{\TYPEDEF{} $G$<\TypeParametersStd> = $H$<\List{T}{1}{s}>;}
+\code{\TYPEDEF{} $F$<\TypeParametersStd> = $T$;}
 
 \noindent
-\NoIndex{expands to a type variable at position} $j$
-when $T_i$ is $X_j$ for some $j \in 1 .. s$.
-We say that a type alias declaration
-\IndexCustom{expands to a type variable}{%
-  type alias!expands to a type variable}
-if it expands to a type variable at any position.
+we say that the parameterized type $U$ of the form
+\code{$F$<\List{U}{1}{s}>}
+in a scope where $F$ resolves to $D$
+\IndexCustom{alias-expands in one step to}{
+  type alias!alias-expands in one step}
+$[U_1/X_1, \ldots, U_s/X_s]T$.
 
 \commentary{%
-This means that if a type alias declaration named $F$
-expands to a type variable
-then \code{$F$<\List{T}{1}{s}>} is $T_j$ for some $j \in 1 .. s$.
-If the declaration does not expand to a type variable then that never occurs.%
+Note that $s$ can be zero, in which case $F$ is non-generic,
+and we are just replacing the type alias name by its body.%
 }
 
 \LMHash{}%
-Let $T$ be a parameterized type \code{$F$<$T_1, \ldots T_k$>}
+If $U$ is a type we may repeatedly replace each subterm of $U$
+which is a parameterized type applying a type alias to some type arguments
+by its expansion in one step
+(\commentary{including the non-generic case where there are no type arguments}).
+When no further steps are possible we say that the resulting type is the
+\IndexCustom{transitive alias-expansion}{
+  type alias!transitive alias-expansion}
+of $U$.
+
+\commentary{%
+Note that the transitive alias-expansion exists,
+because it is an error for a type alias declaration
+to depend on itself.%
+}
+
+\LMHash{}%
+Let $D$ be a type alias declaration of the form
+
+\noindent
+\code{\TYPEDEF{} $F$<\TypeParametersStd> = $T$;}
+
+\noindent
+We say that $D$
+\NoIndex{expands to a type variable}
+if the transitive alias-expansion of $T$ is $X_j$ for some $j \in 1 .. s$.
+
+\LMHash{}%
+Let $T$ be a parameterized type \code{$F$<\List{T}{1}{s}>}
 in a scope where $F$ denotes a type alias declaration $D$.
 We say that $T$
 \IndexCustom{uses $D$ as a class}{type alias!used as a class}
 when $T$ occurs in one of the following ways:
 
 \begin{itemize}
-\item $T$ occurs in an instance creation expression
-  of the form \code{$T$(\ldots)} or the form \code{$T$.\id(\ldots)}
-  (\ref{instanceCreation}),
-  or of the same forms with \NEW{} or \CONST{} prepended.
-\item $T$ is the redirectee in a redirecting factory constructor
+\item
+  $T$ occurs in an instance creation expression of the form
+  \code{$T$(\ldots)} or the form \code{$T$.\id(\ldots)}
+  (\ref{instanceCreation}), or of the same forms with \NEW{} or
+  \CONST{} prepended.
+\item
+  $T$ or \code{$T$.\id} is the redirectee in a redirecting factory constructor
   (\ref{redirectingFactoryConstructors}).
-\item $T$ is used as a superclass, a mixin, or a superinterface
+\item
+  $T$ is used as a superclass, a mixin, or a superinterface
   in a class declaration
   (\ref{superclasses}, \ref{mixinApplication}, \ref{superinterfaces}),
   or as an \ON{} type or a superinterface in a mixin declaration
   (\ref{mixinDeclaration}).
   % It is OK to use it as the \ON{} type of an extension declaration:
   % In that position it is used as a type, not as a class.
+\item
+  $T$ is used in an expression of the form `\code{$T$.\id\;\metavar{args}}'
+  where \metavar{args} is derived from \syntax{<argumentPart>?}.
+
+  \commentary{%
+    This is the situation where the type alias is used to invoke
+    a static getter or a static method.%
+  }
 \end{itemize}
 
 \LMHash{}%

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -19664,8 +19664,7 @@ Let $D_F$ be a type alias declaration of the form
 
 \noindent
 If $T$ or $B_j$ for some $j \in 1 .. s$ is or contains
-an identifier or qualified identifier $G$ denoting
-a type alias declaration $D_G$,
+a \synt{typeName} $G$ denoting a type alias declaration $D_G$,
 then we say that
 \IndexCustom{$D_F$ depends on $D_G$}{type alias!dependency}.
 
@@ -19697,50 +19696,57 @@ which will be specified later
 }
 
 \LMHash{}%
-A type alias can be used as a type annotation,
-as a return type or parameter type in a function declaration,
-in a function type,
-as a type argument,
-in a type test,
-in a type cast,
-and in an \ON{} clause of a \TRY{} statement.
-
-\LMHash{}%
-Consider a type alias declaration of the form
-
-\noindent
+We define the notion that a type alias declaration
+\NoIndex{expands to a type variable}
+inductively as follows:
+When $j \in 1 .. s$, we say that a type alias declaration of the form
 \code{\TYPEDEF{} $F$<\TypeParametersStd> = $X_j$;}
+\NoIndex{expands to a type variable at position} $j$.
+Similarly, if $H$ denotes a type alias declaration
+that declares $k$ type parameters and
+expands to a type variable at position $i \in 1 .. k$,
+we say that the type alias declaration
 
 \noindent
-for some $j \in 1 .. s$.
-In this case we say that $F$
+\code{\TYPEDEF{} $G$<\TypeParametersStd> = $H$<\List{T}{1}{s}>;}
+
+\noindent
+\NoIndex{expands to a type variable at position} $j$
+when $T_i$ is $X_j$ for some $j \in 1 .. s$.
+We say that a type alias declaration
 \IndexCustom{expands to a type variable}{%
-  type alias!expands to a type variable}.
-Similarly, with a type alias of the form
+  type alias!expands to a type variable}
+if it expands to a type variable at any position.
 
-\noindent
-\code{\TYPEDEF{} $G$<\TypeParametersStd> = $H$<$T_1, \ldots\ T_k$>;}
-
-\noindent
-where $H$ denotes a type alias declaration that expands to a type variable,
-we also say that \NoIndex{$G$ expands to a type variable}.
-
-\LMHash{}%
-Consider a type alias $F$.
-$F$, and a parameterized type that starts with $F$, if not an error,
-can be used
-to denote a constructor in an instance creation expression
-(\ref{instanceCreation}),
-it can be used as a redirectee constructor
-in a redirecting factory constructor
-(\ref{redirectingFactoryConstructors}),
-and it can be used as a superclass, mixin, or superinterface
-(\ref{superclasses}, \ref{mixinApplication}, \ref{superinterfaces}).
+\commentary{%
+This means that if a type alias declaration named $F$
+expands to a type variable
+then \code{$F$<\List{T}{1}{s}>} is $T_j$ for some $j \in 1 .. s$.
+If the declaration does not expand to a type variable then that never occurs.%
+}
 
 \LMHash{}%
-In each of these cases,
-a compile-time error occurs if $F$ expands to a type variable,
-or if the usage is a parameterized type which is not regular-bounded.
+Let $T$ be a parameterized type \code{$F$<$T_1, \ldots T_k$>}
+in a scope where $F$ denotes a type alias declaration $D$.
+We say that $T$
+\IndexCustom{uses $D$ as a class}{type alias!used as a class}
+when $T$ occurs in one of the following ways:
+
+\begin{itemize}
+\item $T$ denotes a constructor in an instance creation expression
+  (\ref{instanceCreation}).
+\item $T$ is the redirectee in a redirecting factory constructor
+  (\ref{redirectingFactoryConstructors}).
+\item $T$ is used as a superclass, a mixin, or a superinterface
+  in a class declaration
+  (\ref{superclasses}, \ref{mixinApplication}, \ref{superinterfaces}).
+\end{itemize}
+
+\LMHash{}%
+A compile-time error occurs if $D$ expands to a type variable
+and $T$ uses $D$ as a class.
+A compile-time error occurs if $T$ uses $D$ as a class,
+and $T$ is not regular-bounded.
 \commentary{For example:}
 
 \begin{dartCode}
@@ -19757,6 +19763,18 @@ or if the usage is a parameterized type which is not regular-bounded.
 \LMHash{}%
 Finally, $F$
 can be used to invoke static methods of the denoted class.
+
+\begin{dartCode}
+\CLASS{} C<X> \{
+  static void staticMethod() \{\}
+\}
+\\
+\TYPEDEF{} F = C<int>;
+\\
+\VOID{} main() \{
+  F.staticMethod(); // \comment{OK.}
+\}
+\end{dartCode}
 
 \rationale{%
 This indirectly allows an invocation of a static method to pass


### PR DESCRIPTION
This PL updates the type alias section in the language specification to include an explicit rule about how to determine that there is a cyclicity error ("F depends on itself").

It also adds a specification of the error where a type alias is used in an instance creation, but it expands to a type variable. (Like `typedef F<X> = X;`), and adds a new rule that instance creations using a type alias must be regular-bounded (so with `class C<X> {}` and `typedef F<X extends num> = C<X>;`, `C<dynamic>()` and `A<int>()` are (of course) OK, but `A<dynamic>()` is an error).

This PR preserves the approach that we have used for a long time: The language specification uses a syntax where a type alias can _only_ denote a function type, but everything else has been generalized to handle non-function type aliases as well. This means that we can "enable" non-function type aliases simply by changing `<functionType>` to `<type>` in the grammar rule for `<typeAlias>`.

The reason why this came up now: https://github.com/dart-lang/sdk/issues/45065.
