### PR TITLE
Clean up \commentary, \rationale, specify \DefineSymbol

### DIFF
--- a/specification/dart.sty
+++ b/specification/dart.sty
@@ -156,11 +156,16 @@
 
 % Used for defining occurrence of phrase, with customized index entry.
 \newcommand{\IndexCustom}[2]{%
-  \leavevmode\marginpar{\ensuremath{\diamond}}\emph{#1}\index{#2}}
+  \leavevmode\marginpar{\quad\ensuremath{\diamond}}\emph{#1}\index{#2}}
 
 % Used for the defining occurrence of a local symbol.
 \newcommand{\DefineSymbol}[1]{%
-  \leavevmode\marginpar{\ensuremath{#1}}\ensuremath{#1}}
+  \leavevmode\marginpar{\quad\textcolor{black}{\ensuremath{#1}}}\ensuremath{#1}}
+
+% Used to indicate a defining occurrence of a local symbol without
+% typesetting that symbol.
+\newcommand{\BlindDefineSymbol}[1]{%
+  \leavevmode\marginpar{\quad\textcolor{black}{\ensuremath{#1}}}}
 
 % Used when one concept should have >1 entry in the index. Does not add
 % the diamond in the margin and shows no text where the command occurs.
@@ -172,7 +177,7 @@
 
 % Same appearance, but not adding an entry to the index.
 \newcommand{\NoIndex}[1]{%
-  \leavevmode\marginpar{\ensuremath{\diamond}}\emph{#1}}
+  \leavevmode\marginpar{\quad\ensuremath{\diamond}}\emph{#1}}
 
 % Used to specify comma separated lists of similar symbols.
 \newcommand{\List}[3]{\ensuremath{{#1}_{#2},\,\ldots,\ {#1}_{#3}}}

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -361,8 +361,6 @@ For undated references, the latest edition of the referenced document (including
 
 \LMHash{}%
 Terms and definitions used in this specification are given in the body of the specification proper.
-Such terms are highlighted in italics when they are introduced, e.g., `we use the term \NoIndex{verbosity} to refer to the property of excess verbiage',
-and add a marker in the margin.
 % End Ecma Boilerplate
 
 
@@ -377,27 +375,28 @@ At this time, non-normative text includes:
 \begin{itemize}
 \item[Rationale]
   Discussion of the motivation for language design decisions appears in italics.
-\rationale{
-Distinguishing normative from non-normative helps clarify what part of the text is binding and what part is merely expository.
+\rationale{%
+Distinguishing normative from non-normative helps clarify
+what part of the text is binding and what part is merely expository.%
 }
 \item[Commentary]
   Comments such as ``\commentary{The careful reader will have noticed that the name Dart has four characters}'' serve to illustrate or clarify the specification, but are redundant with the normative text.
-\commentary{
-The difference between commentary and rationale can be subtle.
+\commentary{%
+The difference between commentary and rationale can be subtle.%
 }
-\rationale{
-Commentary is more general than rationale, and may include illustrative examples or clarifications.
+\rationale{%
+Commentary is more general than rationale,
+and may include illustrative examples or clarifications.%
 }
-\item[Open questions] (\Q{in this font}).
-Open questions are points that are unsettled in the mind of the author(s) of the specification; expect them (the questions, not the authors; precision is important in a specification) to be eliminated in the final specification.
-\Q{Should the text at the end of the previous bullet be rationale or commentary?}
 \end{itemize}
 
 \LMHash{}%
-Reserved words and built-in identifiers (\ref{identifierReference}) appear in {\bf bold}.
+Reserved words and built-in identifiers
+(\ref{identifierReference})
+appear in {\bf bold}.
 
-\commentary{
-Examples would be \SWITCH{} or \CLASS{}.
+\commentary{%
+Examples would be \SWITCH{} or \CLASS{}.%
 }
 
 \LMHash{}%
@@ -413,8 +412,8 @@ Negation is represented by prefixing an element of a production with a tilde.
 Negation is similar to the not combinator of PEGs, but it consumes input if it matches.
 In the context of a lexical production it consumes a single character if there is one; otherwise, a single token if there is one.
 
-\commentary{
-An example would be:
+\commentary{%
+An example would be:%
 }
 
 \begin{grammar}\color{commentaryColor}
@@ -445,21 +444,24 @@ A \Index{term} is a syntactic construct.
 It may be considered to be a piece of text which is derivable in the grammar,
 and it may be considered to be a tree created by such a derivation.
 An \Index{immediate subterm} of a given term $t$ is a syntactic construct
-which corresponds to an immediate subtree of $t$ considered as a derivation tree.
+which corresponds to an immediate subtree of $t$
+considered as a derivation tree.
 A \Index{subterm} of a given term $t$ is $t$,
 or an immediate subterm of $t$,
 or a subterm of an immediate subterm of $t$.
 
 \LMHash{}%
-A list $x_1, \ldots, x_n$ denotes any list of $n$ elements of the form $x_i, 1 \le i \le n$.
+A list \DefineSymbol{x_1, \ldots, x_n} denotes any list of
+\DefineSymbol{n} elements of the form $x_i, 1 \le i \le n$.
 Note that $n$ may be zero, in which case the list is empty.
 We use such lists extensively throughout this specification.
 
+\BlindDefineSymbol{j, y_j, x_j}%
 \LMHash{}%
 For $j \in 1 .. n$,
 let $y_j$ be an atomic syntactic entity (like an identifier),
 $x_j$ a composite syntactic entity (like an expression or a type),
-and $E$ again a composite syntactic entity.
+and \DefineSymbol{E} again a composite syntactic entity.
 The notation
 \IndexCustom{$[x_1/y_1, \ldots, x_n/y_n]E$}{[x1/y1, ..., xn/yn]E@$[x/y\ldots]E$}
 then denotes a copy of $E$
@@ -473,18 +475,23 @@ the substitution will not replace $y_i$ in that scope.
 Conversely, if such a replacement would put an identifier \id{} (a subterm of $x_i$) into a scope where \id{} is declared,
 the relevant declarations in $E$ are systematically renamed to fresh names.
 
-\commentary{
-In short, capture freedom ensures that the ``meaning'' of each identifier is preserved during substitution.
+\commentary{%
+In short, capture freedom ensures that the ``meaning'' of each identifier
+is preserved during substitution.%
 }
 
 \LMHash{}%
-We sometimes abuse list or map literal syntax, writing $[o_1, \ldots, o_n]$ (respectively $\{k_1: o_1, \ldots, k_n: o_n\}$) where the $o_i$ and $k_i$ may be objects rather than expressions.
-The intent is to denote a list (respectively map) object whose elements are the $o_i$ (respectively, whose keys are the $k_i$ and values are the $o_i$).
+We sometimes abuse list or map literal syntax, writing $[o_1, \ldots, o_n]$
+(respectively $\{k_1: o_1, \ldots, k_n: o_n\}$)
+where the $o_i$ and $k_i$ may be objects rather than expressions.
+The intent is to denote a list (respectively map) object
+whose elements are the $o_i$
+(respectively, whose keys are the $k_i$ and values are the $o_i$).
 
 \LMHash{}%
+\BlindDefineSymbol{x, op, y}%
 The specifications of operators often involve statements such as
-\code{$x$ \metavar{op} $y$}
-is equivalent to the method invocation
+\code{$x$ \metavar{op} $y$} is equivalent to the method invocation
 \IndexCustom{\rm\code{$x$.\metavar{op}($y$)}}{x.op(y)@\code{$x$.\metavar{op}($y$)}}.
 Such specifications should be understood as a shorthand for:
 \begin{itemize}
@@ -495,15 +502,17 @@ Such specifications should be understood as a shorthand for:
   defining the same function as the operator $op$.
 \end{itemize}
 
-\rationale{
+\rationale{%
 This circumlocution is required because
 {\rm\code{$x$.\metavar{op}($y$)}}, where op is an operator, is not legal syntax.
 However, it is painfully verbose, and we prefer to state this rule once here,
-and use a concise and clear notation across the specification.
+and use a concise and clear notation across the specification.%
 }
 
 \LMHash{}%
-When the specification refers to the order given in the program, it means the order of the program source code text, scanning left-to-right and top-to-bottom.
+When the specification refers to the order given in the program,
+it means the order of the program source code text,
+scanning left-to-right and top-to-bottom.
 
 \LMHash{}%
 When the specification refers to a
@@ -551,6 +560,7 @@ then only the run-time behavior is equivalent,
 and compile-time errors apply only for the original syntax.
 
 \LMHash{}%
+\BlindDefineSymbol{s, s'}%
 When the specification says that one piece of syntax $s$ is
 \Index{treated as}
 another piece of syntax $s'$,
@@ -614,14 +624,14 @@ The syntax of a \LET{} expression is as follows:
 \end{grammar}
 
 \LMHash{}%
+\BlindDefineSymbol{e_{\metavar{let}}, e_j, v_j, k}
 Let $e_{\metavar{let}}$ be a \LET{} expression of the form
 \LetMany{$v_1$}{$e_1$}{$v_k$}{$e_k$}{$e$}.
-It is required that $v_j$ is a fresh variable, $j \in 1 .. k$
-(\commentary{%
-which is tacitly assumed whenever a \LET{} expression is used,
-and nothing is stated to the contrary%
-}).
-$e_{\metavar{let}}$ contains $k$ nested scopes, \List{S}{1}{k}.
+It is tacitly assumed that $v_j$ is a fresh variable, $j \in 1 .. k$,
+unless something is stated to the contrary.
+
+\LMHash{}%
+$e_{\metavar{let}}$ contains $k$ nested scopes, \DefineSymbol{\List{S}{1}{k}}.
 The enclosing scope for $S_1$ is the current scope for $e_{\metavar{let}}$,
 and the enclosing scope for $S_j$ is $S_{j-1}$, $j \in 2 .. k$.
 The current scope of $e_1$ is the current scope of $e_{\metavar{let}}$,
@@ -644,6 +654,34 @@ where $j \in 1 .. k$, in that order.
 Finally, $e$ is evaluated to an object $o$ and then
 $e_{\metavar{let}}$ evaluates to $o$.
 
+\LMHash{}%
+The right margin of each page in this document is used to indicate
+referenced entities.
+
+\LMHash{}%
+The document contains an index at the end.
+Each entry in the index refers to a page number, $p$.
+On page $p$ there is a `$\diamond$' in the margin
+at the definition of the given indexed phrase,
+and the phrase itself is shown using \emph{this typeface}.
+We have hereby introduced the
+\Index{index marker $\diamond$}
+itself.
+
+\LMHash{}%
+The right margin also contains symbols.
+Whenever a symbol (\commentary{say, $C$ or $x_j$}) is introduced
+and used in more than a few lines of text,
+it is shown in the margin.
+
+\commentary{%
+The point is that it is easy to find the definition of a symbol
+by scanning back in the text until that symbol occurs in the margin.
+To avoid useless verbosity, some symbols are not mentioned in the margin.
+For instance, we may introduce \List{e}{1}{k},
+but only show $e_j$ and $k$ in the margin.%
+}
+
 
 \section{Overview}
 \LMLabel{overview}
@@ -660,7 +698,7 @@ This specification makes no attempt to answer additional questions
 about a library or program at the point
 where it is known to have a compile-time error.
 
-\commentary{
+\commentary{%
 However, tools may choose to support execution of some programs with errors.
 For instance, a compiler may compile certain constructs with errors such that
 a dynamic error will be raised if an attempt is made to
@@ -670,7 +708,7 @@ an editor window when such a construct is executed,
 allowing developers to correct the error.
 It is expected that such features would amount to a natural extension of the
 dynamic semantics of Dart as specified here, but, as mentioned,
-this specification makes no attempt to specify exactly what that means.
+this specification makes no attempt to specify exactly what that means.%
 }
 
 \LMHash{}%
@@ -678,13 +716,14 @@ As specified in this document,
 dynamic checks are guaranteed to be performed in certain situations,
 and certain violations of the type system throw exceptions at run time.
 
-\commentary{
+\commentary{%
 An implementation is free to omit such checks whenever they are
-guaranteed to succeed, e.g., based on results from the static analysis.
+guaranteed to succeed, e.g., based on results from the static analysis.%
 }
 
-\commentary{
-The coexistence between optional typing and reification is based on the following:
+\commentary{%
+The coexistence between optional typing and reification
+is based on the following:
 \begin{enumerate}
 \item
   Reified type information reflects the types of objects at run time
@@ -703,18 +742,18 @@ The coexistence between optional typing and reification is based on the followin
   Type annotations may be omitted, in which case they are generally
   filled in with the type \DYNAMIC{}
   (\ref{typeDynamic}).
-\end{enumerate}
+\end{enumerate}%
 }
 
 %% TODO(eernst): Update when we add inference.
-\commentary{
+\commentary{%
 Dart as implemented includes extensive support for inference of omitted types.
 This specification makes the assumption that inference has taken place,
 and hence inferred types are considered to be present in the program already.
 However, in some cases no information is available
 to infer an omitted type annotation,
 and hence this specification still needs to specify how to deal with that.
-A future version of this specification will also specify type inference.
+A future version of this specification will also specify type inference.%
 }
 
 \LMHash{}%
@@ -722,9 +761,10 @@ Dart programs are organized in a modular fashion into
 units called \NoIndex{libraries} (\ref{librariesAndScripts}).
 Libraries are units of encapsulation and may be mutually recursive.
 
-\commentary{
+\commentary{%
 However they are not first class.
-To get multiple copies of a library running simultaneously, one needs to spawn an isolate.
+To get multiple copies of a library running simultaneously,
+one needs to spawn an isolate.%
 }
 
 \LMHash{}%
@@ -779,9 +819,9 @@ if a key of \NamespaceName{} is mapped to $d$.
 \LMHash{}%
 A scope $S_0$ has an associated namespace \NamespaceName{0}.
 The bindings of \NamespaceName{0} is specified in this document by saying that
-a given declaration $D$ named $n$
+a given declaration \BlindDefineSymbol{D, n}$D$ named $n$
 \IndexCustom{introduces}{declaration!introduces an entity into a scope}
-a specific entity $V$ into $S_0$,
+a specific entity \DefineSymbol{V} into $S_0$,
 which means that the binding $n\mapsto{}V$ is added to \NamespaceName{0}.
 
 \commentary{%
@@ -844,16 +884,22 @@ and instance variables are specific to an object.%
 \LMHash{}%
 Dart is lexically scoped.
 Scopes may nest.
-A name or declaration $d$ is \Index{available in scope} $S$ if $d$ is in the namespace induced by $S$ or if $d$ is available in the lexically enclosing scope of $S$.
-We say that a name or declaration $d$ is \Index{in scope} if $d$ is available in the current scope.
+A name or declaration $d$ is \Index{available in scope} $S$
+if $d$ is in the namespace induced by $S$ or
+if $d$ is available in the lexically enclosing scope of $S$.
+We say that a name or declaration $d$ is \Index{in scope}
+if $d$ is available in the current scope.
 
 \LMHash{}%
-If a declaration $d$ named $n$ is in the namespace induced by a scope $S$, then $d$ \Index{hides} any declaration named $n$ that is available in the lexically enclosing scope of $S$.
+If a declaration $d$ named $n$ is in the namespace induced by a scope $S$,
+then $d$ \Index{hides} any declaration named $n$ that is available
+in the lexically enclosing scope of $S$.
 
-\commentary{
-A consequence of these rules is that it is possible to hide a type with a method or variable.
+\commentary{%
+A consequence of these rules is that it is possible to hide a type
+with a method or variable.
 Naming conventions usually prevent such abuses.
-Nevertheless, the following program is legal:
+Nevertheless, the following program is legal:%
 }
 
 \begin{dartCode}
@@ -863,16 +909,20 @@ Nevertheless, the following program is legal:
 \end{dartCode}
 
 \LMHash{}%
-Names may be introduced into a scope by declarations within the scope or by other mechanisms such as imports or inheritance.
+Names may be introduced into a scope by declarations within the scope
+or by other mechanisms such as imports or inheritance.
 
-\rationale{
+\rationale{%
 The interaction of lexical scoping and inheritance is a subtle one.
-Ultimately, the question is whether lexical scoping takes precedence over inheritance or vice versa.
+Ultimately, the question is whether lexical scoping
+takes precedence over inheritance or vice versa.
 Dart chooses the former.
 
-Allowing inherited names to take precedence over locally declared names could create unexpected situations as code evolves.
-Specifically, the behavior of code in a subclass could silently change if a new name is introduced in a superclass.
-Consider:
+Allowing inherited names to take precedence over locally declared names
+could create unexpected situations as code evolves.
+Specifically, the behavior of code in a subclass could silently change
+if a new name is introduced in a superclass.
+Consider:%
 }
 
 \begin{dartCode}
@@ -885,8 +935,8 @@ foo() => 42;
 \CLASS{} C \EXTENDS{} S\{ bar() => foo();\}
 \end{dartCode}
 
-\rationale{
-Now assume a method \code{foo()} is added to \code{S}.
+\rationale{%
+Now assume a method \code{foo()} is added to \code{S}.%
 }
 
 \begin{dartCode}
@@ -894,21 +944,32 @@ Now assume a method \code{foo()} is added to \code{S}.
 \CLASS{} S \{foo() => 91;\}
 \end{dartCode}
 
-\rationale{
-If inheritance took precedence over the lexical scope, the behavior of \code{C} would change in an unexpected way.
-Neither the author of \code{S} nor the author of \code{C} are necessarily aware of this.
-In Dart, if there is a lexically visible method \code{foo()}, it will always be called.
+\rationale{%
+If inheritance took precedence over the lexical scope,
+the behavior of \code{C} would change in an unexpected way.
+Neither the author of \code{S} nor the author of \code{C}
+are necessarily aware of this.
+In Dart, if there is a lexically visible method \code{foo()},
+it will always be called.
 
 Now consider the opposite scenario.
-We start with a version of \code{S} that contains \code{foo()}, but do not declare \code{foo()} in library \code{L2}.
-Again, there is a change in behavior - but the author of \code{L2} is the one who introduced the discrepancy that effects their code, and the new code is lexically visible.
+We start with a version of \code{S} that contains \code{foo()},
+but do not declare \code{foo()} in library \code{L2}.
+Again, there is a change in behavior---but the author of \code{L2}
+is the one who introduced the discrepancy that effects their code,
+and the new code is lexically visible.
 Both these factors make it more likely that the problem will be detected.
 
-These considerations become even more important if one introduces constructs such as nested classes, which might be considered in future versions of the language.
+These considerations become even more important
+if one introduces constructs such as nested classes,
+which might be considered in future versions of the language.
 
-Good tooling should of course endeavor to inform programmers of such situations (discreetly).
-For example, an identifier that is both inherited and lexically visible could be highlighted (via underlining or colorization).
-Better yet, tight integration of source control with language aware tools would detect such changes when they occur.
+Good tooling should of course endeavor to inform programmers
+of such situations (discreetly).
+For example, an identifier that is both inherited and lexically visible
+could be highlighted (via underlining or colorization).
+Better yet, tight integration of source control with language aware tools
+would detect such changes when they occur.%
 }
 
 
@@ -986,38 +1047,60 @@ This specification distinguishes between several kinds of errors.
 \LMHash{}%
 \IndexCustom{Compile-time errors}{compile-time error}
 are errors that preclude execution.
-A compile-time error must be reported by a Dart compiler before the erroneous code is executed.
+A compile-time error must be reported by a Dart compiler
+before the erroneous code is executed.
 
-\rationale{
-A Dart implementation has considerable freedom as to when compilation takes place.
-Modern programming language implementations often interleave compilation and execution, so that compilation of a method may be delayed, e.g., until it is first invoked.
-Consequently, compile-time errors in a method $m$ may be reported as late as the time of $m$'s first invocation.
+\rationale{%
+A Dart implementation has considerable freedom
+as to when compilation takes place.
+Modern programming language implementations
+often interleave compilation and execution,
+so that compilation of a method may be delayed, e.g.,
+until it is first invoked.
+Consequently, compile-time errors in a method $m$ may be reported
+as late as the time of $m$'s first invocation.
 
-Dart is often loaded directly from source, with no intermediate binary representation.
-In the interests of rapid loading, Dart implementations may choose to avoid full parsing of method bodies, for example.
-This can be done by tokenizing the input and checking for balanced curly braces on method body entry.
-In such an implementation, even syntax errors will be detected only when the method needs to be executed, at which time it will be compiled (JITed).
+Dart is often loaded directly from source,
+with no intermediate binary representation.
+In the interests of rapid loading, Dart implementations
+may choose to avoid full parsing of method bodies, for example.
+This can be done by tokenizing the input and
+checking for balanced curly braces on method body entry.
+In such an implementation, even syntax errors will be detected
+only when the method needs to be executed,
+at which time it will be compiled (JITed).
 
-In a development environment a compiler should of course report compilation errors eagerly so as to best serve the programmer.
+In a development environment a compiler should of course
+report compilation errors eagerly so as to best serve the programmer.
 
-A Dart development environment might choose to support error eliminating program transformations, e.g.,
+A Dart development environment might choose to support
+ error eliminating program transformations, e.g.,
 replacing an erroneous expression by the invocation of a debugger.
-It is outside the scope of this document to specify how such transformations work, and where they may be applied.
+It is outside the scope of this document
+to specify how such transformations work,
+and where they may be applied.%
 }
 
 \LMHash{}%
-If an uncaught compile-time error occurs within the code of a running isolate $A$, $A$ is immediately suspended.
-The only circumstance where a compile-time error could be caught would be via code run reflectively, where the mirror system can catch it.
+If an uncaught compile-time error occurs
+within the code of a running isolate $A$, $A$ is immediately suspended.
+The only circumstance where a compile-time error could be caught would be
+via code run reflectively, where the mirror system can catch it.
 
-\rationale{
-Typically, once a compile-time error is thrown and $A$ is suspended, $A$ will then be terminated.
+\rationale{%
+Typically, once a compile-time error is thrown and $A$ is suspended,
+$A$ will then be terminated.
 However, this depends on the overall environment.
 A Dart engine runs in the context of an \Index{embedder},
-a program that interfaces between the engine and the surrounding computing environment.
-The embedder will often be a web browser, but need not be; it may be a C++ program on the server for example.
-When an isolate fails with a compile-time error as described above, control returns to the embedder, along with an exception describing the problem.
+a program that interfaces between the engine and
+the surrounding computing environment.
+The embedder will often be a web browser, but need not be;
+it may be a C++ program on the server for example.
+When an isolate fails with a compile-time error as described above,
+control returns to the embedder,
+along with an exception describing the problem.
 This is necessary so that the embedder can clean up resources etc.
-It is then the embedder's decision whether to terminate the isolate or not.
+It is then the embedder's decision whether to terminate the isolate or not.%
 }
 
 \LMHash{}%
@@ -1025,7 +1108,8 @@ It is then the embedder's decision whether to terminate the isolate or not.
 are situations that do not preclude execution,
 but which are unlikely to be intended,
 and likely to cause bugs or inconveniences.
-A static warning must be reported by a Dart compiler before the associated code is executed.
+A static warning must be reported by a Dart compiler
+before the associated code is executed.
 
 \LMHash{}%
 When this specification says that a \Index{dynamic error} occurs,
@@ -1044,7 +1128,8 @@ When we say that a $C$ \IndexCustom{is thrown}{throwing a class},
 where $C$ is a class, we mean that an instance of class $C$ is thrown.
 
 \LMHash{}%
-If an uncaught exception is thrown by a running isolate $A$, $A$ is immediately suspended.
+If an uncaught exception is thrown by a running isolate $A$,
+$A$ is immediately suspended.
 
 
 \section{Variables}
@@ -1076,7 +1161,7 @@ is equivalent to multiple variable declarations declaring
 the same set of variable names, in the same order,
 with the same initialization, type, and modifiers.
 
-\commentary{
+\commentary{%
 For example,
 \code{\VAR{} x, y;}
 is equivalent to
@@ -1084,7 +1169,7 @@ is equivalent to
 and
 \code{\STATIC{} \FINAL{} String s1, s2 = "foo";}
 is equivalent to
-\code{\STATIC{} \FINAL{} String s1; \STATIC{} \FINAL{} String s2 = "foo";}.
+\code{\STATIC{} \FINAL{} String s1; \STATIC{} \FINAL{} String s2 = "foo";}.%
 }
 
 \LMHash{}%
@@ -1107,11 +1192,11 @@ we say that it is an \Index{referencing occurrence}.
 We also abbreviate that to say that an identifier is
 a \Index{declaring identifier} respectively an \Index{referencing identifier}.
 
-\commentary{
+\commentary{%
 In an expression of the form \code{$e$.\id} it is possible that
 $e$ has static type \DYNAMIC{} and \id{} cannot be associated with
 any specific declaration named \id{} at compile-time,
-but in this situation \id{} is still a referencing identifier.
+but in this situation \id{} is still a referencing identifier.%
 }
 
 \LMHash{}%
@@ -1147,8 +1232,10 @@ which means that \CONST{} modifiers need not be specified explicitly.%
 \LMHash{}%
 A \IndexCustom{final variable}{variable!final}
 is a variable whose binding is fixed upon initialization;
-a final variable $v$ will always refer to the same object after $v$ has been initialized.
-A variable is final if{}f its declaration includes the modifier \FINAL{} or the modifier \CONST{}.
+a final variable $v$ will always refer to the same object
+after $v$ has been initialized.
+A variable is final if{}f its declaration includes
+the modifier \FINAL{} or the modifier \CONST{}.
 
 \LMHash{}%
 A \IndexCustom{mutable variable}{variable!mutable}
@@ -1212,28 +1299,39 @@ induces an implicit setter function with signature
 whose execution sets the value of $v$ to the incoming argument $x$.
 
 \LMHash{}%
-The scope into which the implicit getters and setters are introduced depends on the kind of variable declaration involved.
+The scope into which the implicit getters and setters are introduced
+depends on the kind of variable declaration involved.
 
 \LMHash{}%
-A library variable introduces a getter into the top level scope of the enclosing library.
-A class variable introduces a static getter into the immediately enclosing class.
-An instance variable introduces an instance getter into the immediately enclosing class.
+A library variable introduces a getter into
+the top level scope of the enclosing library.
+A class variable introduces a static getter into
+the immediately enclosing class.
+An instance variable introduces an instance getter into
+the immediately enclosing class.
 
 \LMHash{}%
-A mutable library variable introduces a setter into the top level scope of the enclosing library.
-A mutable class variable introduces a static setter into the immediately enclosing class.
-A mutable instance variable introduces an instance setter into the immediately enclosing class.
+A mutable library variable introduces a setter into
+the top level scope of the enclosing library.
+A mutable class variable introduces a static setter into
+the immediately enclosing class.
+A mutable instance variable introduces an instance setter into
+the immediately enclosing class.
 
 \LMHash{}%
 Let $v$ be variable declared in an initializing variable declaration,
 and let $e$ be the associated initializing expression.
-It is a compile-time error if the static type of $e$ is not assignable to the declared type of $v$.
-It is a compile-time error if a final instance variable whose declaration has an initializer expression
-is also initialized by a constructor, either by an initializing formal or an initializer list entry.
-
-\commentary{
+It is a compile-time error if the static type of $e$
+is not assignable to the declared type of $v$.
 It is a compile-time error if a final instance variable
-that has been initialized by means of an initializing formal of a constructor $k$
+whose declaration has an initializer expression
+is also initialized by a constructor,
+either by an initializing formal or an initializer list entry.
+
+\commentary{%
+It is a compile-time error if a final instance variable
+that has been initialized by means of
+an initializing formal of a constructor $k$
 is also initialized in the initializer list of $k$ (\ref{initializerLists}).
 
 %% TODO(eernst): Not quite true, because of special lookup for assignment!
@@ -1250,26 +1348,32 @@ but initialization and assignment is not the same thing.
 When the receiver has type \DYNAMIC{}
 such an assignment is not a compile-time error,
 % This error can occur because the receiver is dynamic.
-but if there is no setter it will cause a dynamic error.
+but if there is no setter it will cause a dynamic error.%
 }
 
 \LMHash{}%
-A variable that has no initializing expression has the null object (\ref{null}) as its initial value.
+A variable that has no initializing expression has the null object
+(\ref{null})
+as its initial value.
 Otherwise, variable initialization proceeds as follows:
 
 \LMHash{}%
-Static variable declarations with an initializing expression are initialized lazily
+Static variable declarations with an initializing expression
+are initialized lazily
 (\ref{evaluationOfImplicitVariableGetters}).
 
-\rationale{
-The lazy semantics are given because we do not want a language where one tends to define expensive initialization computations, causing long application startup times.
-This is especially crucial for Dart, which must support the coding of client applications.
+\rationale{%
+The lazy semantics are given because we do not want a language
+where one tends to define expensive initialization computations,
+causing long application startup times.
+This is especially crucial for Dart,
+which must support the coding of client applications.%
 }
 
-\commentary{
+\commentary{%
 Initialization of an instance variable with no initializing expression
 takes place during constructor execution
-(\ref{initializerLists}).
+(\ref{initializerLists}).%
 }
 
 \LMHash{}%
@@ -1279,20 +1383,20 @@ proceeds as follows:
 $e$ is evaluated to an object $o$
 and the variable $v$ is bound to $o$.
 
-\commentary{
+\commentary{%
 It is specified elsewhere when this initialization occurs,
 and in which environment
 (p.\,\pageref{executionOfGenerativeConstructors},
 \ref{localVariableDeclaration},
-\ref{bindingActualsToFormals}).
+\ref{bindingActualsToFormals}).%
 }
 
-\commentary{
+\commentary{%
 If the initializing expression throws then
 access to the uninitialized variable is prevented,
 because the instance creation
 that caused this initialization to take place
-will throw.
+will throw.%
 }
 
 \LMHash{}%
@@ -1307,7 +1411,8 @@ a subtype of the actual type of the variable $v$
 \LMLabel{evaluationOfImplicitVariableGetters}
 
 \LMHash{}%
-Let $d$ be the declaration of a static or instance variable $v$.
+Let \DefineSymbol{d} be the declaration of
+a static or instance variable \DefineSymbol{v}.
 If $d$ is an instance variable,
 then the invocation of the implicit getter of $v$ evaluates to
 the object stored in $v$.
@@ -1345,9 +1450,9 @@ If $d$ is of one of the forms
 \code{\STATIC{} \CONST{} $v$ = $e$;} or
 \code{\STATIC{} \CONST{} $T$ $v$ = $e$;}
 the result of the getter is the value of the constant expression $e$.
-\commentary{
+\commentary{%
 Note that a constant expression cannot depend on itself,
-so no cyclic references can occur.
+so no cyclic references can occur.%
 }
 \item {\bf Variable declaration without initializer}.
 The result of executing the getter method is the object stored in $v$.
@@ -1479,7 +1584,8 @@ OR
     (\ref{return}).%
     }
   \item The function is asynchronous, \flatten{T} is not \VOID{},
-    and it would have been a compile-time error to declare the function with the body
+    and it would have been a compile-time error
+    to declare the function with the body
     \code{\ASYNC{} \{ \RETURN{} $e$; \}}
     rather than \code{\ASYNC{} => $e$}.
     \commentary{%
@@ -1493,22 +1599,34 @@ OR
 \end{itemize}
 
 \LMHash{}%
-It is a compile-time error if an \ASYNC, \code{\ASYNC*} or \code{\SYNC*} modifier is attached to the body of a setter or constructor.
+It is a compile-time error
+if an \ASYNC, \code{\ASYNC*} or \code{\SYNC*} modifier is attached to
+the body of a setter or constructor.
 
-\rationale{
-An asynchronous setter would be of little use, since setters can only be used in the context of an assignment (\ref{assignment}),
-and an assignment expression always evaluates to the value of the assignment's right hand side.
+\rationale{%
+An asynchronous setter would be of little use,
+since setters can only be used in the context of an assignment
+(\ref{assignment}),
+and an assignment expression always evaluates to
+the value of the assignment's right hand side.
 If the setter actually did its work asynchronously,
-one might imagine that one would return a future that resolved to the assignment's right hand side after the setter did its work.
+one might imagine that one would return a future that resolved to
+the assignment's right hand side after the setter did its work.
 
-An asynchronous constructor would, by definition, never return an instance of the class it purports to construct, but instead return a future.
+An asynchronous constructor would, by definition, never return
+an instance of the class it purports to construct,
+but instead return a future.
 Calling such a beast via \NEW{} would be very confusing.
 If you need to produce an object asynchronously, use a method.
 
 One could allow modifiers for factories.
-A factory for \code{Future} could be modified by \ASYNC{}, a factory for \code{Stream} could be modified by \code{\ASYNC*} and a factory for \code{Iterable} could be modified by \code{\SYNC*}.
-No other scenario makes sense because the object returned by the factory would be of the wrong type.
-This situation is very unusual so it is not worth making an exception to the general rule for constructors in order to allow it.
+A factory for \code{Future} could be modified by \ASYNC{},
+a factory for \code{Stream} could be modified by \code{\ASYNC*},
+and a factory for \code{Iterable} could be modified by \code{\SYNC*}.
+No other scenario makes sense because
+the object returned by the factory would be of the wrong type.
+This situation is very unusual so it is not worth making an exception
+to the general rule for constructors in order to allow it.%
 }
 
 \LMHash{}%
@@ -1529,7 +1647,7 @@ We define the notion of the
 \IndexCustom{element type of a generator}{function!generator!element type}
 as follows:
 %
-If the function $f$ is a synchronous generator
+If the function \DefineSymbol{f} is a synchronous generator
 whose declared return type implements \code{Iterable<$U$>} for some $U$
 (\ref{interfaceSuperinterfaces})
 then the element type of $f$ is $U$.
@@ -1555,7 +1673,8 @@ the type of elements that the generator will yield.%
 \LMLabel{functionDeclarations}
 
 \LMHash{}%
-A \Index{function declaration} is a function that is neither a member of a class nor a function literal.
+A \Index{function declaration} is a function that
+is neither a member of a class nor a function literal.
 Function declarations include exactly the following:
 \IndexCustom{library functions}{function!library},
 which are function declarations
@@ -1566,32 +1685,47 @@ which are function declarations declared inside other functions.
 Library functions are often referred to simply as top-level functions.
 
 \LMHash{}%
-A function declaration consists of an identifier indicating the function's name, possibly prefaced by a return type.
+A function declaration consists of an identifier indicating the function's name,
+possibly prefaced by a return type.
 The function name is followed by a signature and body.
 For getters, the signature is empty.
 The body is empty for functions that are external.
 
 \LMHash{}%
 The scope of a library function is the scope of the enclosing library.
-The scope of a local function is described in section \ref{localFunctionDeclaration}.
-In both cases, the name of the function is in scope in its formal parameter scope (\ref{formalParameters}).
+The scope of a local function is described
+in section~\ref{localFunctionDeclaration}.
+In both cases, the name of the function is in scope
+in its formal parameter scope
+(\ref{formalParameters}).
 
 \LMHash{}%
-It is a compile-time error to preface a function declaration with the built-in identifier \STATIC{}.
+It is a compile-time error to preface a function declaration
+with the built-in identifier \STATIC{}.
 
 \LMHash{}%
-When we say that a function $f_1$ \Index{forwards} to another function $f_2$, we mean that invoking $f_1$ causes $f_2$ to be executed with the same arguments and/or receiver as $f_1$, and returns the result of executing $f_2$ to the caller of $f_1$, unless $f_2$ throws an exception, in which case $f_1$ throws the same exception.
-Furthermore, we only use the term for synthetic functions introduced by the specification.
+When we say that a function $f_1$ \Index{forwards} to another function $f_2$, 
+we mean that invoking $f_1$ causes $f_2$ to be executed
+with the same arguments and/or receiver as $f_1$,
+and returns the result of executing $f_2$ to the caller of $f_1$,
+unless $f_2$ throws an exception,
+in which case $f_1$ throws the same exception.
+Furthermore, we only use the term for
+synthetic functions introduced by the specification.
 
 
 \subsection{Formal Parameters}
 \LMLabel{formalParameters}
 
 \LMHash{}%
-Every non-getter function declaration includes a \Index{formal parameter list},
-which consists of a list of required positional parameters (\ref{requiredFormals}),
+Every non-getter function declaration includes a
+\Index{formal parameter list},
+which consists of a list of required positional parameters
+(\ref{requiredFormals}),
 followed by any optional parameters (\ref{optionalFormals}).
-The optional parameters may be specified either as a set of named parameters or as a list of positional parameters, but not both.
+The optional parameters may be specified either as
+a set of named parameters or as a list of positional parameters,
+but not both.
 
 \LMHash{}%
 Some function declarations include a
@@ -1602,56 +1736,72 @@ A \IndexCustom{non-generic function}{function!non-generic}
 is a function which is not generic.
 
 \LMHash{}%
-The \Index{formal parameter part} of a function declaration consists of the formal type parameter list, if any, and the formal parameter list.
+The \Index{formal parameter part} of a function declaration consists of
+the formal type parameter list, if any, and the formal parameter list.
 
-\commentary{
+\commentary{%
 The following kinds of functions cannot be generic:
-Getters, setters, operators, and constructors.
+Getters, setters, operators, and constructors.%
 }
 
 \LMHash{}%
 The formal type parameter list of a function declaration introduces
 a new scope known as the function's
 \IndexCustom{type parameter scope}{scope!type parameter}.
-The type parameter scope of a generic function $f$ is enclosed in the scope where $f$ is declared.
+The type parameter scope of a generic function \DefineSymbol{f} is enclosed in
+the scope where $f$ is declared.
 Every formal type parameter introduces a type into the type parameter scope.
 
 \LMHash{}%
-If it exists, the type parameter scope of a function $f$ is the current scope for the signature of $f$, and for the formal type parameter list itself;
-otherwise the scope where $f$ is declared is the current scope for the signature of $f$.
+If it exists, the type parameter scope of a function $f$ is
+the current scope for the signature of $f$,
+and for the formal type parameter list itself;
+otherwise the scope where $f$ is declared is
+the current scope for the signature of $f$.
 
-\commentary{
-This means that formal type parameters are in scope in the bounds of parameter declarations,
+\commentary{%
+This means that formal type parameters are in scope
+in the bounds of parameter declarations,
 allowing for so-called F-bounded type parameters like
 
 \code{class C<X \EXTENDS{} Comparable<X>{}> \{ \ldots{} \}},
 
 \noindent
-and the formal type parameters are in scope for each other, allowing dependencies like
-\code{class D<X \EXTENDS{} Y, Y> \{ \ldots{} \}}.
+and the formal type parameters are in scope for each other,
+allowing dependencies like
+\code{class D<X \EXTENDS{} Y, Y> \{ \ldots{} \}}.%
 }
 
 \LMHash{}%
-The formal parameter list of a function declaration introduces a new scope known as the function's
+The formal parameter list of a function declaration introduces
+a new scope known as the function's
 \IndexCustom{formal parameter scope}{scope!formal parameter}.
-The formal parameter scope of a non-generic function $f$ is enclosed in the scope where $f$ is declared.
-The formal parameter scope of a generic function $f$ is enclosed in the type parameter scope of $f$.
-Every formal parameter introduces a local variable into the formal parameter scope.
-The current scope for the function's signature is the scope that encloses the formal parameter scope.
+The formal parameter scope of a non-generic function $f$ is enclosed in
+the scope where $f$ is declared.
+The formal parameter scope of a generic function $f$ is enclosed in
+the type parameter scope of $f$.
+Every formal parameter introduces a local variable into
+the formal parameter scope.
+The current scope for the function's signature is
+the scope that encloses the formal parameter scope.
 
-\commentary{
+\commentary{%
 This means that in a generic function declaration,
-the return type and parameter type annotations can use the formal type parameters,
-but the formal parameters are not in scope in the signature.
+the return type and parameter type annotations can use
+the formal type parameters,
+but the formal parameters are not in scope in the signature.%
 }
 
 \LMHash{}%
-The body of a function declaration introduces a new scope known as the function's
+The body of a function declaration introduces
+a new scope known as the function's
 \IndexCustom{body scope}{scope!function body}.
-The body scope of a function $f$ is enclosed in the scope introduced by the formal parameter scope of $f$.
+The body scope of a function $f$ is enclosed in the scope introduced by
+the formal parameter scope of $f$.
 
 \LMHash{}%
-It is a compile-time error if a formal parameter is declared as a constant variable (\ref{variables}).
+It is a compile-time error if a formal parameter
+is declared as a constant variable (\ref{variables}).
 
 \begin{grammar}
 <formalParameterList> ::= `(' `)'
@@ -1672,9 +1822,14 @@ It is a compile-time error if a formal parameter is declared as a constant varia
   `{' <defaultNamedParameter> (`,' <defaultNamedParameter>)* `,'? `}'
 \end{grammar}
 
-Formal parameter lists allow an optional trailing comma after the last parameter (\syntax{`,'?}).
-A parameter list with such a trailing comma is equivalent in all ways to the same parameter list without the trailing comma.
-All parameter lists in this specification are shown without a trailing comma, but the rules and semantics apply equally to the corresponding parameter list with a trailing comma.
+\LMHash{}%
+Formal parameter lists allow an optional trailing comma
+after the last parameter (\syntax{`,'?}).
+A parameter list with such a trailing comma is
+equivalent in all ways to the same parameter list without the trailing comma.
+All parameter lists in this specification are shown without a trailing comma,
+but the rules and semantics apply equally to
+the corresponding parameter list with a trailing comma.
 
 
 \subsubsection{Required Formals}
@@ -1683,10 +1838,16 @@ All parameter lists in this specification are shown without a trailing comma, bu
 \LMHash{}%
 A \Index{required formal parameter} may be specified in one of three ways:
 \begin{itemize}
-\item By means of a function signature that names the parameter and describes its type as a function type (\ref{functionTypes}).
-It is a compile-time error if any default values are specified in the signature of such a function type.% explain what the type is in this case? Where is this described in general?
-\item As an initializing formal, which is only valid as a parameter to a generative constructor (\ref{generativeConstructors}). % do we need to say this, or anything more?
-\item Via an ordinary variable declaration (\ref{variables}).
+\item
+  By means of a function signature that names the parameter and
+  describes its type as a function type (\ref{functionTypes}).
+  It is a compile-time error if any default values are specified
+  in the signature of such a function type.
+\item
+  As an initializing formal, which is only valid as a parameter to
+  a generative constructor (\ref{generativeConstructors}).
+\item
+  Via an ordinary variable declaration (\ref{variables}).
 \end{itemize}
 
 \begin{grammar}
@@ -1732,10 +1893,10 @@ in some forms of parameter declarations.
 The effect of doing this is described in a separate section
 (\ref{covariantParameters}).
 
-\commentary{
+\commentary{%
 Note that the non-terminal \synt{normalFormalParameter} is also used
 in the grammar rules for optional parameters,
-which means that such parameters can also be covariant.
+which means that such parameters can also be covariant.%
 }
 
 \LMHash{}%
@@ -1770,11 +1931,17 @@ If no default is explicitly specified for an optional parameter an implicit defa
 \LMHash{}%
 It is a compile-time error if the name of a named optional parameter begins with an `_' character.
 
-\rationale{
-The need for this restriction is a direct consequence of the fact that naming and privacy are not orthogonal.
-If we allowed named parameters to begin with an underscore, they would be considered private and inaccessible to callers from outside the library where it was defined.
-If a method outside the library overrode a method with a private optional name, it would not be a subtype of the original method.
-The static checker would of course flag such situations, but the consequence would be that adding a private named formal would break clients outside the library in a way they could not easily correct.
+\rationale{%
+The need for this restriction is a direct consequence of
+the fact that naming and privacy are not orthogonal.
+If we allowed named parameters to begin with an underscore,
+they would be considered private and inaccessible to
+callers from outside the library where it was defined.
+If a method outside the library overrode a method with a private optional name,
+it would not be a subtype of the original method.
+The static checker would of course flag such situations, 
+but the consequence would be that adding a private named formal would break
+clients outside the library in a way they could not easily correct.%
 }
 
 
@@ -1785,8 +1952,10 @@ The static checker would of course flag such situations, but the consequence wou
 Dart allows formal parameters of instance methods,
 including setters and operators,
 to be declared \COVARIANT{}.
-\commentary{
-The syntax for doing this is specified in an earlier section (\ref{requiredFormals}).
+
+\commentary{%
+The syntax for doing this is specified in an earlier section
+(\ref{requiredFormals}).%
 }
 
 \LMHash{}%
@@ -1794,17 +1963,17 @@ It is a compile-time error if the modifier \COVARIANT{} occurs
 in the declaration of a formal parameter of a function
 which is not an instance method, an instance setter, or an operator.
 
-\commentary{
+\commentary{%
 As specified below, a parameter can also be covariant for other reasons.
 The overall effect of having a covariant parameter $p$
 in the signature of a given method $m$
 is to allow the type of $p$ to be overridden covariantly,
 which means that the type required at run time for a given actual argument
 may be a proper subtype of the type which is known at compile time
-at the call site.
+at the call site.%
 }
 
-\rationale{
+\rationale{%
 This mechanism allows developers to explicitly request that
 a compile-time guarantee which is otherwise supported
 (namely: that an actual argument whose static type satisfies the requirement
@@ -1813,17 +1982,21 @@ is replaced by dynamic type checks.
 In return for accepting these dynamic type checks,
 developers can use covariant parameters to express software designs
 where the dynamic type checks are known (or at least trusted) to succeed,
-based on reasoning that the static type analysis does not capture.
+based on reasoning that the static type analysis does not capture.%
 }
 
 \LMHash{}%
+\BlindDefineSymbol{m, X_j, s}%
 Let $m$ be a method signature with formal type parameters
 \List{X}{1}{s},
 positional formal parameters \List{p}{1}{n},
+\BlindDefineSymbol{p, n, q, k}%
 and named formal parameters \List{q}{1}{k}.
+\BlindDefineSymbol{m', X'_j}%
 Let $m'$ be a method signature with formal type parameters
 \List{X'\!}{1}{s},
 positional formal parameters \List{p'\!}{1}{n'},
+\BlindDefineSymbol{p', n', q', k'}%
 and named formal parameters \List{q'\!}{1}{k'}.
 %
 Assume that $j \in 1 .. n'$, and $j \leq n$;
@@ -1840,12 +2013,12 @@ $X'_j$ from $m'$
 \NoIndex{corresponds} to the formal type parameter
 $X_j$ from $m$, for all $j \in 1 .. s$.
 
-\commentary{
+\commentary{%
 This includes the case where $m$ respectively $m'$ has
 optional positional parameters,
 in which case $k = 0$ respectively $k' = 0$ must hold,
 but we can have $n \not= n'$.
-The case where the numbers of formal type parameters differ is not relevant.
+The case where the numbers of formal type parameters differ is not relevant.%
 }
 
 % Being covariant is a property of a parameter of the interface of a class;
@@ -1859,7 +2032,9 @@ The case where the numbers of formal type parameters differ is not relevant.
 % that parameter. The same approach is applicable for covariant-by-class.
 
 \LMHash{}%
-Let $C$ be a class that declares a method $m$ which has
+\BlindDefineSymbol{C, m, p}%
+Let $C$ be a class that declares
+a method $m$ which has
 a parameter $p$ whose declaration has the modifier \COVARIANT{};
 in this case we say that the parameter $p$ is
 \IndexCustom{covariant-by-declaration}{parameter!covariant-by-declaration}.
@@ -1878,7 +2053,8 @@ which has a parameter $p'$ that corresponds to $p$,
 such that $p'$ is covariant-by-declaration.
 
 \LMHash{}%
-Assume that $C$ is a generic class with formal type parameter declarations
+Assume that \BlindDefineSymbol{C, X_j, B_j, s}$C$ is a generic class
+with formal type parameter declarations
 \code{$X_1\ \EXTENDS\ B_1 \ldots,\ X_s\ \EXTENDS\ B_s$},
 let $m$ be a declaration of an instance method in $C$
 (which can be a method, a setter, or an operator),
@@ -1907,7 +2083,7 @@ A formal parameter $p$ is
 \IndexCustom{covariant}{parameter!covariant}
 if $p$ is covariant-by-declaration or $p$ is covariant-by-class.
 
-\commentary{
+\commentary{%
 It is possible for a parameter to be simultaneously
 covariant-by-declaration and covariant-by-class.
 Note that a parameter may be
@@ -1917,7 +2093,7 @@ including any superclass:
 The definitions above propagate these properties
 to an interface from each of its direct superinterfaces,
 but they will in turn receive the property from their direct superinterfaces,
-and so on.
+and so on.%
 }
 
 
@@ -1954,11 +2130,11 @@ Similarly, the optional brackets \code{[]} and \code{\{\}} are omitted
 when there are no optional parameters.
 
 % We promise that the two forms always get the same treatment for k=0.
-\commentary{
+\commentary{%
 Both forms with optionals cover function types with no optionals when $k = 0$,
 and every rule in this specification is such that
 any of the two forms may be used without ambiguity
-to determine the treatment of function types with no optionals.
+to determine the treatment of function types with no optionals.%
 }
 
 \LMHash{}%
@@ -1973,22 +2149,24 @@ in which case its return type is \VOID{}.
 A function declaration may declare formal type parameters.
 The type of the function includes the names of the type parameters
 and for each type parameter the upper bound,
-which is considered to be the built-in class \code{Object} if no bound is specified.
-When consistent renaming of type parameters can make two function types identical,
+which is considered to be the built-in class \code{Object}
+if no bound is specified.
+When consistent renaming of type parameters
+can make two function types identical,
 they are considered to be the same type.
 
-\commentary{
+\commentary{%
 It is convenient to include the formal type parameter names in function types
 because they are needed in order to express such things as relations among
 different type parameters, F-bounds, and the types of formal parameters.
 However, we do not wish to distinguish between two function types if they have
 the same structure and only differ in the choice of names.
-This treatment of names is also known as alpha-equivalence.
+This treatment of names is also known as alpha-equivalence.%
 }
 
 \LMHash{}%
 In the following three paragraphs,
-if the number $m$ of formal type parameters is zero then
+if the number \DefineSymbol{s} of formal type parameters is zero then
 the type parameter list in the function type is omitted.
 
 \LMHash{}%
@@ -2030,7 +2208,9 @@ applied to $F$,
 and let $t$ be the actual type corresponding to $T$
 at the occasion where $o$ was created
 (\ref{actualTypes}).
-\commentary{$T$ may contain free type variables, but $t$ contains their actual values.}
+\commentary{%
+$T$ may contain free type variables, but $t$ contains their actual values.%
+}
 The following must then hold:
 $u$ is a class that implements the built-in class \FUNCTION{};
 $u$ is a subtype of $t$;
@@ -2043,7 +2223,7 @@ could evaluate to \TRUE{} with the declaration
 which is obviously not the intention.%
 }
 
-\rationale{
+\rationale{%
 It is up to the implementation to choose
 an appropriate representation for function objects.
 For example, consider that
@@ -2056,7 +2236,7 @@ Arity may be implicitly affected by whether a function is
 an instance method (with an implicit receiver parameter) or not.
 The variations are manifold and, e.g.,
 one cannot assume that any two distinct function objects
-will necessarily have the same run-time type.
+will necessarily have the same run-time type.%
 }
 
 
@@ -2231,23 +2411,23 @@ whose declaration is abstract, and
 a \IndexCustom{concrete class}{class!concrete} is a class
 whose declaration is concrete.
 
-\rationale{
+\rationale{%
 We want different behavior for concrete classes and abstract classes.
 If $A$ is intended to be abstract,
 we want the static checker to warn about any attempt to instantiate $A$,
 and we do not want the checker to complain about unimplemented methods in $A$.
 In contrast, if $A$ is intended to be concrete,
 the checker should warn about all unimplemented methods,
-but allow clients to instantiate it freely.
+but allow clients to instantiate it freely.%
 }
 
-\commentary{
+\commentary{%
 The interface of a class $C$ is
 an implicit interface that declares instance member signatures
 that correspond to the instance members declared by $C$,
 and whose direct superinterfaces are
 the direct superinterfaces of $C$
-(\ref{interfaces}, \ref{superinterfaces}).
+(\ref{interfaces}, \ref{superinterfaces}).%
 }
 
 \LMHash{}%
@@ -2260,6 +2440,7 @@ that name denotes the interface of the class.
 % underscores the fact that even when an abstract declaration of $m$ is
 % declared in $C$, $C$ does not "have" $m$.
 A concrete class must fully implement its interface:
+\BlindDefineSymbol{C, I, m}%
 Let $C$ be a concrete class with interface $I$.
 Assume that $I$ has an accessible member signature $m$.
 It is a compile-time error if $C$ does not have
@@ -2273,7 +2454,7 @@ with a method signature $m'$ which is not a correct override of $m$
 unless that concrete member is a \code{noSuchMethod} forwarder
 (\ref{theMethodNoSuchMethod}).
 
-\commentary{
+\commentary{%
 In particular, it is an error for a class to be concrete even if it inherits
 a member implementation for every member signature in its interface,
 unless each of them has parameters and types such that they satisfy
@@ -2282,24 +2463,25 @@ But when there is a non-trivial \code{noSuchMethod} it is allowed
 to leave some members unimplemented,
 and it is allowed to to have a \code{noSuchMethod} forwarder which does not
 satisfy the class interface
-(in which case it will be overridden by another \code{noSuchMethod} forwarder).
+(in which case it will be overridden by another \code{noSuchMethod} forwarder).%
 }
 
-\commentary{
+\commentary{%
 It is a compile-time error if a class declares two members of the same name,
 either because it declares the same name twice in the same scope
 (\ref{scoping}),
 or because it declares a static member and an instance member
 with the same name
-(\ref{classMemberConflicts}).
+(\ref{classMemberConflicts}).%
 }
 
-\commentary{
-Here are simple examples, that illustrate the difference between ``has a member'' and ``declares a member''.
+\commentary{%
+Here are simple examples, that illustrate the difference between
+``has a member'' and ``declares a member''.
 For example, \code{B} \IndexCustom{declares}{declares member}
  one member named \code{f},
 but \IndexCustom{has}{has member} two such members.
-The rules of inheritance determine what members a class has.
+The rules of inheritance determine what members a class has.%
 }
 
 \begin{dartCode}
@@ -2337,7 +2519,8 @@ or if $G$ has a constructor named \code{$G$.$X$}.
 are functions (\ref{functions})
 whose declarations are immediately contained within a class declaration
 and that are not declared \STATIC{}.
-The \Index{instance methods of a class} $C$ are the instance methods declared by $C$
+The \Index{instance methods of a class} $C$ are
+the instance methods declared by $C$
 and the instance methods inherited by $C$ from its superclass
 (\ref{inheritanceAndOverriding}).
 
@@ -2353,13 +2536,13 @@ from a direct superinterface of $C$
 unless this is a correct member override
 (\ref{correctMemberOverrides}).
 
-\commentary{
+\commentary{%
 This is not the only kind of conflict that may exist:
 An instance member declaration $D$ may conflict with another declaration $D'$,
 even in the case where they do not have the same name
 or they are not the same kind of declaration.
 E.g., $D$ could be an instance getter and $D'$ a static setter
-(\ref{classMemberConflicts}).
+(\ref{classMemberConflicts}).%
 }
 
 \LMHash{}%
@@ -2371,7 +2554,7 @@ such that $m''$ has a parameter $p''$ that corresponds to $p$
 (\ref{covariantParameters}),
 unless the type of $p$ is assignable to the type of $p''$.
 
-\commentary{
+\commentary{%
 This means that
 a parameter which is covariant-by-declaration can have a type
 which is a supertype or a subtype of the type of
@@ -2379,10 +2562,10 @@ a corresponding parameter in a superinterface,
 but the two types cannot be unrelated.
 Note that this requirement must be satisfied
 for each direct or indirect superinterface separately,
-because assignability is not transitive.
+because assignability is not transitive.%
 }
 
-\rationale{
+\rationale{%
 The superinterface may be the statically known type of the receiver,
 so this means that we relax the potential typing relationship
 between the statically known type of a parameter and the
@@ -2397,7 +2580,7 @@ a proper subtype of the statically known type of the receiver.
 We chose to give priority to flexibility rather than safety here,
 because the whole point covariant parameters is that developers
 can make the choice to increase the flexibility
-in a trade-off where some static type safety is lost.
+in a trade-off where some static type safety is lost.%
 }
 
 
@@ -2479,19 +2662,19 @@ It is a compile-time error if the arity of the user-declared operator
 \lit{-}
 is not 0 or 1.
 
-\commentary{
+\commentary{%
 The \lit{-} operator is unique
 in that two overloaded versions are permitted.
 If the operator has no arguments, it denotes unary minus.
-If it has an argument, it denotes binary subtraction.
+If it has an argument, it denotes binary subtraction.%
 }
 
 \LMHash{}%
 The name of the unary operator \lit{-} is \code{unary-}.
 
-\rationale{
+\rationale{%
 This device allows the two methods to be distinguished
-for purposes of method lookup, override and reflection.
+for purposes of method lookup, override and reflection.%
 }
 
 \LMHash{}%
@@ -2506,13 +2689,13 @@ It is a compile-time error to declare an optional parameter in an operator.
 It is a compile-time error if a user-declared operator \lit{[]=}
 declares a return type other than \VOID{}.
 
-\commentary{
+\commentary{%
 If no return type is specified for a user-declared operator
 \lit{[]=},
-its return type is \VOID{} (\ref{typeOfAFunction}).
+its return type is \VOID{} (\ref{typeOfAFunction}).%
 }
 
-\rationale{
+\rationale{%
 The return type is \VOID{} because
 a return statement in an implementation of operator
 \lit{[]=}
@@ -2526,7 +2709,7 @@ and even if the executed body of operator
 completes with an object $o'$,
 that is, if $o'$ is returned it is simply ignored.
 The rationale for this behavior is that
-assignments should be guaranteed to evaluate to the assigned object.
+assignments should be guaranteed to evaluate to the assigned object.%
 }
 
 
@@ -2540,7 +2723,7 @@ in situations where one or more member lookups fail
 \ref{getterAccessAndMethodExtraction},
 \ref{assignment}).
 
-\commentary{
+\commentary{%
 We may think of \code{noSuchMethod} as a backup
 which kicks in when an invocation of a member $m$ is attempted,
 but there is no member named $m$,
@@ -2561,7 +2744,7 @@ the invoked function has static type \FUNCTION{} or \DYNAMIC.
 The method \code{noSuchMethod} can also be invoked in other ways, e.g.,
 it can be called explicitly like any other method,
 and it can be invoked from a \code{noSuchMethod} forwarder,
-as explained below.
+as explained below.%
 }
 
 \LMHash{}%
@@ -2569,7 +2752,7 @@ We say that a class $C$ \Index{has a non-trivial \code{noSuchMethod}}
 if $C$ has a concrete member named \code{noSuchMethod}
 which is distinct from the one declared in the built-in class \code{Object}.
 
-\commentary{
+\commentary{%
 Note that it must be a method that accepts one positional argument,
 in order to correctly override \code{noSuchMethod} in \code{Object}.
 For instance, it can have signature
@@ -2590,7 +2773,7 @@ rather than a repeated attempt to invoke \code{noSuchMethod}
 (\ref{bindingActualsToFormals}).
 Here is an example where a dynamic type error occurs because
 an attempt is made to pass an \code{Invocation}
-where only the null object is accepted:
+where only the null object is accepted:%
 }
 
 \begin{dartCode}
@@ -2681,7 +2864,7 @@ correctly override $S$. Consider the following example:%
 \}
 \end{dartCode}
 
-\commentary{
+\commentary{%
 In this example,
 an implementation with signature \code{foo(int i)} is inherited by \code{C},
 and the superinterface \code{B} declares
@@ -2705,20 +2888,20 @@ would override an explicitly declared inherited implementation.
 It is no problem, however,
 to let a \code{noSuchMethod} forwarder override
 another \code{noSuchMethod} forwarder,
-and hence there is no error in that situation.
+and hence there is no error in that situation.%
 }
 
-\commentary{
+\commentary{%
 This implies that a \code{noSuchMethod} forwarder has the same
 properties as an explicitly declared concrete member,
 except of course that a \code{noSuchMethod} forwarder
 does not prevent itself or another noSuchMethod forwarder from being induced.
 We do not specify the body of a \code{noSuchMethod} forwarder,
 but it will invoke \code{noSuchMethod},
-and we specify the dynamic semantics of executing it below.
+and we specify the dynamic semantics of executing it below.%
 }
 
-\commentary{
+\commentary{%
 At the beginning of this section we mentioned that implicit invocations
 of \code{noSuchMethod} can only occur
 with a receiver of static type \DYNAMIC{}
@@ -2728,10 +2911,10 @@ With a \code{noSuchMethod} forwarder,
 on a receiver whose static type is not \DYNAMIC{}.
 No similar situation exists for functions,
 because it is impossible to induce a \code{noSuchMethod} forwarder
-into the class of a function object.
+into the class of a function object.%
 }
 
-\commentary{
+\commentary{%
 For a concrete class $C$,
 we may think of a non-trivial \code{noSuchMethod}
 (declared in or inherited by $C$)
@@ -2744,7 +2927,7 @@ whether or not there is a non-trivial \code{noSuchMethod}.
 Note that the latter cannot be written explicitly in Dart,
 because their names are inaccessible;
 but the language can still specify that they are induced implicitly,
-because compilers control the treatment of private names.
+because compilers control the treatment of private names.%
 }
 
 \LMHash{}%
@@ -2760,11 +2943,11 @@ and named formal parameters with names
 \code{$x_1,\ \ldots,\ x_m$}
 (\commentary{with default values as mentioned above}).
 
-\commentary{
+\commentary{%
 For this purpose we need not distinguish between
 a signature that has optional positional parameters and
 a signature that has named parameters,
-because the former is covered by $m = 0$.
+because the former is covered by $m = 0$.%
 }
 
 \LMHash{}%
@@ -2796,7 +2979,7 @@ such that:
 Next, \code{noSuchMethod} is invoked with $i$ as the actual argument,
 and the result obtained from there is returned by the execution of $m$.
 
-\commentary{
+\commentary{%
 This is an ordinary method invocation of \code{noSuchMethod}
 (\ref{ordinaryInvocation}).
 That is, a \code{noSuchMethod} forwarder in a class $C$ can invoke
@@ -2821,7 +3004,7 @@ In that situation we will get an invocation of
 \code{Object.noSuchMethod}
 rather than the \code{noSuchMethod} in the original receiver,
 because this is an invocation of a function object
-(and they do not override \code{noSuchMethod}):
+(and they do not override \code{noSuchMethod}):%
 }
 
 \begin{dartCode}
@@ -2883,7 +3066,7 @@ In order to specify these constraints just once we introduce the notion of a
   a map literal
   (\ref{maps}), or
   a set literal
-  (\ref{sets}).
+  (\ref{sets}).%
   }
 \end{itemize}
 
@@ -2920,14 +3103,14 @@ and the instance getters inherited by $C$ from its superclass.
 The \Index{static getters of a class} $C$ are
 those static getters declared by $C$.
 
-\commentary{
+\commentary{%
 A getter declaration may conflict with other declarations
 (\ref{classMemberConflicts}).
 In particular, a getter can never override a method,
 and a method can never override a getter or an instance variable.
 The rules for when a getter correctly overrides another member
 are given elsewhere
-(\ref{correctMemberOverrides}).
+(\ref{correctMemberOverrides}).%
 }
 
 
@@ -2941,8 +3124,9 @@ Setters are functions (\ref{functions}) that are used to set the values of objec
 <setterSignature> ::= <type>? \SET{} <identifier> <formalParameterList>
 \end{grammar}
 
-\commentary{
-If no return type is specified, the return type of the setter is \VOID{} (\ref{typeOfAFunction}).
+\commentary{%
+If no return type is specified, the return type of the setter is \VOID{}
+(\ref{typeOfAFunction}).%
 }
 
 \LMHash{}%
@@ -2950,8 +3134,9 @@ A setter definition that is prefixed with the \STATIC{} modifier defines a stati
 Otherwise, it defines an instance setter.
 The name of a setter is obtained by appending the string `=' to the identifier given in its signature.
 
-\commentary{
-Hence, a setter name can never conflict with, override or be overridden by a getter or method.
+\commentary{%
+Hence, a setter name can never conflict with, override or be overridden by
+a getter or method.%
 }
 
 \LMHash{}%
@@ -2966,8 +3151,9 @@ either implicitly or explicitly.
 \LMHash{}%
 It is a compile-time error if a setter's formal parameter list
 does not consist of exactly one required formal parameter $p$.
-\rationale{
-We could enforce this via the grammar, but we'd have to specify the evaluation rules in that case.
+\rationale{%
+We could enforce this via the grammar,
+but we'd have to specify the evaluation rules in that case.%
 }
 
 \LMHash{}%
@@ -2977,12 +3163,12 @@ a setter named \code{$v$=} with argument type $T$ and
 a getter named $v$ with return type $S$,
 and $S$ may not be assigned to $T$.
 
-\commentary{
+\commentary{%
 The rules for when a setter correctly overrides another member
 are given elsewhere
 (\ref{correctMemberOverrides}).
 A setter declaration may conflict with other declarations as well
-(\ref{classMemberConflicts}).
+(\ref{classMemberConflicts}).%
 }
 
 
@@ -3001,7 +3187,7 @@ A \IndexCustom{concrete method}{method!concrete}
 \IndexCustom{concrete setter}{setter!concrete})
 is an instance method, getter or setter that is not abstract.
 
-\rationale{
+\rationale{%
 Abstract instance members are useful because of their interplay with classes.
 Every Dart class induces an implicit interface,
 and Dart does not support specifying interfaces explicitly.
@@ -3009,11 +3195,12 @@ Using an abstract class instead of a traditional interface
 has important advantages.
 An abstract class can provide default implementations.
 It can also provide static methods,
-obviating the need for service classes such as \code{Collections} or \code{Lists},
-whose entire purpose is to group utilities related to a given type.
+obviating the need for service classes
+such as \code{Collections} or \code{Lists},
+whose entire purpose is to group utilities related to a given type.%
 }
 
-\commentary{
+\commentary{%
 Invocation of an abstract method, getter, or setter cannot occur,
 because lookup (\ref{lookup}) will never yield an abstract member as its result.
 One way to think about this is that
@@ -3022,19 +3209,19 @@ does not override or shadow an inherited member implementation.
 It only serves to specify the signature of the given member that
 every concrete subtype must have an implementation of;
 that is, it contributes to the interface of the class,
-not to the class itself.
+not to the class itself.%
 }
 
-\rationale{
+\rationale{%
 The purpose of an abstract method is to provide a declaration
 for purposes such as type checking and reflection.
 In mixins, it is often useful to introduce such declarations for methods that
-the mixin expects will be provided by the superclass the mixin is applied to.
+the mixin expects will be provided by the superclass the mixin is applied to.%
 }
 
-\rationale{
+\rationale{%
 We wish to detect if one declares a concrete class with abstract members.
-However, code like the following should work:
+However, code like the following should work:%
 }
 
 \begin{dartCode}
@@ -3050,9 +3237,12 @@ class Base \{
 \CLASS{} C extends Base with Mix \{ \}
 \end{dartCode}
 
-\rationale{
-At run time, the concrete method \code{one} declared in \code{Base} will be executed, and no problem should arise.
-Therefore no error should be raised if a corresponding concrete member exists in the hierarchy.
+\rationale{%
+At run time, the concrete method \code{one} declared in \code{Base}
+will be executed,
+and no problem should arise.
+Therefore no error should be raised
+if a corresponding concrete member exists in the hierarchy.%
 }
 
 
@@ -3071,16 +3261,22 @@ and the instance variables inherited by $C$ from its superclass.
 \LMHash{}%
 It is a compile-time error if an instance variable is declared to be constant.
 
-\rationale{
-The notion of a constant instance variable is subtle and confusing to programmers.
+\rationale{%
+The notion of a constant instance variable
+is subtle and confusing to programmers.
 An instance variable is intended to vary per instance.
-A constant instance variable would have the same value for all instances, and as such is already a dubious idea.
+A constant instance variable would have the same value for all instances,
+and as such is already a dubious idea.
 
-The language could interpret const instance variable declarations as instance getters that return a constant.
-However, a constant instance variable could not be treated as a true compile-time constant, as its getter would be subject to overriding.
+The language could interpret const instance variable declarations as
+instance getters that return a constant.
+However, a constant instance variable could not be treated as
+a true compile-time constant,
+as its getter would be subject to overriding.
 
-Given that the value does not depend on the instance, it is better to use a class variable.
-An instance getter for it can always be defined manually if desired.
+Given that the value does not depend on the instance,
+it is better to use a class variable.
+An instance getter for it can always be defined manually if desired.%
 }
 
 \LMHash{}%
@@ -3092,12 +3288,12 @@ the corresponding implicitly induced setter
 is considered to be covariant-by-declaration
 (\ref{covariantParameters}).
 
-\commentary{
+\commentary{%
 The modifier \COVARIANT{} on an instance variable has no other effects.
 In particular, the return type of the implicitly induced getter
 can already be overridden covariantly without \COVARIANT{},
 and it can never be overridden to a supertype or an unrelated type,
-regardless of whether the modifier \COVARIANT{} is present.
+regardless of whether the modifier \COVARIANT{} is present.%
 }
 
 
@@ -3120,7 +3316,7 @@ whose return type is the class that contains the declaration of $k$,
 and whose formal parameter types, optionality, and names of named parameters
 correspond to the declaration of $k$.
 
-\commentary{
+\commentary{%
 Note that the function type $F$ of a constructor $k$ may contain
 type variables declared by the enclosing class $C$.
 In that case we can apply a substitution to $F$, as in
@@ -3128,7 +3324,7 @@ $[T_1/X_1, \ldots, T_m/X_m]F$,
 where $X_j, j \in 1 .. m$ are the formal type parameters of $C$
 and $T_j, j \in 1 .. m$ are specified in the given context.
 We may also omit such a substitution when the given context is
-the body scope of $C$, where $X_1, \ldots, X_m$ are in scope.
+the body scope of $C$, where $X_1, \ldots, X_m$ are in scope.%
 }
 
 \commentary{%
@@ -3214,10 +3410,15 @@ which is the current scope of the initializer list of the constructor,
 and which is enclosed in the scope where the constructor is declared.
 Each initializing formal in the formal parameter list introduces a final local variable into the formal parameter initializer scope, but not into the formal parameter scope; every other formal parameter introduces a local variable into both the formal parameter scope and the formal parameter initializer scope.
 
-\commentary{
-This means that formal parameters, including initializing formals, must have distinct names, and that initializing formals are in scope for the initializer list, but they are not in scope for the body of the constructor.
-When a formal parameter introduces a local variable into two scopes, it is still one variable and hence one storage location.
-The type of the constructor is defined in terms of its formal parameters, including the initializing formals.
+\commentary{%
+This means that formal parameters, including initializing formals,
+must have distinct names, and that initializing formals
+are in scope for the initializer list, 
+but they are not in scope for the body of the constructor.
+When a formal parameter introduces a local variable into two scopes,
+it is still one variable and hence one storage location.
+The type of the constructor is defined in terms of its formal parameters,
+including the initializing formals.%
 }
 
 \LMHash{}%
@@ -3231,8 +3432,8 @@ unless the assigned object has a dynamic type
 which is not a subtype of the declared type of the instance variable \id{},
 in which case a dynamic error occurs.
 
-\commentary{
-The above rule allows initializing formals to be used as optional parameters:
+\commentary{%
+The above rule allows initializing formals to be used as optional parameters:%
 }
 
 \begin{dartCode}
@@ -3242,8 +3443,8 @@ class A \{
 \}
 \end{dartCode}
 
-\commentary{
-is legal, and has the same effect as
+\commentary{%
+is legal, and has the same effect as%
 }
 
 \begin{dartCode}
@@ -3257,14 +3458,16 @@ class A \{
 A \Index{fresh instance} is an instance whose identity is distinct from any previously allocated instance of its class.
 A generative constructor always operates on a fresh instance of its immediately enclosing class.
 
-\commentary{
+\commentary{%
 The above holds if the constructor is actually run, as it is by \NEW{}.
-If a constructor $c$ is referenced by \CONST{}, $c$ may not be run; instead, a canonical object may be looked up.
-See the section on instance creation (\ref{instanceCreation}).
+If a constructor $c$ is referenced by \CONST{}, $c$ may not be run;
+instead, a canonical object may be looked up.
+See the section on instance creation (\ref{instanceCreation}).%
 }
 
 \LMHash{}%
-If a generative constructor $c$ is not a redirecting constructor and no body is provided, then $c$ implicitly has an empty body \code{\{\}}.
+If a generative constructor $c$ is not a redirecting constructor
+and no body is provided, then $c$ implicitly has an empty body \code{\{\}}.
 
 
 \paragraph{Redirecting Generative Constructors}
@@ -3275,7 +3478,9 @@ A generative constructor may be
 \IndexCustom{redirecting}{constructor!redirecting},
 in which case its only action is to invoke another generative constructor.
 A redirecting constructor has no body;
-instead, it has a redirect clause that specifies which constructor the invocation is redirected to, and with which arguments.
+instead, it has a redirect clause that specifies
+which constructor the invocation is redirected to,
+and with which arguments.
 
 \begin{grammar}
 <redirection> ::= `:' \THIS{} (`.' <identifier>)? <arguments>
@@ -3312,13 +3517,17 @@ It is a compile-time error if the static argument list type (\ref{actualArgument
 \code{($e_1 \ldots,\ e_p,\ x_1$: $e_{p+1}, \ldots,\ x_q$: $e_{p+q}$)}
 is not an assignable match for the formal parameter list of the redirectee.
 
-\commentary{
-Note that the case where no named parameters are passed is covered by letting $q$ be zero,
-and the case where $C$ is a non-generic class is covered by letting $m$ be zero,
-in which case the formal type parameter list and actual type argument lists are omitted (\ref{generics}).
+\commentary{%
+Note that the case where no named parameters are passed
+is covered by letting $q$ be zero,
+and the case where $C$ is a non-generic class
+is covered by letting $m$ be zero,
+in which case the formal type parameter list and actual type argument lists
+are omitted
+(\ref{generics}).%
 }
 
-\rationale{
+\rationale{%
 We require an assignable match rather than the stricter subtype match
 because a generative redirecting constructor $k$ invokes its redirectee $k'$
 in a manner which resembles function invocation in general.
@@ -3326,7 +3535,7 @@ For instance, $k$ could accept an argument \code{x}
 and pass on an expression $e_j$ using \code{x} such as \code{x.f(42)} to $k'$,
 and it would be surprising
 if $e_j$ were subject to more strict constraints than the ones applied to
-actual arguments to function invocations in general.
+actual arguments to function invocations in general.%
 }
 
 \LMHash{}%
@@ -3356,7 +3565,7 @@ of the corresponding formal parameter in the declaration of the redirectee.
 \LMHash{}%
 An initializer list begins with a colon, and consists of a comma-separated list of individual \Index{initializers}.
 
-\commentary{
+\commentary{%
 There are three kinds of initializers.
 \begin{itemize}
 \item[$\bullet$] A \emph{superinitializer} identifies a
@@ -3367,7 +3576,7 @@ There are three kinds of initializers.
 \item[$\bullet$] An \emph{instance variable initializer}
   assigns an object to an individual instance variable.
 \item[$\bullet$] An assertion.
-\end{itemize}
+\end{itemize}%
 }
 
 \begin{grammar}
@@ -3439,26 +3648,31 @@ by one of the following means:
 \LMHash{}%
 It is a compile-time error if $k$'s initializer list contains an initializer for a variable that is not an instance variable declared in the immediately surrounding class.
 
-\commentary{
-The initializer list may of course contain an initializer for any instance variable declared by the immediately surrounding class, even if it is not final.
+\commentary{%
+The initializer list may of course contain an initializer for
+any instance variable declared by the immediately surrounding class,
+even if it is not final.%
 }
 
 \LMHash{}%
-It is a compile-time error if a generative constructor of class \code{Object} includes a superinitializer.
+It is a compile-time error if a generative constructor of class \code{Object}
+includes a superinitializer.
 
 
 \paragraph{Execution of Generative Constructors}
 \LMLabel{executionOfGenerativeConstructors}
 
 \LMHash{}%
-Execution of a generative constructor $k$ of type $T$ to initialize a fresh instance $i$
+Execution of a generative constructor $k$ of type $T$
+to initialize a fresh instance $i$
 is always done with respect to a set of bindings for its formal parameters
 and the type parameters of the immediately enclosing class bound to
 a set of actual type arguments of $T$, $t_1, \ldots, t_m$.
 
-\commentary{
-These bindings are usually determined by the instance creation expression that invoked the constructor (directly or indirectly).
-However, they may also be determined by a reflective call.
+\commentary{%
+These bindings are usually determined by the instance creation expression
+that invoked the constructor (directly or indirectly).
+However, they may also be determined by a reflective call.%
 }
 
 \LMHash{}%
@@ -3500,9 +3714,9 @@ Then, the initializers of $k$'s initializer list are executed to initialize $i$
 in the order they appear in the program, as described below
 (p.\,\pageref{executionOfInitializerLists}).
 
-\rationale{
+\rationale{%
 We could observe the order by side effecting external routines called.
-So we need to specify the order.
+So we need to specify the order.%
 }
 
 \LMHash{}%
@@ -3518,11 +3732,14 @@ further initialize $i$.
 \LMHash{}%
 After the superinitializer has completed, the body of $k$ is executed in a scope where \THIS{} is bound to $i$.
 
-\rationale{
-This process ensures that no uninitialized final instance variable is ever seen by code.
-Note that \THIS{} is not in scope on the right hand side of an initializer (see \ref{this}) so no instance method can execute during initialization:
+\rationale{%
+This process ensures that no uninitialized final instance variable
+is ever seen by code.
+Note that \THIS{} is not in scope on the right hand side of an initializer
+(see \ref{this})
+so no instance method can execute during initialization:
 an instance method cannot be directly invoked,
-nor can \THIS{} be passed into any other code being invoked in the initializer.
+nor can \THIS{} be passed into any other code being invoked in the initializer.%
 }
 
 
@@ -3606,15 +3823,17 @@ whose type is not a subtype of its actual
 (\ref{actualTypes})
 return type.
 
-\rationale{
+\rationale{%
 It seems useless to allow a factory to return the null object (\ref{null}).
-But it is more uniform to allow it, as the rules currently do.
+But it is more uniform to allow it, as the rules currently do.%
 }
 
-\rationale{
-Factories address classic weaknesses associated with constructors in other languages.
-Factories can produce instances that are not freshly allocated: they can come from a cache.
-Likewise, factories can return instances of different classes.
+\rationale{%
+Factories address classic weaknesses associated with constructors
+in other languages.
+Factories can produce instances that are not freshly allocated:
+they can come from a cache.
+Likewise, factories can return instances of different classes.%
 }
 
 
@@ -3689,7 +3908,7 @@ when $k$ takes some named arguments.
 It is a compile-time error if $\argumentList{T}$
 is not a subtype match for the formal parameter list of the redirectee.
 
-\rationale{
+\rationale{%
 We require a subtype match
 (rather than the more forgiving assignable match
 which is used with a generative redirecting constructor),
@@ -3700,17 +3919,21 @@ This means that a downcast on an actual argument
 ``between'' $k$ and $k'$
 would either be unused because the actual argument has
 the type required by $k'$,
-or it would amount to a dynamic error which is simply delayed a single step.
+or it would amount to a dynamic error which is simply delayed a single step.%
 }
 
-\commentary{
-Note that the non-generic case is covered by letting $m$ or $p$ or both be zero,
+\commentary{%
+Note that the non-generic case is covered by
+letting $m$ or $p$ or both be zero,
 in which case the formal type parameter list of the class $C$
-and/or the actual type argument list of the redirectee constructor is omitted (\ref{generics}).
+and/or the actual type argument list of
+the redirectee constructor is omitted
+(\ref{generics}).%
 }
 
 \LMHash{}%
-It is a compile-time error if $k$ explicitly specifies a default value for an optional parameter.
+It is a compile-time error if $k$ explicitly specifies
+a default value for an optional parameter.
 
 \rationale{%
 Default values specified in $k$ would be ignored,
@@ -3723,21 +3946,29 @@ It is a compile-time error if a formal parameter of $k'$ has a default value
 whose type is not a subtype of the type annotation
 on the corresponding formal parameter in $k$.
 
-\commentary{
-Note that it is not possible to modify the arguments being passed to $k'$.
+\commentary{%
+Note that it is not possible to modify the arguments being passed to $k'$.%
 }
 
-\rationale{
-At first glance, one might think that ordinary factory constructors could simply create instances of other classes and return them, and that redirecting factories are unnecessary.
+\rationale{%
+At first glance, one might think that
+ordinary factory constructors could simply create
+instances of other classes and return them,
+and that redirecting factories are unnecessary.
 However, redirecting factories have several advantages:
 \begin{itemize}
-\item An abstract class may provide a constant constructor that utilizes the constant constructor of another class.
-\item A redirecting factory constructor avoids the need for forwarders to repeat the formal parameters and their default values.
-\end{itemize}
+\item
+  An abstract class may provide a constant constructor
+  that utilizes the constant constructor of another class.
+\item
+  A redirecting factory constructor avoids the need for forwarders
+  to repeat the formal parameters and their default values.
+\end{itemize}%
 }
 
 \LMHash{}%
-It is a compile-time error if $k$ is prefixed with the \CONST{} modifier but $k'$ is not a constant constructor (\ref{constantConstructors}).
+It is a compile-time error if $k$ is prefixed with the \CONST{} modifier
+but $k'$ is not a constant constructor (\ref{constantConstructors}).
 
 \LMHash{}%
 Let $T_1, \ldots, T_m$ be the actual type arguments passed to $k'$
@@ -3748,11 +3979,11 @@ Let $F'$ be the function type of $k'$ (\ref{constructors}).
 It is a compile-time error if $[T_1/X_1, \ldots, T_m/X_m]F'$
 is not a subtype of the function type of $k$.
 
-\commentary{
+\commentary{%
 In the case where the two classes are non-generic
 this is just a subtype check on the function types of the two constructors.
 In general, this implies that the resulting object conforms to
-the interface of the immediately enclosing class of $k$.
+the interface of the immediately enclosing class of $k$.%
 }
 
 \LMHash{}%
@@ -3857,17 +4088,15 @@ substitution of the actual arguments for the formal parameters
 yields an initializing expression $e$ in the initializer list of $k$
 which is not a constant expression.
 
-\commentary{
+\commentary{%
 For instance, if $e$ is \code{a.length}
 where \code{a} is a formal argument of $k$ with type \DYNAMIC{},
 $e$ is potentially constant and can be used in the initializer list of $k$.
 It is an error to invoke $k$ with an argument of type \code{C}
 if \code{C} is a class different from \code{String},
 even if \code{C} has a \code{length} getter,
-and that same expression would evaluate without errors at run time.
+and that same expression would evaluate without errors at run time.%
 }
-
-%Discuss External Constructors in ne subsubsection here
 
 
 \subsection{Static Methods}
@@ -3878,7 +4107,7 @@ and that same expression would evaluate without errors at run time.
 are functions, other than getters or setters, whose declarations are immediately contained within a class declaration and that are declared \STATIC{}.
 The static methods of a class $C$ are those static methods declared by $C$.
 
-\rationale{
+\rationale{%
 Inheritance of static methods has little utility in Dart.
 Static methods cannot be overridden.
 Any required static function can be obtained from its declaring library,
@@ -3888,12 +4117,12 @@ the idea of inherited methods that are not instance methods.
 
 Of course, the entire notion of static methods is debatable,
 but it is retained here because so many programmers are familiar with it.
-Dart static methods may be seen as functions of the enclosing library.
+Dart static methods may be seen as functions of the enclosing library.%
 }
 
-\commentary{
+\commentary{%
 Static method declarations may conflict with other declarations
-(\ref{classMemberConflicts}).
+(\ref{classMemberConflicts}).%
 }
 
 
@@ -3957,8 +4186,11 @@ and similar restrictions are specified for other types like
 }
 
 \commentary{%
-The type parameters of a generic class are available in the lexical scope of the superclass clause, potentially shadowing classes in the surrounding scope.
-The following code is therefore illegal and should cause a compile-time error:
+The type parameters of a generic class are available in
+the lexical scope of the superclass clause,
+potentially shadowing classes in the surrounding scope.
+The following code is therefore illegal
+and should cause a compile-time error:%
 }
 
 \begin{dartCode}
@@ -3991,16 +4223,19 @@ let $S_1, \ldots, S_k$ be superclasses of $C$ that are also subclasses of $A$.
 $C$ \Index{inherits} all concrete, accessible instance members of $A$
 that have not been overridden by a concrete declaration in $C$ or in at least one of $S_1, \ldots, S_k$.
 
-\rationale{
-It would be more attractive to give a purely local definition of inheritance, that depended only on the members of the direct superclass $S$.
-However, a class $C$ can inherit a member $m$ that is not a member of its superclass $S$.
+\rationale{%
+It would be more attractive to give a purely local definition of inheritance,
+that depended only on the members of the direct superclass $S$.
+However, a class $C$ can inherit a member $m$ that
+is not a member of its superclass $S$.
 This can occur when the member $m$ is private to the library $L_1$ of $C$,
 whereas $S$ comes from a different library $L_2$,
-but the superclass chain of $S$ includes a class declared in $L_1$.
+but the superclass chain of $S$ includes a class declared in $L_1$.%
 }
 
 \LMHash{}%
-A class may override instance members that would otherwise have been inherited from its superclass.
+A class may override instance members
+that would otherwise have been inherited from its superclass.
 
 \LMHash{}%
 Let $C = S_0$ be a class declared in library $L$, and
@@ -4014,17 +4249,17 @@ Then $m$ overrides $m'$
 if $m'$ is not already overridden by a concrete member of at least one of $S_1, \ldots, S_{j-1}$
 and neither $m$ nor $m'$ are instance variables.
 
-\commentary{
+\commentary{%
 Instance variables never override each other.
-The getters and setters induced by instance variables do.
+The getters and setters induced by instance variables do.%
 }
 
-\rationale{
+\rationale{%
 Again, a local definition of overriding would be preferable,
-but fails to account for library privacy.
+but fails to account for library privacy.%
 }
 
-\commentary{
+\commentary{%
 Whether an override is legal or not is specified relative to
 all direct superinterfaces, not just the interface of the superclass,
 and that is described elsewhere
@@ -4032,10 +4267,10 @@ and that is described elsewhere
 Static members never override anything,
 but they may participate in some conflicts
 involving declarations in superinterfaces
-(\ref{classMemberConflicts}).
+(\ref{classMemberConflicts}).%
 }
 
-\commentary{
+\commentary{%
 For convenience, here is a summary of the relevant rules,
 using `error' to denote compile-time errors.
 Remember that this is not normative.
@@ -4111,7 +4346,7 @@ The controlling language is in the relevant sections of the specification.
 \item The identifier of a named constructor cannot be
   the same as the name of a static member declared in the same class
   (\ref{classMemberConflicts}).
-\end{enumerate}
+\end{enumerate}%
 }
 
 
@@ -4177,9 +4412,9 @@ in its \EXTENDS{} or \IMPLEMENTS{} clause.%
 \LMHash{}%
 It is a compile-time error if the interface of a class $C$ is a superinterface of itself.
 
-\commentary{
+\commentary{%
 A class does not inherit members from its superinterfaces.
-However, its implicit interface does.
+However, its implicit interface does.%
 }
 
 
@@ -4233,7 +4468,7 @@ includes a computation of the combined member signature
 (\ref{combinedMemberSignatures})
 of that getter and that method,
 and it is an error for a combined member signature
-to include a getter and a non-getter.
+to include a getter and a non-getter.%
 }
 
 
@@ -4287,7 +4522,7 @@ to specify member signatures.
 The difference is that the names of positional parameters are omitted.
 This syntax is only used for the purposes of specification.
 
-\rationale{
+\rationale{%
 Member signatures are synthetic entities, that is,
 they are not supported as concrete syntax in a Dart program,
 they are computed entities used during static analysis.
@@ -4301,7 +4536,7 @@ but it remains implicit whether it is covariant-by-class
 The reason for this is that the rule for determining whether
 a given override relation is correct
 (\ref{correctMemberOverrides})
-depends on the former and not on the latter.
+depends on the former and not on the latter.%
 }
 
 \LMHash{}%
@@ -4351,9 +4586,9 @@ The \NoIndex{function type of} $m$ is then
 The function type of a member signature remains unchanged if
 some or all default values are omitted.
 
-\commentary{
+\commentary{%
 We do not specify the function type of a getter signature.
-For such signatures we will instead directly refer to the return type.
+For such signatures we will instead directly refer to the return type.%
 }
 
 \LMHash{}%
@@ -4377,7 +4612,7 @@ each instance member declared by $C$.
 The \Index{direct superinterfaces} of $I$ are the direct superinterfaces of $C$
 (\ref{superinterfaces}).
 
-\commentary{
+\commentary{%
 We say that the class interface 'declares' these member signatures,
 such that we can say that an interface 'declares' or 'has' a member,
 just like we do for classes.
@@ -4389,7 +4624,7 @@ have that modifier.
 This is because $p$ may have ``inherited''
 the property of being covariant-by-declaration
 from one of its superinterfaces
-(\ref{covariantParameters}).
+(\ref{covariantParameters}).%
 }
 
 \LMHash{}%
@@ -4425,10 +4660,10 @@ $M$ is then the smallest set satisfying the following:
   Otherwise, $M$ contains $m$.
 \end{itemize}
 
-\rationale{
+\rationale{%
 Interfaces must be able to contain inaccessible member signatures,
 because they may be accessible from the interfaces associated with
-declarations of subtypes.
+declarations of subtypes.%
 }
 
 \commentary{%
@@ -4455,7 +4690,7 @@ must return an `int` according to the first member signature,
 and it must return a function object according to the second one,
 and an invocation of \code{\_foo(42)}
 must return a \code{String} with the first member signature, and it must fail
-(at compile time or, for a dynamic invocation, run time) with the second.
+(at compile time or, for a dynamic invocation, run time) with the second.%
 }
 
 \rationale{%
@@ -4469,7 +4704,7 @@ in the library where the private declarations exist,
 because they only arise for private members with
 the same name and incompatible signatures.
 Renaming that private member to anything not used in that library
-will eliminate the conflict and will not break any clients.
+will eliminate the conflict and will not break any clients.%
 }
 
 
@@ -4481,7 +4716,7 @@ This section specifies how to compute a member signature which will
 appropriately stand for a prioritized set of several member signatures,
 taken from a given list of interfaces.
 
-\commentary{
+\commentary{%
 In general, a combined member signature has a type which is
 a subtype of all the types given for that member.
 This is needed in order to ensure that the type of
@@ -4495,7 +4730,7 @@ The member signatures are prioritized in the sense that we will select
 a member signature from the interface with the lowest possible index
 in the case where several member signatures are equally suitable
 to be chosen as the combined member signature.
-That is, ``the first interface wins''.
+That is, ``the first interface wins''.%
 }
 
 \LMHash{}%
@@ -4510,14 +4745,14 @@ have the same same return type (for getters),
 or the same function type and the same occurrences of \COVARIANT{}
 (for methods and setters).
 
-\commentary{
+\commentary{%
 In particular, private methods from different libraries are never equal.
 Top types differ as well.
 For instance,
 \FunctionTypeSimple{\DYNAMIC}{} and \FunctionTypeSimple{\code{Object}}{}
 are not equal, even though they are subtypes of each other.
 We need this distinction because management of top type discrepancies is
-one of the purposes of computing a combined interface.
+one of the purposes of computing a combined interface.%
 }
 
 \LMHash{}%
@@ -4578,7 +4813,7 @@ A useful intuition about this situation is that
 the given member signatures do not agree on
 which type is suitable for the member named \id.
 Otherwise we have a set of member signatures which are ``most specific''
-in the sense that their function types are subtypes of them all.
+in the sense that their function types are subtypes of them all.%
 }
 
 { % Scope for N_min, M_min, N_firstMin.
@@ -4591,7 +4826,7 @@ in the sense that their function types are subtypes of them all.
 Otherwise, when a set $N$ as specified above exists,
 let \Nall{} be the greatest set satisfying the requirement on $N$,
 and let $\Mall{} = \{ m_i\;|\;i \in \Nall\}$.
-\commentary{
+\commentary{%
 That is, \Mall{} contains all member signatures named \id{}
 with the most specific type.
 Dart subtyping is a partial pre-order,
@@ -4601,19 +4836,19 @@ We can have several such signatures because member signatures
 can be such that they are not equal,
 and yet their function types are subtypes of each other.
 We need to compute one member signature from \Mall{},
-and we do that by using the ordering of the given interfaces.
+and we do that by using the ordering of the given interfaces.%
 }
 
 \LMHash{}%
 Let $j \in 1 .. k$ be the smallest number such that
 $\MallFirst{} = \Mall{} \cap I_j$ is non-empty.
 Let $m_i$ be the single element that \MallFirst{} contains.
-\commentary{
+\commentary{%
 This set contains exactly one element because it is non-empty
 and no interface contains more than one member signature named \id.
 In other words, we choose $m_i$ as the member signature from
 the first possible interface
-among the most specific member signatures \Mall.
+among the most specific member signatures \Mall.%
 }
 }
 
@@ -4625,7 +4860,7 @@ when there exists a $j \in 1 .. q$
 such that the parameter corresponding to $p$
 (\ref{covariantParameters})
 has the modifier \COVARIANT{}.
-\commentary{
+\commentary{%
 In other words,
 each parameter in the combined member signature is marked covariant
 if any of the corresponding parameters are marked covariant,
@@ -4691,7 +4926,8 @@ is \code{int}.
 This concept is particularly useful when
 the chain of direct superinterfaces from $S$ to $G$
 does not just pass all type arguments on unchanged, e.g.,
-with a declaration like \code{\CLASS\,\,C<X,\,Y>\,\,\EXTENDS\,\,B<List<Y>,\,Y,\,X> \{\}}.%
+with a declaration like
+\code{\CLASS\,\,C<X,\,Y>\,\,\EXTENDS\,\,B<List<Y>,\,Y,\,X> \{\}}.%
 }
 
 
@@ -4794,7 +5030,7 @@ if{}f the following criteria are all satisfied:
   (\ref{instanceMethods}).
   But we cannot cover that here as a property of member overrides,
   because it is concerned with declarations in all superinterfaces,
-  indirect as well as direct.
+  indirect as well as direct.%
   }
 \item
   If $m$ and $m'$ are both methods,
@@ -4887,8 +5123,11 @@ It is a compile-time error if the declaration of $K$ would cause a compile-time 
 % We do not want super-invocations on covariant implementations
 % to be compile-time errors.
 
-\commentary{
-It is an error, for example, if $M$ contains a member declaration $d$ which overrides a member signature $m$ in the interface of $S$, but which is not a correct override of $m$ (\ref{correctMemberOverrides}).
+\commentary{%
+It is an error, for example, if $M$ contains a member declaration $d$ 
+which overrides a member signature $m$ in the interface of $S$,
+but which is not a correct override of $m$
+(\ref{correctMemberOverrides}).%
 }
 
 \subsection{Mixin Declaration}
@@ -4963,16 +5202,18 @@ Let $M_S$ be the interface declared by the class declaration
 where $M_{super}$ is a fresh name.
 It is a compile-time error for the mixin declaration if the $M_S$
 class declaration would cause a compile-time error,
-\commentary{
+\commentary{%
 that is, if any member is declared by more than one declared superinterface,
 and there is not a most specific signature for that member among the super
-interfaces}.
+interfaces%
+}.
 The interface $M_S$ is called the
 \Index{superinvocation interface} of the mixin declaration $M$.
-\commentary{
+\commentary{%
 If the mixin declaration $M$ has only one declared superinterface, $T_1$,
 then the superinvocation interface $M_{super}$ has exactly the same members
-as the interface $T_1$.}
+as the interface $T_1$.%
+}
 
 \LMHash{}%
 Let $M_I$ be the interface that would be defined by the class declaration
@@ -6106,9 +6347,11 @@ Otherwise, $i$ is treated as the expression $i'$ which is
 \code{$e$.\CALL<$A_1, \ldots,\ A_r$>($a_1, \ldots,\ a_n,\ x_{n+1}$:\ $a_{n+1}, \ldots,\ x_{n+k}$:\ $a_{n+k}$)}.
 
 \commentary{%
-Note that $i'$ can be an implicit invocation of an extension method named \CALL,
+Note that $i'$ can be an implicit invocation of
+an extension method named \CALL,
 and it can be an error.
-In the latter case, error messages should be worded in terms of $i$, not $i'$.%
+In the latter case, error messages should be worded in terms of $i$,
+not $i'$.%
 }
 
 \LMHash{}%
@@ -6176,9 +6419,12 @@ $m$ \CLASS{} $E$ \{
 \}
 \end{normativeDartCode}
 
-\commentary{
-It is also a compile-time error to subclass, mix-in or implement an enum or to explicitly instantiate an enum.
-These restrictions are given in normative form in sections \ref{superclasses}, \ref{superinterfaces}, \ref{mixinApplication} and \ref{instanceCreation} as appropriate.
+\commentary{%
+It is also a compile-time error to subclass, mix-in or implement an enum
+or to explicitly instantiate an enum.
+These restrictions are given in normative form
+in sections \ref{superclasses}, \ref{superinterfaces}, \ref{mixinApplication}
+and \ref{instanceCreation} as appropriate.%
 }
 
 
@@ -6198,14 +6444,14 @@ When an entity in this specification is described as generic,
 and the special case is considered where the number of type arguments is zero,
 the type argument list should be omitted.
 
-\commentary{
+\commentary{%
 This allows non-generic cases to be included implicitly as special cases.
 For example,
 an invocation of a non-generic function arises as the special case
 where the function takes zero type arguments,
 and zero type arguments are passed.
 In this situation some operations are also omitted (have no effect), e.g.,
-operations where formal type parameters are replaced by actual type arguments.
+operations where formal type parameters are replaced by actual type arguments.%
 }
 
 \LMHash{}%
@@ -6225,11 +6471,12 @@ It is a compile-time error if $T$ is not well-bounded
 \LMHash{}%
 Otherwise, said parameterized type \code{$C$<$T_1, \ldots,\ T_m$>} denotes an application of the generic class declared by $G$ to the type arguments $T_1, \ldots, T_m$.
 This yields a class $C'$ whose members are equivalent to those of a class declaration which is obtained from the declaration $G$ by replacing each occurrence of $X_j$ by $T_j$.
-\commentary{
 
+\commentary{%
 % TODO(eernst): make sure this list of properties is complete.
-Other properties of $C'$ such as the subtype relationships are specified elsewhere
-(\ref{subtypes}).
+Other properties of $C'$ such as the subtype relationships
+are specified elsewhere
+(\ref{subtypes}).%
 }
 
 \LMHash{}%
@@ -6264,13 +6511,13 @@ $X_j <: B_j$, for all $j \in 1 .. s$,
 it is a compile-time error if $T$ is not regular-bounded,
 and it is a compile-time error if any type occurring in $T$ is not well-bounded.
 
-\commentary{
+\commentary{%
 This means that the bounds declared for
 the formal type parameters of a generic type alias
 must be such that when they are satisfied,
 the bounds that pertain to the body are also satisfied,
 and a type occurring as a subterm of the body can violate its bounds,
-but only if it is a correct super-bounded type.
+but only if it is a correct super-bounded type.%
 }
 
 \LMHash{}%
@@ -6299,7 +6546,7 @@ These restrictions exist because that syntax was defined
 before generic functions were added to Dart.%
 }
 
-\rationale{
+\rationale{%
 The requirement that satisfaction of the bounds on
 the formal type parameters of a generic type alias $D$
 must imply satisfaction of all bounds pertaining to
@@ -6308,11 +6555,11 @@ limits the expressive power of generic type aliases.
 However, it would require the constraints on formal type parameters
 to be expressed in a much more powerful language
 if we were to allow a significantly larger set of types
-to be expressed using a generic type alias.
+to be expressed using a generic type alias.%
 }
 
-\commentary{
-For example, consider the following code:
+\commentary{%
+For example, consider the following code:%
 }
 
 \begin{dartCode}
@@ -6320,7 +6567,7 @@ For example, consider the following code:
 \TYPEDEF{} F<Y> = A<\VOID{} \FUNCTION(Y)> \FUNCTION(); // \comment{compile-time error}
 \end{dartCode}
 
-\commentary{
+\commentary{%
 There is no way to specify a bound on \code{Y} in the declaration of \code{F}
 which will ensure that all bounds on the right hand side are respected.
 This is because the actual requirement is that \code{Y} must be
@@ -6330,7 +6577,7 @@ The type \code{A<\VOID{} \FUNCTION(U)> \FUNCTION()}
 can still be specified explicitly
 for every \code{U} which satisfies the bounds declared by \code{A}.
 So the types can be expressed,
-they just cannot be abbreviated using a generic type alias.
+they just cannot be abbreviated using a generic type alias.%
 }
 
 \LMHash{}%
@@ -6351,10 +6598,12 @@ It is a compile-time error if $m \not= l$.
 It is a compile-time error if there exists a $j$
 such that $T_j$ is not a subtype of $[T_1/X_1, \ldots, T_m/X_m]B_j$.
 
-\commentary{
+\commentary{%
 That is, if the number of type arguments is wrong,
-or if the $j$th actual type argument is not a subtype of the corresponding bound,
-where each formal type parameter has been replaced by the corresponding actual type argument.
+or if the $j$th actual type argument is not a subtype of
+the corresponding bound,
+where each formal type parameter has been replaced by
+the corresponding actual type argument.%
 }
 
 \begin{grammar}
@@ -6369,11 +6618,11 @@ If no \EXTENDS{} clause is present, the upper bound is \code{Object}.
 It is a compile-time error if a type parameter is a supertype of its upper bound
 when that upper bound is itself a type variable.
 
-\commentary{
+\commentary{%
 This prevents circular declarations like
 \code{X \EXTENDS{} X}
 and
-\code{X \EXTENDS{} Y, Y \EXTENDS{} X}.
+\code{X \EXTENDS{} Y, Y \EXTENDS{} X}.%
 }
 
 \LMHash{}%
@@ -6387,19 +6636,22 @@ However, a type parameter of a generic class
 is considered to be a malformed type
 when referenced by a static member
 (\ref{staticTypes}).
-The scopes associated with the type parameters of a generic function are described in (\ref{formalParameters}).
+The scopes associated with the type parameters of a generic function
+are described in (\ref{formalParameters}).%
 }
 
-\rationale{
-The restriction on static members is necessary since a type variable has no meaning in the context of a static member,
+\rationale{%
+The restriction on static members is necessary since
+a type variable has no meaning in the context of a static member,
 because statics are shared among all generic instantiations of a generic class.
 However, a type variable may be referenced from an instance initializer,
-even though \THIS{} is not available.
+even though \THIS{} is not available.%
 }
 
-\commentary{
-Because type parameters are in scope in their bounds, we support F-bounded quantification.
-This enables typechecking code such as:
+\commentary{%
+Because type parameters are in scope in their bounds,
+we support F-bounded quantification.
+This enables typechecking code such as:%
 }
 
 \begin{dartCode}
@@ -6414,14 +6666,21 @@ This enables typechecking code such as:
 \end{dartCode}
 
 \commentary{%
-Even where type parameters are in scope there are numerous restrictions at this time:
+Even where type parameters are in scope
+there are numerous restrictions at this time:
 \begin{itemize}
-\item[$\bullet$] A type parameter cannot be used to name a constructor in an instance creation expression (\ref{instanceCreation}).
-\item[$\bullet$] A type parameter cannot be used as a superclass or superinterface (\ref{superclasses}, \ref{superinterfaces}, \ref{interfaceSuperinterfaces}).
-\item[$\bullet$] A type parameter cannot be used as a generic type.
+\item[$\bullet$]
+  A type parameter cannot be used to name a constructor in
+  an instance creation expression (\ref{instanceCreation}).
+\item[$\bullet$]
+  A type parameter cannot be used as a superclass or superinterface
+  (\ref{superclasses}, \ref{superinterfaces}, \ref{interfaceSuperinterfaces}).
+\item[$\bullet$]
+  A type parameter cannot be used as a generic type.
 \end{itemize}
 
-The normative versions of these are given in the appropriate sections of this specification.
+The normative versions of these are given
+in the appropriate sections of this specification.
 Some of these restrictions may be lifted in the future.%
 }
 
@@ -6597,7 +6856,7 @@ if{}f $X_j$ occurs covariantly in $T$, and $X_j$
 \IndexCustom{is contravariant}{type parameter!contravariant}
 if{}f $X_j$ occurs contravariantly in $T$.
 
-\rationale{
+\rationale{%
 Variance gives a characterization of the way a type varies
 as the value of a subterm varies, e.g., a type variable:
 Assume that $T$ is a type where a type variable $X$ occurs,
@@ -6607,10 +6866,11 @@ then $[L/X]T$ is a subtype of $[U/X]T$.
 Similarly, if $X$ occurs contravariantly in $T$
 then $[U/X]T$ is a subtype of $[L/X]T$.
 If $X$ occurs invariantly
-then $[L/X]T$ and $[U/X]T$ are not guaranteed to be subtypes of each other in any direction.
+then $[L/X]T$ and $[U/X]T$ are not guaranteed
+to be subtypes of each other in any direction.
 In short: with covariance, the type covaries;
 with contravariance, the type contravaries;
-with invariance, all bets are off.
+with invariance, all bets are off.%
 }
 
 
@@ -6624,9 +6884,9 @@ including some cases where a limited form of violation is allowed.
 
 \LMHash{}%
 A \Index{top type} is a type $T$ such that \code{Object} is a subtype of $T$.
-\commentary{
+\commentary{%
 For instance, \code{Object}, \DYNAMIC, and \VOID{} are top types,
-and so are \code{FutureOr<\VOID>} and \code{FutureOr<FutureOr<\DYNAMIC>{}>}.
+and so are \code{FutureOr<\VOID>} and \code{FutureOr<FutureOr<\DYNAMIC>{}>}.%
 }
 
 % We define the property of being regular-bounded for all types,
@@ -6639,9 +6899,9 @@ and so are \code{FutureOr<\VOID>} and \code{FutureOr<FutureOr<\DYNAMIC>{}>}.
 \LMHash{}%
 Every type which is not a parameterized type is \Index{regular-bounded}.
 
-\commentary{
+\commentary{%
 In particular, every non-generic class and every function type
-is a regular-bounded type.
+is a regular-bounded type.%
 }
 
 \LMHash{}%
@@ -6656,9 +6916,9 @@ $S_j$ is a subtype of
 $[S_1/X_1, \ldots,\ S_n/X_n]B_j$,
 for all $j \in 1 .. n$.
 
-\commentary{
+\commentary{%
 This means that regular-bounded types are those types
-that do not violate their type parameter bounds.
+that do not violate their type parameter bounds.%
 }
 
 \LMHash{}%
@@ -6683,10 +6943,10 @@ $T$ is \Index{super-bounded} if{}f the following conditions are both true:
   is well-bounded (defined below).
 \end{itemize}
 
-\commentary{
+\commentary{%
 In short, at least one type argument violates its bound, but the type is
 regular-bounded after replacing all occurrences of an extreme type by an
-opposite extreme type, depending on their variance.
+opposite extreme type, depending on their variance.%
 }
 
 \LMHash{}%
@@ -6715,18 +6975,18 @@ when it is used in any of the following ways:
   (\ref{classes}).
 \end{itemize}
 
-\commentary{
+\commentary{%
 It is \emph{not} an error if a super-bounded type occurs
 as an immediate subterm of an \EXTENDS{} clause
 that specifies the bound of a type variable
-(\ref{generics}).
+(\ref{generics}).%
 }
 
-\commentary{
+\commentary{%
 Types of members from super-bounded class types are computed using the same
 rules as types of members from other types. Types of function applications
 involving super-bounded types are computed using the same rules as types of
-function applications involving other types. Here is an example:
+function applications involving other types. Here is an example:%
 }
 
 \begin{dartCode}
@@ -6737,18 +6997,19 @@ function applications involving other types. Here is an example:
 A<Object> a;
 \end{dartCode}
 
-\commentary{
+\commentary{%
 With this, \code{a.x} has static type \code{Object},
-even though the upper bound on the type variable \code{X} is \code{num}.
+even though the upper bound on the type variable \code{X} is \code{num}.%
 }
 
-\rationale{
+\rationale{%
 Super-bounded types enable the expression of informative common supertypes
-of some sets of types whose common supertypes would otherwise be much less informative.
+of some sets of types whose common supertypes
+would otherwise be much less informative.%
 }
 
-\commentary{
-For example, consider the following class:
+\commentary{%
+For example, consider the following class:%
 }
 
 \begin{dartCode}
@@ -6757,7 +7018,7 @@ For example, consider the following class:
 \}
 \end{dartCode}
 
-\commentary{
+\commentary{%
 Without super-bounded types,
 there is no type $T$ which makes \code{C<$T$>} a common supertype of
 all types of the form \code{C<$S$>}
@@ -6767,10 +7028,10 @@ So if we wish to allow a variable to hold any instance ``of type \code{C}''
 then that variable must use \code{Object} or another top type
 as its type annotation,
 which means that a member like \code{next} is not known to exist
-(which is what we mean by saying that the type is `less informative').
+(which is what we mean by saying that the type is `less informative').%
 }
 
-\rationale{
+\rationale{%
 We could introduce a notion of recursive (infinite) types, and express
 the least upper bound of all types of the form \code{C<$S$>} as
 some syntax whose meaning could be approximated by
@@ -6780,10 +7041,11 @@ However, we expect that any such concept in Dart would incur a significant cost
 on developers and implementations in terms of added complexity and subtlety,
 so we have chosen not to do that.
 Super-bounded types are finite,
-but they offer a useful developer-controlled approximation to such infinite types.
+but they offer a useful developer-controlled approximation
+to such infinite types.%
 }
 
-\commentary{
+\commentary{%
 For example,
 \code{C<Object>} and
 \code{C<C<C<\VOID>{}>{}>}
@@ -6799,7 +7061,7 @@ and \code{c.next.next.whatever} has no compile-time error,
 but if \code{c} has type \code{C<C<\VOID>{}>} then already
 \code{Object x = c.next.next;} is a compile-time error.
 It is thus possible for developers to get a more or less strict treatment
-of expressions whose type proceeds beyond the given finite unfolding.
+of expressions whose type proceeds beyond the given finite unfolding.%
 }
 
 
@@ -6898,7 +7160,7 @@ E.g., with
 instantiation to bound on \code{F} yields \code{F<dynamic>},
 and this means that \code{F f;} can be used to declare a variable \code{f}
 whose value will be a function that can be passed to clients expecting
-an \code{F<$T$>} for \emph{all possible} values of $T$.
+an \code{F<$T$>} for \emph{all possible} values of $T$.%
 }
 
 
@@ -6968,7 +7230,7 @@ because we only need to inspect
 all types of the form \synt{typeName} in its body,
 and they are not affected by such a substitution.
 In other words, raw-dependency is a relation
-which is simple and cheap to compute.
+which is simple and cheap to compute.%
 }
 
 \LMHash{}%
@@ -7049,7 +7311,7 @@ e.g., when it occurs as a type annotation of a variable or a parameter,
 as a return type of a function,
 as a type which is tested in a type test,
 as the type in an \synt{onPart},
-etc.
+etc.%
 }
 
 
@@ -7111,7 +7373,7 @@ be determined by the following iterative process, where $V_m$ denotes
   (\commentary{that is, if the dependency graph has a cycle})
   let \List{M}{1}{p} be the strongly connected components (SCCs)
   with respect to \Depends{}.
-  \commentary{
+  \commentary{%
   That is, the maximal subsets of \List{X}{1}{k}
   where every pair of variables in each subset
   are related in both directions by \TransitivelyDepends;
@@ -7154,7 +7416,7 @@ be determined by the following iterative process, where $V_m$ denotes
 This process will always terminate, because the total number of
 occurrences of type variables from $\{\,\List{X}{1}{k}\,\}$ in
 the current bounds is strictly decreasing with each step, and we terminate
-when that number reaches zero.
+when that number reaches zero.%
 }
 
 \rationale{%
@@ -7304,7 +7566,7 @@ It is a compile-time error if $e$ is not one of the following:
 \commentary{%
 The expression $e$ occurs in a constant context
 (\ref{constantContexts}),
-which means that \CONST{} modifiers need not be specified explicitly.
+which means that \CONST{} modifiers need not be specified explicitly.%
 }
 
 \LMHash{}%
@@ -7314,29 +7576,30 @@ and which is not itself metadata or a comment.
 Metadata can be retrieved at run time via a reflective call,
 provided the annotated program construct $p$ is accessible via reflection.
 
-\commentary{
+\commentary{%
 Obviously, metadata can also be retrieved statically by
 parsing the program and evaluating the constants via a suitable interpreter.
-In fact, many if not most uses of metadata are entirely static.
+In fact, many if not most uses of metadata are entirely static.%
 }
 
-\rationale{
+\rationale{%
 It is important that no run-time overhead be incurred by
 the introduction of metadata that is not actually used.
 Because metadata only involves constants,
 the time at which it is computed is irrelevant.
 So implementations may skip the metadata during ordinary parsing and execution,
-and evaluate it lazily.
+and evaluate it lazily.%
 }
 
-\commentary{
+\commentary{%
 It is possible to associate metadata with constructs
 that may not be accessible via reflection,
 such as local variables
 (though it is conceivable that in the future,
 richer reflective libraries might provide access to these as well).
 This is not as useless as it might seem.
-As noted above, the data can be retrieved statically if source code is available.
+As noted above, the data can be retrieved statically
+if source code is available.%
 }
 
 \LMHash{}%
@@ -7400,7 +7663,7 @@ Every object has an associated dynamic type (\ref{dynamicTypeSystem}).
 \LMHash{}%
 An expression $e$ may always be enclosed in parentheses, but this never has any semantic effect on $e$.
 
-\commentary{
+\commentary{%
 However, it may have an effect on the surrounding expression.
 For instance, given a class \code{C} with a static method
 \code{m() => 42}, \code{C.m()} returns 42,
@@ -7412,7 +7675,7 @@ rather than being specified in a strictly compositional manner.
 Concretely, the meaning of \code{C} and \code{(C)} as expressions is the same,
 but the meaning of \code{C.m()} is not defined in terms of
 the meaning of \code{C} as an expression,
-and it differs from the meaning of \code{(C).m()}.
+and it differs from the meaning of \code{(C).m()}.%
 % A strictly compositional evaluation would always evaluate every subexpression
 % using the same rules (`evaluation` is always the same thing), and then it
 % would combine the evaluation results into the result of the whole expression.
@@ -7468,18 +7731,23 @@ The predefined Dart function \code{identical()} is defined such that \code{ident
 \item $c_1$ and $c_2$ are the same object.
 \end{itemize}
 
-\commentary{
-The definition of \code{identity} for doubles differs from that of equality in that a NaN is identical to itself, and that negative and positive zero are distinct.
+\commentary{%
+The definition of \code{identity} for doubles differs from that of equality
+in that a NaN is identical to itself,
+and that negative and positive zero are distinct.%
 }
 
-\rationale{
-The definition of equality for doubles is dictated by the IEEE 754 standard, which posits that NaNs do not obey the law of reflexivity.
-Given that hardware implements these rules, it is necessary to support them for reasons of efficiency.
+\rationale{%
+The definition of equality for doubles is dictated by the IEEE 754 standard,
+which posits that NaNs do not obey the law of reflexivity.
+Given that hardware implements these rules,
+it is necessary to support them for reasons of efficiency.
 
 The definition of identity is not constrained in the same way.
 Instead, it assumes that bit-identical doubles are identical.
 
-The rules for identity make it impossible for a Dart programmer to observe whether a boolean or numerical value is boxed or unboxed.
+The rules for identity make it impossible for a Dart programmer
+to observe whether a boolean or numerical value is boxed or unboxed.%
 }
 
 
@@ -7494,7 +7762,7 @@ The constant expressions is a subset of the potentially constant expressions
 that \emph{can} be evaluated at compile time.%
 }
 
-\rationale{
+\rationale{%
 The constant expressions are restricted to expressions that
 perform only simple arithmetic operations, boolean conditions,
 and string and instance creation.
@@ -7502,7 +7770,7 @@ No user-written function body is executed
 during constant expression evaluation,
 only members of the system classes
 \code{Object}, \code{bool}, \code{int}, \code{double},
-\code{String}, \code{Type}, \code{Symbol}, or \code{Null}.
+\code{String}, \code{Type}, \code{Symbol}, or \code{Null}.%
 }
 
 \LMHash{}%
@@ -7855,8 +8123,8 @@ and the assertion would throw an exception.
 It is a compile-time error if the value of a constant expression
 depends on itself.
 
-\commentary{
-As an example, consider:
+\commentary{%
+As an example, consider:%
 }
 
 \begin{dartCode}
@@ -7944,17 +8212,17 @@ Second, it seems more useful to give
 the error stemming from the evaluation explicitly.%
 }
 
-\rationale{
+\rationale{%
 One might reasonably ask why
 $e_1$\,?\,\,$e_2$\,:\,$e_3$ and $e_1$\,??\,\,$e_2$
 have constant forms.
 If $e_1$ is known statically, why do we need to test it?
 The answer is that there are contexts where $e_1$ is a variable,
 e.g., in constant constructor initializers such as
-\code{\CONST{} C(foo):\ \THIS.foo = foo ??\ someDefaultValue;}
+\code{\CONST{} C(foo):\ \THIS.foo = foo ??\ someDefaultValue;}%
 }
 
-\commentary{
+\commentary{%
 The difference between
 a potentially constant expression and a constant expression
 deserves some explanation.
@@ -7979,7 +8247,7 @@ Specifically, we allow the usage of
 the formal parameters of a constant constructor
 for expressions that involve built-in operators,
 but not for constant objects, lists and maps.
-For instance:
+For instance:%
 }
 
 \begin{dartCode}
@@ -7989,7 +8257,7 @@ For instance:
 \}
 \end{dartCode}
 
-\commentary{
+\commentary{%
 The assignment to \code{x} is allowed under the assumption
 that \code{q} is constant
 (even though \code{q} is not, in general a compile-time constant).
@@ -8003,7 +8271,7 @@ for an invocation of this constructor in a constant expression.
 A similar argument holds for \code{p} and \code{q}
 in the assignment to \code{z}.
 
-However, the following constructors are disallowed:
+However, the following constructors are disallowed:%
 }
 
 \begin{dartCode}
@@ -8152,9 +8420,11 @@ and let $T$ be the static context type of $l$.
 If \code{double} is assignable to $T$ and \code{int} is not assignable to $T$,
 then the static type of $l$ is \code{double};
 otherwise the static type of $l$ is \code{int}.
-\commentary{
-  This means that an integer literal denotes a \code{double}
-  when it would satisfy the type requirement, and an \code{int} would not. Otherwise it is an \code{int}, even in situations where that is an error.
+
+\commentary{%
+This means that an integer literal denotes a \code{double}
+when it would satisfy the type requirement, and an \code{int} would not.
+Otherwise it is an \code{int}, even in situations where that is an error.%
 }
 
 \LMHash{}%
@@ -8179,14 +8449,14 @@ then evaluation of $l$ proceeds as follows:
   exactly by an instance of \code{int}.
 \end{itemize}
 
-\commentary{
+\commentary{%
 Integers in Dart are designed to be implemented as
 64-bit two's complement integer representations.
 In practice, implementations may be limited by other considerations.
 For example, Dart compiled to JavaScript may use the JavaScript number type,
 equivalent to Dart \code{double}, to represent integers, and if so,
 integer literals with more than 53 bits of precision cannot be represented
-exactly.
+exactly.%
 }
 
 \LMHash{}%
@@ -8256,10 +8526,11 @@ The static type of a boolean literal is \code{bool}.
 \LMHash{}%
 A \Index{string} is a sequence of UTF-16 code units.
 
-\rationale{
+\rationale{%
 This decision was made for compatibility with web browsers and Javascript.
-Earlier versions of the specification required a string to be a sequence of valid Unicode code points.
-Programmers should not depend on this distinction.
+Earlier versions of the specification required a string to be
+a sequence of valid Unicode code points.
+Programmers should not depend on this distinction.%
 }
 
 \begin{grammar}
@@ -8320,32 +8591,36 @@ A string can be a sequence of single line strings and multiline strings.
 \LMHash{}%
 A single line string is delimited by either matching single quotes or matching double quotes.
 
-\commentary{
-Hence, `abc' and ``abc'' are both legal strings, as are `He said ``To be or not to be'' did he not?' and ``He said `To be or not to be' didn't he''.
-However ``This ` is not a valid string, nor is `this''.
+\commentary{%
+Hence, `abc' and ``abc'' are both legal strings,
+as are `He said ``To be or not to be'' did he not?' and
+``He said `To be or not to be' didn't he''.
+However ``This ` is not a valid string, nor is `this''.%
 }
 
-\commentary{
-The grammar ensures that a single line string cannot span more than one line of source code, unless it includes an interpolated expression that spans multiple lines.
+\commentary{%
+The grammar ensures that a single line string cannot span more than
+one line of source code,
+unless it includes an interpolated expression that spans multiple lines.%
 }
 
 \LMHash{}%
 Adjacent strings are implicitly concatenated to form a single string literal.
 
-\commentary{
-Here is an example
+\commentary{%
+Here is an example:%
 }
 
 \begin{dartCode}
 print("A string" "and then another"); // \comment{A stringand then another}
 \end{dartCode}
 
-\rationale{
+\rationale{%
 Dart also supports the operator + for string concatenation.
 
 The + operator on Strings requires a String argument.
 It does not coerce its argument into a string.
-This helps avoid puzzlers such as
+This helps avoid puzzlers such as%
 }
 
 \begin{dartCode}
@@ -8353,21 +8628,26 @@ print("A simple sum: 2 + 2 = " +
             2 + 2);
 \end{dartCode}
 
-\rationale{
-which this prints 'A simple sum: 2 + 2 = 22' rather than 'A simple sum: 2 + 2 = 4'.
-However, the use of the concatenation operation is still discouraged for efficiency reasons.
-Instead, the recommended Dart idiom is to use string interpolation.
+\rationale{%
+which prints 'A simple sum: 2 + 2 = 22' rather than
+'A simple sum: 2 + 2 = 4'.
+However, the use of the concatenation operation is still discouraged
+for efficiency reasons.
+Instead, the recommended Dart idiom is to use string interpolation.%
 }
 
 \begin{dartCode}
 print("A simple sum: 2 + 2 = \$\{2+2\}");
 \end{dartCode}
 
-\rationale{
+\rationale{%
 String interpolation works well for most cases.
-The main situation where it is not fully satisfactory is for string literals that are too large to fit on a line.
-Multiline strings can be useful, but in some cases, we want to visually align the code.
-This can be expressed by writing smaller strings separated by whitespace, as shown here:
+The main situation where it is not fully satisfactory
+is for string literals that are too large to fit on a line.
+Multiline strings can be useful, but in some cases,
+we want to visually align the code.
+This can be expressed by writing
+smaller strings separated by whitespace, as shown here:%
 }
 
 \begin{dartCode}
@@ -8673,19 +8953,32 @@ or to a \code{Symbol} instance that is \lit{==} to that instance.
 The objects created by symbol literals all override
 the \lit{==} operator inherited from the \code{Object} class.
 
-\rationale{
-One may well ask what is the motivation for introducing literal symbols? In some languages, symbols are canonicalized whereas strings are not.
+\rationale{%
+One may well ask what is the motivation for introducing literal symbols?
+In some languages, symbols are canonicalized whereas strings are not.
 However literal strings are already canonicalized in Dart.
-Symbols are slightly easier to type compared to strings and their use can become strangely addictive, but this is not nearly sufficient justification for adding a literal form to the language.
-The primary motivation is related to the use of reflection and a web specific practice known as minification.
+Symbols are slightly easier to type compared to strings
+and their use can become strangely addictive,
+but this is not nearly sufficient justification for adding
+a literal form to the language.
+The primary motivation is related to the use of reflection
+and a web specific practice known as minification.
 
-Minification compresses identifiers consistently throughout a program in order to reduce download size.
-This practice poses difficulties for reflective programs that refer to program declarations via strings.
-A string will refer to an identifier in the source, but the identifier will no longer be used in the minified code, and reflective code using these would fail.
-Therefore, Dart reflection uses objects of type \code{Symbol} rather than strings.
-Instances of \code{Symbol} are guaranteed to be stable with respect to minification.
-Providing a literal form for symbols makes reflective code easier to read and write.
-The fact that symbols are easy to type and can often act as convenient substitutes for enums are secondary benefits.
+Minification compresses identifiers consistently throughout a program
+in order to reduce download size.
+This practice poses difficulties for reflective programs
+that refer to program declarations via strings.
+A string will refer to an identifier in the source,
+but the identifier will no longer be used in the minified code,
+and reflective code using these would fail.
+Therefore, Dart reflection uses objects of type \code{Symbol}
+rather than strings.
+Instances of \code{Symbol} are guaranteed to be stable
+with respect to minification.
+Providing a literal form for symbols makes
+reflective code easier to read and write.
+The fact that symbols are easy to type and can often act as
+convenient substitutes for enums are secondary benefits.%
 }
 
 \LMHash{}%
@@ -9387,8 +9680,8 @@ then the variable \code{v} is in scope for $\ell$.%
 
 Inference for the parts
 (\commentary{%
-  such as the iterable expression of a for-in,
-  or the \synt{forInitializerStatement} of a for loop%
+such as the iterable expression of a for-in,
+or the \synt{forInitializerStatement} of a for loop%
 })
 is done as for the corresponding \FOR{} statement,
 including \AWAIT{} if and only if the element includes \AWAIT.
@@ -9575,14 +9868,14 @@ is evaluated as follows:
 The objects created by list literals do not override
 the \lit{==} operator inherited from the \code{Object} class.
 
-\commentary{
+\commentary{%
 Note that this document does not specify an order
 in which the elements are set.
 This allows for parallel assignments into the list
 if an implementation so desires.
 The order can only be observed as follows (and may not be relied upon):
 if element $i$ is not a subtype of the element type of the list,
-a dynamic type error will occur when $a[i]$ is assigned $o_{i-1}$.
+a dynamic type error will occur when $a[i]$ is assigned $o_{i-1}$.%
 }
 
 
@@ -9775,7 +10068,7 @@ which is determined as follows:
     being unconstrained means having \FreeContext{} as the context type.
     Having a context type that \emph{contains}
     one or more occurrences of \FreeContext{}
-    provides a partial constraint on the inferred type.
+    provides a partial constraint on the inferred type.%
   }
 \item
   If \metavar{collection} is unambiguously a map
@@ -9860,7 +10153,7 @@ Then:
     using the constraint $S\,\,<:\,\,\code{Iterable<$X$>}$.
     Note that when $S$ implements a class like \code{Map} or \code{Iterable},
     it cannot be a subtype of \code{Null}
-    (\ref{interfaceSuperinterfaces}).
+    (\ref{interfaceSuperinterfaces}).%
   }
 \item
   If $S$ implements \code{Map},
@@ -10021,8 +10314,8 @@ then the variable \code{v} is in scope for $\ell$.%
 
 Inference for the parts
 (\commentary{%
-  such as the iterable expression of a for-in,
-  or the \synt{forInitializerStatement} of a for loop%
+such as the iterable expression of a for-in,
+or the \synt{forInitializerStatement} of a for loop%
 })
 is done as for the corresponding \FOR{} statement,
 including \AWAIT{} if and only if the element includes \AWAIT.
@@ -10536,8 +10829,9 @@ Evaluation of a throw expression of the form \code{\THROW{} $e$;} proceeds as fo
 The expression $e$ is evaluated to an object $v$
 (\ref{expressionEvaluation}).
 
-\commentary{
-There is no requirement that the expression $e$ must evaluate to any special kind of object.
+\commentary{%
+There is no requirement that the expression $e$ must evaluate to
+any special kind of object.%
 }
 
 \LMHash{}%
@@ -10552,8 +10846,10 @@ and it is the first time that \code{Error} object is thrown,
 the stack trace $t$ is stored on $v$ so that it will be returned
 by the $v$'s \code{stackTrace} getter
 
-\commentary{
-If the same \code{Error} object is thrown more than once, its \code{stackTrace} getter will return the stack trace from the \emph{first} time it was thrown.
+\commentary{%
+If the same \code{Error} object is thrown more than once,
+its \code{stackTrace} getter will return the stack trace from
+the \emph{first} time it was thrown.%
 }
 
 \LMHash{}%
@@ -10595,7 +10891,7 @@ when we refer to the declared return type of a function.
 Type inference will be specified in a future version of this document.
 Currently we consider type inference to be a phase that has completed,
 and this document specifies the meaning of Dart programs
-where inferred types have already been added.
+where inferred types have already been added.%
 }
 
 \LMHash{}%
@@ -10614,14 +10910,14 @@ and for all $R$, if
 \code{$T <:$ Future<$R$>}
 then $S <: R$.
 
-\rationale{
+\rationale{%
 This ensures that
 \code{Future<$S$>}
 is the most specific generic instantiation of \code{Future} that is a supertype of $T$.
 %% TODO[class-interfaces]: When we have finished the specification of class
 %% interface computations we may have the following property, but it is not
 %% true at this point. Adjust the following by then!
-Note that $S$ is well-defined because of the requirements on superinterfaces.
+Note that $S$ is well-defined because of the requirements on superinterfaces.%
 }
 
 Then $\flatten{T} = S$.
@@ -10838,12 +11134,12 @@ it is considered to have been specified as \DYNAMIC{}.
 \LMHash{}%
 Evaluation of a function literal yields a function object $o$.
 
-\commentary{
+\commentary{%
 The run-time type of $o$ is specified based on
 the static type $T$ of the function literal
 and the binding of type variables occurring in $T$
 at the occasion where the evaluation occurred
-(\ref{typeOfAFunction}).
+(\ref{typeOfAFunction}).%
 }
 
 
@@ -10860,8 +11156,8 @@ The reserved word \THIS{} denotes the target of the current instance member invo
 \LMHash{}%
 The static type of \THIS{} is the interface of the immediately enclosing class.
 
-\commentary{
-We do not support self-types at this point.
+\commentary{%
+We do not support self-types at this point.%
 }
 
 \LMHash{}%
@@ -10875,13 +11171,13 @@ It is a compile-time error if \THIS{} appears, implicitly or explicitly, in a to
 Instance creation expressions generally produce instances
 and invoke constructors to initialize them.
 
-\commentary{
+\commentary{%
 The exception is that
 a factory constructor invocation works like a regular function call.
 It may of course evaluate an instance creation expression and thus
 produce a fresh instance,
 but no fresh instances are created as a direct consequence of
-the factory constructor invocation.
+the factory constructor invocation.%
 }
 
 \LMHash{}%
@@ -10922,9 +11218,9 @@ or the form
 It is a compile-time error if $T$ is not
 a class or a parameterized type accessible in the current scope,
 or if $T$ is a parameterized type which is not a class.
-\commentary{
+\commentary{%
 For instance, \code{\NEW{} F<int>()} is an error if \code{F} is a type alias
-that does not denote a class.
+that does not denote a class.%
 }
 
 \LMHash{}%
@@ -10973,13 +11269,13 @@ and $T$ is not regular-bounded
 If $q$ is a redirecting factory constructor,
 it is a compile-time error if $q$ in some number of
 redirecting factory redirections redirects to itself.
-\commentary{
+\commentary{%
 It is possible and allowed for a redirecting factory $q'$
 to enter an infinite loop, e.g.,
 because $q'$ redirects to a non-redirecting factory constructor
 $q''$ whose body uses $q'$ in an instance creation expression.
 Only loops that consist exclusively of redirecting factory redirections
-are detected at compile time.
+are detected at compile time.%
 }
 
 \LMHash{}%
@@ -10989,8 +11285,8 @@ corresponding to the actual argument $a_i$, $i \in 1 .. n+k$.
 It is a compile-time error if the static type of
 $a_i, i \in 1 .. n + k$
 is not assignable to $[U_1/X_1, \ldots, U_m/X_m]S_i$.
-\commentary{
-The non-generic case is covered with $m = 0$.
+\commentary{%
+The non-generic case is covered with $m = 0$.%
 }
 
 \LMHash{}%
@@ -11083,9 +11379,9 @@ Otherwise the execution throws an exception $x$ and stack trace $t$,
 and then evaluation of $e$ also throws $x$ and $t$
 (\ref{expressionEvaluation}).
 
-\rationale{
+\rationale{%
 A factory constructor can be declared in an abstract class and used safely,
-as it will either produce a valid instance or throw.
+as it will either produce a valid instance or throw.%
 }
 \EndCase
 
@@ -11115,8 +11411,8 @@ a class or a parameterized type accessible in the current scope,
 or if $T$ is a parameterized type which is not a class.
 It is a compile-time error if $T$ is a deferred type
 (\ref{staticTypes}).
-\commentary{
-In particular, $T$ must not be a type variable.
+\commentary{%
+In particular, $T$ must not be a type variable.%
 }
 
 \LMHash{}%
@@ -11181,8 +11477,8 @@ corresponding to the actual argument $a_i$, $i \in 1 .. n+k$.
 It is a compile-time error if the static type of
 $a_i, i \in 1 .. n + k$
 is not assignable to $[U_1/X_1, \ldots, U_m/X_m]S_i$.
-\commentary{
-The non-generic case is covered with $m = 0$.
+\commentary{%
+The non-generic case is covered with $m = 0$.%
 }
 
 \LMHash{}%
@@ -11199,7 +11495,7 @@ let $i$ be the value of the expression $e'$:
 \noindent
 \code{\NEW{} $T$.\id($a_1, \ldots,\ a_n,\ x_{n+1}$: $a_{n+1}, \ldots,\ x_{n+k}$: $a_{n+k}$)}.
 
-\commentary{
+\commentary{%
 Let $o$ be the result of an evaluation of $e'$,
 at some point in time of some execution of the program
 in the library $L$ where $e$ occurs.
@@ -11207,7 +11503,7 @@ The result of an evaluation of $e'$ in $L$
 at some other time and/or in some other execution will
 yield a result $o'$, such that $o'$ would be replaced by $o$
 by canonicalization as described below.
-This means that the value is well-defined.
+This means that the value is well-defined.%
 }
 
 \LMHash{}%
@@ -11215,8 +11511,8 @@ If $e$ is of the form
 \code{\CONST{} $T$($a_1, \ldots,\ a_n,\ x_{n+1}$: $a_{n+1}, \ldots,\ x_{n+k}$: $a_{n+k}$)},
 let $i$ be the value of
 \code{\NEW{} $T$($a_1, \ldots,\ a_n,\ x_{n+1}$: $a_{n+1}, \ldots,\ x_{n+k}$: $a_{n+k}$)}.
-\commentary{
-Which is well-defined for the same reason.
+\commentary{%
+Which is well-defined for the same reason.%
 }
 
 \LMHash{}%
@@ -11234,7 +11530,7 @@ Which is well-defined for the same reason.
 \item Otherwise the value of $e$ is $i$.
 \end{itemize}
 
-\commentary{
+\commentary{%
 In other words, constant objects are canonicalized.
 In order to determine if an object is actually new, one has to compute it;
 then it can be compared to any cached instances.
@@ -11244,15 +11540,15 @@ Objects are equivalent if
 they have identical type arguments and identical instance variables.
 Since the constructor cannot induce any side effects,
 the execution of the constructor is unobservable.
-The constructor need only be executed once per call site, at compile time.
+The constructor need only be executed once per call site, at compile time.%
 }
 
 \LMHash{}%
 It is a compile-time error if evaluation of a constant object
 results in an uncaught exception being thrown.
 
-\commentary{
-To see how such situations might arise, consider the following examples:
+\commentary{%
+To see how such situations might arise, consider the following examples:%
 }
 
 %% TODO(eernst): Delete some \CONST{} when integrating implicit-creation.md
@@ -11274,7 +11570,7 @@ To see how such situations might arise, consider the following examples:
 \CONST a3 = \CONST{} A(\CONST{} IntPair(1,2)); // \comment{compile-time error}
 \end{dartCode}
 
-\commentary{
+\commentary{%
 Due to the rules governing constant constructors,
 evaluating the constructor \code{A()}
 with the argument \code{"x"} or the argument \code{\CONST{} IntPair(1, 2)}
@@ -11282,7 +11578,7 @@ would cause it to throw an exception, resulting in a compile-time error.
 In the latter case, the error is caused by the fact that
 \code{\OPERATOR{} *} can only be used with a few ``well-known'' types,
 which is required in order to avoid running arbitrary code during
-the evaluation of constant expressions.
+the evaluation of constant expressions.%
 }
 
 
@@ -11301,8 +11597,9 @@ It is possible for a running isolate to exhaust its memory or stack,
 resulting in a dynamic error that cannot be effectively caught,
 which will force the isolate to be suspended.
 
-\commentary{
-As discussed in section \ref{errorsAndWarnings}, the handling of a suspended isolate is the responsibility of the embedder.
+\commentary{%
+As discussed in section \ref{errorsAndWarnings},
+the handling of a suspended isolate is the responsibility of the embedder.%
 }
 
 
@@ -11357,25 +11654,34 @@ Let $T$ be the actual return type of $f$ (\ref{actualTypes}).
 If $T$ is \code{Iterable<$S$>} for some type $S$, then $U$ is $S$,
 otherwise $U$ is \code{Object}.
 
-\commentary{
-A Dart implementation will need to provide a specific implementation of \code{Iterable} that will be returned by \code{\SYNC*} methods.
-A typical strategy would be to produce an instance of a subclass of class \code{IterableBase} defined in \code{dart:core}.
-The only method that needs to be added by the Dart implementation in that case is \code{iterator}.
+\commentary{%
+A Dart implementation will need to provide
+a specific implementation of \code{Iterable}
+that will be returned by \code{\SYNC*} methods.
+A typical strategy would be to produce an instance of
+a subclass of class \code{IterableBase} defined in \code{dart:core}.
+The only method that needs to be added
+by the Dart implementation in that case is \code{iterator}.%
 }
 
 \LMHash{}%
 The iterable implementation must comply with the contract of \code{Iterable} and should not take any steps identified as exceptionally efficient in that contract.
 
-\commentary{
-The contract explicitly mentions a number of situations where certain iterables could be more efficient than normal.
+\commentary{%
+The contract explicitly mentions a number of situations
+where certain iterables could be more efficient than normal.
 For example, by precomputing their length.
 Normal iterables must iterate over their elements to determine their length.
-This is certainly true in the case of a synchronous generator, where each element is computed by a function.
-It would not be acceptable to pre-compute the results of the generator and cache them, for example.
+This is certainly true in the case of a synchronous generator,
+where each element is computed by a function.
+It would not be acceptable to pre-compute the results of the generator
+and cache them, for example.%
 }
 
 \LMHash{}%
-When iteration over the iterable is started, by getting an iterator $j$ from the iterable and calling \code{moveNext()}, execution of the body of $f$ will begin.
+When iteration over the iterable is started, by getting
+an iterator $j$ from the iterable and calling \code{moveNext()},
+execution of the body of $f$ will begin.
 When execution of the body of $f$ completes (\ref{statementCompletion}),
 \begin{itemize}
 \item If it returns without an object or it completes normally
@@ -11396,21 +11702,26 @@ When execution of the body of $f$ completes (\ref{statementCompletion}),
 Each iterator starts a separate computation.
 If the \code{\SYNC*} function is impure, the sequence of objects yielded by each iterator may differ.
 
-\commentary{
+\commentary{%
 One can derive more than one iterator from a given iterable.
 Note that operations on the iterable itself can create distinct iterators.
 An example would be \code{length}.
-It is conceivable that different iterators might yield sequences of different length.
+It is conceivable that different iterators might yield
+sequences of different length.
 The same care needs to be taken when writing \code{\SYNC*} functions as when
 writing an \code{Iterator} class.
 In particular, it should handle multiple simultaneous iterators gracefully.
-If the iterator depends on external state that might change, it should check that the state is still valid after every yield (and maybe throw a \code{ConcurrentModificationError} if it isn't).
+If the iterator depends on external state that might change,
+it should check that the state is still valid after every yield
+(and maybe throw a \code{ConcurrentModificationError} if it isn't).%
 }
 
 \LMHash{}%
-Each iterator runs with its own shallow copies of all local variables; in particular, each iterator has the same initial arguments, even if their bindings are modified by the function.
-\commentary{
-Two executions of an iterator interact only via state outside the function.
+Each iterator runs with its own shallow copies of all local variables;
+in particular, each iterator has the same initial arguments,
+even if their bindings are modified by the function.
+\commentary{%
+Two executions of an iterator interact only via state outside the function.%
 }
 % The alternative would be to cache the results of an iterator in the iterable, and check the cache at each \YIELD{}. This would have strange issues as well. The yielded value might differ from the expression in the yield. And it is a potential memory leak as the cache is kept alive by any iterator.
 
@@ -11420,10 +11731,12 @@ then a fresh instance (\ref{generativeConstructors}) $o$ is associated with the 
 where the dynamic type of $o$ implements \code{Future<$flatten(T)$>},
 and $T$ is the actual return type of $f$ (\ref{actualTypes}).
 Then the body of $f$ is executed until it either suspends or completes, at which point $o$ is returned.
-\commentary{
-The body of $f$ may suspend during the evaluation of an \AWAIT{} expression or execution of an asynchronous \FOR{} loop.
+\commentary{%
+The body of $f$ may suspend during the evaluation of an \AWAIT{} expression
+or execution of an asynchronous \FOR{} loop.%
 }
-The future $o$ is completed when execution of the body of $f$ completes (\ref{statementCompletion}).
+The future $o$ is completed when execution of the body of $f$ completes
+(\ref{statementCompletion}).
 If execution of the body returns an object, $o$ is completed with that object.
 If it completes normally or returns without an object,
 $o$ is completed with the null object (\ref{null}),
@@ -11431,9 +11744,10 @@ and if it throws an exception $e$ and stack trace $t$,
 $o$ is completed with the error $e$ and stack trace $t$.
 If execution of the body throws before the body suspends the first time,
 completion of $o$ happens at some future time after the invocation has returned.
-\rationale{
+\rationale{%
 The caller needs time to set up error handling for the returned future,
-so the future is not completed with an error \emph{before} it has been returned.
+so the future is not completed with an error
+\emph{before} it has been returned.%
 }
 
 \LMHash{}%
@@ -11458,23 +11772,22 @@ When execution of the body of $f$ completes:
   \end{itemize}
 \item $s$ is closed.
 \end{itemize}
-\commentary{
+\commentary{%
 The body of an asynchronous generator function
 cannot break, continue or return with an object
 (\ref{statementCompletion}).
-The first two are only allowed in contexts that will handle the break or continue,
-and return statements with an expression are not allowed in generator functions.
+The first two are only allowed in contexts that
+will handle the break or continue,
+and return statements with an expression are not allowed
+in generator functions.%
 }
 
-\rationale{
+\rationale{%
 When an asynchronous generator's stream has been canceled,
 cleanup will occur in the \FINALLY{} clauses (\ref{try}) inside the generator.
 We choose to direct any exceptions that occur at this time
-to the cancellation future rather than have them be lost.
+to the cancellation future rather than have them be lost.%
 }
-
-%\LMHash{}%
-%When a stream is canceled, the implementation must wait for the cancelation future returned by \code{cancell()} to complete before proceeding.
 
 
 \subsubsection{Actual Argument Lists}
@@ -11564,9 +11877,9 @@ and $S_i$ is assignable to $T_j$ whenever $y_i = x_j$ and
 $j \in n + 1 .. n + k$, for all
 $i \in m + 1 .. m + p$.
 
-\commentary{
+\commentary{%
 In short, an actual argument list is a match for a formal parameter list
-whenever the former can safely be passed to the latter.
+whenever the former can safely be passed to the latter.%
 }
 
 
@@ -11588,14 +11901,26 @@ In this situation, the expression is always parsed as a generic function invocat
 %   'x..y(...).m<...>(...', etc, basically everything that can precede
 %   argumentPart in the grammar.
 
-\commentary{
-An example is \code{f(a<B, C>($d$))}, which may be an invocation of \code{f} passing two actual arguments of type \code{bool}, or an invocation of \code{f} passing the result returned by an invocation of the generic function \code{a}.
-Note that the ambiguity can be eliminated by omitting the parentheses around the expression $d$, or adding parentheses around one of the relational expressions.
+\commentary{%
+An example is \code{f(a<B, C>($d$))},
+which may be an invocation of \code{f} passing
+two actual arguments of type \code{bool}, or
+an invocation of \code{f} passing the result returned by
+an invocation of the generic function \code{a}.
+Note that the ambiguity can be eliminated by omitting
+the parentheses around the expression $d$,
+or adding parentheses around one of the relational expressions.%
 }
 
-\rationale{
-When the intention is to pass several relational or shift expressions as actual arguments and there is an ambiguity, the source code can easily be adjusted to a form which is unambiguous.
-Also, we expect that it will be more common to have generic function invocations as actual arguments than having relational or shift expressions that happen to match up and have parentheses at the end, such that the ambiguity arises.
+\rationale{%
+When the intention is to pass
+several relational or shift expressions as actual arguments
+and there is an ambiguity, the source code can easily be adjusted
+to a form which is unambiguous.
+Also, we expect that it will be more common to have
+generic function invocations as actual arguments
+than having relational or shift expressions that happen to match up
+and have parentheses at the end, such that the ambiguity arises.%
 }
 
 \LMHash{}%
@@ -11609,27 +11934,30 @@ proceeds as follows:
 The type arguments $A_1, \ldots, A_r$ are evaluated in the order they appear in the program, producing types $t_1, \ldots, t_r$.
 The arguments $a_1, \ldots, a_{m+l}$ are evaluated in the order they appear in the program, producing objects $o_1, \ldots, o_{m+l}$.
 
-\commentary{
-Simply stated, an argument part consisting of $s$ type arguments, $m$ positional arguments, and $l$ named arguments is evaluated from left to right.
-Note that the type argument list is omitted when $r = 0$ (\ref{generics}).
+\commentary{%
+Simply stated, an argument part consisting of $s$ type arguments,
+$m$ positional arguments, and $l$ named arguments is
+evaluated from left to right.
+Note that the type argument list is omitted when $r = 0$
+(\ref{generics}).%
 }
 
 
 \subsubsection{Binding Actuals to Formals}
 \LMLabel{bindingActualsToFormals}
 
-\commentary{
+\commentary{%
 In the following, the non-generic case is covered implicitly:
 When the number of actual type arguments is zero
 the entire type argument list \code{<\ldots{}>} is omitted,
-and similarly for empty type parameter lists (\ref{generics}).
+and similarly for empty type parameter lists (\ref{generics}).%
 }
 
 \LMHash{}%
 Consider an invocation $i$ of a function $f$ with an actual argument part of the form
 \code{<$A_1, \ldots,\ A_r$>($a_1, \ldots,\ a_m,\ q_1$: $a_{m+1}, \ldots,\ q_l$: $a_{m+l}$)}.
 
-\commentary{
+\commentary{%
 Note that $f$ denotes a function in a semantic sense,
 rather than a syntactic construct.
 A reference to this section is used in other sections
@@ -11718,12 +12046,12 @@ where each parameter type is obtained by replacing $X_j$ by $A_j, j \in 1 .. s$,
 in the given parameter type annotation.
 Finally, let $T_i$ be the static type of $a_i$.
 
-\commentary{
+\commentary{%
 We have an actual argument list consisting of $r$ type arguments,
 $m$ positional arguments, and $l$ named arguments.
 We have a function with $s$ type parameters,
 $h$ required parameters, and $k$ optional parameters.
-Figure~\ref{fig:argumentsAndParameters} shows how this situation arises.
+Figure~\ref{fig:argumentsAndParameters} shows how this situation arises.%
 }
 
 % View on declaration:
@@ -11795,12 +12123,12 @@ If $l > 0$,
 it is a compile-time error unless $F$ has named parameters and
 $q_j \in \{p_{h+1}, \ldots, p_{h+k}\}, j \in 1 .. l$.
 
-\commentary{
+\commentary{%
 That is, the number of type arguments must match the number of type parameters,
 and the bounds must be respected.
 We must receive at least the required number of positional arguments,
 and not more than the total number of positional parameters.
-For each named argument there must be a named parameter with the same name.
+For each named argument there must be a named parameter with the same name.%
 }
 
 \LMHash{}%
@@ -11810,16 +12138,16 @@ The static type of $i$ is $[A_1/X_1, \ldots, A_r/X_s]S_0$.
 It is a compile-time error if $T_j$ may not be assigned to $S_j, j \in 1 .. m$.
 It is a compile-time error if $T_{m+j}$ may not be assigned to $S_{q_j}, j \in 1 .. l$.
 
-\commentary{
+\commentary{%
 Consider the case where the function invocation in focus here is
 an instance method invocation.
 In that case, for each actual argument,
 the corresponding parameter may be covariant.
 However, the above assignability requirements apply equally
-both when the parameter is covariant and when it is not.
+both when the parameter is covariant and when it is not.%
 }
 
-\rationale{
+\rationale{%
 Parameter covariance in an instance method invocation can be introduced by
 a subtype of the statically known receiver type,
 which means that any attempt to flag a given actual argument as dangerous
@@ -11833,7 +12161,7 @@ that this specific kind of compile-time safety is violated.
 The point is that this mechanism postpones the enforcement of
 the underlying invariant to run time,
 and in return allows some useful program designs
-that would otherwise be rejected at compile-time.
+that would otherwise be rejected at compile-time.%
 }
 
 \LMHash{}%
@@ -11924,8 +12252,8 @@ An unqualified function invocation $i$ has the form
 \noindent
 where \id{} is an identifier.
 
-\commentary{
-Note that the type argument list is omitted when $r = 0$ (\ref{generics}).
+\commentary{%
+Note that the type argument list is omitted when $r = 0$ (\ref{generics}).%
 }
 
 \LMHash{}%
@@ -12039,8 +12367,9 @@ A function expression invocation $i$ has the form
 \noindent
 where $e_f$ is an expression.
 
-\commentary{
-Note that the type argument list is omitted when $r = 0$ (\ref{generics}).
+\commentary{%
+Note that the type argument list is omitted when $r = 0$
+(\ref{generics}).%
 }
 
 \LMHash{}%
@@ -12167,14 +12496,15 @@ A new instance $im$ of the predefined class \code{Invocation} is created, such t
 Then the method invocation \code{f.noSuchMethod($im$)} is evaluated,
 and its result is then the result of evaluating $i$.
 
-\commentary{
+\commentary{%
 The situation where \code{noSuchMethod} is invoked can only arise
 when the static type of $e_f$ is \DYNAMIC{}.
 The run-time semantics ensures that
-a function invocation may amount to an invocation of the instance method \CALL{}.
+a function invocation may amount to an invocation of
+the instance method \CALL{}.
 However, an interface type with a method named \CALL{}
 is not itself a subtype of any function type
-(\ref{subtypeRules}).
+(\ref{subtypeRules}).%
 }
 
 
@@ -12255,7 +12585,7 @@ based on a reference to a generic function.
 It is a mechanism which is very similar to function closurization
 (\ref{functionClosurization}),
 but it only occurs in situations where
-a compile-time error would otherwise occur.
+a compile-time error would otherwise occur.%
 }
 
 \rationale{%
@@ -12289,7 +12619,7 @@ Each function object stored in \code{functions}
 has dynamic type \code{int\,\,\FUNCTION(int)},
 and it is obtained by implicitly
 ``passing the actual type argument \code{int}''
-to the corresponding generic function.
+to the corresponding generic function.%
 }
 
 \LMHash{}%
@@ -12332,7 +12662,7 @@ in the case where type inference fails,
 in which case the above mentioned compile-time error occurs.
 It will be specified in a future version of this document
 how type inference computes \List{T}{1}{s}
-(\ref{overview}).
+(\ref{overview}).%
 }
 
 \LMHash{}%
@@ -12375,7 +12705,7 @@ String bar(List<int> f(int)) => "\${f(42)}";
 In this example,
 \code{foo} as an actual argument to \code{bar} will be modified
 as if the call had been \code{bar(fooOfInt)},
-except for equality, which is specified next.
+except for equality, which is specified next.%
 }
 
 \LMHash{}%
@@ -12461,9 +12791,12 @@ at run time. It may succeed or fail.
 \commentary{%
 We define several kinds of lookup with a very similar structure.
 We spell out each of them in spite of the redundancy,
-in order to avoid introducing meta-level abstraction mechanisms just for this purpose.
-The point is that we must indicate for each lookup which kind of member it is looking for,
-because, e.g., a `method lookup' and a `getter lookup' are used in different situations.%
+in order to avoid introducing meta-level abstraction mechanisms
+just for this purpose.
+The point is that we must indicate for each lookup
+which kind of member it is looking for,
+because, e.g., a `method lookup' and a `getter lookup' are used
+in different situations.%
 }
 
 { % Scope for 'lookup' definition.
@@ -12509,20 +12842,21 @@ Let $m$ be an identifier, $o$ an object, and $L$ a library.
 
 } % End of scope for lookup definitions.
 
-\commentary{
+\commentary{%
 Note that for getter (setter) lookup, the result may be
 a getter (setter) which has been induced by an instance variable
-declaration.
+declaration.%
 }
 
-\commentary{
+\commentary{%
 Note that we sometimes use phrases like `looking up method $m$'
 to indicate that a method lookup is performed,
-and similarly for setter lookups and getter lookups.
+and similarly for setter lookups and getter lookups.%
 }
 
-\rationale{
-The motivation for ignoring abstract members during lookup is largely to allow smoother mixin composition.
+\rationale{%
+The motivation for ignoring abstract members during lookup
+is largely to allow smoother mixin composition.%
 }
 
 
@@ -12535,9 +12869,11 @@ Evaluation of a top-level getter invocation $i$ of the form $m$, where $m$ is an
 \LMHash{}%
 The getter function $m$ is invoked.
 The value of $i$ is the result returned by the call to the getter function.
-\commentary{
+\commentary{%
 Note that the invocation is always defined.
-Per the rules for identifier references, an identifier will not be treated as a top-level getter invocation unless the getter $i$ is defined.
+Per the rules for identifier references,
+an identifier will not be treated as a top-level getter invocation
+unless the getter $i$ is defined.%
 }
 
 \LMHash{}%
@@ -12821,10 +13157,11 @@ Consider a
 $i$ of the form
 \code{$e$?.$m$<$A_1, \ldots,\ A_r$>($a_1, \ldots,\ a_n,\ x_{n+1}$: $a_{n+1}, \ldots,\ x_{n+k}$: $a_{n+k}$)}.
 
-\commentary{
-Note that non-generic invocations arise as the special case where the number of type arguments is zero,
+\commentary{%
+Note that non-generic invocations arise as the special case where
+the number of type arguments is zero,
 in which case the type argument list is omitted,
-and similarly for formal type parameter lists (\ref{generics}).
+and similarly for formal type parameter lists (\ref{generics}).%
 }
 
 \LMHash{}%
@@ -12867,9 +13204,9 @@ $i$ is an invocation of the form
 \code{$C$.$m$<$A_1, \ldots,\ A_r$>($a_1, \ldots,\ a_n,\ x_{n+1}$:\ $a_{n+1}, \ldots,\ x_{n+k}$:\ $a_{n+k}$)},
 where $C$ is a type literal, or $C$ denotes an extension.
 
-\commentary{
+\commentary{%
 Non-generic invocations arise as the special case
-where the number of type arguments is zero (\ref{generics}).
+where the number of type arguments is zero (\ref{generics}).%
 }
 
 \LMHash{}%
@@ -12924,9 +13261,9 @@ $i$ has the form
 where $e$ is an expression that is not a type literal,
 and does not denote an extension.
 
-\commentary{
+\commentary{%
 Non-generic invocations arise as the special case
-where the number of type arguments is zero (\ref{generics}).
+where the number of type arguments is zero (\ref{generics}).%
 }
 
 \LMHash{}%
@@ -12983,7 +13320,9 @@ and if the method lookup succeeded then let $F$ be the static type of $d$.
 \LMHash{}%
 Otherwise, let $d$ be the result of getter lookup for $m$ in $T$ with respect to $L$
 and let $F$ be the return type of $d$.
-(\commentary{Since \code{$T$.$m$} exists we cannot have a failure in both lookups.})
+(\commentary{
+Since \code{$T$.$m$} exists we cannot have a failure in both lookups.%
+})
 If the getter return type $F$ is an interface type
 that has a method named \CALL,
 $i$ is treated as
@@ -13201,10 +13540,10 @@ A super method invocation $i$ has the form
 
 \code{\SUPER{}.$m$<$A_1, \ldots,\ A_r$>($a_1, \ldots,\ a_n,\ x_{n+1}$: $a_{n+1}, \ldots,\ x_{n+k}$: $a_{n+k}$)}.
 
-\commentary{
+\commentary{%
 Note that non-generic invocations arise as the special case where the number of type arguments is zero,
 in which case the type argument list is omitted,
-and similarly for formal type parameter lists (\ref{generics}).
+and similarly for formal type parameter lists (\ref{generics}).%
 }
 
 \LMHash{}%
@@ -13239,10 +13578,11 @@ the static analysis of $i$ is performed as specified in Section~\ref{bindingActu
 considering the function to have static type $F$,
 and the static type of $i$ is as specified there.
 
-\commentary{
+\commentary{%
 Note that member lookups ignore abstract declarations,
-which means that there will be a compile-time error if the targeted member $m$ is abstract,
-as well as when it does not exist at all.
+which means that there will be a compile-time error
+if the targeted member $m$ is abstract,
+as well as when it does not exist at all.%
 }
 
 \LMHash{}%
@@ -13264,9 +13604,9 @@ If the getter lookup succeeded,
 invoke said getter with \THIS{} bound to $o$,
 and let $f$ denote the returned object.
 
-\commentary{
+\commentary{%
 If both lookups failed, the exact same lookups would have failed
-at compile-time, and the program then has a compile-time error.
+at compile-time, and the program then has a compile-time error.%
 }
 
 \LMHash{}%
@@ -13287,8 +13627,10 @@ The result returned by $f$ is then the result of evaluating $i$.
 Messages are the sole means of communication among isolates.
 Messages are sent by invoking specific methods in the Dart libraries; there is no specific syntax for sending a message.
 
-\commentary{
-In other words, the methods supporting sending messages embody primitives of Dart that are not accessible to ordinary code, much like the methods that spawn isolates.
+\commentary{%
+In other words, the methods supporting sending messages 
+embody primitives of Dart that are not accessible to ordinary code,
+much like the methods that spawn isolates.%
 }
 
 
@@ -13309,9 +13651,9 @@ A property extraction can be either:
   (\ref{getterAccessAndMethodExtraction}).
 \end{enumerate}
 
-\commentary{
+\commentary{%
 Function objects derived from members via closurization
-are colloquially known as tear-offs.
+are colloquially known as tear-offs.%
 }
 
 Property extraction can be either conditional or unconditional.
@@ -13408,21 +13750,21 @@ It is a compile-time error if \id{} is the name of
 an instance member of the built-in class \code{Object}
 and $e$ is a type literal.
 
-\commentary{
+\commentary{%
 This means that we cannot use \code{int.toString}
 to obtain a function object for the \code{toString} method of the
 \code{Type} object for \code{int}.
 But we can use \code{(int).toString}:
-$e$ is then not a type literal, but a parenthesized expression.
+$e$ is then not a type literal, but a parenthesized expression.%
 }
 
-\rationale{
+\rationale{%
 This is a pragmatic trade-off.
 The ability to tear off instance methods on instances of \code{Type}
 was considered less useful,
 and it was considered more useful to insist on the simple rule that
 a method tear-off on a type literal is \emph{always} a tear-off
-of a static method on the denoted class.
+of a static method on the denoted class.%
 }
 
 \LMHash{}%
@@ -13443,11 +13785,11 @@ The static type of $i$ is:
   \commentary{This only occurs when $T$ is \DYNAMIC{} bounded.}
 \end{itemize}
 
-\commentary{
+\commentary{%
 Note that the type of a method tear-off ignores
 whether any given parameter is covariant.
 However, the dynamic type of a function object
-thus obtained does take parameter covariance into account.
+thus obtained does take parameter covariance into account.%
 }
 
 \LMHash{}%
@@ -13463,15 +13805,17 @@ If method lookup succeeds then $i$ evaluates to
 the closurization of method $f$ on object $o$
 (\ref{ordinaryMemberClosurization}).
 
-\commentary{
-Note that $f$ is never an abstract method, because method lookup skips abstract methods.
+\commentary{%
+Note that $f$ is never an abstract method,
+because method lookup skips abstract methods.
 If the method lookup failed, e.g.,
 because there is an abstract declaration of \id, but no concrete declaration,
 we will continue to the next step.
 However, since methods and getters never override each other,
 getter lookup will necessarily fail as well,
 and \code{noSuchMethod()} will ultimately be invoked.
-The regrettable implication is that the error will refer to a missing getter rather than an attempt to closurize an abstract method.
+The regrettable implication is that the error will refer to a missing getter
+rather than an attempt to closurize an abstract method.%
 }
 
 \LMHash{}%
@@ -13503,9 +13847,9 @@ then a new instance $im$ of the predefined class \code{Invocation} is created, s
 Then the method \code{noSuchMethod()} is looked up in $o$ and invoked with argument $im$,
 and the result of this invocation is the result of evaluating $i$.
 
-\commentary {
+\commentary{%
 The situation where \code{noSuchMethod} is invoked can only arise
-when the static type of $e$ is \DYNAMIC{}.
+when the static type of $e$ is \DYNAMIC{}.%
 }
 
 
@@ -13530,11 +13874,11 @@ The static type of $i$ is:
   \commentary{This only occurs when $T$ is \DYNAMIC{} or \FUNCTION.}
 \end{itemize}
 
-\commentary{
+\commentary{%
 Note that the type of a method tear-off ignores
 whether any given parameter is covariant.
 However, the dynamic type of a function object
-thus obtained does take parameter covariance into account.
+thus obtained does take parameter covariance into account.%
 }
 
 \LMHash{}%
@@ -13558,10 +13902,10 @@ getter \id{} in $S$ with respect to $L$.
 The body of $f$ is executed with \THIS{} bound to the current value of \THIS{}.
 The value of $i$ is the result returned by the call to the getter function.
 
-\commentary{
+\commentary{%
 The getter lookup will not fail, because it is a compile-time error to have
 a super property extraction of a member \id{} when the superclass $S$
-does not have a concrete member named \id.
+does not have a concrete member named \id.%
 }
 
 
@@ -13572,11 +13916,11 @@ does not have a concrete member named \id.
 This section specifies the dynamic semantics of
 ordinary member closurizations.
 
-\commentary{
+\commentary{%
 Note that the non-generic case is covered implicitly using $s = 0$,
 in which case the type parameter declaration lists
 and the actual type argument lists passed in invocations
-are omitted (\ref{generics}).
+are omitted (\ref{generics}).%
 }
 
 \LMHash{}%
@@ -13628,9 +13972,10 @@ Otherwise, let $X'_1, \ldots, X'_{s'}$ be the formal type parameters of the clas
 and $t'_1, \ldots, t'_{s'}$ be the actual type arguments.
 Then $B'_j = [t'_1/X'_1, \ldots, t'_{s'}/X'_{s'}]B_j, j \in 1 .. s$.
 
-\commentary{
-That is, we replace the formal type parameters of the enclosing class, if any,
-by the corresponding actual type arguments.
+\commentary{%
+That is, we replace the formal type parameters of the enclosing class,
+if any,
+by the corresponding actual type arguments.%
 }
 
 \LMHash{}%
@@ -13639,8 +13984,8 @@ Let the method declaration $D$ be the implementation of $m$
 which is invoked by the expression in the body.
 Let $T$ be the class that contains $D$.
 
-\commentary{
-Note that $T$ is the dynamic type of $o$, or a superclass thereof.
+\commentary{%
+Note that $T$ is the dynamic type of $o$, or a superclass thereof.%
 }
 
 \LMHash{}%
@@ -13648,14 +13993,14 @@ For each parameter $p_j$, $j \in 1 .. n+k$, if $p_j$ is covariant
 (\ref{covariantParameters})
 then $T_j$ is the built-in class \code{Object}.
 
-\commentary{
+\commentary{%
 This is concerned with the dynamic type of the function object obtained by
 the member closurization.
 The static type of the expression that gives rise to the member closurization
 is specified elsewhere
 (\ref{propertyExtraction},
 \ref{getterAccessAndMethodExtraction}).
-Note that for the static type it is ignored whether a parameter is covariant.
+Note that for the static type it is ignored whether a parameter is covariant.%
 }
 
 \LMHash{}%
@@ -13681,21 +14026,25 @@ and $c_1$ and $c_2$ are function objects
 obtained by closurization of $m$ on $o_1$ respectively $o_2$.
 Then \code{$c_1$ == $c_2$} evaluates to true if and only if $o_1$ and $o_2$ is the same object.
 
-\commentary{
+\commentary{%
 % Spell out the consequences for `==` and for `identical`, for the receivers
 % and for the closurizations.
-In particular, two closurizations of a method $m$ from the same object are equal,
-and two closurizations of a method $m$ from non-identical objects are not equal.
+In particular, two closurizations of a method $m$
+from the same object are equal,
+and two closurizations of a method $m$
+from non-identical objects are not equal.
 Assuming that $v_i$ is a fresh variable bound to an object, $i \in 1 .. 2$,
 it also follows that \code{identical($v_1.m, v_2.m$)} must be false when $v_1$ and $v_2$ are not bound to the same object.
 However, Dart implementations are not required to canonicalize function objects,
 which means that \code{identical($v_1.m, v_2.m$)} is not guaranteed to be true,
-even when it is known that $v_1$ and $v_2$ are bound to the same object.
+even when it is known that $v_1$ and $v_2$ are bound to the same object.%
 }
 
-\rationale{
-The special treatment of equality in this case facilitates the use of extracted property functions in APIs where callbacks such as event listeners must often be registered and later unregistered.
-A common example is the DOM API in web browsers.
+\rationale{%
+The special treatment of equality in this case facilitates
+the use of extracted property functions in APIs where callbacks
+such as event listeners must often be registered and later unregistered.
+A common example is the DOM API in web browsers.%
 }
 
 
@@ -13706,9 +14055,9 @@ A common example is the DOM API in web browsers.
 This section specifies the dynamic semantics of
 super closurizations.
 
-\commentary{
+\commentary{%
 Note that the non-generic case is covered implicitly using $s = 0$,
-in which case the type parameter declarations are omitted (\ref{generics}).
+in which case the type parameter declarations are omitted (\ref{generics}).%
 }
 
 \LMHash{}%
@@ -13716,8 +14065,9 @@ Consider expressions in the body of a class $T$ which is a subclass of a given c
 where a method declaration that implements $f$ exists in $S$,
 and there is no class $U$ which is a subclass of $S$ and a superclass of $T$ which implements $f$.
 
-\commentary{
-In short, consider a situation where a super invocation of $f$ will execute $f$ as declared in $S$.
+\commentary{%
+In short, consider a situation where
+a super invocation of $f$ will execute $f$ as declared in $S$.%
 }
 
 \LMHash{}%
@@ -13758,9 +14108,9 @@ and optional positional parameters
 \List{p}{n+1}{n+k} with defaults \List{d}{1}{k}.
 \end{itemize}
 
-\commentary{
+\commentary{%
 Note that a super closurization is an instance method closurization,
-as defined in (\ref{ordinaryMemberClosurization}).
+as defined in (\ref{ordinaryMemberClosurization}).%
 }
 
 \LMHash{}%
@@ -13770,12 +14120,12 @@ Otherwise, let $X'_1, \ldots, X'_{s'}$ be the formal type parameters of $S$,
 and $t'_1, \ldots, t'_{s'}$ be the actual type arguments of \THIS{} at $S$.
 Then $B'_j = [t'_1/X'_1, \ldots, t'_{s'}/X'_{s'}]B_j, j \in 1 .. s$.
 
-\commentary{
+\commentary{%
 That is, we replace the formal type parameters of the enclosing class, if any,
 by the corresponding actual type arguments.
 We need to consider the type arguments with respect to a specific class because
 it is possible for a class to pass different type arguments to its superclass
-than the ones it receives itself.
+than the ones it receives itself.%
 }
 
 \LMHash{}%
@@ -13787,14 +14137,14 @@ For each parameter $p_j$, $j \in 1 .. n+k$, if $p_j$ is covariant
 (\ref{covariantParameters})
 then $T_j$ is the built-in class \code{Object}.
 
-\commentary{
+\commentary{%
 This is concerned with the dynamic type of the function object obtained by
 the super closurization.
 The static type of the expression that gives rise to the super closurization
 is specified elsewhere
 (\ref{propertyExtraction},
 \ref{superGetterAccessAndMethodClosurization}).
-Note that for the static type it is ignored whether a parameter is covariant.
+Note that for the static type it is ignored whether a parameter is covariant.%
 }
 
 \LMHash{}%
@@ -13879,7 +14229,7 @@ thus obtaining a non-generic function object of the specified type.
 Note that this function object accepts an optional positional argument,
 even though this is not part of
 the statically known type of the corresponding instance method,
-nor of the context type.
+nor of the context type.%
 }
 
 \rationale{%
@@ -13981,7 +14331,8 @@ Let \gmiName{} be a fresh name which is associated with \id{},
 which is private if and only if \id{} is private.
 \commentary{%
 An implementation could use, say, \code{foo_*} when \id{} is \code{foo},
-which is known to be fresh because user-written identifiers cannot contain `\code{*}'.%
+which is known to be fresh because
+user-written identifiers cannot contain `\code{*}'.%
 }
 The program is then modified as follows:
 
@@ -14029,7 +14380,7 @@ For instance, if $G$ is
 \FunctionTypeSimpleGeneric{\VOID}{$X$, $Y$ \EXTENDS\ num}{X x, List<Y> ys}
 then $G'$ is
 \FunctionTypeSimple{\VOID}{X x, List<Y> ys}.
-Note that $G'$ will typically contain free type variables.
+Note that $G'$ will typically contain free type variables.%
 }
 
 \LMHash{}%
@@ -14196,7 +14547,7 @@ Perform a lexical lookup of \code{\id=} from the location of \id.
     yields a member signature cannot occur,
     because that case is treated as
     \code{\THIS.\id{} = $e$},
-    whose evaluation is specified elsewhere.
+    whose evaluation is specified elsewhere.%
   }
 \end{itemize}
 \EndCase
@@ -14288,9 +14639,9 @@ If the setter lookup has failed, then a new instance $im$ of the predefined clas
 \LMHash{}%
 Then the method \code{noSuchMethod()} is looked up in $o_1$ and invoked with argument $im$.
 
-\commentary{
+\commentary{%
 The situation where \code{noSuchMethod} is invoked can only arise
-when the static type of $e_1$ is \DYNAMIC{}.
+when the static type of $e_1$ is \DYNAMIC{}.%
 }
 
 \LMHash{}%
@@ -14316,9 +14667,9 @@ Then, the setter \code{$v$=} is looked up (\ref{lookup}) in $S_{dynamic}$ with r
 The body of \code{$v$=} is executed with its formal parameter bound to $o$
 and \THIS{} bound to the current value of \THIS{}.
 
-\commentary{
+\commentary{%
 The setter lookup will not fail, because it is a compile-time error
-when no concrete setter named \code{$v$=} exists in $S_{static}$.
+when no concrete setter named \code{$v$=} exists in $S_{static}$.%
 }
 
 \LMHash{}%
@@ -14773,12 +15124,17 @@ Otherwise,
 \item evaluation of $ee$ is equivalent to the method invocation \code{\SUPER{}.==($o$)}.
 \end{itemize}
 
-\commentary{
-As a result of the above definition, user defined \lit{==} methods can assume that their argument is non-null, and avoid the standard boiler-plate prelude:
+\commentary{%
+As a result of the above definition,
+user defined \lit{==} methods can assume that their argument is non-null,
+and avoid the standard boiler-plate prelude:
 
 \code{if (identical(\NULL{}, arg)) return \FALSE{};}
 
-Another implication is that there is never a need to use \code{identical()} to test against \NULL{}, nor should anyone ever worry about whether to write \NULL{} == $e$ or $e$ == \NULL{}.
+Another implication is that there is never a need
+to use \code{identical()} to test against \NULL{},
+nor should anyone ever worry about whether to write
+\NULL{} == $e$ or $e$ == \NULL{}.%
 }
 
 \LMHash{}%
@@ -14846,9 +15202,12 @@ A \Index{bitwise expression} is either a shift expression (\ref{shift}), or an i
 A bitwise expression of the form \code{$e_1$ $op$ $e_2$} is equivalent to the method invocation $e_1.op(e_2)$.
 A bitwise expression of the form \code{\SUPER{} $op$ $e_2$} is equivalent to the method invocation \code{\SUPER{}.$op$($e_2$)}.
 
-\commentary{
-It should be obvious that the static type rules for these expressions are defined by the equivalence above - ergo, by the type rules for method invocation and the signatures of the operators on the type $e_1$.
-The same holds in similar situations throughout this specification.
+\commentary{%
+It should be obvious that the static type rules for these expressions
+are defined by the equivalence above---ergo,
+by the type rules for method invocation and
+the signatures of the operators on the type $e_1$.
+The same holds in similar situations throughout this specification.%
 }
 
 
@@ -14875,13 +15234,14 @@ A \Index{shift expression} is either an additive expression (\ref{additiveExpres
 A shift expression of the form $e_1$ $op$ $e_2$ is equivalent to the method invocation \code{$e_1$.$op$($e_2$)}.
 A shift expression of the form \SUPER{} $op$ $e_2$ is equivalent to the method invocation \code{\SUPER{}.$op$($e_2$)}.
 
-\commentary{
-Note that this definition implies left-to-right evaluation order among shift expressions:
+\commentary{%
+Note that this definition implies left-to-right evaluation order
+among shift expressions:
 \code{$e_1$\,<\mbox<\,$e_2$\,<\mbox<\,$e_3$}
 is evaluated as
 \code{($e_1$\,<\mbox<\,$e_2$).<\mbox< ($e_3$)} which is equivalent to
 \code{($e_1$\,<\mbox<\,$e_2$)\,<\mbox<\,$e_3$}.
-The same holds for additive and multiplicative expressions.
+The same holds for additive and multiplicative expressions.%
 }
 
 
@@ -15137,7 +15497,7 @@ Note that $e$ cannot be anything other than an instance creation
 (constant or not)
 because $e$ provides actual type arguments to $n$,
 which is not supported if $n$ denotes a library prefix,
-nor if $e$ is a static method invocation.
+nor if $e$ is a static method invocation.%
 }
 \EndCase
 
@@ -15294,12 +15654,13 @@ Then $e$ evaluates to $o$.
 Assignable expressions are expressions that can appear on the left hand side of an assignment.
 This section describes how to evaluate these expressions when they do not constitute the complete left hand side of an assignment.
 
-\rationale{
-Of course, if assignable expressions always appeared \emph{as} the left hand side,
+\rationale{%
+Of course, if assignable expressions
+always appeared \emph{as} the left hand side,
 one would have no need for their value,
 and the rules for evaluating them would be unnecessary.
 However, assignable expressions can be subexpressions of other expressions
-and therefore must be evaluated.
+and therefore must be evaluated.%
 }
 
 \begin{grammar}
@@ -15763,9 +16124,9 @@ No static type is associated with $e$ in this case.
 % of every construct of the form $p$.something is specified without referring
 % to the static type of $p$. So we do not mention that type here.
 \commentary{%
-No such type is needed, because every construct where an import prefix $p$ is
-used and followed by \lit{.} is specified in such a way that the type
-of $p$ is not used.%
+No such type is needed, because every construct where
+an import prefix $p$ is used and followed by \lit{.} is specified
+in such a way that the type of $p$ is not used.%
 }
 \EndCase
 
@@ -15888,17 +16249,21 @@ If the dynamic type of $v$ is a subtype of $T$,
 the is-expression evaluates to \TRUE.
 Otherwise it evaluates to \FALSE.
 
-\commentary{
+\commentary{%
 It follows that \code{$e$ \IS{} Object} is always true.
 This makes sense in a language where everything is an object.
 
-Also note that \code{\NULL{} \IS{} $T$} is false unless $T = \code{Object}$, $T = \code{\DYNAMIC{}}$ or $T = \code{Null}$.
-The former two are useless, as is anything of the form \code{$e$ \IS{} Object} or \code{$e$ \IS{} \DYNAMIC{}}.
-Users should test for the null object (\ref{null}) directly rather than via type tests.
+Also note that \code{\NULL{} \IS{} $T$} is false
+unless $T = \code{Object}$, $T = \code{\DYNAMIC{}}$ or $T = \code{Null}$.
+The former two are useless, as is anything
+of the form \code{$e$ \IS{} Object} or \code{$e$ \IS{} \DYNAMIC{}}.
+Users should test for the null object (\ref{null}) directly
+rather than via type tests.%
 }
 
 \LMHash{}%
-The is-expression \code{$e$ \IS{}! $T$} is equivalent to \code{!($e$ \IS{} $T$)}.
+The is-expression \code{$e$ \IS{}! $T$} is equivalent to
+\code{!($e$ \IS{} $T$)}.
 
 \LMHash{}%
 Let $v$ be a local variable (\commentary{which can be a formal parameter}).
@@ -15914,21 +16279,29 @@ then $e$ shows that $v$ has type $X \& T$.
 %
 Otherwise $e$ does not show that $v$ has type $T$ for any $T$.
 
-\rationale{
-The motivation for the ``shows that v has type T" relation is to reduce spurious errors thereby enabling a more natural coding style.
+\rationale{%
+The motivation for the ``shows that v has type T" relation is
+to reduce spurious errors thereby enabling a more natural coding style.
 The rules in the current specification are deliberately kept simple.
-It would be upwardly compatible to refine these rules in the future; such a refinement would accept more code without errors, but not reject any code now error-free.
+It would be upwardly compatible to refine these rules in the future;
+such a refinement would accept more code without errors,
+but not reject any code now error-free.
 
-The rule only applies to locals and parameters, as instance and static variables could be modified via side-effecting functions or methods that are not accessible to a local analysis.
+The rule only applies to locals and parameters,
+as instance and static variables could be modified
+via side-effecting functions or methods that are not accessible
+to a local analysis.
 
 It is pointless to deduce a weaker type than what is already known.
-Furthermore, this would lead to a situation where multiple types are associated with a variable at a given point, which complicates the specification.
+Furthermore, this would lead to a situation where multiple types are
+associated with a variable at a given point,
+which complicates the specification.
 Hence the requirement that the promoted type is a subtype of the current type.
 
 In any case, it is not an error when a type test does not show
 that a given variable does not have a ``better'' type than previously known,
 but tools may choose to give a hint in such cases,
-if suitable heuristics indicate that a promotion is likely to be intended.
+if suitable heuristics indicate that a promotion is likely to be intended.%
 }
 
 \LMHash{}%
@@ -16029,12 +16402,12 @@ If the execution of a statement is defined in terms of evaluating an expression
 and the evaluation of that expression throws,
 then, unless otherwise stated, the execution of the statement stops
 at that point and throws the same exception object and stack trace.
-\commentary{
+\commentary{%
 For example,
 if evaluation of the condition expression of an \IF{} statement throws,
 then so does execution of the \IF{} statement.
 Likewise, if evaluation of the expression of a \RETURN{} statement throws,
-so does execution of the \RETURN{} statement.
+so does execution of the \RETURN{} statement.%
 }
 
 %% TODO(eernst): Use proposal from Lasse to add a definition of the concept of
@@ -16074,18 +16447,18 @@ begin with a \lit{\{} character.
 \LMHash{}%
 The expression of an expression statement is not allowed
 to begin with a \lit{\{}.
-\commentary{
+\commentary{%
 This means that if some source text could otherwise be parsed as an expression
 followed by a \lit{;}, then this grammar production does not apply
-when the expression starts with a \lit{\{}.
+when the expression starts with a \lit{\{}.%
 }
-\rationale{
+\rationale{%
 The restriction resolves an ambiguity while parsing where a
 \lit{\{} can start either a block (\ref{blocks}) or
 a map literal (\ref{maps}).
 By disallowing the latter from starting an expression statement,
 the parser does not need to look further ahead
-before deciding that it is parsing a block statement.
+before deciding that it is parsing a block statement.%
 }
 
 \LMHash{}%
@@ -16111,11 +16484,11 @@ Each local variable declaration introduces
 a \IndexCustom{local variable}{variable!local}
 into the current scope.
 
-\commentary{
+\commentary{%
 Local variables do not induce getters and setters.
 Note that a formal parameter declaration also introduces
 a local variable into the associated formal parameter scope
-(\ref{formalParameters}).
+(\ref{formalParameters}).%
 }
 
 \LMHash{}%
@@ -16136,9 +16509,9 @@ if $v$ is mutable, and an assignment to $v$ occurs in $s$.
 A local variable declaration of the form \code{\VAR{} $v$;} is equivalent to \code{\VAR{} $v$ = \NULL{};}.
 A local variable declaration of the form \code{$T$ $v$;} is equivalent to \code{$T$ $v$ = \NULL{};}.
 
-\commentary{
+\commentary{%
 This holds regardless of the type $T$.
-E.g., \code{int i;} is equivalent to \code{int i = null;}.
+E.g., \code{int i;} is equivalent to \code{int i = null;}.%
 }
 
 \LMHash{}%
@@ -16160,9 +16533,9 @@ It is a compile-time error if the static type of $e$ is not assignable to the ty
 It is a compile-time error if a local variable $v$ is final,
 and the declaration of $v$ is not an initializing variable declaration.
 
-\commentary{
+\commentary{%
 It is also a compile-time error to assign to a final local variable
-(\ref{assignment}).
+(\ref{assignment}).%
 }
 
 \LMHash{}%
@@ -16172,10 +16545,10 @@ the end of its initializing expression, if any,
 and otherwise before the declaring occurrence of
 the identifier which names the variable.
 
-\commentary{
+\commentary{%
 The example below illustrates the expected behavior.
 A variable `\code{x}' is declared at the library level,
-and another `\code{x}' is declared inside the function `\code{f}'.
+and another `\code{x}' is declared inside the function `\code{f}'.%
 }
 
 \begin{dartCode}
@@ -16192,7 +16565,7 @@ f(y) \{
 \}
 \end{dartCode}
 
-\commentary{
+\commentary{%
 The declaration inside `\code{f}' hides the enclosing one.
 So all references to `\code{x}' inside `\code{f}'
 refer to the inner declaration of `\code{x}'.
@@ -16212,17 +16585,17 @@ read `\code{x}' before the declaration has terminated.
 The occurrence of `\code{x}' that declares and names the variable
 (that is, the one to the left of `\code{=}' in the inner declaration)
 is not a reference, and so is legal.
-The last print statement is perfectly legal as well.
+The last print statement is perfectly legal as well.%
 }
 
-\commentary{
+\commentary{%
 As another example \code{\VAR{} x = 3, y = x;} is legal,
 because \code{x} is referenced after its initializer.
 
 A particularly perverse example involves
 a local variable name shadowing a type.
 This is possible because Dart has a
-single namespace for types, functions and variables.
+single namespace for types, functions and variables.%
 }
 
 \begin{dartCode}
@@ -16234,12 +16607,12 @@ perverse() \{
 \}
 \end{dartCode}
 
-\commentary{
+\commentary{%
 Inside \code{perverse()}, `\code{C}' denotes a local variable.
 The type `\code{C}' is hidden by the variable of the same name.
 The attempt to instantiate `\code{C}' causes a compile-time error
 because it references a local variable prior to its declaration.
-Similarly, for the declaration of `\code{aC}'.
+Similarly, for the declaration of `\code{aC}'.%
 }
 
 \LMHash{}%
@@ -16283,9 +16656,10 @@ or
 causes a new function named \id{} to be added to the current scope.
 It is a compile-time error to reference a local function before its declaration.
 
-\commentary{
-This implies that local functions can be directly recursive, but not mutually recursive.
-Consider these examples:
+\commentary{%
+This implies that local functions can be directly recursive,
+but not mutually recursive.
+Consider these examples:%
 }
 
 \begin{dartCode}
@@ -16306,12 +16680,12 @@ top() \{ // \comment{another top level function}
 \}
 \end{dartCode}
 
-\commentary{
+\commentary{%
 There is no way to write a pair of mutually recursive local functions,
 because one always has to come before the other is declared.
 These cases are quite rare,
 and can always be managed by defining a pair of variables first,
-then assigning them appropriate function literals:
+then assigning them appropriate function literals:%
 }
 
 \begin{dartCode}
@@ -16322,10 +16696,15 @@ top2() \{ // \comment{a top level function}
 \}
 \end{dartCode}
 
-\rationale{
-The rules for local functions differ slightly from those for local variables in that a function can be accessed within its declaration but a variable can only be accessed after its declaration.
-This is because recursive functions are useful whereas recursively defined variables are almost always errors.
-It therefore makes sense to harmonize the rules for local functions with those for functions in general rather than with the rules for local variables.
+\rationale{%
+The rules for local functions differ slightly from those for local variables
+in that a function can be accessed within its declaration
+but a variable can only be accessed after its declaration.
+This is because recursive functions are useful
+whereas recursively defined variables are almost always errors.
+It therefore makes sense to harmonize the rules for local functions
+with those for functions in general rather than
+with the rules for local variables.%
 }
 
 
@@ -16343,8 +16722,8 @@ The \Index{if statement} allows for conditional execution of statements.
 An if statement of the form \code{\IF{} ($e$) $s_1$ \ELSE{} $s_2$} where $s_1$ is not a block statement is equivalent to the statement \code{\IF{} ($e$) \{$s_1$\} \ELSE{} $s_2$}.
 An if statement of the form \code{\IF{} ($e$) $s_1$ \ELSE{} $s_2$} where $s_2$ is not a block statement is equivalent to the statement \code{\IF{} ($e$) $s_1$ \ELSE{} \{$s_2$\}}.
 
-\rationale{
-The reason for this equivalence is to catch errors such as
+\rationale{%
+The reason for this equivalence is to catch errors such as%
 }
 
 \begin{dartCode}
@@ -16355,15 +16734,24 @@ The reason for this equivalence is to catch errors such as
 \}
 \end{dartCode}
 
-\rationale{
+\rationale{%
 Under reasonable scope rules such code is problematic.
-If we assume that \code{v} is declared in the scope of the method \code{main()}, then when \code{somePredicate} is false, \code{v} will be uninitialized when accessed.
-The cleanest approach would be to require a block following the test, rather than an arbitrary statement.
-However, this goes against long standing custom, undermining Dart's goal of familiarity.
-Instead, we choose to insert a block, introducing a scope, around the statement following the predicate (and similarly for \ELSE{} and loops).
+If we assume that \code{v} is declared 
+in the scope of the method \code{main()}, 
+then when \code{somePredicate} is false, 
+\code{v} will be uninitialized when accessed.
+The cleanest approach would be to require a block following the test, 
+rather than an arbitrary statement.
+However, this goes against long standing custom, 
+undermining Dart's goal of familiarity.
+Instead, we choose to insert a block, introducing a scope,
+around the statement following the predicate
+(and similarly for \ELSE{} and loops).
 This will cause a compile-time error in the case above.
-Of course, if there is a declaration of \code{v} in the surrounding scope, programmers might still be surprised.
-We expect tools to highlight cases of shadowing to help avoid such situations.
+Of course, if there is a declaration of \code{v} in the surrounding scope,
+programmers might still be surprised.
+We expect tools to highlight cases of shadowing
+to help avoid such situations.%
 }
 
 \LMHash{}%
@@ -16454,17 +16842,20 @@ $v''$ is bound to the value of $v'$.
 The expression $[v''/v]e$ is evaluated, and the process recurses at step \ref{beginFor}.
 \end{enumerate}
 
-\rationale{
-The definition above is intended to prevent the common error where users create a function object inside a for loop,
+\rationale{%
+The definition above is intended to prevent the common error
+where users create a function object inside a for loop,
 intending to close over the current binding of the loop variable, and find
 (usually after a painful process of debugging and learning)
-that all the created function objects have captured the same value---the one current in the last iteration executed.
+that all the created function objects have captured
+the same value---the one current in the last iteration executed.
 
 Instead, each iteration has its own distinct variable.
 The first iteration uses the variable created by the initial declaration.
-The expression executed at the end of each iteration uses a fresh variable $v''$,
+The expression executed at the end of each iteration uses
+a fresh variable $v''$,
 bound to the value of the current iteration variable,
-and then modifies $v''$ as required for the next iteration.
+and then modifies $v''$ as required for the next iteration.%
 }
 
 \LMHash{}%
@@ -16508,12 +16899,12 @@ then $T$ is \code{Iterable<\DYNAMIC>},
 otherwise $T$ is the static type of $e$.
 It is a compile-time error if $T$ is not assignable to \code{Iterable<\DYNAMIC>}.
 
-\commentary{
+\commentary{%
 It follows that it is a compile-time error
 if $D$ is empty and \id{} is a final variable;
 and it is a dynamic error if $e$ has a top type,
 but $e$ evaluates to an instance of a type
-which is not a subtype of \code{Iterable<dynamic>}.
+which is not a subtype of \code{Iterable<dynamic>}.%
 }
 
 
@@ -16542,28 +16933,34 @@ The stream associated with the innermost enclosing asynchronous for loop, if any
 The stream $o$ is listened to, producing a stream subscription $u$,
 and execution of the asynchronous for-in loop is suspended
 until a stream event is available.
-\commentary{
-This allows other asynchronous events to execute while this loop is waiting for stream events.
+\commentary{%
+This allows other asynchronous events to execute
+while this loop is waiting for stream events.%
 }
 
 Pausing an asynchronous for loop means pausing the associated stream subscription.
 A stream subscription is paused by calling its \code{pause} method.
 If the subscription is already paused, an implementation may omit further calls to \code{pause}.
 
-\commentary{
-The \code{pause} call can throw, although that should never happen for a correctly implemented stream.
+\commentary{%
+The \code{pause} call can throw, although that should never happen
+for a correctly implemented stream.%
 }
 
 \LMHash{}%
 For each \Index{data event} from $u$,
 the statement $s$ is executed with \id{} bound to the value of the current data event.
 
-\commentary{
+\commentary{%
 Either execution of $s$ is completely synchronous, or it contains an
 asynchronous construct (\AWAIT{}, \AWAIT{} \FOR{}, \YIELD{} or \YIELD*)
 which will pause the stream subscription of its surrounding asynchronous loop.
-This ensures that no other event of $u$ occurs before execution of $s$ is complete, if $o$ is a correctly implemented stream.
-If $o$ doesn't act as a valid stream, for example by not respecting pause requests, the behavior of the asynchronous loop may become unpredictable.
+This ensures that no other event of $u$ occurs
+before execution of $s$ is complete,
+if $o$ is a correctly implemented stream.
+If $o$ doesn't act as a valid stream,
+for example by not respecting pause requests,
+the behavior of the asynchronous loop may become unpredictable.%
 }
 
 \LMHash{}%
@@ -16577,10 +16974,10 @@ Otherwise execution of $f$ completes in the same way as the execution of $s$.
 % a subscripton is canceled. This text is explicit, and existing
 % implementations may not properly await the cancel call.
 Otherwise the execution of $f$ is suspended again, waiting for the next stream subscription event, and $u$ is resumed if it has been paused.
-\commentary{
+\commentary{%
 The \code{resume} call can throw, in which case the asynchronous for
 loop also throws.
-That should never happen for a correctly implemented stream.
+That should never happen for a correctly implemented stream.%
 }
 
 \LMHash{}%
@@ -16599,8 +16996,10 @@ When $u$ is done, execution of $f$ completes normally.
 It is a compile-time error if an asynchronous for-in statement appears inside a synchronous function (\ref{functions}).
 It is a compile-time error if a traditional for loop (\ref{forLoop}) is prefixed by the \AWAIT{} keyword.
 
-\rationale{
-An asynchronous loop would make no sense within a synchronous function, for the same reasons that an await expression makes no sense in a synchronous function.
+\rationale{%
+An asynchronous loop would make no sense within a synchronous function, 
+for the same reasons that an await expression makes no sense
+in a synchronous function.%
 }
 
 
@@ -16629,13 +17028,16 @@ If $o$ is \FALSE{}, then execution of the while statement completes normally (\r
 Otherwise $o$ is \TRUE{} and then the statement $\{s\}$ is executed.
 If that execution completes normally or it continues with no label or to a label (\ref{labels}) that prefixes the \WHILE{} statement (\ref{statementCompletion}), then the while statement is re-executed.
 If the execution breaks without a label, execution of the while statement completes normally.
-\commentary{
+\commentary{%
 If the execution breaks with a label that prefixes the \WHILE{} statement,
-it does end execution of the loop, but the break itself is handled by the surrounding labeled statement (\ref{labels}).
+it does end execution of the loop,
+but the break itself is handled by
+the surrounding labeled statement (\ref{labels}).%
 }
 
 \LMHash{}%
-It is a compile-time error if the static type of $e$ may not be assigned to \code{bool}.
+It is a compile-time error if
+the static type of $e$ may not be assigned to \code{bool}.
 
 
 \subsection{Do}
@@ -16719,13 +17121,14 @@ It is a compile-time error if the value of the expressions $e_j, j \in 1 .. n$ a
 \item instances of a class that implements \code{String}, for all $j \in 1 .. n$.
 \end{itemize}
 
-\commentary{
+\commentary{%
 In other words, all the expressions in the cases evaluate to constants of the exact same user defined class or are of certain known types.
 %% TODO(eernst): Update when we specify inference: const List<int> xs = [];
 %% may be a counter-example: The value is a list that "knows" it is a
 %% `List<int>` independently of the type annotation, but it wouldn't be a
 %% `List<int>` if that type annotation hadn't been there.
-Note that the values of the expressions are known at compile time, and are independent of any type annotations.
+Note that the values of the expressions are known at compile time,
+and are independent of any type annotations.%
 }
 
 \LMHash{}%
@@ -16733,19 +17136,19 @@ It is a compile-time error if the operator \lit{==} of class $C$
 is not primitive
 (\ref{theOperatorEqualsEquals}).
 
-\rationale{
+\rationale{%
 The prohibition on user defined equality allows us to
 implement the switch efficiently for user defined types.
 We could formulate matching in terms of identity instead,
 with the same efficiency.
 However, if a type defines an equality operator,
 programmers would presumably find it quite surprising
-if equal objects did not match.
+if equal objects did not match.%
 }
 
-\commentary{
+\commentary{%
 The \SWITCH{} statement should only be used in
-very limited situations (e.g., interpreters or scanners).
+very limited situations (e.g., interpreters or scanners).%
 }
 
 \LMHash{}%
@@ -16779,8 +17182,9 @@ The statement \code{\VAR{} \id{} = $e$;} is evaluated, where \id{} is a fresh va
 It is a dynamic error if the value of $e$ is
 not an instance of the same class as the constants $e_1, \ldots, e_n$.
 
-\commentary{
-Note that if there are no case clauses ($n = 0$), the type of $e$ does not matter.
+\commentary{%
+Note that if there are no case clauses ($n = 0$),
+the type of $e$ does not matter.%
 }
 
 \LMHash{}%
@@ -16839,20 +17243,29 @@ If $s$ is a non-empty block statement, let $s$ instead be the last statement of 
 It is a compile-time error if $s$ is not a \BREAK{}, \CONTINUE{}, \RETHROW{} or \RETURN{} statement
 or an expression statement where the expression is a \THROW{} expression.
 
-\rationale{
+\rationale{%
 The behavior of switch cases intentionally differs from the C tradition.
-Implicit fall through is a known cause of programming errors and therefore disallowed.
-Why not simply break the flow implicitly at the end of every case, rather than requiring explicit code to do so?
+Implicit fall through is a known cause of programming errors
+and therefore disallowed.
+Why not simply break the flow implicitly at the end of every case,
+rather than requiring explicit code to do so?
 This would indeed be cleaner.
-It would also be cleaner to insist that each case have a single (possibly compound) statement.
-We have chosen not to do so in order to facilitate porting of switch statements from other languages.
-Implicitly breaking the control flow at the end of a case would silently alter the meaning of ported code that relied on fall-through, potentially forcing the programmer to deal with subtle bugs.
-Our design ensures that the difference is immediately brought to the coder's attention.
-The programmer will be notified at compile time if they forget to end a case with a statement that terminates the straight-line control flow.
+It would also be cleaner to insist that each case have
+a single (possibly compound) statement.
+We have chosen not to do so in order to
+facilitate porting of switch statements from other languages.
+Implicitly breaking the control flow at the end of a case would silently alter
+the meaning of ported code that relied on fall-through,
+potentially forcing the programmer to deal with subtle bugs.
+Our design ensures that the difference is immediately brought to
+the coder's attention.
+The programmer will be notified at compile time if they forget to end a case
+with a statement that terminates the straight-line control flow.
 
 The sophistication of the analysis of fall-through is another issue.
 For now, we have opted for a very straightforward syntactic requirement.
-There are obviously situations where code does not fall through, and yet does not conform to these simple rules, e.g.:
+There are obviously situations where code does not fall through,
+and yet does not conform to these simple rules, e.g.:%
 }
 
 \begin{dartCode}
@@ -16861,8 +17274,9 @@ There are obviously situations where code does not fall through, and yet does no
 \}
 \end{dartCode}
 
-\rationale{
-  Very elaborate code in a case clause is probably bad style in any case, and such code can always be refactored.
+\rationale{%
+Very elaborate code in a case clause is probably bad style in any case,
+and such code can always be refactored.%
 }
 
 \LMHash{}%
@@ -16873,8 +17287,9 @@ It is a static warning if all of the following conditions hold:
 \item The sets $\{e_1, \ldots, e_k\} $ and $\{\id_1, \ldots, \id_n\}$ are not the same.
 \end{itemize}
 
-\commentary{
-In other words, a static warning will be emitted if a switch statement over an enum is not exhaustive.
+\commentary{%
+In other words, a static warning will be emitted
+if a switch statement over an enum is not exhaustive.%
 }
 
 
@@ -16915,9 +17330,10 @@ then the execution of the switch case throws an error.
 Otherwise $s_h$ are the last statements of the switch case,
 and execution of the switch case completes normally.
 
-\commentary{
+\commentary{%
 In other words, there is no implicit fall-through between non-empty cases.
-The last case in a switch (default or otherwise) can `fall-through' to the end of the statement.
+The last case in a switch (default or otherwise) can `fall-through'
+to the end of the statement.%
 }
 
 If execution of $\{s_h\}$ breaks with no label (\ref{statementCompletion}), then the execution of the switch statement completes normally.
@@ -16946,9 +17362,12 @@ Execution of a \code{\RETHROW{}} statement proceeds as follows:
 \LMHash{}%
 Let $f$ be the immediately enclosing function, and let \code{\ON{} $T$ \CATCH{} ($p_1$, $p_2$)} be the immediately enclosing catch clause (\ref{try}).
 
-\rationale{
-A \RETHROW{} statement always appears inside a \CATCH{} clause, and any \CATCH{} clause is semantically equivalent to some \CATCH{} clause of the form \code{\ON{} $T$ \CATCH{} (p1, p2)}.
-So we can assume that the \RETHROW{} is enclosed in a \CATCH{} clause of that form.
+\rationale{%
+A \RETHROW{} statement always appears inside a \CATCH{} clause,
+and any \CATCH{} clause is semantically equivalent to
+some \CATCH{} clause of the form \code{\ON{} $T$ \CATCH{} (p1, p2)}.
+So we can assume that the \RETHROW{} is enclosed in
+a \CATCH{} clause of that form.%
 }
 
 \LMHash{}%
@@ -16984,9 +17403,11 @@ A set of \ON{}-\CATCH{} clauses, each of which specifies (either explicitly or i
 A \FINALLY{} clause, which consists of a block statement.
 \end{enumerate}
 
-\rationale{
-The syntax is designed to be upward compatible with existing Javascript programs.
-The \ON{} clause can be omitted, leaving what looks like a Javascript catch clause.
+\rationale{%
+The syntax is designed to be upward compatible with
+existing Javascript programs.
+The \ON{} clause can be omitted,
+leaving what looks like a Javascript catch clause.%
 }
 
 \LMHash{}%
@@ -17208,7 +17629,7 @@ It is a compile-time error if a return statement of
 the form \code{\RETURN{} $e$;} appears in a generative constructor
 (\ref{generativeConstructors}).
 
-\rationale{
+\rationale{%
 It is quite easy to forget to add the \FACTORY{} modifier for a constructor,
 accidentally converting a factory into a generative constructor.
 The static checker may detect a type mismatch
@@ -17216,7 +17637,7 @@ in some, but not all, of these cases.
 The rule above helps catch such errors,
 which can otherwise be very hard to recognize.
 There is no real downside to it,
-as returning an object from a generative constructor is meaningless.
+as returning an object from a generative constructor is meaningless.%
 }
 \EndCase
 
@@ -17291,8 +17712,9 @@ A \Index{label} is an identifier followed by a colon.
 A \Index{labeled statement} is a statement prefixed by a label $L$.
 A \Index{labeled case clause} is a case clause within a switch statement (\ref{switch}) prefixed by a label $L$.
 
-\rationale{
-The sole role of labels is to provide targets for the break (\ref{break}) and continue (\ref{continue}) statements.
+\rationale{%
+The sole role of labels is to provide targets for
+the break (\ref{break}) and continue (\ref{continue}) statements.%
 }
 
 \begin{grammar}
@@ -17312,9 +17734,10 @@ The namespace of labels is distinct from the one used for types, functions and v
 The scope of a label that labels a statement $s$ is $s$.
 The scope of a label that labels a case clause of a switch statement $s$ is $s$.
 
-\rationale{
+\rationale{%
 Labels should be avoided by programmers at all costs.
-The motivation for including labels in the language is primarily making Dart a better target for code generation.
+The motivation for including labels in the language
+is primarily making Dart a better target for code generation.%
 }
 
 
@@ -17619,8 +18042,9 @@ execution of an assertion \code{\ASSERT{}($c$, $e$)} proceeds as follows:
 The expression $c$ is evaluated to an object $r$.
 % This error can occur due to implicit casts and null.
 It is a dynamic type error if $r$ is not of type \code{bool}.
-\commentary{
-Hence it is a compile-time error if that situation arises during evaluation of an assertion in a \CONST{} constructor invocation.
+\commentary{%
+Hence it is a compile-time error if that situation arises
+during evaluation of an assertion in a \CONST{} constructor invocation.%
 }
 If $r$ is \TRUE{} then execution of the assert statement completes normally (\ref{statementCompletion}).
 Otherwise, $e$ is evaluated to an object $m$
@@ -17629,34 +18053,16 @@ and then the execution of the assert statement throws (\ref{statementCompletion}
 \LMHash{}%
 It is a compile-time error if the type of $c$ may not be assigned to \code{bool}.
 
-\rationale{
-Why is this a statement, not a built in function call? Because it is handled magically so it has no effect and no overhead when assertions are disabled.
-Also, in the absence of final methods, one could not prevent it being overridden (though there is no real harm in that).
-It cannot be viewed as a function call that is being optimized away because the arguments might have side effects.
+\rationale{%
+Why is this a statement, not a built in function call?
+Because it is handled magically
+so it has no effect and no overhead when assertions are disabled.
+Also, in the absence of final methods,
+one could not prevent it being overridden
+(though there is no real harm in that).
+It cannot be viewed as a function call that is being optimized away
+because the arguments might have side effects.%
 }
-
-%If a lexically visible declaration named \code{assert} is in scope, an assert statement
-%\code{\ASSERT{} (e); }
-%is interpreted as an expression statement \code{(assert(e));} .
-
-%\rationale{
-%Since \ASSERT{} is a built-in identifier, one might define a function or method with this name.
-%It is impossible to distinguish as \ASSERT{} statement from a method invocation in such a situation.
-%One could choose to always interpret such code as an \ASSERT{} statement. Or we could choose to give priority to any lexically visible user defined function. The former can cause rather puzzling situations, e.g.,}
-
-%\begin{dartCode}
-% assert(bool b)\{print('My Personal Assertion \$b');\}
-
-% assert\_puzzler() \{
-%   (assert(\TRUE{})); // prints true
-%   assert(\TRUE{}); // would do nothing
-%   (assert(\FALSE{})); // prints false
-%   assert(\FALSE{}); // would throw if asserts enabled, or do nothing otherwise
-% \}
-
-%\end{dartCode}
-
-%\rationale{therefore, we opt for the second option. Alternately, one could insist that assert be a reserved word, which may have an undesirable effect with respect to compatibility of Javascript code ported to Dart.}
 
 
 \section{Libraries and Scripts}
@@ -17727,23 +18133,28 @@ An \Index{explicitly named library} begins with the word \LIBRARY{}
 (possibly prefaced with any applicable metadata annotations),
 followed by a qualified identifier that gives the name of the library.
 
-\commentary{
-Technically, each dot and identifier is a separate token and so spaces between them are acceptable.
-However, the actual library name is the concatenation of the simple identifiers and dots and contains no spaces.
+\commentary{%
+Technically, each dot and identifier is a separate token
+and so spaces between them are acceptable.
+However, the actual library name is the concatenation of
+the simple identifiers and dots and contains no spaces.%
 }
 
 \LMHash{}%
 An implicitly named library has the empty string as its name.
 
-\rationale{
-The name of a library is used to tie it to separately compiled parts of the library (called parts) and can be used for printing and, more generally, reflection.
-The name may be relevant for further language evolution.
+\rationale{%
+The name of a library is used to tie it to
+separately compiled parts of the library (called parts) and
+can be used for printing and, more generally, reflection.
+The name may be relevant for further language evolution.%
 }
 
-\commentary{
+\commentary{%
 Libraries intended for widespread use should avoid name collisions.
 Dart's \code{pub} package management system provides a mechanism for doing so.
-Each pub package is guaranteed a unique name, effectively enforcing a global namespace.
+Each pub package is guaranteed a unique name,
+effectively enforcing a global namespace.%
 }
 
 \LMHash{}%
@@ -17760,8 +18171,9 @@ Libraries are units of privacy.
 A private declaration declared within a library $L$ can only be accessed by code within $L$.
 Any attempt to access a private member declaration from outside $L$ will cause a method, getter or setter lookup failure.
 
-\commentary{
-Since top level privates are not imported, using the top level privates of another library is never possible.
+\commentary{%
+Since top level privates are not imported,
+using the top level privates of another library is never possible.%
 }
 
 \LMHash{}%
@@ -18612,13 +19024,14 @@ and let $L_1$ and $L_2$ be distinct libraries which are reachable from $L$.
 It is a compile-time error if $L_1$ and $L_2$ both contain
 a part directive with URI $u$.
 
-\commentary{
-In particular, it is an error to use the same part twice in the same program
+\commentary{%
+In particular, it is an error to use the same part twice
+in the same program
 (\ref{scripts}).
 Note that a relative URI is interpreted as relative to the location of the
 enclosing library (\ref{uris}), which means that $L_1$ and $L_2$ may both
 have a part identified by \code{'myPart.dart'}, but they are not the same
-URI unless $L_1$ and $L_2$ have the same location.
+URI unless $L_1$ and $L_2$ have the same location.%
 }
 
 
@@ -18652,13 +19065,13 @@ as the only argument.
 If \code{main} cannot be called with one or two positional arguments,
 it is invoked with no arguments.
 
-\commentary{
+\commentary{%
 Note that if \code{main} requires more than two positional arguments,
-the library is not considered a script.
+the library is not considered a script.%
 }
 
-\commentary{
-A Dart program will typically be executed by executing a script.
+\commentary{%
+A Dart program will typically be executed by executing a script.%
 }
 
 \LMHash{}%
@@ -18710,13 +19123,13 @@ A \Index{configurable URI} $c$ of the form
   omitting any spaces between them that may occur in the source.
   \item{} Look up \metavar{key} in the available
   \Index{compilation environment}.
-  \commentary{
+  \commentary{%
   The compilation environment is provided by the platform.
   It maps some string keys to string values,
   and can be accessed programmatically using the
   \code{const String.fromEnvironment} constructor.
   Tools may choose to only make some parts of the compilation environment
-  available for choosing configuration URIs.
+  available for choosing configuration URIs.%
   }
   \item{} If the environment contains an entry for \metavar{key} and the
   associated value is equal, as a constant string value, to the value of
@@ -18730,10 +19143,14 @@ A \Index{configurable URI} $c$ of the form
 \LMHash{}%
 This specification does not discuss the interpretation of URIs, with the following exceptions.
 
-\rationale{
-The interpretation of URIs is mostly left to the surrounding computing environment.
-For example, if Dart is running in a web browser, that browser will likely interpret some URIs.
-While it might seem attractive to specify, say, that URIs are interpreted with respect to a standard such as IETF RFC 3986, in practice this will usually depend on the browser and cannot be relied upon.
+\rationale{%
+The interpretation of URIs is mostly left to
+the surrounding computing environment.
+For example, if Dart is running in a web browser,
+that browser will likely interpret some URIs.
+While it might seem attractive to specify, say, that
+URIs are interpreted with respect to a standard such as IETF RFC 3986,
+in practice this will usually depend on the browser and cannot be relied upon.%
 }
 
 \LMHash{}%
@@ -18742,16 +19159,17 @@ A URI of the form \code{dart:$s$} is interpreted as a reference to a system libr
 \LMHash{}%
 A URI of the form \code{package:$s$} is interpreted in an implementation specific manner.
 
-\rationale{
-The intent is that, during development, Dart programmers can rely on a package manager to find elements of their program.
+\rationale{%
+The intent is that, during development, Dart programmers can rely on
+a package manager to find elements of their program.%
 }
 
 \LMHash{}%
 Otherwise, any relative URI is interpreted as relative to the location of the current library.
 All further interpretation of URIs is implementation dependent.
 
-\commentary{
-This means it is dependent on the embedder.
+\commentary{%
+This means it is dependent on the embedder.%
 }
 
 
@@ -18761,11 +19179,13 @@ This means it is dependent on the embedder.
 \LMHash{}%
 Dart supports optional typing based on interface types.
 
-\rationale{
+\rationale{%
 The type system is unsound, due to the covariance of generic classes.
 This is a deliberate choice (and undoubtedly controversial).
-Experience has shown that sound type rules for generics fly in the face of programmer intuition.
-It is easy for tools to provide a sound type analysis if they choose, which may be useful for tasks like refactoring.
+Experience has shown that sound type rules for generics
+fly in the face of programmer intuition.
+It is easy for tools to provide a sound type analysis if they choose,
+which may be useful for tasks like refactoring.%
 }
 
 
@@ -18795,12 +19215,12 @@ the name of a type, that is, it denotes an \synt{IDENTIFIER} which is not a
 %% \EXTENDS{}, \WITH{}, \IMPLEMENTS{} syntax and for mixin applications
 %% in Dart.g, and it seems likely that we will use them here as well.
 
-\commentary{
+\commentary{%
 Non-terminals with names of the form \synt{\ldots{}NotFunction}
 derive terms which are types that are not function types.
 Note that it \emph{does} derive the type \FUNCTION{},
 which is not itself a function type,
-but it is the least upper bound of all function types.
+but it is the least upper bound of all function types.%
 }
 
 \begin{grammar}
@@ -18866,9 +19286,13 @@ and only those situations.
 Similarly, the static checker must emit static warnings
 for at least the situations specified as such in this specification.
 
-\commentary{
-Nothing precludes additional tools that implement alternative static analyses (e.g., interpreting the existing type annotations in a sound manner such as either non-variant generics, or inferring declaration based variance from the actual declarations).
-However, using these tools must not preclude successful compilation and execution of Dart code.
+\commentary{%
+Nothing precludes additional tools that implement alternative static analyses
+(e.g., interpreting the existing type annotations in a sound manner
+such as either non-variant generics, or inferring declaration based variance
+from the actual declarations).
+However, using these tools must not preclude
+successful compilation and execution of Dart code.%
 }
 
 \LMHash{}%
@@ -18928,7 +19352,8 @@ under the assumption that all deferred libraries have successfully been loaded.
 
 \LMHash{}%
 The static type system ascribes a static type to every expression.
-In some cases, the type of a local variable (\commentary{which can be a formal parameter})
+In some cases, the type of a local variable
+(\commentary{which can be a formal parameter})
 may be promoted from the declared type, based on control flow.
 
 \LMHash{}%
@@ -18969,7 +19394,7 @@ except of course that said superinterface constraint must be satisfied.%
 The dynamic types of a running Dart program are equivalent to
 the static types with regard to subtyping.
 
-\commentary{
+\commentary{%
 Certain dynamic type checks are performed during execution
 (\ref{variables},
 \ref{redirectingGenerativeConstructors},
@@ -18990,7 +19415,7 @@ Certain dynamic type checks are performed during execution
 As specified in those locations,
 these dynamic checks are based on the dynamic types of instances,
 and the actual types of declarations
-(\ref{actualTypes}).
+(\ref{actualTypes}).%
 }
 
 \LMHash{}%
@@ -19000,7 +19425,7 @@ inherited from the \code{Object} class, so that
 two \code{Type} objects are equal according to operator \lit{==}
 if{}f the corresponding types are subtypes of each other.
 
-\commentary{
+\commentary{%
 For example, the \code{Type} objects for the types
 \DYNAMIC{} and \code{Object} are equal to each other
 and hence \code{dynamic\,==\,Object} must evaluate to \TRUE.
@@ -19008,7 +19433,7 @@ No constraints are imposed on the built-in function \code{identical},
 so \code{identical(dynamic, Object)} may be \TRUE{} or \FALSE.
 
 Similarly, \code{Type} instances for distinct type alias declarations
-declaring a name for the same function type are equal:
+declaring a name for the same function type are equal:%
 }
 
 \begin{dartCode}
@@ -19021,11 +19446,11 @@ declaring a name for the same function type are equal:
 \end{dartCode}
 
 \LMHash{}%
-\commentary{
+\commentary{%
 Instances of \code{Type} can be obtained in various ways,
 for example by using reflection,
 by reading the \code{runtimeType} of an object,
-or by evaluating a \emph{type literal} expression.
+or by evaluating a \emph{type literal} expression.%
 }
 
 \LMHash{}%
@@ -19035,8 +19460,8 @@ which denotes a class, mixin or type alias declaration, or it is
 an identifier denoting a type parameter of a generic class or function.
 It is a \emph{constant type literal} if it does not denote a type parameter,
 and it is not qualified by a deferred prefix.
-\commentary{
-A constant type literal is a constant expression (\ref{constants}).
+\commentary{%
+A constant type literal is a constant expression (\ref{constants}).%
 }
 
 
@@ -19046,9 +19471,9 @@ A constant type literal is a constant expression (\ref{constants}).
 \LMHash{}%
 A \Index{type alias} declares a name for a type expression.
 
-\commentary{
+\commentary{%
 It is common to use the phrase ``a typedef'' for such a declaration,
-because of the prominent occurrence of the token \TYPEDEF.
+because of the prominent occurrence of the token \TYPEDEF.%
 }
 
 % TODO(eernst): We include <metadata> in <typeAlias> even though it is not
@@ -19137,7 +19562,7 @@ and it can be used as a superclass, mixin, or superinterface
 (\ref{superclasses}, \ref{superinterfaces}, \ref{mixinApplication}).
 Moreover, $F$ or a parameterized type that starts with $F$,
 whichever is not an error,
-can be used to invoke static methods of the denoted class.
+can be used to invoke static methods of the denoted class.%
 }
 
 \rationale{%
@@ -19151,15 +19576,15 @@ in which case both the direct and indirect approach will be allowed.
 At that time,
 existing invocations where type arguments are passed indirectly will not break,
 because it is currently an error for a static method to depend on the value
-of a formal type parameter of the enclosing class.
+of a formal type parameter of the enclosing class.%
 }
 
 %% TODO(eernst): Move specification of generic type aliases to this
 %% section, change the non-generic case to a special case.
-\commentary{
+\commentary{%
 The generic variants of type alias declarations are specified
 in the section about generics
-(\ref{generics}).
+(\ref{generics}).%
 }
 
 
@@ -19183,7 +19608,7 @@ and how to choose the right initial environment, $\Gamma$.
 For a reader who is not familiar with the notation used in this section,
 the explanations given here should suffice to clarify what it means,
 with reference to the natural language explanations given at the end of
-the section for obtaining an intuition about the meaning.
+the section for obtaining an intuition about the meaning.%
 }
 
 \LMHash{}%
@@ -19198,7 +19623,8 @@ and type casts
 \commentary{%
 A variant of the rules described here is shown in an appendix
 (\ref{algorithmicSubtyping}),
-demonstrating that Dart subtyping can be decided efficiently.}
+demonstrating that Dart subtyping can be decided efficiently.%
+}
 
 \LMHash{}%
 %% TODO(eernst): Introduce these specialized intersection types
@@ -19339,7 +19765,7 @@ and the subtype relationship is always determined in the same way.
 A \Index{meta-variable} is a symbol which stands for a syntactic construct
 that satisfies some static semantic requirements.
 
-\commentary{
+\commentary{%
 For instance, $X$ is a meta-variable standing for
 an identifier \code{W},
 but only if \code{W} denotes a type variable declared in an enclosing scope.
@@ -19348,7 +19774,7 @@ In the definitions below, we specify this by saying that
 Similarly, $C$ is a meta-variable standing for
 a \synt{typeName}, for instance, \code{p.D},
 but only if \code{p.D} denotes a class in the given scope.
-We specify this as `$C$ ranges over classes'.
+We specify this as `$C$ ranges over classes'.%
 }
 
 \LMHash{}%
@@ -19416,7 +19842,7 @@ The failure to prove
 ``\Subtype{\emptyset}{\code{C}}{\code{C}}''
 will then occur, e.g., in a situation where we check whether
 such a variable can be passed as an actual argument to such a function,
-because the two occurrences of \code{C} do not denote the same type.
+because the two occurrences of \code{C} do not denote the same type.%
 }
 
 \LMHash{}%
@@ -19435,7 +19861,7 @@ and one or more \synt{typeName}s receives an actual type argument list
 whose length does not match the declaration
 (including the case where some type arguments are given to a non-generic class,
 and the case where a generic class occurs, but no type arguments are given)
-then the attempt to prove the relationship simply fails.
+then the attempt to prove the relationship simply fails.%
 }
 
 \LMHash{}%
@@ -19465,7 +19891,7 @@ Extension of environments uses the operator \Index{$\uplus$},
 which is the operator that produces the union of disjoint sets,
 and gives priority to the right hand operand in case of conflicts.
 
-\commentary{
+\commentary{%
 So
 $\{ \code{X} \mapsto \code{int}, \code{Y} \mapsto \code{double} \} \uplus
 \{ \code{Z} \mapsto \code{Object} \} =
@@ -19475,7 +19901,7 @@ $\{ \code{X} \mapsto \code{int}, \code{Y} \mapsto \code{FutureOr<List<double>{}>
 \{ \code{Y} \mapsto \code{int} \} =
 \{ \code{X} \mapsto \code{int}, \code{Y} \mapsto \code{int} \}$.
 Note that operator $\uplus$ is concerned with scopes and shadowing,
-with no connection to, e.g., subtypes or instance method overriding.
+with no connection to, e.g., subtypes or instance method overriding.%
 }
 
 \LMHash{}%
@@ -19501,12 +19927,11 @@ which are typically also subtype judgments.
 When that is not the case for a given premise,
 we specify the meaning explicitly.
 
-\commentary{
+\commentary{%
 Instantiation of a rule, mentioned above,
 denotes the consistent replacement of meta-variables
 by actual syntactic terms denoting types everywhere in the rule,
-that is, in the premises as well as in the conclusion, simultaneously.
-%% TODO(eernst): Consider showing a full proof tree here.
+that is, in the premises as well as in the conclusion, simultaneously.%
 }
 
 
@@ -19527,7 +19952,7 @@ For rule \SrnNull, note that the \code{Null} type
 is a subtype of all non-$\bot$ types,
 even though it doesn't actually extend or implement those types.
 The other types are effectively treated as if they were nullable,
-which makes the null object (\ref{null}) assignable to them.
+which makes the null object (\ref{null}) assignable to them.%
 }
 
 \LMHash{}%
@@ -19546,9 +19971,10 @@ This premise is satisfied in each of the following situations:
   A generic type alias named $F$ is declared,
   with formal type parameters \List{X}{1}{s}.
   \commentary{%
-  Each formal type parameter $X_j$ may have a bound,
-  but the bounds are never used in this context,
-  so we do not introduce metavariables for them.}
+    Each formal type parameter $X_j$ may have a bound,
+    but the bounds are never used in this context,
+    so we do not introduce metavariables for them.%
+  }
 \end{itemize}
 
 \LMHash{}%
@@ -19559,7 +19985,7 @@ section~\ref{typeOfAFunction}.
 This is the same as the forms of type that occur at top level
 in the conclusions of
 rule~\SrnPositionalFunctionType{} and
-rule~\SrnNamedFunctionType{}.
+rule~\SrnNamedFunctionType{}.%
 }
 
 \LMHash{}%
@@ -19577,9 +20003,10 @@ This premise is satisfied in each of the following situations:
   A generic class named $C$ is declared,
   with formal type parameters \List{X}{1}{s}.
   \commentary{%
-  Each formal type parameter $X_j$ may have a bound,
-  but the bounds are never used in this context,
-  so we do not introduce metavariables for them.}
+    Each formal type parameter $X_j$ may have a bound,
+    but the bounds are never used in this context,
+    so we do not introduce metavariables for them.%
+  }
 \end{itemize}
 
 \LMHash{}%
@@ -19598,14 +20025,14 @@ and that may be a mixin application
 in which case $D$ in the rule is
 the synthetic class which specifies
 the semantics of that mixin application
-(\ref{mixinComposition}).
+(\ref{mixinComposition}).%
 }
 
 \commentary{%
 The last premise of rule~\SrnSuperinterface{}
 substitutes the actual type arguments \List{S}{1}{s} for the
 formal type parameters \List{X}{1}{s},
-because \List{T}{1}{m} may contain those formal type parameters.
+because \List{T}{1}{m} may contain those formal type parameters.%
 }
 
 \commentary{%
@@ -19616,14 +20043,14 @@ because a non-generic class $C$ which is used as a type
 denotes the interface of $C$,
 and similarly for a parameterized type
 \code{$C$<\List{T}{1}{k}>}
-where $C$ denotes a generic class.
+where $C$ denotes a generic class.%
 }
 
 
 \subsubsection{Informal Subtype Rule Descriptions}
 \LMLabel{informalSubtypeRuleDescriptions}
 
-\commentary{
+\commentary{%
 This section gives an informal and non-normative natural language description
 of each rule in Figure~\ref{fig:subtypeRules}.
 
@@ -19780,7 +20207,7 @@ include the application of a rule where the environment is used.
   (\ref{mixinApplication}),
   and this means that there may be multiple subtype steps from
   a given class declaration to the class specified in an \EXTENDS{} clause.
-\end{itemize}
+\end{itemize}%
 }
 
 
@@ -19801,7 +20228,7 @@ if{}f either \SubtypeStd{S}{T} or \SubtypeStd{T}{S}.
 In this case we say that the types $S$ and $T$ are
 \Index{assignable}.
 
-\rationale{
+\rationale{%
 This rule may surprise readers accustomed to conventional typechecking.
 The intent of the \AssignableRelationSymbol{} relation
 is not to ensure that an assignment is guaranteed to succeed dynamically.
@@ -19815,7 +20242,7 @@ while not guaranteed to be correct,
 might be fine if the run-time value happens to be a string.
 
 A static analyzer or compiler
-may support more strict static checks as an option.
+may support more strict static checks as an option.%
 }
 
 
@@ -19836,25 +20263,28 @@ come in two variants:
   \FunctionTypeNamedStd{T}.
 \end{enumerate}
 
-\commentary{
+\commentary{%
 Note that the non-generic case is covered by having $s = 0$,
 in which case the type parameter declarations are omitted
 (\ref{generics}).
 The case with no optional parameters is covered by having $k = 0$;
 note that all rules involving function types of the two kinds
-coincide in this case.
+coincide in this case.%
 }
 
 \LMHash{}%
 Two function types are considered equal if consistent renaming of type
 parameters can make them identical.
 
-\commentary{
-A common way to say this is that we do not distinguish function types which are alpha-equivalent.
-For the subtyping rule below this means we can assume that a suitable renaming has already taken place.
+\commentary{%
+A common way to say this is that we do not distinguish
+function types which are alpha-equivalent.
+For the subtyping rule below this means we can assume that
+a suitable renaming has already taken place.
 In cases where this is not possible
-because the number of type parameters in the two types differ or the bounds are different,
-no subtype relationship exists.
+because the number of type parameters in the two types differ
+or the bounds are different,
+no subtype relationship exists.%
 }
 
 \LMHash{}%
@@ -19896,12 +20326,14 @@ implement \FUNCTION{}. \commentary{The \FUNCTION{} class declares no
 concrete instance members, so the mixin application creates a sub-class
 of the superclass with no new members and no new interfaces.}
 
-\rationale{Since using \FUNCTION{} in these ways has no effect, it would be
+\rationale{%
+Since using \FUNCTION{} in these ways has no effect, it would be
 reasonable to disallow it completely, like we do extending, implementing or
 mixing in types like \code{int} or \code{String}.
 For backwards compatibility with Dart 1 programs,
 the syntax is allowed to remain, even if it has no effect.
-Tools may choose to warn users that their code has no effect.}
+Tools may choose to warn users that their code has no effect.%
+}
 
 
 \subsection{Type \DYNAMIC{}}
@@ -19914,7 +20346,7 @@ but it it differs from other types in that the static analysis
 assumes that every member access has a corresponding member
 with a signature that admits the given access.
 
-\commentary{
+\commentary{%
 For instance,
 when the receiver in an ordinary method invocation has type \DYNAMIC{},
 any method name can be invoked,
@@ -19924,7 +20356,7 @@ and any set of named arguments,
 of any type,
 without error.
 Note that the invocation will still cause a compile-time error
-if there is an error in one or more arguments or other subterms.
+if there is an error in one or more arguments or other subterms.%
 }
 
 \LMHash{}%
@@ -19935,7 +20367,7 @@ the type system considers declarations to have type \DYNAMIC{}.
 If a generic type is used but type arguments are not provided,
 the type arguments default to type \DYNAMIC{}.
 
-\commentary{
+\commentary{%
 %% TODO(eernst): Amend when adding specification of instantiate-to-bound.
 This means that given a generic declaration
 \code{$G$<$P_1, \ldots,\ P_n$>$\ldots$},
@@ -19943,7 +20375,7 @@ where $P_i$ is a formal type parameter declaration, $i \in 1 .. n$,
 the type $G$ is equivalent to
 
 \noindent
-\code{$G$<$\DYNAMIC{}, \ldots,\ \DYNAMIC{}$>}.
+\code{$G$<$\DYNAMIC{}, \ldots,\ \DYNAMIC{}$>}.%
 }
 
 \LMHash{}%
@@ -19954,10 +20386,10 @@ When the name \DYNAMIC{} exported by \code{dart:core} is evaluated as an express
 it evaluates to a \code{Type} object representing the \DYNAMIC{} type,
 even though \DYNAMIC{} is not a class.
 
-\commentary{
+\commentary{%
 This \code{Type} object must compare equal to the corresponding \code{Type}
 objects for \code{Object} and \VOID{} according to operator \lit{==}
-(\ref{dynamicTypeSystem}).
+(\ref{dynamicTypeSystem}).%
 }
 
 \LMHash{}%
@@ -19973,9 +20405,9 @@ whenever doing so is sound.
   argument part, where the static type of $d$ is \DYNAMIC, and \id{} is the name of a
   getter declared in \code{Object}; if the return type of \code{Object.\id} is $T$
   then the static type of $e$ is $T$.
-  \commentary{
+  \commentary{%
   For instance, \code{d.hashCode} has type \code{int}
-  and \code{d.runtimeType} has type \code{Type}.
+  and \code{d.runtimeType} has type \code{Type}.%
   }
 
 \item
@@ -19983,8 +20415,8 @@ whenever doing so is sound.
   argument part, where the static type of $d$ is \DYNAMIC, and \id{} is the name of a
   method declared in \code{Object} whose method signature has type $F$
   (\commentary{which is a function type}). The static type of $e$ is then $F$.
-  \commentary{
-  For instance, \code{$d$.toString} has type \code{String \FUNCTION()}.
+  \commentary{%
+  For instance, \code{$d$.toString} has type \code{String \FUNCTION()}.%
   }
 
 \item
@@ -19996,7 +20428,7 @@ whenever doing so is sound.
   \metavar{typeArguments} are derived from \synt{typeArguments}, if present.
   Static analysis will then process $e$ as a function expression invocation
   where an object of static type $F$ is applied to the given argument part.
-  \commentary{
+  \commentary{%
   So this is always a compile-time error.
   For instance, \code{$d$.runtimeType(42)} is a compile-time error,
   because it is checked as a
@@ -20006,7 +20438,7 @@ whenever doing so is sound.
   of \code{Type} that has a \CALL{} method.
   We decided to make it an error because it is likely to be a mistake,
   especially in cases like \code{$d$.hashCode()}
-  where a developer might have forgotten that \code{hashCode} is a getter.
+  where a developer might have forgotten that \code{hashCode} is a getter.%
   }
 
 \item
@@ -20020,11 +20452,11 @@ whenever doing so is sound.
   of positional arguments in $F$, or if \metavar{arguments} includes any named
   arguments with a name that is not declared in $F$, the type of $e$ is
   \DYNAMIC. Otherwise, the type of $e$ is the return type in $F$.
-  \commentary{
+  \commentary{%
     So \code{$d$.toString(bazzle:\,42)} has type \DYNAMIC{} whereas
     \code{$d$.toString()} has type \code{String}.
     Note that invocations which "do not fit" the statically
-    known declaration are not errors, they just get return type \DYNAMIC.
+    known declaration are not errors, they just get return type \DYNAMIC.%
   }
 
 \item
@@ -20035,7 +20467,7 @@ whenever doing so is sound.
   \metavar{arguments} is an actual argument list derived from \synt{arguments}.
   It is a compile-time error if \id{} is the name of
   a non-generic method declared in \code{Object}.
-  \commentary{
+  \commentary{%
   No generic methods are declared in \code{Object}.
   Hence, we do not specify that there must be
   the statically required number of actual type arguments, and
@@ -20043,7 +20475,7 @@ whenever doing so is sound.
   That would otherwise be the consistent approach,
   because the invocation is guaranteed to fail when any of those
   requirements are violated,
-  but generalizations of this mechanism would need to include such rules.
+  but generalizations of this mechanism would need to include such rules.%
   }
 
 \item
@@ -20054,12 +20486,12 @@ whenever doing so is sound.
   When an expression derived from \synt{cascadeSection} performs
   a getter or method invocation that corresponds to one of the cases above,
   the corresponding static analysis and compile-time errors apply.
-  \commentary{
-  For instance, \code{$d$..foobar(16)..hashCode()} is an error.
+  \commentary{%
+  For instance, \code{$d$..foobar(16)..hashCode()} is an error.%
   }
 \end{itemize}
 
-\commentary{
+\commentary{%
 Note that only very few forms of instance method invocation with a
 receiver of type \DYNAMIC{} can be a compile-time error.
 Of course, some expressions like \code{x[1, 2]} are syntax errors
@@ -20076,7 +20508,7 @@ a \DYNAMIC{} receiver admits almost all instance method invocations.
 The few cases where an instance method invocation with
 a receiver of type \DYNAMIC{} is an error
 are either guaranteed to fail at run time,
-or they are very, very likely to be developer mistakes.
+or they are very, very likely to be developer mistakes.%
 }
 
 
@@ -20119,13 +20551,13 @@ the same compile-time errors are issued for \code{FutureOr}.
 The name \code{FutureOr} as an expression
 denotes a \code{Type} object representing the type \code{FutureOr<dynamic>}.
 
-\rationale{
+\rationale{%
 The \code{FutureOr<$T$>} type represents a case where an object can be
 either an instance of the type $T$
 or the type \code{Future<$T$>}.
 Such cases occur naturally in asynchronous code.
 The available alternative would be to use a top type (e.g., \DYNAMIC{}),
-but \code{FutureOr} allows some tools to provide a more precise type analysis.
+but \code{FutureOr} allows some tools to provide a more precise type analysis.%
 }
 
 \LMHash{}%
@@ -20136,7 +20568,7 @@ That is, only members that \code{Object} has can be invoked
 on an object with static type \code{FutureOr<$T$>}.%
 }
 
-\rationale{
+\rationale{%
 We only want to allow invocations of members that are inherited from
 a common supertype of both $T$ and \code{Future<$T$>}.
 In most cases the only common supertype is \code{Object}.
@@ -20144,7 +20576,7 @@ The exceptions, like \code{FutureOr<Future<Object\gtgt}
 which has \code{Future<Object>} as common supertype,
 are few and not practically useful,
 so for now we choose to only allow invocations of
-members inherited from \code{Object}.
+members inherited from \code{Object}.%
 }
 
 \LMHash{}%
@@ -20183,7 +20615,7 @@ It could be any object whatsoever.
 But the developer who chose the return type \VOID{}
 did that to indicate that it is a misunderstanding to
 ascribe any meaning to that object,
-or to use it for any purpose.
+or to use it for any purpose.%
 }
 
 \commentary{%
@@ -20203,7 +20635,7 @@ In fact, it is not recommended that implementations strive to achieve this,
 because it may be more important to ensure that diagnostic messages
 (including stack traces and dynamic error messages)
 preserve enough information to use the word `void' when referring to types
-which are specified as such in source code.
+which are specified as such in source code.%
 }
 
 \LMHash{}%
@@ -20288,7 +20720,7 @@ unless it is permitted according to one of the following rules.
   Usages of that parameter in the body of the callee
   are statically expected to be constrained by having type \VOID.
   See the discussion about soundness below
-  (\ref{voidSoundness}).
+  (\ref{voidSoundness}).%
   }
 \item
   In an expression of the form \code{$e_1$\,=\,$e_2$}
@@ -20299,7 +20731,7 @@ unless it is permitted according to one of the following rules.
   Usages of that variable or formal parameter
   are statically expected to be constrained by having type \VOID.
   See the discussion about soundness below
-  (\ref{voidSoundness}).
+  (\ref{voidSoundness}).%
   }
 \item
   Let $e$ be an expression ending in a \synt{cascadeSection}
@@ -20343,7 +20775,7 @@ instantiation of \code{Stream} that is a superinterface of $T$,
 unless the iteration variable has type \VOID.
 
 \commentary{%
-Here are some examples:
+Here are some examples:%
 }
 
 \begin{dartCode}
@@ -20371,7 +20803,7 @@ are not strictly enforced.
 \commentary{%
 The usage of a ``void value'' is not a soundness issue, that is,
 no invariants needed for correct execution of a Dart program
-can be violated because of such a usage.
+can be violated because of such a usage.%
 }
 
 \rationale{%
@@ -20501,9 +20933,10 @@ that the indirect cases are covered as closely as needed in practice.%
 A \emph{parameterized type} is a syntactic construct where the name of a generic type declaration is applied to a list of actual type arguments.
 A \emph{generic instantiation} is the operation where a generic type is applied to actual type arguments.
 
-\commentary{
-So a parameterized type is the syntactic concept that corresponds to the semantic concept of a generic instantiation.
-When using the former, we will often leave the latter implicit.
+\commentary{%
+So a parameterized type is the syntactic concept that corresponds to
+the semantic concept of a generic instantiation.
+When using the former, we will often leave the latter implicit.%
 }
 
 \LMHash{}%
@@ -20688,9 +21121,9 @@ Then the least upper bound of $F$ and $G$ is
 where $L_i$ is the least upper bound of $T_i$ and $S_i, i \in 0 .. r$
 \end{itemize}
 
-\commentary{
+\commentary{%
 Note that the non-generic case is covered by using $s = 0$,
-in which case the type parameter declarations are omitted (\ref{generics}).
+in which case the type parameter declarations are omitted (\ref{generics}).%
 }
 
 
@@ -20772,7 +21205,7 @@ the declaration of a function $f$ is the formal parameter scope of $f$.
 \LMHash{}%
 Operator precedence is given implicitly by the grammar.
 
-\commentary{
+\commentary{%
 The following non-normative table may be helpful
 \newline
 
@@ -20813,7 +21246,7 @@ Cascade & \code{..} & Left & 2\\
 \hline
 Assignment & \code{=}, \code{*=}, \code{/=}, \code{+=}, \code{-=}, \code{\&=}, \code{\^{}=}, etc. & Right & 1\\
 \hline
-\end{tabular}
+\end{tabular}%
 }
 
 
@@ -20876,7 +21309,7 @@ because all rules given here can be proven
 by means of rules in Figure~\ref{fig:subtypeRules}.
 It is also relatively straightforward to sketch out proofs
 that the algorithmic rules can prove at least the same subtype relationships,
-also when the following ordering and termination constraints are observed.
+also when the following ordering and termination constraints are observed.%
 }
 
 \LMHash{}%
@@ -20902,7 +21335,7 @@ The point is that the remaining rules will force
 a structural traversal anyway, as far as needed,
 and we may hence just as well omit the initial structural traversal
 which might take many steps only to report that two large type terms
-are not quite identical.
+are not quite identical.%
 }
 
 \LMHash{}%
@@ -20936,7 +21369,7 @@ In particular, for the original query \SubtypeStd{S}{T},
 we do not backtrack into trying to use a rule that has
 a higher rule number than that of $R$,
 except that we may try all of
-the rules with \code{FutureOr<$T$>} to the right.
+the rules with \code{FutureOr<$T$>} to the right.%
 }
 
 \commentary{%
@@ -20967,14 +21400,14 @@ a promoted type variable,
 \code{Object}, \DYNAMIC{}, \VOID{},
 \code{FutureOr<$T$>} for any $T$, or \FUNCTION{},
 it is known that it will never occur as $T$ for rule~\SrnSuperinterface{},
-which means that this seemingly expensive step can be confined to some extent.
+which means that this seemingly expensive step can be confined to some extent.%
 }
 
 
 \section*{Appendix: Integer Implementations}
 \LMLabel{integerImplementations}
 
-\commentary{
+\commentary{%
 The \code{int} type represents integers.
 The specification is written with 64-bit two's complement integers as the
 intended implementation. But when Dart is compiled to JavaScript,
@@ -21009,7 +21442,7 @@ This introduces a number of differences:
   operands to 32-bit two's complement integers, perform 32-bit
   operations on those, and the resulting 32 bits are interpreted as a
   32-bit unsigned integer. For example, \code{-1\,\ltlt\,1} evaluates
-  to 4294967294 (also known as \code{(-2).toUnsigned(32)}. The right
+  to 4294967294 (also known as \code{(-2).toUnsigned(32)}). The right
   shift operator, \lit{\gtgt}, performs a signed right shift on the
   32 bits when the original number is negative, and an unsigned right
   shift when the original number is non-negative. Both kinds of shift
@@ -21026,7 +21459,7 @@ This introduces a number of differences:
   $-0.0$, and it cannot recognize any \Index{NaN} value as identical
   to itself.  For efficiency, the \code{identical} operation uses the
   JavaScript \code{===} operator.
-\end{itemize}
+\end{itemize}%
 }
 
 \printindex

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -401,16 +401,22 @@ Examples would be \SWITCH{} or \CLASS{}.%
 
 \LMHash{}%
 Grammar productions are given in a common variant of EBNF.
-The left hand side of a production ends with a colon.
-On the right hand side, alternation is represented by vertical bars, and sequencing by spacing.
+The left hand side of a production ends with `\lit{::=}'.
+On the right hand side, alternation is represented by vertical bars,
+and sequencing by spacing.
 As in PEGs, alternation gives priority to the left.
-Optional elements of a production are suffixed by a question mark like so: \code{anElephant?}.
-Appending a star to an element of a production means it may be repeated zero or more times.
+Optional elements of a production are suffixed by a question mark
+like so: \code{anElephant?}.
+Appending a star to an element of a production means
+it may be repeated zero or more times.
 Appending a plus sign to a production means it occurs one or more times.
 Parentheses are used for grouping.
 Negation is represented by prefixing an element of a production with a tilde.
-Negation is similar to the not combinator of PEGs, but it consumes input if it matches.
-In the context of a lexical production it consumes a single character if there is one; otherwise, a single token if there is one.
+Negation is similar to the not combinator of PEGs,
+but it consumes input if it matches.
+In the context of a lexical production it consumes
+a single character if there is one;
+otherwise, a single token if there is one.
 
 \commentary{%
 An example would be:%
@@ -452,7 +458,7 @@ or a subterm of an immediate subterm of $t$.
 
 \LMHash{}%
 A list \DefineSymbol{x_1, \ldots, x_n} denotes any list of
-\DefineSymbol{n} elements of the form $x_i, 1 \le i \le n$.
+$n$ elements of the form $x_i, 1 \le i \le n$.
 Note that $n$ may be zero, in which case the list is empty.
 We use such lists extensively throughout this specification.
 
@@ -481,8 +487,8 @@ is preserved during substitution.%
 }
 
 \LMHash{}%
-We sometimes abuse list or map literal syntax, writing $[o_1, \ldots, o_n]$
-(respectively $\{k_1: o_1, \ldots, k_n: o_n\}$)
+We sometimes abuse list or map literal syntax, writing \code{[\List{o}{1}{n}]}
+(respectively \code{\{$k_1$:\ $o_1$, \ldots, $k_n$:\ $o_n$\}})
 where the $o_i$ and $k_i$ may be objects rather than expressions.
 The intent is to denote a list (respectively map) object
 whose elements are the $o_i$
@@ -670,8 +676,11 @@ itself.
 
 \LMHash{}%
 The right margin also contains symbols.
-Whenever a symbol (\commentary{say, $C$ or $x_j$}) is introduced
-and used in more than a few lines of text,
+Whenever a symbol
+\BlindDefineSymbol{\textcolor{commentaryColor}{C}}%
+\BlindDefineSymbol{\textcolor{commentaryColor}{x_j}}%
+(\commentary{say, $C$ or $x_j$})
+is introduced and used in more than a few lines of text,
 it is shown in the margin.
 
 \commentary{%
@@ -679,7 +688,12 @@ The point is that it is easy to find the definition of a symbol
 by scanning back in the text until that symbol occurs in the margin.
 To avoid useless verbosity, some symbols are not mentioned in the margin.
 For instance, we may introduce \List{e}{1}{k},
-but only show $e_j$ and $k$ in the margin.%
+but only show $e_j$ and $k$ in the margin.
+
+Note that it may be necessary to look at a few lines of text
+above the `$\diamond$' or symbol,
+because the margin markers can be pushed down one line
+when there is more than one marker for a single line.%
 }
 
 
@@ -1411,8 +1425,8 @@ a subtype of the actual type of the variable $v$
 \LMLabel{evaluationOfImplicitVariableGetters}
 
 \LMHash{}%
-Let \DefineSymbol{d} be the declaration of
-a static or instance variable \DefineSymbol{v}.
+\BlindDefineSymbol{d, v}%
+Let $d$ be the declaration of a static or instance variable $v$.
 If $d$ is an instance variable,
 then the invocation of the implicit getter of $v$ evaluates to
 the object stored in $v$.
@@ -1647,7 +1661,7 @@ We define the notion of the
 \IndexCustom{element type of a generator}{function!generator!element type}
 as follows:
 %
-If the function \DefineSymbol{f} is a synchronous generator
+If the function $f$ is a synchronous generator
 whose declared return type implements \code{Iterable<$U$>} for some $U$
 (\ref{interfaceSuperinterfaces})
 then the element type of $f$ is $U$.
@@ -1748,7 +1762,7 @@ Getters, setters, operators, and constructors.%
 The formal type parameter list of a function declaration introduces
 a new scope known as the function's
 \IndexCustom{type parameter scope}{scope!type parameter}.
-The type parameter scope of a generic function \DefineSymbol{f} is enclosed in
+The type parameter scope of a generic function $f$ is enclosed in
 the scope where $f$ is declared.
 Every formal type parameter introduces a type into the type parameter scope.
 
@@ -1990,13 +2004,13 @@ based on reasoning that the static type analysis does not capture.%
 Let $m$ be a method signature with formal type parameters
 \List{X}{1}{s},
 positional formal parameters \List{p}{1}{n},
-\BlindDefineSymbol{p, n, q, k}%
+\BlindDefineSymbol{p_j, n, q_j, k}%
 and named formal parameters \List{q}{1}{k}.
 \BlindDefineSymbol{m', X'_j}%
 Let $m'$ be a method signature with formal type parameters
 \List{X'\!}{1}{s},
 positional formal parameters \List{p'\!}{1}{n'},
-\BlindDefineSymbol{p', n', q', k'}%
+\BlindDefineSymbol{p'_j, n', q'_j, k'}%
 and named formal parameters \List{q'\!}{1}{k'}.
 %
 Assume that $j \in 1 .. n'$, and $j \leq n$;
@@ -2056,6 +2070,7 @@ such that $p'$ is covariant-by-declaration.
 Assume that \BlindDefineSymbol{C, X_j, B_j, s}$C$ is a generic class
 with formal type parameter declarations
 \code{$X_1\ \EXTENDS\ B_1 \ldots,\ X_s\ \EXTENDS\ B_s$},
+\BlindDefineSymbol{m, p, T}%
 let $m$ be a declaration of an instance method in $C$
 (which can be a method, a setter, or an operator),
 let $p$ be a parameter declared by $m$, and
@@ -2933,7 +2948,7 @@ because compilers control the treatment of private names.%
 }
 
 \LMHash{}%
-\BlindDefineSymbol{C, m, X_j}%
+\BlindDefineSymbol{C, m, X_j, r}%
 For the dynamic semantics,
 assume that a class $C$ has an implicitly induced
 \code{noSuchMethod} forwarder named $m$,
@@ -2956,7 +2971,7 @@ because the former is covered by $n = 0$.%
 
 \LMHash{}%
 The execution of the body of $m$ creates
-an instance $im$ of the predefined class \code{Invocation}
+an instance \DefineSymbol{im} of the predefined class \code{Invocation}
 such that:
 
 \begin{itemize}
@@ -3498,10 +3513,12 @@ and with which arguments.
 Assume that
 \code{$C$<$X_1\ \EXTENDS\ B_1 \ldots,\ X_m\ \EXTENDS\ B_m$>}
 is the name and formal type parameters of the enclosing class,
+\BlindDefineSymbol{\ConstMetavar}%
 $\ConstMetavar$ stands for either \CONST{} or nothing,
 $N$ is $C$ or $C.\id_0$ for some identifier $\id_0$,
+\BlindDefineSymbol{N, \id}%
 and \id{} is an identifier.
-Consider a declaration of a redirecting generative constructor $k$
+Consider a declaration of a redirecting generative constructor
 of one of the forms
 
 \noindent
@@ -3517,7 +3534,7 @@ where $R$ is of one of the forms
 \code{$\THIS{}$($e_1 \ldots,\ e_p,\ x_1$:\ $e_{p+1}, \ldots,\ x_q$:\ $e_{p+q}$)}
 
 \noindent
-\code{$\THIS{}.\id$($e_1 \ldots,\ e_p,\ x_1$:\ $e_{p+1}, \ldots,\ x_q$:\ $e_{p+q}$)}
+\code{$\THIS{}.\id$($e_1 \ldots,\ e_p,\ x_1$:\ $e_{p+1}, \ldots,\ x_q$:\ $e_{p+q}$)}.
 
 \LMHash{}%
 The
@@ -3612,8 +3629,8 @@ an initializer of the form \code{\THIS{}.$v$ = $e$},
 both forms are called \Index{instance variable initializers}.
 It is a compile-time error if the enclosing class
 does not declare an instance variable named $v$.
-Otherwise, let $T$ be the static type of $v$.
-It is a compile-time error unless the static type of $e$ is assignable to $T$.
+It is a compile-time error unless the static type of $e$
+is assignable to the declared type of $v$.
 
 \LMHash{}%
 Consider a \Index{superinitializer} $s$ of the form
@@ -3793,7 +3810,7 @@ execution of an initializer of the form \code{\THIS{}.$v$ = $e$}
 proceeds as follows:
 
 \LMHash{}%
-First, the expression $e$ is evaluated to an object \DefineSymbol{o}.
+First, the expression $e$ is evaluated to an object $o$.
 Then, the instance variable $v$ of $i$ is bound to $o$.
 % This error can occur due to an implicit cast.
 It is a dynamic type error if the dynamic type of $o$ is not
@@ -3908,8 +3925,9 @@ Assume that
 \BlindDefineSymbol{C, X_j, B_j, m}%
 \code{$C$<$X_1\ \EXTENDS\ B_1 \ldots,\ X_m\ \EXTENDS\ B_m$>}
 is the name and formal type parameters of the enclosing class,
+\BlindDefineSymbol{\ConstMetavar, N}%
 $\ConstMetavar$ is \CONST{} or empty,
-\DefineSymbol{N} is $C$ or $C.\id_0$ for some identifier $\id_0$,
+$N$ is $C$ or $C.\id_0$ for some identifier $\id_0$,
 and \DefineSymbol{\id} is an identifier,
 then consider a declaration of a redirecting factory constructor
 \DefineSymbol{k} of one of the forms
@@ -4108,8 +4126,7 @@ The above refers to both locally declared and inherited instance variables.%
 }
 
 \LMHash{}%
-\BlindDefineSymbol{k, C}%
-If a non-redirecting generative constant constructor $k$
+If a non-redirecting generative constant constructor \DefineSymbol{k}
 is declared by a class $C$,
 it is a compile-time error
 for an instance variable declared in $C$
@@ -4717,7 +4734,7 @@ The \Index{direct superinterfaces} of $I$ is the set \List{I}{1}{k}.
 
 \LMHash{}%
 Let $M_0$ be the set of all member signatures declared by \List{I}{1}{k}.
-$M$ is then the smallest set satisfying the following:
+\DefineSymbol{M} is then the smallest set satisfying the following:
 
 \begin{itemize}
 \item For each name \id{} and library $L$ such that $M_0$ contains
@@ -5696,7 +5713,7 @@ Let $a$ be an extension application of the form
 where $E$ denotes an extension declared as
 
 \noindent
-\BlindDefineSymbol{X_j, B_j, s}
+\BlindDefineSymbol{X_j, B_j, s, T}%
 \EXTENSION{} E<\TypeParametersStd> \ON{} $T$ \{\,\ldots\,\}.
 
 \LMHash{}%
@@ -6255,7 +6272,8 @@ in a similar manner as class instance methods
 Let $a$ be an extension application
 (\ref{explicitExtensionInvocations})
 of the form \code{$E$<\List{S}{1}{m}>($e_1$)}.
-Let \DefineSymbol{\List{Y}{1}{m}} be the formal type parameters
+\BlindDefineSymbol{Y_j, m}%
+Let \List{Y}{1}{m} be the formal type parameters
 of the extension $E$.
 %
 \BlindDefineSymbol{e, \id}%

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -1105,16 +1105,15 @@ via code run reflectively, where the mirror system can catch it.
 Typically, once a compile-time error is thrown and $A$ is suspended,
 $A$ will then be terminated.
 However, this depends on the overall environment.
-A Dart engine runs in the context of an \Index{embedder},
+A Dart engine runs in the context of a \Index{runtime},
 a program that interfaces between the engine and
 the surrounding computing environment.
-The embedder will often be a web browser, but need not be;
-it may be a C++ program on the server for example.
+The runtime may be, for instance, a C++ program on the server.
 When an isolate fails with a compile-time error as described above,
-control returns to the embedder,
+control returns to the runtime,
 along with an exception describing the problem.
-This is necessary so that the embedder can clean up resources etc.
-It is then the embedder's decision whether to terminate the isolate or not.%
+This is necessary so that the runtime can clean up resources etc.
+It is then the runtime's decision whether to terminate the isolate or not.%
 }
 
 \LMHash{}%
@@ -8775,11 +8774,10 @@ print("A simple sum: 2 + 2 = " +
 \end{dartCode}
 
 \rationale{%
-which prints 'A simple sum: 2 + 2 = 22' rather than
-'A simple sum: 2 + 2 = 4'.
-However, the use of the concatenation operation is still discouraged
-for efficiency reasons.
-Instead, the recommended Dart idiom is to use string interpolation.%
+which would print `\code{A simple sum: 2 + 2 = 22}' rather than
+`\code{A simple sum: 2 + 2 = 4}'.
+However, for efficiency reasons,
+the recommended Dart idiom is to use string interpolation.%
 }
 
 \begin{dartCode}
@@ -10990,7 +10988,7 @@ and $t$ as stack trace (\ref{expressionEvaluation}).
 If $v$ is an instance of class \code{Error} or a subclass thereof,
 and it is the first time that \code{Error} object is thrown,
 the stack trace $t$ is stored on $v$ so that it will be returned
-by the $v$'s \code{stackTrace} getter
+by the \code{stackTrace} getter inherited from \code{Error}.
 
 \commentary{%
 If the same \code{Error} object is thrown more than once,
@@ -11745,7 +11743,7 @@ which will force the isolate to be suspended.
 
 \commentary{%
 As discussed in section \ref{errorsAndWarnings},
-the handling of a suspended isolate is the responsibility of the embedder.%
+the handling of a suspended isolate is the responsibility of the runtime.%
 }
 
 
@@ -19315,7 +19313,7 @@ Otherwise, any relative URI is interpreted as relative to the location of the cu
 All further interpretation of URIs is implementation dependent.
 
 \commentary{%
-This means it is dependent on the embedder.%
+This means it is dependent on the runtime.%
 }
 
 

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -2525,15 +2525,16 @@ and the instance methods inherited by $C$ from its superclass
 (\ref{inheritanceAndOverriding}).
 
 \LMHash{}%
-Consider a class $C$.
-It is a compile-time error if an instance method declaration in $C$ has
-a member signature $m$
-(\ref{interfaces})
+\BlindDefineSymbol{C, D, m}
+Consider a class $C$
+and an instance member declaration $D$ in $C$, with member signature $m$
+(\ref{interfaces}).
+It is a compile-time error if $D$ overrides a declaration
 % Note that $m'$ is accessible, due to the definition of 'overrides'.
-which overrides a member signature $m'$
+with member signature $m'$
 from a direct superinterface of $C$
 (\ref{interfaceInheritanceAndOverriding}),
-unless this is a correct member override
+unless $m$ is a correct member override of $m'$
 (\ref{correctMemberOverrides}).
 
 \commentary{%
@@ -2548,7 +2549,7 @@ E.g., $D$ could be an instance getter and $D'$ a static setter
 \LMHash{}%
 For each parameter $p$ of $m$ where \COVARIANT{} is present,
 it is a compile-time error if there exists
-a direct or indirect superinterface $J$ of $C$ which has
+a direct or indirect superinterface of $C$ which has
 an accessible method signature $m''$ with the same name as $m$,
 such that $m''$ has a parameter $p''$ that corresponds to $p$
 (\ref{covariantParameters}),
@@ -2788,6 +2789,7 @@ where only the null object is accepted:%
 \end{dartCode}
 
 \LMHash{}%
+\BlindDefineSymbol{C, L, m}%
 Let $C$ be a concrete class,
 let $L$ be the library that contains the declaration of $C$,
 and let $m$ be a name.
@@ -2931,23 +2933,25 @@ because compilers control the treatment of private names.%
 }
 
 \LMHash{}%
+\BlindDefineSymbol{C, m, X_j}%
 For the dynamic semantics,
 assume that a class $C$ has an implicitly induced
 \code{noSuchMethod} forwarder named $m$,
 with formal type parameters
 \code{$X_1,\ \ldots,\ X_r$},
 positional formal parameters
-\code{$a1,\ \ldots,\ a_k$}
-(\commentary{some of which may be optional when $m = 0$}),
+\BlindDefineSymbol{a_j, k, x_j, n}%
+\code{$a_1,\ \ldots,\ a_k$}
+(\commentary{some of which may be optional when $n = 0$}),
 and named formal parameters with names
-\code{$x_1,\ \ldots,\ x_m$}
+\code{$x_1,\ \ldots,\ x_n$}
 (\commentary{with default values as mentioned above}).
 
 \commentary{%
 For this purpose we need not distinguish between
 a signature that has optional positional parameters and
 a signature that has named parameters,
-because the former is covered by $m = 0$.%
+because the former is covered by $n = 0$.%
 }
 
 \LMHash{}%
@@ -2976,7 +2980,7 @@ such that:
 \end{itemize}
 
 \LMHash{}%
-Next, \code{noSuchMethod} is invoked with $i$ as the actual argument,
+Next, \code{noSuchMethod} is invoked with $im$ as the actual argument,
 and the result obtained from there is returned by the execution of $m$.
 
 \commentary{%
@@ -3354,6 +3358,7 @@ it implicitly has a default constructor \code{C():\ \SUPER()\ \{\}},
 unless $C$ is the built-in class \code{Object}.
 %% TODO(eernst): With null safety, add `or \code{Null}`.
 
+
 \subsubsection{Generative Constructors}
 \LMLabel{generativeConstructors}
 
@@ -3489,32 +3494,39 @@ and with which arguments.
 \def\ConstMetavar{\mbox{\CONST?}}
 
 \LMHash{}%
+\BlindDefineSymbol{C, X_j, B_j, m}%
 Assume that
 \code{$C$<$X_1\ \EXTENDS\ B_1 \ldots,\ X_m\ \EXTENDS\ B_m$>}
 is the name and formal type parameters of the enclosing class,
 $\ConstMetavar$ stands for either \CONST{} or nothing,
 $N$ is $C$ or $C.\id_0$ for some identifier $\id_0$,
 and \id{} is an identifier.
-Consider a declaration of a redirecting generative constructor $k$ of one of the forms
+Consider a declaration of a redirecting generative constructor $k$
+of one of the forms
 
-\code{$\ConstMetavar$ $N$($T_1\ x_1 \ldots,\ T_n\ x_n,\ $[$T_{n+1}\ x_{n+1} = d_1 \ldots,\ T_{n+k}\ x_{n+k} = d_k$]): $R$;}
+\noindent
+\code{$\ConstMetavar$ $N$($T_1\ x_1 \ldots,\ T_n\ x_n,\ $[$T_{n+1}\ x_{n+1} = d_1 \ldots,\ T_{n+k}\ x_{n+k} = d_k$]):\ $R$;}
 
-\code{$\ConstMetavar$ $N$($T_1\ x_1 \ldots,\ T_n\ x_n,\ $\{$T_{n+1}\ x_{n+1} = d_1 \ldots,\ T_{n+k}\ x_{n+k} = d_k$\}): $R$;}
+\noindent
+\code{$\ConstMetavar$ $N$($T_1\ x_1 \ldots,\ T_n\ x_n,\ $\{$T_{n+1}\ x_{n+1} = d_1 \ldots,\ T_{n+k}\ x_{n+k} = d_k$\}):\ $R$;}
 
 \noindent
 where $R$ is of one of the forms
 
-\code{$\THIS{}$($e_1 \ldots,\ e_p,\ x_1$: $e_{p+1}, \ldots,\ x_q$: $e_{p+q}$)}
+\noindent
+\code{$\THIS{}$($e_1 \ldots,\ e_p,\ x_1$:\ $e_{p+1}, \ldots,\ x_q$:\ $e_{p+q}$)}
 
-\code{$\THIS{}.\id$($e_1 \ldots,\ e_p,\ x_1$: $e_{p+1}, \ldots,\ x_q$: $e_{p+q}$)}
+\noindent
+\code{$\THIS{}.\id$($e_1 \ldots,\ e_p,\ x_1$:\ $e_{p+1}, \ldots,\ x_q$:\ $e_{p+q}$)}
 
 \LMHash{}%
 The
 \IndexCustom{redirectee constructor}{constructor!redirectee}
 for this declaration is then the constructor denoted by
 \code{$C$<$X_1 \ldots,\ X_m$>} respectively \code{$C$<$X_1 \ldots,\ X_m$>.\id}.
-It is a compile-time error if the static argument list type (\ref{actualArgumentLists}) of
-\code{($e_1 \ldots,\ e_p,\ x_1$: $e_{p+1}, \ldots,\ x_q$: $e_{p+q}$)}
+It is a compile-time error if the static argument list type
+(\ref{actualArgumentLists})
+of \code{($e_1 \ldots,\ e_p,\ x_1$:\ $e_{p+1}, \ldots,\ x_q$:\ $e_{p+q}$)}
 is not an assignable match for the formal parameter list of the redirectee.
 
 \commentary{%
@@ -3563,7 +3575,8 @@ of the corresponding formal parameter in the declaration of the redirectee.
 \LMLabel{initializerLists}
 
 \LMHash{}%
-An initializer list begins with a colon, and consists of a comma-separated list of individual \Index{initializers}.
+An initializer list begins with a colon,
+and consists of a comma-separated list of individual \Index{initializers}.
 
 \commentary{%
 There are three kinds of initializers.
@@ -3597,22 +3610,27 @@ There are three kinds of initializers.
 An initializer of the form \code{$v$ = $e$} is equivalent to
 an initializer of the form \code{\THIS{}.$v$ = $e$},
 both forms are called \Index{instance variable initializers}.
-It is a compile-time error if the enclosing class does not declare an instance variable named $v$.
+It is a compile-time error if the enclosing class
+does not declare an instance variable named $v$.
 Otherwise, let $T$ be the static type of $v$.
 It is a compile-time error unless the static type of $e$ is assignable to $T$.
 
 \LMHash{}%
 Consider a \Index{superinitializer} $s$ of the form
 
-\code{\SUPER{}($a_1, \ldots,\ a_n,\ x_{n+1}: a_{n+1}, \ldots,\ x_{n+k}$: $a_{n+k}$)}
+\noindent
+\code{\SUPER{}($a_1, \ldots,\ a_n,\ x_{n+1}:\ a_{n+1}, \ldots,\ x_{n+k}$:\ $a_{n+k}$)}
 respectively
 
-\code{\SUPER{}.\id($a_1, \ldots,\ a_n,\ x_{n+1}: a_{n+1}, \ldots,\ x_{n+k}$: $a_{n+k}$)}.
+\noindent
+\code{\SUPER{}.\id($a_1, \ldots,\ a_n,\ x_{n+1}:\ a_{n+1}, \ldots,\ x_{n+k}$:\ $a_{n+k}$)}.
 
 \noindent{}%
 Let $S$ be the superclass of the enclosing class of $s$.
-It is a compile-time error if class $S$ does not declare a generative constructor named $S$ (respectively \code{$S$.\id}).
-Otherwise, the static analysis of $s$ is performed as specified in Section~\ref{bindingActualsToFormals},
+It is a compile-time error if class $S$ does not declare
+a generative constructor named $S$ (respectively \code{$S$.\id}).
+Otherwise, the static analysis of $s$ is performed
+as specified in Section~\ref{bindingActualsToFormals},
 as if \code{\SUPER{}} respectively \code{\SUPER{}.\id}
 had had the function type of the denoted constructor,
 %% TODO(eernst): The following is very imprecise, it just serves to remember
@@ -3624,18 +3642,29 @@ for the corresponding actual type arguments passed to the superclass
 in the header of the current class.
 
 \LMHash{}%
-Let $k$ be a generative constructor.
-Then $k$ may include at most one superinitializer in its initializer list or a compile-time error occurs.
-If no superinitializer is provided, an implicit superinitializer of the form \SUPER{}() is added at the end of $k$'s initializer list,
+Let \DefineSymbol{k} be a generative constructor.
+Then $k$ may include at most one superinitializer in its initializer list
+or a compile-time error occurs.
+If no superinitializer is provided,
+an implicit superinitializer of the form \SUPER{}() is added
+at the end of $k$'s initializer list,
 unless the enclosing class is class \code{Object}.
-It is a compile-time error if a superinitializer appears in $k$'s initializer list at any other position than at the end.
-It is a compile-time error if more than one initializer corresponding to a given instance variable appears in $k$'s initializer list.
-It is a compile-time error if $k$'s initializer list contains an initializer for a variable that is initialized by means of an initializing formal of $k$.
-It is a compile-time error if $k$'s initializer list contains an initializer for a final variable $f$ whose declaration includes an initialization expression.
-It is a compile-time error if $k$ includes an initializing formal for a final variable $f$ whose declaration includes an initialization expression.
+It is a compile-time error if a superinitializer appears
+in $k$'s initializer list at any other position than at the end.
+It is a compile-time error if more than one initializer corresponding
+to a given instance variable appears in $k$'s initializer list.
+It is a compile-time error if $k$'s initializer list contains
+an initializer for a variable that is initialized by means of
+an initializing formal of $k$.
+It is a compile-time error if $k$'s initializer list contains
+an initializer for a final variable $f$ whose declaration includes
+an initialization expression.
+It is a compile-time error if $k$ includes an initializing formal
+for a final variable $f$ whose declaration includes
+an initialization expression.
 
 \LMHash{}%
-Let $f$ be a final instance variable declared in
+Let \DefineSymbol{f} be a final instance variable declared in
 the immediately enclosing class.
 A compile-time error occurs unless $f$ is initialized
 by one of the following means:
@@ -3646,7 +3675,9 @@ by one of the following means:
 \end{itemize}
 
 \LMHash{}%
-It is a compile-time error if $k$'s initializer list contains an initializer for a variable that is not an instance variable declared in the immediately surrounding class.
+It is a compile-time error if $k$'s initializer list contains
+an initializer for a variable that is not
+an instance variable declared in the immediately surrounding class.
 
 \commentary{%
 The initializer list may of course contain an initializer for
@@ -3663,11 +3694,12 @@ includes a superinitializer.
 \LMLabel{executionOfGenerativeConstructors}
 
 \LMHash{}%
+\BlindDefineSymbol{k, T, i}%
 Execution of a generative constructor $k$ of type $T$
 to initialize a fresh instance $i$
 is always done with respect to a set of bindings for its formal parameters
 and the type parameters of the immediately enclosing class bound to
-a set of actual type arguments of $T$, $t_1, \ldots, t_m$.
+a set of actual type arguments of $T$, \DefineSymbol{\List{t}{1}{m}}.
 
 \commentary{%
 These bindings are usually determined by the instance creation expression
@@ -3678,21 +3710,27 @@ However, they may also be determined by a reflective call.%
 \LMHash{}%
 If $k$ is redirecting then its redirect clause has the form
 
-\code{\THIS{}.$g$($a_1, \ldots,\ a_n,\ x_{n+1}$: $a_{n+1}, \ldots,\ x_{n+k}$: $a_{n+k}$)}
+\code{\THIS{}.$g$($a_1, \ldots,\ a_n,\ x_{n+1}$:\ $a_{n+1}, \ldots,\ x_{n+k}$:\ $a_{n+k}$)}
 
-where $g$ identifies another generative constructor of the immediately surrounding class.
-Then execution of $k$ to initialize $i$ proceeds by evaluating the argument list
-\code{($a_1, \ldots,\ a_n,\ x_{n+1}$: $a_{n+1}, \ldots,\ x_{n+k}$: $a_{n+k}$)}
+where \DefineSymbol{g} identifies another generative constructor
+of the immediately surrounding class.
+Then execution of $k$ to initialize $i$ proceeds by
+evaluating the argument list
+\code{($a_1, \ldots,\ a_n,\ x_{n+1}$:\ $a_{n+1}, \ldots,\ x_{n+k}$:\ $a_{n+k}$)}
 to an actual argument list $a$ of the form
-\code{($o_1, \ldots,\ o_n,\ x_{n+1}$: $o_{n+1}, \ldots,\ x_{n+k}$: $o_{n+k}$)}
-in an environment where the type parameters of the enclosing class are bound to
+\code{($o_1, \ldots,\ o_n,\ x_{n+1}$:\ $o_{n+1}, \ldots,\ x_{n+k}$:\ $o_{n+k}$)}
+in an environment where the
+type parameters of the enclosing class are bound to
 $t_1, \ldots, t_m$.
 
 \LMHash{}%
-Next, the body of $g$ is executed to initialize $i$ with respect to the bindings that map
-the formal parameters of $g$ to the corresponding objects in the actual argument list $a$,
+Next, the body of $g$ is executed to initialize $i$
+with respect to the bindings that map
+the formal parameters of $g$ to the corresponding objects
+in the actual argument list $a$,
 with \THIS{} bound to $i$,
-and the type parameters of the immediately enclosing class bound to $t_1, \ldots, t_m$.
+and the type parameters of the immediately enclosing class bound to
+\List{t}{1}{m}.
 
 \LMHash{}%
 Otherwise, $k$ is not redirecting.
@@ -3707,9 +3745,10 @@ then $e$ is evaluated to an object $o$
 and the instance variable $v$ of $i$ is bound to $o$.
 
 \LMHash{}%
-Any initializing formals declared in $k$'s parameter list are executed in the order they appear in the program text.
-% In fact, this order is unobservable; this could be done any time prior to running the body, since
-% these only effect \THIS{}.
+Any initializing formals declared in $k$'s parameter list
+are executed in the order they appear in the program text.
+% In fact, this order is unobservable; this could be done any time
+% prior to running the body, since these only effect \THIS{}.
 Then, the initializers of $k$'s initializer list are executed to initialize $i$
 in the order they appear in the program, as described below
 (p.\,\pageref{executionOfInitializerLists}).
@@ -3730,7 +3769,8 @@ implicitly added superinitializer (\ref{initializerLists}) is executed to
 further initialize $i$.
 
 \LMHash{}%
-After the superinitializer has completed, the body of $k$ is executed in a scope where \THIS{} is bound to $i$.
+After the superinitializer has completed, the body of $k$ is executed
+in a scope where \THIS{} is bound to $i$.
 
 \rationale{%
 This process ensures that no uninitialized final instance variable
@@ -3747,12 +3787,13 @@ nor can \THIS{} be passed into any other code being invoked in the initializer.%
 \LMLabel{executionOfInitializerLists}
 
 \LMHash{}%
-During the execution of a generative constructor to initialize an instance $i$,
+During the execution of a generative constructor to initialize an instance
+\DefineSymbol{i},
 execution of an initializer of the form \code{\THIS{}.$v$ = $e$}
 proceeds as follows:
 
 \LMHash{}%
-First, the expression $e$ is evaluated to an object $o$.
+First, the expression $e$ is evaluated to an object \DefineSymbol{o}.
 Then, the instance variable $v$ of $i$ is bound to $o$.
 % This error can occur due to an implicit cast.
 It is a dynamic type error if the dynamic type of $o$ is not
@@ -3761,26 +3802,28 @@ a subtype of the actual type
 of the instance variable $v$.
 
 \LMHash{}%
-Execution of an initializer that is an assertion proceeds by executing the assertion (\ref{assert}).
+Execution of an initializer that is an assertion proceeds by
+executing the assertion (\ref{assert}).
 
 \LMHash{}%
-Consider a superinitializer $s$ of the form
+Consider a superinitializer \DefineSymbol{s} of the form
 
-\code{\SUPER{}($a_1, \ldots,\ a_n,\ x_{n+1}: a_{n+1}, \ldots,\ x_{n+k}$: $a_{n+k}$)}
+\noindent
+\code{\SUPER{}($a_1, \ldots,\ a_n,\ x_{n+1}:\ a_{n+1}, \ldots,\ x_{n+k}$:\ $a_{n+k}$)}
 respectively
 
-\code{\SUPER{}.\id($a_1, \ldots,\ a_n,\ x_{n+1}$: $a_{n+1}, \ldots,\ x_{n+k}$: $a_{n+k}$)}.
+\noindent
+\code{\SUPER{}.\id($a_1, \ldots,\ a_n,\ x_{n+1}$:\ $a_{n+1}, \ldots,\ x_{n+k}$:\ $a_{n+k}$)}.
 
 \LMHash{}%
+\BlindDefineSymbol{C, S, u_j, p}
 Let $C$ be the class in which $s$ appears and let $S$ be the superclass of $C$.
 If $S$ is generic (\ref{generics}),
 let $u_1, \ldots, u_p$ be the actual type arguments passed to $S$,
-obtained by substituting $t_1, \ldots, t_m$
-for the formal type parameters of $C$
-in the superclass as specified in the header of $C$, and
-$t_1, \ldots, t_m$
-are the actual bindings of the type variables of $C$.
-Let $k$ be the constructor declared in $S$ and named
+obtained by substituting the actual bindings \List{t}{1}{m}
+of the formal type parameters of $C$
+in the superclass as specified in the header of $C$.
+Let \DefineSymbol{k} be the constructor declared in $S$ and named
 $S$ respectively \code{$S$.\id}.
 
 \LMHash{}%
@@ -3810,11 +3853,17 @@ is a constructor prefaced by the built-in identifier
 \end{grammar}
 
 \LMHash{}%
-The return type of a factory whose signature is of the form \FACTORY{} $M$ or the form \FACTORY{} \code{$M$.\id} is $M$ if $M$ is not a generic type;
-otherwise the return type is \code{$M$<$T_1, \ldots,\ T_n$>} where $T_1, \ldots, T_n$ are the type parameters of the enclosing class.
+The return type of a factory whose signature is of
+the form \FACTORY{} $M$ or
+the form \FACTORY{} \code{$M$.\id}
+is $M$ if $M$ is not a generic type;
+otherwise the return type is
+\code{$M$<$T_1, \ldots,\ T_n$>}
+where $T_1, \ldots, T_n$ are the type parameters of the enclosing class.
 
 \LMHash{}%
-It is a compile-time error if $M$ is not the name of the immediately enclosing class.
+It is a compile-time error if $M$ is not the name of
+the immediately enclosing class.
 
 \LMHash{}%
 % This error can occur due to an implicit cast.
@@ -3856,12 +3905,14 @@ whenever the redirecting constructor is called.
 \end{grammar}
 
 Assume that
+\BlindDefineSymbol{C, X_j, B_j, m}%
 \code{$C$<$X_1\ \EXTENDS\ B_1 \ldots,\ X_m\ \EXTENDS\ B_m$>}
 is the name and formal type parameters of the enclosing class,
 $\ConstMetavar$ is \CONST{} or empty,
-$N$ is $C$ or $C.\id_0$ for some identifier $\id_0$,
-$T$ is a type name, and \id{} is an identifier,
-then consider a declaration of a redirecting factory constructor $k$ of one of the forms
+\DefineSymbol{N} is $C$ or $C.\id_0$ for some identifier $\id_0$,
+and \DefineSymbol{\id} is an identifier,
+then consider a declaration of a redirecting factory constructor
+\DefineSymbol{k} of one of the forms
 
 \begin{normativeDartCode}
 $\ConstMetavar$ \FACTORY{}
@@ -3872,6 +3923,7 @@ $\ConstMetavar$ \FACTORY{}
 \end{normativeDartCode}
 
 \noindent
+\BlindDefineSymbol{R, T}%
 where $R$ is of one of the forms
 \code{$T$<$S_1 \ldots,\ S_p$>} or
 \code{$T$<$S_1 \ldots,\ S_p$>.\id}.
@@ -3888,7 +3940,7 @@ Otherwise, it is a compile-time error
 if $R$ denotes a generative constructor and $D$ is abstract.
 Otherwise, the
 \IndexCustom{redirectee constructor}{constructor!redirectee}
-for this declaration is the constructor denoted by $R$.
+for this declaration is the constructor \DefineSymbol{k'} denoted by $R$.
 
 \LMHash{}%
 A redirecting factory constructor $q'$ is \Index{redirection-reachable}
@@ -3900,7 +3952,8 @@ It is a compile-time error if a redirecting factory constructor
 is redirection-reachable from itself.
 
 \LMHash{}%
-Let $\argumentList{T}$ be the static argument list type (\ref{actualArgumentLists})
+Let $\argumentList{T}$ be the static argument list type
+(\ref{actualArgumentLists})
 \code{($T_1 \ldots,\ T_{n+k}$)}
 when $k$ takes no named arguments, and
 \code{($T_1 \ldots,\ T_n,\ T_{n+1}\ x_{n+1},\ \ldots,\ T_{n+k}\ x_{n+k}$)}
@@ -3971,11 +4024,11 @@ It is a compile-time error if $k$ is prefixed with the \CONST{} modifier
 but $k'$ is not a constant constructor (\ref{constantConstructors}).
 
 \LMHash{}%
-Let $T_1, \ldots, T_m$ be the actual type arguments passed to $k'$
+Let \DefineSymbol{\List{T}{1}{m}} be the actual type arguments passed to $k'$
 in the declaration of $k$.
-Let $X_1, \ldots, X_m$ be the formal type arguments declared by
+Let \DefineSymbol{\List{X}{1}{m}} be the formal type parameters declared by
 the class that contains the declaration of $k'$.
-Let $F'$ be the function type of $k'$ (\ref{constructors}).
+Let \DefineSymbol{F'} be the function type of $k'$ (\ref{constructors}).
 It is a compile-time error if $[T_1/X_1, \ldots, T_m/X_m]F'$
 is not a subtype of the function type of $k$.
 
@@ -3988,8 +4041,8 @@ the interface of the immediately enclosing class of $k$.%
 
 \LMHash{}%
 For the dynamic semantics,
-assume that $k$ is a redirecting factory constructor
-and $k'$ is the redirectee of $k$.
+assume that \DefineSymbol{k} is a redirecting factory constructor
+and \DefineSymbol{k'} is the redirectee of $k$.
 
 \LMHash{}%
 % This error can occur due to an implicit cast.
@@ -3999,7 +4052,8 @@ of the corresponding formal parameter in the declaration of $k$.
 
 \LMHash{}%
 When the redirectee $k'$ is a factory constructor,
-execution of $k$ amounts to execution of $k'$ with the actual arguments passed to $k$.
+execution of $k$ amounts to execution of $k'$
+with the actual arguments passed to $k$.
 The result of the execution of $k'$ is the result of $k$.
 
 \LMHash{}%
@@ -4007,9 +4061,12 @@ When the redirectee $k'$ is a generative constructor,
 let $o$ be a fresh instance (\ref{generativeConstructors})
 of the class that contains $k'$.
 Execution of $k$ then amounts to execution of $k'$ to initialize $o$,
-governed by the same rules as an instance creation expression (\ref{instanceCreation}).
-If $k$ completed normally then the execution of $k'$ completes normally returning $o$,
-otherwise $k'$ completes by throwing the exception and stack trace thrown by $k$.
+governed by the same rules as an instance creation expression
+(\ref{instanceCreation}).
+If $k'$ completed normally then the execution of $k$
+completes normally returning $o$,
+otherwise $k$ completes by throwing the exception and stack trace
+thrown by $k'$.
 
 
 \subsubsection{Constant Constructors}
@@ -4051,6 +4108,7 @@ The above refers to both locally declared and inherited instance variables.%
 }
 
 \LMHash{}%
+\BlindDefineSymbol{k, C}%
 If a non-redirecting generative constant constructor $k$
 is declared by a class $C$,
 it is a compile-time error
@@ -4080,7 +4138,8 @@ must be a potentially constant expression
 or a compile-time error occurs.
 
 \LMHash{}%
-When a constant constructor $k$ is invoked from a constant object expression,
+When a constant constructor \DefineSymbol{k} is invoked from
+a constant object expression,
 it is a compile-time error if
 the invocation of $k$ at run time would throw an exception,
 and it is a compile-time error if
@@ -4171,8 +4230,10 @@ The scope of the \EXTENDS{} and \WITH{} clauses of a class $C$ is
 the type-parameter scope of $C$.
 
 \LMHash{}%
-It is a compile-time error if the type in the \EXTENDS{} clause of a class $C$ is
-a type variable (\ref{generics}), a type alias that does not denote a class (\ref{typedef}),
+It is a compile-time error if the type
+in the \EXTENDS{} clause of a class $C$ is
+a type variable (\ref{generics}),
+a type alias that does not denote a class (\ref{typedef}),
 an enumerated type (\ref{enums}),
 a deferred type (\ref{staticTypes}), type \DYNAMIC{} (\ref{typeDynamic}),
 or type \code{FutureOr<$T$>} for any $T$ (\ref{typeFutureOr}).
@@ -4221,7 +4282,8 @@ It is a compile-time error if a class $C$ is a superclass of itself.
 Let $C$ be a class, let $A$ be a superclass of $C$, and
 let $S_1, \ldots, S_k$ be superclasses of $C$ that are also subclasses of $A$.
 $C$ \Index{inherits} all concrete, accessible instance members of $A$
-that have not been overridden by a concrete declaration in $C$ or in at least one of $S_1, \ldots, S_k$.
+that have not been overridden by a concrete declaration in $C$
+or in at least one of $S_1, \ldots, S_k$.
 
 \rationale{%
 It would be more attractive to give a purely local definition of inheritance,
@@ -4243,10 +4305,12 @@ let $\{S_1, \ldots, S_k\}$ be the set of all superclasses of $C$,
 where $S_i$ is the superclass of $S_{i-1}$ for $i \in 1 .. k$.
 \commentary{$S_k$ is the built-in class \code{Object}.}
 Let $C$ declare a concrete member $m$, and
-let $m'$ be a concrete member of $S_j, j \in 1 .. k$, that has the same name as $m$,
+let $m'$ be a concrete member of $S_j, j \in 1 .. k$, that has
+the same name as $m$,
 such that $m'$ is accessible to $L$.
 Then $m$ overrides $m'$
-if $m'$ is not already overridden by a concrete member of at least one of $S_1, \ldots, S_{j-1}$
+if $m'$ is not already overridden by a concrete member of
+at least one of $S_1, \ldots, S_{j-1}$
 and neither $m$ nor $m'$ are instance variables.
 
 \commentary{%
@@ -4364,11 +4428,14 @@ the \IMPLEMENTS{} clause of the class.
 \end{grammar}
 
 \LMHash{}%
-The scope of the \IMPLEMENTS{} clause of a class $C$ is the type-parameter scope of $C$.
+The scope of the \IMPLEMENTS{} clause of a class $C$ is
+the type-parameter scope of $C$.
 
 \LMHash{}%
-It is a compile-time error if an element in the type list of the \IMPLEMENTS{} clause of a class $C$ is
-a type variable (\ref{generics}), a type alias that does not denote a class (\ref{typedef}),
+It is a compile-time error if an element
+in the type list of the \IMPLEMENTS{} clause of a class $C$ is
+a type variable (\ref{generics}),
+a type alias that does not denote a class (\ref{typedef}),
 an enumerated type (\ref{enums}),
 a deferred type (\ref{staticTypes}), type \DYNAMIC{} (\ref{typeDynamic}),
 or type \code{FutureOr<$T$>} for any $T$ (\ref{typeFutureOr}).
@@ -4410,7 +4477,8 @@ in its \EXTENDS{} or \IMPLEMENTS{} clause.%
 }
 
 \LMHash{}%
-It is a compile-time error if the interface of a class $C$ is a superinterface of itself.
+It is a compile-time error if the interface of a class $C$ is
+a superinterface of itself.
 
 \commentary{%
 A class does not inherit members from its superinterfaces.
@@ -4434,7 +4502,7 @@ The basename of an operator named $n$ is $n$,
 except for operator \code{[]=} whose basename is \code{[]}.
 
 \LMHash{}%
-Let $C$ be a class.
+Let \DefineSymbol{C} be a class.
 It is a compile-time error if $C$
 declares a constructor named \code{$C$.$n$} and
 a static member with basename $n$.
@@ -4445,7 +4513,7 @@ It is a compile-time error if the interface of $C$
 has a method named $n$ and a setter with basename $n$.
 
 \LMHash{}%
-When $C$ is a mixin or an extension,
+When \DefineSymbol{C} is a mixin or an extension,
 the compile-time errors occur according to the same rules.
 \commentary{%
 This is redundant in some cases.
@@ -4540,7 +4608,7 @@ depends on the former and not on the latter.%
 }
 
 \LMHash{}%
-Let $m$ be a method signature of the form
+Let \DefineSymbol{m} be a method signature of the form
 
 \noindent
 \code{$T_0$ \id<\TypeParametersStd>(}
@@ -4559,7 +4627,7 @@ $m$ is then
 \FunctionTypePositionalStd{T_0}.
 
 \LMHash{}%
-Let $m$ be a method signature of the form
+Let \DefineSymbol{m} be a method signature of the form
 
 \noindent
 \code{$T_0$ \id<\TypeParametersStd>(}
@@ -4577,7 +4645,7 @@ The \NoIndex{function type of} $m$ is then
 \FunctionTypeNamedStd{T_0}.
 
 \LMHash{}%
-Let $m$ be a setter signature of the form
+Let \DefineSymbol{m} be a setter signature of the form
 \code{\VOID\ \SET\ \id(\COVARIANT?\ $T$ $p$)}.
 The \NoIndex{function type of} $m$ is then
 \FunctionTypeSimple{\VOID}{$T$}.
@@ -4641,6 +4709,7 @@ $T$ is considered to have a method named \CALL{} with signature $m$,
 such that the function type of $m$ is $T_0$.
 
 \LMHash{}%
+\BlindDefineSymbol{I, \List{I}{1}{k}}
 The \Index{combined interface} $I$ of a list of interfaces \List{I}{1}{k}
 is the interface that declares the set of member signatures $M$,
 where $M$ is determined as specified below.
@@ -4756,10 +4825,11 @@ one of the purposes of computing a combined interface.%
 }
 
 \LMHash{}%
+\BlindDefineSymbol{\id, L, I_j, k}%
 Now we define combined member signatures.
 Let \id{} be an identifier, $L$ a library,
 \List{I}{1}{k} a list of interfaces,
-and $M_0$ the set of
+and \DefineSymbol{M_0} the set of
 all member signatures from \List{I}{1}{k} named \id{}
 and accessible to $L$.
 The
@@ -4776,7 +4846,8 @@ If $M_0$ contains exactly one member signature $m'$,
 the combined member signature is $m'$.
 
 \LMHash{}%
-Otherwise, $M_0$ contains more than one member signature \List{m}{1}{q}.
+Otherwise, $M_0$ contains more than one member signature
+\DefineSymbol{\List{m}{1}{q}}.
 
 \LMHash{}%
 \Case{Failing mixtures}
@@ -4802,6 +4873,7 @@ because the name \id{} in the former case always ends in \lit{=},
 which is never true in the latter case.
 
 \LMHash{}%
+\BlindDefineSymbol{N}%
 Determine whether there exists a non-empty set $N \subseteq 1 .. q$ such that
 for each $i \in N$,
 the function type of $m_i$ is a subtype of
@@ -4825,6 +4897,7 @@ in the sense that their function types are subtypes of them all.%
 \LMHash{}%
 Otherwise, when a set $N$ as specified above exists,
 let \Nall{} be the greatest set satisfying the requirement on $N$,
+\BlindDefineSymbol{\Mall}%
 and let $\Mall{} = \{ m_i\;|\;i \in \Nall\}$.
 \commentary{%
 That is, \Mall{} contains all member signatures named \id{}
@@ -4840,6 +4913,7 @@ and we do that by using the ordering of the given interfaces.%
 }
 
 \LMHash{}%
+\BlindDefineSymbol{\MallFirst}%
 Let $j \in 1 .. k$ be the smallest number such that
 $\MallFirst{} = \Mall{} \cap I_j$ is non-empty.
 Let $m_i$ be the single element that \MallFirst{} contains.
@@ -4935,8 +5009,10 @@ with a declaration like
 \LMLabel{interfaceInheritanceAndOverriding}
 
 \LMHash{}%
+\BlindDefineSymbol{J, K}%
 Let $J$ be an interface and $K$ be a library.
-We define $\inherited{J, K}$ to be the set of member signatures $m$
+We define $\inherited{J, K}$ to be the set of member signatures
+\DefineSymbol{m}
 such that all of the following hold:
 \begin{itemize}
 \item $m$ is accessible to $K$ and
@@ -4950,7 +5026,7 @@ such that all of the following hold:
 
 \LMHash{}%
 Furthermore, we define $\overrides{J, K}$ to be
-the set of member signatures $m'$
+the set of member signatures \DefineSymbol{m'}
 such that all of the following hold:
 \begin{itemize}
 \item $J$ is the interface of a class $C$.
@@ -4991,6 +5067,7 @@ if the computation of said combined member signature fails.
 \LMLabel{correctMemberOverrides}
 
 \LMHash{}%
+\BlindDefineSymbol{m, m', \id}%
 Let $m$ and $m'$ be member signatures with the same name \id.
 Then $m$ is a \Index{correct override} of $m'$
 if{}f the following criteria are all satisfied:
@@ -5054,9 +5131,12 @@ A mixin is either derived from an existing class declaration
 or introduced by a mixin declaration.
 
 \LMHash{}%
-Mixin application occurs when one or more mixins are mixed into a class declaration via its \WITH{} clause (\ref{mixinApplication}).
+Mixin application occurs when one or more mixins are mixed into
+a class declaration via its \WITH{} clause (\ref{mixinApplication}).
 Mixin application may be used to extend a class per section \ref{classes};
-alternatively, a class may be defined as a mixin application as described in the following section.
+alternatively, a class may be defined as a mixin application
+as described in the following section.
+
 
 \subsection{Mixin Classes}
 \LMLabel{mixinClasses}
@@ -5069,7 +5149,8 @@ alternatively, a class may be defined as a mixin application as described in the
 \end{grammar}
 
 \LMHash{}%
-It is a compile-time error if an element in the type list of the \WITH{} clause of a mixin application is
+It is a compile-time error if an element in
+the type list of the \WITH{} clause of a mixin application is
 a type variable (\ref{generics}),
 a function type (\ref{functionTypes}),
 a type alias that does not denote a class (\ref{typedef}),
@@ -5091,13 +5172,19 @@ Let $D$ be a mixin application class declaration of the form
 
 \LMHash{}%
 It is a compile-time error if $S$ is an enumerated type (\ref{enums}).
-It is a compile-time error if any of $M_1, \ldots, M_k$ is an enumerated type (\ref{enums}).
-It is a compile-time error if a well formed mixin cannot be derived from each of $M_1, \ldots, M_k$.
+It is a compile-time error if any of $M_1, \ldots, M_k$ is an enumerated type
+(\ref{enums}).
+It is a compile-time error if a well formed mixin
+cannot be derived from each of $M_1, \ldots, M_k$.
 
 \LMHash{}%
-The effect of $D$ in library $L$ is to introduce the name $N$ into the scope of $L$, bound to the class (\ref{classes}) defined by the clause \code{$S$ \WITH{} $M_1$, \ldots{}, $M_n$} with name $N$, as described below.
+The effect of $D$ in library $L$ is to introduce the name $N$ into
+the scope of $L$, bound to the class (\ref{classes}) defined by the clause
+\code{$S$ \WITH{} $M_1$, \ldots{}, $M_n$}
+with name $N$, as described below.
 If $k > 0$ then the class also implements $I_1$, \ldots{}, $I_k$.
-If{}f the class declaration is prefixed by the built-in identifier \ABSTRACT{}, the class being defined is made an abstract class.
+If{}f the class declaration is prefixed by the built-in identifier \ABSTRACT{},
+the class being defined is made an abstract class.
 
 \LMHash{}%
 A clause of the form \code{$S$ \WITH{} $M_1$, \ldots{}, $M_n$}
@@ -5117,8 +5204,11 @@ Then \code{$S$ \WITH{} $M_1$, \ldots{}, $M_n$} defines the class yielded
 by the mixin application of the mixin of $M_n$ to the class $X$ with name $N$.
 
 \LMHash{}%
-In either case, let $K$ be a class declaration with the same constructors, superclass, interfaces and instance members as the defined class.
-It is a compile-time error if the declaration of $K$ would cause a compile-time error.
+In either case, let $K$ be a class declaration with
+the same constructors, superclass, interfaces and instance members as
+the defined class.
+It is a compile-time error if the declaration of $K$ would cause
+a compile-time error.
 % TODO(eernst): Not completely!
 % We do not want super-invocations on covariant implementations
 % to be compile-time errors.
@@ -5134,10 +5224,14 @@ but which is not a correct override of $m$
 \LMLabel{mixinDeclaration}
 
 \LMHash{}%
-A mixin defines zero or more \IndexCustom{mixin member declarations}{mixin!member declaration},
-zero or more \IndexCustom{required superinterfaces}{mixin!required superinterface},
-one \IndexCustom{combined superinterface}{mixin!combined superinterface},
-and zero or more \IndexCustom{implemented interfaces}{mixin!implemented interface}.
+A mixin defines zero or more
+\IndexCustom{mixin member declarations}{mixin!member declaration},
+zero or more
+\IndexCustom{required superinterfaces}{mixin!required superinterface},
+one
+\IndexCustom{combined superinterface}{mixin!combined superinterface},
+and zero or more
+\IndexCustom{implemented interfaces}{mixin!implemented interface}.
 
 \LMHash{}%
 The mixin derived from a class declaration:
@@ -5181,6 +5275,7 @@ Let $M$ be a \MIXIN{} declaration of the form
 \}
 \end{normativeDartCode}
 
+\LMHash{}%
 It is a compile-time error if any of the types $T_1$ through $T_n$
 or $I_1$ through $I_k$ is
 a type variable (\ref{generics}),
@@ -5199,6 +5294,7 @@ Let $M_S$ be the interface declared by the class declaration
 \ABSTRACT{} \CLASS{} $M_{super}$<$P_1$, \ldots{}, $P_m$> \IMPLEMENTS{} $T_1$, $\dots{}$, $T_n$ \{\}
 \end{normativeDartCode}
 
+\noindent
 where $M_{super}$ is a fresh name.
 It is a compile-time error for the mixin declaration if the $M_S$
 class declaration would cause a compile-time error,
@@ -5244,6 +5340,7 @@ the \NoIndex{combined superinterface} $M_S$,
 \NoIndex{implemented interface}s $I_1$, \ldots{}, $I_k$
 and the instance members declared in $M$ as \Index{mixin member declarations}.
 
+
 \subsection{Mixin Application}
 \LMLabel{mixinApplication}
 
@@ -5287,7 +5384,10 @@ to the mixin application.}
 
 Let $S_N$ be the name of $S$.
 
-For each generative constructor of the form \code{$S_q$($T_{1}$ $a_{1}$, $\ldots$, $T_{k}$ $a_{k}$)} of $S$ that is accessible to $L_C$, $C$ has an implicitly declared constructor of the form
+For each generative constructor of the form
+\code{$S_q$($T_{1}$ $a_{1}$, $\ldots$, $T_{k}$ $a_{k}$)}
+of $S$ that is accessible to $L_C$, $C$ has
+an implicitly declared constructor of the form
 
 \begin{normativeDartCode}
 $C_q$($T_{1}$ $a_{1}$, \ldots, $T_{k}$ $a_{k}$): $\SUPER_q$($a_{1}$, $\ldots$, $a_{k}$);
@@ -5301,7 +5401,10 @@ If $S_q$ is a generative const constructor, and $C$ does not declare any
 instance variables, $C_q$ is also a const constructor.
 
 \LMHash{}%
-For each generative constructor of the form \code{$S_q$($T_{1}$ $a_{1}$, \ldots , $T_{k}$ $a_{k}$, [$T_{k+1}$ $a_{k+1}$ = $d_1$, \ldots , $T_{k+p}$ $a_{k+p}$ = $d_p$])} of $S$ that is accessible to $L_C$, $C$ has an implicitly declared constructor of the form
+For each generative constructor of the form
+\code{$S_q$($T_{1}$ $a_{1}$, \ldots , $T_{k}$ $a_{k}$, [$T_{k+1}$ $a_{k+1}$ = $d_1$, \ldots , $T_{k+p}$ $a_{k+p}$ = $d_p$])}
+of $S$ that is accessible to $L_C$, $C$ has
+an implicitly declared constructor of the form
 
 \begin{normativeDartCode}
 $C_q$($T_{1}$ $a_{1}$, \ldots , $T_{k}$ $a_{k}$, [$T_{k+1}$ $a_{k+1}$ = $d'_{1}$, \ldots , $T_{k+p}$ $a_{k+p}$ = $d'_p$])
@@ -5319,7 +5422,10 @@ If $S_q$ is a generative const constructor, and $MC$ does not declare any
 instance variables, $C_q$ is also a const constructor.
 
 \LMHash{}%
-For each generative constructor of the form \code{$S_q$($T_{1}$ $a_{1}$, \ldots , $T_{k}$ $a_{k}$, \{$T_{k+1}$ $a_{k+1}$ = $d_1$, \ldots , $T_{k+n}$ $a_{k+n}$ = $d_n$\})} of $S$ that is accessible to $L_C$, $C$ has an implicitly declared constructor of the form
+For each generative constructor of the form
+\code{$S_q$($T_{1}$ $a_{1}$, \ldots , $T_{k}$ $a_{k}$, \{$T_{k+1}$ $a_{k+1}$ = $d_1$, \ldots , $T_{k+n}$ $a_{k+n}$ = $d_n$\})}
+of $S$ that is accessible to $L_C$, $C$ has
+an implicitly declared constructor of the form
 
 \begin{normativeDartCode}
 $C_q$($T_{1}$ $a_{1}$, \ldots , $T_{k}$ $a_{k}$, \{$T_{k+1}$ $a_{k+1}$ = $d'_1$, \ldots , $T_{k+n}$ $a_{k+n}$ = $d'_n$\})
@@ -5331,7 +5437,8 @@ where $C_q$ is obtained from $S_q$ by replacing occurrences of $S_N$
 which denote the superclass by $N$,
 $\SUPER_q$ is obtained from $S_q$ by replacing occurrences of $S_N$
 which denote the superclass by \SUPER{},
-and $d'_i$, $i \in 1..n$, is a constant expression evaluating to the same value as $d_i$.
+and $d'_i$, $i \in 1..n$, is a constant expression evaluating to
+the same value as $d_i$.
 If $S_q$ is a generative const constructor, and $M$ does not declare any
 fields, $C_q$ is also a const constructor.
 
@@ -5410,7 +5517,7 @@ of a given extension, an implicit invocation can use it.%
 }
 
 \LMHash{}%
-It is a compile-time error if the current library $L$ has
+It is a compile-time error if the current library has
 a deferred import of a library $L'$
 such that the imported namespace from $L'$ contains
 a name denoting an extension.
@@ -5476,6 +5583,7 @@ An extension declaration introduces two scopes:
 \end{itemize}
 
 \LMHash{}%
+\BlindDefineSymbol{D, \code{E}}%
 Let $D$ be an extension declaration with declared name \code{E}.
 A member declaration in $D$ with the modifier \STATIC{} is designated as a
 \IndexCustom{static member}{extension!static member}
@@ -5527,7 +5635,8 @@ which would be confusing and error-prone.%
 \LMLabel{explicitExtensionInvocations}
 
 \LMHash{}%
-Let $E$ be a simple or qualified identifier that denotes an extension.
+Let \DefineSymbol{E} be a simple or qualified identifier
+that denotes an extension.
 An \IndexCustom{extension application}{extension!application}
 is then an expression of the form
 \syntax{$E$ <typeArguments>? `(' <expression> `)'}.
@@ -5581,11 +5690,13 @@ a context type that makes it a set literal.%
 }
 
 \LMHash{}%
+\BlindDefineSymbol{a, E, T_j, e}%
 Let $a$ be an extension application of the form
 \code{$E$<\List{T}{1}{s}>($e$)},
 where $E$ denotes an extension declared as
 
 \noindent
+\BlindDefineSymbol{X_j, B_j, s}
 \EXTENSION{} E<\TypeParametersStd> \ON{} $T$ \{\,\ldots\,\}.
 
 \LMHash{}%
@@ -5638,17 +5749,20 @@ where a type is needed is a compile-time error.%
 }
 
 \LMHash{}%
+\BlindDefineSymbol{i, r}%
 Let $i$ be a simple member invocation
 (\ref{memberInvocations})
 whose receiver $r$ is an extension application of the form
+\BlindDefineSymbol{E, T_j, k, e}%
 \code{$E$<\List{T}{1}{k}>($e$)}
 (\commentary{which is \code{$E$($e$)} when $k$ is zero})
-whose corresponding member name is $n$,
+whose corresponding member name is \DefineSymbol{n},
 and assume that $r$ has no compile-time errors.
 A compile-time error occurs unless the extension denoted by $E$
 declares a member named $n$.
-Otherwise let \List{X}{1}{k} be the type parameters of said extension.
-Let $s$ be the member signature of the member $n$ declared by $E$.
+Otherwise let \DefineSymbol{\List{X}{1}{k}} be
+the type parameters of said extension.
+Let \DefineSymbol{s} be the member signature of the member $n$ declared by $E$.
 Exactly the same compile-time errors occur for $i$ as
 the ones that would occur for a member invocation $i_1$
 which is obtained from $i$ by replacing $r$ by
@@ -5698,13 +5812,16 @@ function type of $s_1$.%
 }
 
 \LMHash{}%
+\BlindDefineSymbol{i, r}%
 For the dynamic semantics,
 let $i$ be a simple, unconditional member invocation
 whose receiver $r$ is an extension application of the form
+\BlindDefineSymbol{E, T_j, k, e}%
 \code{$E$<\List{T}{1}{k}>($e$)}
-where the type parameters of $E$ are \List{X}{1}{k}
-and the actual values of \List{T}{1}{k} are \List{t}{1}{k}
+where the type parameters of $E$ are \DefineSymbol{\List{X}{1}{k}}
+and the actual values of \List{T}{1}{k} are \DefineSymbol{\List{t}{1}{k}}
 (\ref{actualTypes}),
+\BlindDefineSymbol{n, m}%
 and whose corresponding member name is $n$.
 Let $m$ be the member of $E$ that has the name $n$.
 Evaluation of $i$ proceeds by evaluating
@@ -5763,6 +5880,7 @@ a different extension than the intended one.%
 }
 
 \LMHash{}%
+\BlindDefineSymbol{i, r, m}%
 An implicit extension member invocation occurs
 for a member invocation $i$
 (\ref{memberInvocations})
@@ -5830,6 +5948,7 @@ then it is accessible everywhere in $L$.%
 \LMLabel{extensionApplicability}
 
 \LMHash{}%
+\BlindDefineSymbol{E, e, r, S, m}%
 Let $E$ be an extension.
 Let $e$ be a member invocation
 (\ref{memberInvocations})
@@ -5910,6 +6029,7 @@ the context type may affect the member invocation.%
 \LMLabel{extensionSpecificity}
 
 \LMHash{}%
+\BlindDefineSymbol{E_j, k}%
 When \List{E}{1}{k}, $k > 1$, are extensions
 which are accessible and applicable to a member invocation $e$
 (\ref{memberInvocations}),
@@ -5923,10 +6043,13 @@ in the situation where more than one choice is possible.%
 }
 
 \LMHash{}%
+\BlindDefineSymbol{e, r, m}%
 Let $e$ be a member invocation with receiver $r$
 and correspsonding member name $m$,
+\BlindDefineSymbol{E_1, E_2}%
 and let $E_1$ and $E_2$ denote two distinct
 accessible and applicable extensions for $e$.
+\BlindDefineSymbol{T_j, S_j}%
 Let $T_j$ be the instantiated \ON{} type of $e$ with respect to $E_j$,
 and $S_j$ be the instantiation-to-bound \ON{} type of $e$ with respect to $E_j$,
 for $j \in 1 .. 2$
@@ -6128,11 +6251,14 @@ in a similar manner as class instance methods
 (\ref{superGetterAccessAndMethodClosurization}).
 
 \LMHash{}%
+\BlindDefineSymbol{a, E, S_j, e_1}%
 Let $a$ be an extension application
 (\ref{explicitExtensionInvocations})
 of the form \code{$E$<\List{S}{1}{m}>($e_1$)}.
-Let \List{Y}{1}{m} be the formal type parameters of the extension $E$.
+Let \DefineSymbol{\List{Y}{1}{m}} be the formal type parameters
+of the extension $E$.
 %
+\BlindDefineSymbol{e, \id}%
 An expression $e$ of the form \code{$a$.\id}
 where \id{} is an identifier is then known as an
 \IndexCustom{extension property extraction}{%
@@ -6304,6 +6430,7 @@ We expect developers to use this power responsibly.%
 }
 
 \LMHash{}%
+\BlindDefineSymbol{a, i}%
 Let $a$ be an extension application
 (\ref{explicitExtensionInvocations}),
 and $i$ an expression of the form
@@ -6325,6 +6452,7 @@ is immediately treated as an invocation of an extension method named \CALL.%
 }
 
 \LMHash{}%
+\BlindDefineSymbol{e, S, i}%
 Let $e$ be an expression with static type $S$
 which is not a property extraction expression
 (\ref{propertyExtraction}),


### PR DESCRIPTION
This is a LaTeX clean-up and enhancement PR (no changes to the contents, except for a small change at two locations, which have been marked by a comment from me).

It corrects all `\commentary{}` and `\rationale{}` such that they do not introduce spaces in front or at the end (this is needed in order to avoid spurious extra line breaks when the text fills up the last line of the paragraph). It also reformats the `\commentary{}` and `\rationale{}` to fit in 80 columns.

Finally, it introduces `\DefineSymbol` from the beginning and until & including section 'Enums'. This is a macro that adds the given symbol in the margin, such that it is possible to quickly look up the location where a symbol is defined. Symbols are only shown like this if they are used in more than a few lines of text. So if $C$ is used and we want to see how it's defined, scan backwards in the text: It could be defined just a couple of lines earlier, otherwise it should occur in the margin.