### PR TITLE
Specify identifier references denoting extension members

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -16352,10 +16352,9 @@ The evaluation of $e$ proceeds as follows:
 \item
   If $D$ is an instance method declaration in an extension $E$
   with type parameters \List{X}{1}{s},
-  then $e$ evaluates to the extension method closurization
-  \code{$E$<\List{t}{1}{s}>(\THIS).\id}
-  (\ref{extensionMethodClosurization}),
-  where \List{t}{1}{s} are the current bindings of said type parameters.
+  then $e$ evaluates to the result of the extension method closurization
+  \code{$E$<\List{X}{1}{s}>(\THIS).\id}
+  (\ref{extensionMethodClosurization}).
 \item
   If $D$ is a local variable $v$
   (\commentary{which can be a formal parameter})

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -41,6 +41,7 @@
 %   'class' scope.
 % - Add specification of `>>` in JavaScript compiled code, in appendix.
 % - Integrate the specification of extension methods into this document.
+% - Specify identifier references denoting extension members.
 %
 % 2.7
 % - Rename non-terminals `<...Definition>` to `<...Declaration>` (e.g., it is
@@ -16245,9 +16246,18 @@ Let $D$ be the declaration yielded by the lexical lookup of \id.
   such that $v$ is known to have type $S$,
   in which case the static type of $e$ is $T$.
 \item
+  % Extension getter invocation by scope.
+  If $D$ is a declaration of an instance getter in an extension $E$
+  then the static type of $e$ is the return type of $D$.
+\item
+  % Extension method tear-off by scope.
+  If $D$ is a declaration of an instance method
+  in an extension $E$ then the static type of $e$ is
+  the function type of $D$.
+\item
   \commentary{%
     A lexical lookup will never yield a declaration $D$
-    which is an instance member.%
+    which is an instance member of a class.%
   }
 \end{itemize}
 \vspace{-1ex}
@@ -16334,6 +16344,18 @@ The evaluation of $e$ proceeds as follows:
   then $e$ evaluates to the function object obtained by closurization
   (\ref{functionClosurization})
   of $D$.
+\item
+  If $D$ is an instance getter declaration in an extension $E$,
+  then $e$ evaluates to the result of invoking said getter
+  with the current binding of \THIS{}, and
+  the current bindings of the type parameters declared by $D$.
+\item
+  If $D$ is an instance method declaration in an extension $E$
+  with type parameters \List{X}{1}{s},
+  then $e$ evaluates to the extension method closurization
+  \code{$E$<\List{t}{1}{s}>(\THIS).\id}
+  (\ref{extensionMethodClosurization}),
+  where \List{t}{1}{s} are the current bindings of said type parameters.
 \item
   If $D$ is a local variable $v$
   (\commentary{which can be a formal parameter})

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -16214,7 +16214,8 @@ Let $D$ be the declaration yielded by the lexical lookup of \id.
 
 \begin{itemize}
 \item
-  If $D$ declares a class, mixin, type alias or type parameter,
+  If $D$ declares a class, mixin, type alias, an enumerated type,
+  or a type parameter,
   the static type of $e$ is \code{Type}.
 \item
   If $D$ is the declaration of a library getter
@@ -16247,16 +16248,17 @@ Let $D$ be the declaration yielded by the lexical lookup of \id.
   in which case the static type of $e$ is $T$.
 \item
   % Extension getter invocation by scope.
-  If $D$ is a declaration of an instance getter in an extension $E$
+  If $D$ is a declaration of an instance getter
+  in an extension declaration $E$,
   then the static type of $e$ is the return type of $D$.
 \item
   % Extension method tear-off by scope.
   If $D$ is a declaration of an instance method
-  in an extension $E$ then the static type of $e$ is
-  the function type of $D$.
+  in an extension declaration $E$,
+  then the static type of $e$ is the function type of $D$.
 \item
   \commentary{%
-    A lexical lookup will never yield a declaration $D$
+    A lexical lookup will never yield a declaration
     which is an instance member of a class.%
   }
 \end{itemize}
@@ -16345,12 +16347,12 @@ The evaluation of $e$ proceeds as follows:
   (\ref{functionClosurization})
   of $D$.
 \item
-  If $D$ is an instance getter declaration in an extension $E$,
+  If $D$ is an instance getter declaration in an extension declaration $E$,
   then $e$ evaluates to the result of invoking said getter
   with the current binding of \THIS{}, and
   the current bindings of the type parameters declared by $D$.
 \item
-  If $D$ is an instance method declaration in an extension $E$
+  If $D$ is an instance method declaration in an extension declaration $E$
   with type parameters \List{X}{1}{s},
   then $e$ evaluates to the result of the extension method closurization
   \code{$E$<\List{X}{1}{s}>(\THIS).\id}


### PR DESCRIPTION
This corrects an omission in the recent update where extension methods where specified: How to find the static type and execute an identifier reference, when it denotes an extension member.