### PR TITLE
Adjust lexical lookup to include implicit extension method invocation

### DIFF
--- a/specification/dart.sty
+++ b/specification/dart.sty
@@ -374,6 +374,10 @@
 % A special value in a namespace, used to indicate a conflict.
 \newcommand{\ConflictValue}{\mbox{NAME\_CONFLICT}}
 
+% A special value yielded by lexical lookups, indicating that the
+% given expression should be transformed by prepending \THIS.
+\newcommand{\PrependThisValue}{\mbox{PREPEND\_THIS}}
+
 % Context types: Avoid the `?` because that is also concrete type
 % syntax.
 %% TODO(eernst): Find a suitable symbol for this, e.g., a curly questionmark.

--- a/specification/dart.sty
+++ b/specification/dart.sty
@@ -374,10 +374,6 @@
 % A special value in a namespace, used to indicate a conflict.
 \newcommand{\ConflictValue}{\mbox{NAME\_CONFLICT}}
 
-% A special value yielded by lexical lookups, indicating that the
-% given expression should be transformed by prepending \THIS.
-\newcommand{\PrependThisValue}{\mbox{PREPEND\_THIS}}
-
 % Context types: Avoid the `?` because that is also concrete type
 % syntax.
 %% TODO(eernst): Find a suitable symbol for this, e.g., a curly questionmark.

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -15998,7 +15998,7 @@ Now proceed as described in the first applicable case from the following list:
   Otherwise, the lexical lookup yields $D$.
 \item
   Consider the case where $D$ is an instance member declaration in
-  a class \DefineSymbol{C}.
+  a class $C$.
   The lexical lookup then yields the member signature named $n$
   in the interface of $C$.
   \commentary{%

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -15861,20 +15861,32 @@ the following errors apply:
 \item
   Consider the case where $\ell$ has access to \THIS,
   and $\ell$ occurs in a class \DefineSymbol{C}.
-  A compile-time error occurs
-  if the interface of $C$ does not have a member named $n$,
-  and there is no accessible extension $E$
-  such that $C$ matches the \ON{} type of $E$
-  and $E$ has an instance member named $n$.
+  A compile-time error occurs in each of the following two situations:
+  \begin{itemize}
+  \item
+    The interface of $C$ does not have a member named $n$,
+    but it does have a member with basename \id.
+  \item
+    The interface of $C$ does not have a member with basename \id,
+    and there is no accessible extension $E$,
+    such that $C$ matches the \ON{} type of $E$,
+    and $E$ has an instance member named $n$.
+  \end{itemize}
 \item
   \BlindDefineSymbol{E, T}%
   Consider the case where $\ell$ has access to \THIS,
   and $\ell$ occurs in an extension $E$ with \ON{} type $T$.
-  A compile-time error occurs
-  if the interface of $T$ does not have a member named $n$,
-  and there is no accessible extension $E_1$
-  such that $T$ matches the \ON{} type of $E_1$
-  and $E_1$ has an instance member named $n$.
+  A compile-time error occurs in the following two situations:
+  \begin{itemize}
+  \item
+    The interface of $T$ does not have a member named $n$,
+    but it does have a member with basename \id.
+  \item
+    The interface of $T$ does not have a member with basename \id,
+    and there is no accessible extension $E_1$,
+    such that $T$ matches the \ON{} type of $E_1$,
+    and $E_1$ has an instance member named $n$.
+  \end{itemize}
 \end{itemize}
 \vspace{-2ex}
 \EndCase

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -15845,6 +15845,39 @@ even though it may have the name \id{} when $n$ is \code{\id=} or vice versa.
 That situation may cause an error, as specified below.%
 }
 
+% Even when we have found a declaration, it may have the wrong name.
+\LMHash{}%
+\Case{$D$ exists}
+In this case, at least one declaration with basename \id{}
+is in scope at the location $\ell$.
+
+\LMHash{}%
+It is a compile-time error if the name of $D$ is not $n$,
+unless $D$ is an instance member or a local variable
+(\commentary{which may be a formal parameter}).
+
+%% TODO(eernst): Come NNBD, `this` is accessible in a `late` instance variable
+%% initializer, so they must also be included in the first case.
+\LMHash{}%
+% Has chosen instance member, wants getter/setter, has only the opposite.
+When $\ell$ has access to \THIS{}
+(\ref{classes})
+and is located in a class or mixin \DefineSymbol{A},
+it is a compile-time error if $D$ is an instance member,
+and the interface of $A$ does not have a member named $n$.
+% Has chosen extension instance member, wants getter/setter,
+% has only the opposite.
+When $\ell$ has access to \THIS{}
+and occurs in an extension \DefineSymbol{E},
+it is a compile-time error if $D$ is an instance member,
+and $E$ does not declare a member named $n$.
+% No access to this.
+When $\ell$ does not have access to \THIS,
+it is a compile-time error if $D$ is an instance member.
+% An instance variable initializer is in the body scope, so it is
+% actually possible for $D$ to be an instance member here.
+\EndCase
+
 \LMHash{}%
 \Case{$D$ does not exist}
 When no declaration with basename \id{} is in scope at the location $\ell$,
@@ -15862,18 +15895,23 @@ the following errors apply:
   (\ref{classes}).
 \item
   Consider the case where $\ell$ has access to \THIS,
-  and $\ell$ occurs in a class \DefineSymbol{C}.
+  and $\ell$ occurs in a class or a mixin \DefineSymbol{A}.
   A compile-time error occurs in each of the following two situations:
   \begin{itemize}
   \item
-    The interface of $C$ does not have a member named $n$,
+    The interface of $A$ does not have a member named $n$,
     but it does have a member with basename \id.
   \item
-    The interface of $C$ does not have a member with basename \id,
-    and there is no accessible extension $E$,
-    such that $C$ matches the \ON{} type of $E$,
-    and $E$ has an instance member named $n$.
+    The interface of $A$ does not have a member with basename \id,
+    and there is no accessible extension $E$
+    such that $A$ matches the \ON{} type of $E$,
+    and $E$ has an instance member with basename \id.
   \end{itemize}
+  \commentary{%
+    In other words, we get an error if
+    we find a getter, but we are looking for a setter, or vice versa;
+    and we get an error if we cannot find anything at all.%
+  }
 \item
   \BlindDefineSymbol{E, T}%
   Consider the case where $\ell$ has access to \THIS,
@@ -15894,45 +15932,11 @@ the following errors apply:
 \EndCase
 
 \commentary{%
-So it is an error if there is no member with the right basename,
-and there is also no applicable extension member with the right basename.
-It is also an error if there is one such member,
-but it is a non-setter and we are looking for a setter,
-or vice versa.%
+We could describe these rules as having a built-in priority system:
+The lexically enclosing scopes have the highest priority;
+members of the interface of \THIS{} have the next priority;
+and implicitly invoked extension methods have the lowest priority.%
 }
-
-% Even when we have found a declaration, it may have the wrong name.
-\LMHash{}%
-\Case{$D$ exists}
-In this case, at least one declaration with basename \id{}
-is in scope at the location $\ell$.
-
-\LMHash{}%
-It is a compile-time error if the name of $D$ is not $n$,
-unless $D$ is an instance member or a local variable
-(\commentary{which may be a formal parameter}).
-
-%% TODO(eernst): Come NNBD, `this` is accessible in a `late` instance variable
-%% initializer, so they must also be included in the first case.
-\LMHash{}%
-% Has chosen instance member, wants getter/setter, has only the opposite.
-When $\ell$ has access to \THIS{}
-(\ref{classes})
-and is located in a class \DefineSymbol{C},
-it is a compile-time error if $D$ is an instance member,
-and the interface of $C$ does not have a member named $n$.
-% Has chosen extension instance member, wants getter/setter,
-% has only the opposite.
-When $\ell$ has access to \THIS{}
-and occurs in an extension \DefineSymbol{E},
-it is a compile-time error if $D$ is an instance member,
-and $E$ does not declare a member named $n$.
-% No access to this.
-When $\ell$ does not have access to \THIS,
-it is a compile-time error if $D$ is an instance member.
-% An instance variable initializer is in the body scope, so it is
-% actually possible for $D$ to be an instance member here.
-\EndCase
 
 \rationale{%
 We are always looking up \emph{both} \id{} and \code{\id=},

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -12384,8 +12384,8 @@ When the lexical lookup of \id{} yields an import prefix,
 a compile-time error occurs.
 \EndCase
 
-\Case{Lexical lookup yields \PrependThisValue}
-When the lexical lookup of \id{} yields \PrependThisValue,
+\Case{Lexical lookup yields nothing}
+When the lexical lookup of \id{} yields nothing,
 $i$ is treated as
 (\ref{notation})
 the ordinary method invocation
@@ -14541,7 +14541,7 @@ Perform a lexical lookup of \code{\id=} from the location of \id.
   Otherwise, a compile-time error occurs,
   unless the static type of $e$ is assignable to the parameter type of $D$.
 \item
-  When the lexical lookup yields \PrependThisValue,
+  When the lexical lookup yields nothing,
   $a$ is treated as
   (\ref{notation})
   \code{\THIS.\id{} = $e$}.
@@ -14602,7 +14602,7 @@ Perform a lexical lookup of \code{\id=} from the location of \id.
 \item
   \commentary{%
     The case where the lexical lookup of \code{\id=}
-    yields \PrependThisValue{} cannot occur,
+    yields nothing cannot occur,
     because that case is treated as
     \code{\THIS.\id{} = $e$},
     whose evaluation is specified elsewhere.%
@@ -15772,24 +15772,31 @@ When \id{} is an identifier,
 it may look up a name $n$ of the form \id{} as well as of the form \code{\id=}.
 
 \LMHash{}%
-A lexical lookup yields a result which is
-a declaration, an import prefix,
-or the special value
-\Index{\PrependThisValue},
-which indicates that the lookup should be transformed into
-a member access on \THIS.
+A lexical lookup can yield a declaration or an import prefix,
+and it can yield nothing.
+
+\commentary{%
+It is not a compile-time error when the lexical lookup yields nothing.
+In this situation the given name $n$ will be transformed into
+\code{\THIS.$n$},
+and the static analysis of the resulting expression
+may or may not have any compile-time errors.%
+}
 
 \LMHash{}%
-A lexical lookup may incur a compile-time error.
-However, that is different from a result yielded by the lexical lookup
-because this specification never specifies propagation of errors.
+A lexical lookup may incur a compile-time error,
+as specified below.
+However, that is different from a result yielded by the lexical lookup,
+because this specification never specifies the propagation of errors.
+
 \commentary{%
 In other words, when other parts of this specification indicate that
 a lexical lookup is performed,
-they need to consider the further steps taken when the result
-is a declaration, when it is an import prefix,
-and when it is \PrependThisValue,
-but they do not mention that, e.g., \code{\id.m} is an error
+they need to consider the further steps taken
+when the lookup yields a declaration,
+when it yields an import prefix,
+and when it yields nothing.
+But they do not mention that, e.g., \code{\id.m} is an error
 because the lexical lookup for \id{} incurred an error.%
 }
 
@@ -15872,10 +15879,11 @@ unless $D$ is an instance member or a local variable
 That is, it is an error if we look for a setter and find a getter,
 or vice versa,
 but not an error if we look for a setter and find a local variable.
-If we look for a setter and find an instance getter (or vice versa)
+If we look for a setter and find an instance getter, or vice versa,
 it is not an error,
 because the setter could be inherited.
-That is checked after adding \THIS{} below.%
+That is checked after yielding nothing
+(which implies that \THIS{} will be prepended).%
 }
 
 \LMHash{}%
@@ -15930,7 +15938,7 @@ proceed as described in the first applicable case from the following list:
 \begin{itemize}
 \item
   When $D$ does not exist,
-  the lexical lookup yields \PrependThisValue.
+  the lexical lookup yields nothing.
   \commentary{%
     In this case it is guaranteed that $\ell$ has access to \THIS,
     and $n$ will be treated as \code{\THIS.$n$}.
@@ -15951,10 +15959,9 @@ proceed as described in the first applicable case from the following list:
 \item
   Consider the case where $D$ is an instance member declaration in
   a class or mixin $A$.
-  The lexical lookup then yields \PrependThisValue.
+  The lexical lookup then yields nothing.
   \commentary{%
-    In this case it is guaranteed that $\ell$ has access to \THIS,
-    but some errors may still occur.%
+    In this case it is guaranteed that $\ell$ has access to \THIS.%
   }
 \item
   % Cases covered here: $D$ is
@@ -15971,18 +15978,16 @@ proceed as described in the first applicable case from the following list:
 \rationale{%
 Note that a lexical lookup will never yield a declaration of
 an instance member.
-In each case where it is determined that there is no error
+In each case where it is determined that there is no error,
 and an instance member is the result of the lookup,
-\PrependThisValue{} is yielded.
+the lexical lookup yields nothing.
 
-The reason for this is that there may not be a declaration, e.g.,
-in the case where $D$ does not exist,
-but the interface of the class has the required member
-because more than one superinterface has the same member signature
-for the given name,
-or an extension method is applicable.
+The reason for this is that there may not be a declaration in scope,
+but the interface of the class could have the required member,
+or an extension method could be applicable.
 So, for uniformity,
-in these situations we always report that \THIS{} should be added.%
+in these situations we always report that nothing was found,
+which implies that \THIS{} should be added.%
 }
 
 
@@ -16156,19 +16161,17 @@ in such a way that the type of $p$ is not used.%
 \EndCase
 
 \LMHash{}%
-\Case{Lexical lookup yields \PrependThisValue}
-In this case the lexical lookup
+\Case{Lexical lookup yields nothing}
+When the lexical lookup
 (\ref{lexicalLookup})
-for \id{} yields \PrependThisValue.
-%
-In this situation $e$ is treated as
+for \id{} yields nothing,
+$e$ is treated as
 (\ref{notation})
 \code{\THIS.\id}.
 
 \commentary{%
 In this case it is known that $e$ has access to \THIS{}
-(\ref{classes}),
-and the interface of the enclosing class has a member named \id.
+(\ref{classes}).
 Both the static analysis and evaluation proceeds with
 \code{\THIS.\id},
 so there is no need to further specify the treatment of $e$.%
@@ -16255,7 +16258,7 @@ will evaluate the import prefix.
 \EndCase
 
 \LMHash{}%
-\Case{Lexical lookup yields \PrependThisValue}
+\Case{Lexical lookup yields nothing}
 This situation cannot arise,
 because this only occurs when $e$ is treated as
 \code{\THIS.\id},

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -12395,7 +12395,7 @@ the ordinary method invocation
 \commentary{%
 This occurs when the lexical lookup has determined that
 $i$ must invoke an instance member of a class or an extension,
-and the location of $i$ can access \THIS{},
+and the location of $i$ can access \THIS,
 and the interface of the enclosing class has a member named \id,
 or there is an applicable extension with such a member.
 Both the static analysis and evaluation proceeds with
@@ -15777,11 +15777,21 @@ a declaration, an import prefix,
 or the special value
 \Index{\PrependThisValue},
 which indicates that the lookup should be transformed into
-a member access on \THIS{}.
-A lexical lookup can not fail
-(\commentary{so it also makes no sense to say that it succeeds}):
-a compile-time error may occur during the lexical lookup,
-but this specification does not mention the propagation of errors.
+a member access on \THIS.
+
+\LMHash{}%
+A lexical lookup may incur a compile-time error.
+However, that is different from a result yielded by the lexical lookup
+because this specification never specifies propagation of errors.
+\commentary{%
+In other words, when other parts of this specification indicate that
+a lexical lookup is performed,
+they need to consider the further steps taken when the result
+is a declaration, when it is an import prefix,
+and when it is \PrependThisValue,
+but they do not mention that, e.g., \code{\id.m} is an error
+because the lexical lookup for \id{} incurred an error.%
+}
 
 \commentary{%
 A lexical lookup differs from a lookup of an instance member
@@ -15794,8 +15804,9 @@ as detailed below.%
 }
 
 \LMHash{}%
-Consider the situation where a name \DefineSymbol{n}
-has basename \DefineSymbol{\id}
+\BlindDefineSymbol{n, id}%
+Consider the situation where a name $n$
+has basename \id{}
 (\ref{classMemberConflicts})
 where \id{} is an identifier,
 and a lexical lookup of $n$ is performed from a given location
@@ -15841,7 +15852,7 @@ we stop searching if we find any declaration named \id{} or \code{\id=}.
 If, in that scope, there are declarations for both \id{} and \code{\id=},
 we return the one which has the requested name $n$.
 In the case where only one declaration is present, we return it,
-even though it may have the name \id{} when $n$ is \code{\id=} or vice versa.
+even though it may have the name \id{} when $n$ is \code{\id=}, or vice versa.
 That situation may cause an error, as specified below.%
 }
 
@@ -15856,21 +15867,31 @@ It is a compile-time error if the name of $D$ is not $n$,
 unless $D$ is an instance member or a local variable
 (\commentary{which may be a formal parameter}).
 
+\commentary{%
+That is, it is an error if we look for a setter and find a getter,
+or vice versa,
+but not an error if we look for a setter and find a local variable.
+If we look for a setter and find an instance getter (or vice versa)
+it is not an error,
+because the setter could be inherited.
+That is checked below.%
+}
+
 %% TODO(eernst): Come NNBD, `this` is accessible in a `late` instance variable
 %% initializer, so they must also be included in the first case.
 \LMHash{}%
 % Has chosen instance member, wants getter/setter, has only the opposite.
 When $\ell$ has access to \THIS{}
 (\ref{classes})
-and is located in a class or mixin \DefineSymbol{A},
+and is located in a class or mixin $A$,
 it is a compile-time error if $D$ is an instance member,
 and the interface of $A$ does not have a member named $n$.
 % Has chosen extension instance member, wants getter/setter,
 % has only the opposite.
 When $\ell$ has access to \THIS{}
-and occurs in an extension \DefineSymbol{E},
+and occurs in an extension $E$,
 it is a compile-time error if $D$ is an instance member,
-and $E$ does not declare a member named $n$.
+and the name of $D$ is not $n$.
 % No access to this.
 When $\ell$ does not have access to \THIS,
 it is a compile-time error if $D$ is an instance member.
@@ -15880,63 +15901,10 @@ it is a compile-time error if $D$ is an instance member.
 
 \LMHash{}%
 \Case{$D$ does not exist}
-When no declaration with basename \id{} is in scope at the location $\ell$,
-the following errors apply:
-
-\begin{itemize}
-\item
-  % Here is the list of cases covered by this item: \ell is..
-  % - inside a library function, getter, setter, variable initializer;
-  % - inside a static method, getter, setter, variable initializer;
-  % - inside an instance variable initializer;
-  % - in an expression in the initializer list of a constructor
-  %   (be it a superinitializer, a field initializer, or an assertion).
-  It is a compile-time error if $\ell$ does not have access to \THIS{}
-  (\ref{classes}).
-\item
-  Consider the case where $\ell$ has access to \THIS,
-  and $\ell$ occurs in a class or a mixin \DefineSymbol{A}.
-  A compile-time error occurs in each of the following two situations:
-  \begin{itemize}
-  \item
-    The interface of $A$ does not have a member named $n$,
-    but it does have a member with basename \id.
-  \item
-    The interface of $A$ does not have a member with basename \id,
-    and there is no accessible extension $E$
-    such that $A$ matches the \ON{} type of $E$,
-    and $E$ has an instance member with basename \id.
-  \end{itemize}
-  \commentary{%
-    In other words, we get an error if
-    we find a getter, but we are looking for a setter, or vice versa;
-    and we get an error if we cannot find anything at all.%
-  }
-\item
-  \BlindDefineSymbol{E, T}%
-  Consider the case where $\ell$ has access to \THIS,
-  and $\ell$ occurs in an extension $E$ with \ON{} type $T$.
-  A compile-time error occurs in the following two situations:
-  \begin{itemize}
-  \item
-    The interface of $T$ does not have a member named $n$,
-    but it does have a member with basename \id.
-  \item
-    The interface of $T$ does not have a member with basename \id,
-    and there is no accessible extension $E_1$,
-    such that $T$ matches the \ON{} type of $E_1$,
-    and $E_1$ has an instance member named $n$.
-  \end{itemize}
-\end{itemize}
-\vspace{-2ex}
+If $\ell$ does not have access to \THIS{}
+(\ref{classes}),
+a compile-time error occurs.
 \EndCase
-
-\commentary{%
-We could describe these rules as having a built-in priority system:
-The lexically enclosing scopes have the highest priority;
-members of the interface of \THIS{} have the next priority;
-and implicitly invoked extension methods have the lowest priority.%
-}
 
 \rationale{%
 We are always looking up \emph{both} \id{} and \code{\id=},
@@ -15990,12 +15958,13 @@ and we could say that this ``pair'' shadows $s$:%
 % extension member.
 
 \LMHash{}%
-Now proceed as described in the first applicable case from the following list:
+If no error occurred,
+proceed as described in the first applicable case from the following list:
 
 \begin{itemize}
 \item
   When $D$ does not exist,
-  the lexical lookup yields the value \PrependThisValue.
+  the lexical lookup yields \PrependThisValue.
   \commentary{%
     In this case it is guaranteed that $\ell$ has access to \THIS,
     and there is a class or extension instance member
@@ -16016,8 +15985,7 @@ Now proceed as described in the first applicable case from the following list:
   a class or mixin $A$.
   The lexical lookup then yields \PrependThisValue.
   \commentary{%
-    In this case it is guaranteed that $\ell$ has access to \THIS,
-    and there is a class instance member with the requested name.%
+    In this case it is guaranteed that $\ell$ has access to \THIS.%
   }
 \item
   % Cases covered here: $D$ is
@@ -16031,12 +15999,12 @@ Now proceed as described in the first applicable case from the following list:
   Otherwise, the lexical lookup yields $D$.
 \end{itemize}
 
-\commentary{%
+\rationale{%
 Note that a lexical lookup will never yield a declaration of
 an instance member.
 In each case where it is determined that there is no error
 and an instance member is the result of the lookup,
-the value \PrependThisValue{} is yielded.
+\PrependThisValue{} is yielded.
 
 The reason for this is that there may not be a declaration, e.g.,
 in the case where $D$ does not exist,

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -15995,8 +15995,7 @@ Now proceed as described in the first applicable case from the following list:
 \begin{itemize}
 \item
   When $D$ does not exist,
-  the lexical lookup yields the
-  special value \PrependThisValue.
+  the lexical lookup yields the value \PrependThisValue.
   \commentary{%
     In this case it is guaranteed that $\ell$ has access to \THIS,
     and there is a class or extension instance member
@@ -16014,12 +16013,11 @@ Now proceed as described in the first applicable case from the following list:
   Otherwise, the lexical lookup yields $D$.
 \item
   Consider the case where $D$ is an instance member declaration in
-  a class $C$.
+  a class or mixin $A$.
   The lexical lookup then yields \PrependThisValue.
   \commentary{%
-    It is again guaranteed that $\ell$ has access to \THIS,
-    and there is a class instance member or an applicable extension member
-    with the requested name.%
+    In this case it is guaranteed that $\ell$ has access to \THIS,
+    and there is a class instance member with the requested name.%
   }
 \item
   % Cases covered here: $D$ is
@@ -16038,7 +16036,7 @@ Note that a lexical lookup will never yield a declaration of
 an instance member.
 In each case where it is determined that there is no error
 and an instance member is the result of the lookup,
-the special value \PrependThisValue{} is yielded.
+the value \PrependThisValue{} is yielded.
 
 The reason for this is that there may not be a declaration, e.g.,
 in the case where $D$ does not exist,

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -15856,13 +15856,14 @@ even though it may have the name \id{} when $n$ is \code{\id=}, or vice versa.
 That situation may cause an error, as specified below.%
 }
 
+\LMHash{}%
+In the first step, we check for several potential errors.
+
 % Even when we have found a declaration, it may have the wrong name.
 \LMHash{}%
 \Case{$D$ exists}
 In this case, at least one declaration with basename \id{}
 is in scope at the location $\ell$.
-
-\LMHash{}%
 It is a compile-time error if the name of $D$ is not $n$,
 unless $D$ is an instance member or a local variable
 (\commentary{which may be a formal parameter}).
@@ -15874,36 +15875,18 @@ but not an error if we look for a setter and find a local variable.
 If we look for a setter and find an instance getter (or vice versa)
 it is not an error,
 because the setter could be inherited.
-That is checked below.%
+That is checked after adding \THIS{} below.%
 }
 
-%% TODO(eernst): Come NNBD, `this` is accessible in a `late` instance variable
-%% initializer, so they must also be included in the first case.
 \LMHash{}%
-% Has chosen instance member, wants getter/setter, has only the opposite.
-When $\ell$ has access to \THIS{}
-(\ref{classes})
-and is located in a class or mixin $A$,
-it is a compile-time error if $D$ is an instance member,
-and the interface of $A$ does not have a member named $n$.
-% Has chosen extension instance member, wants getter/setter,
-% has only the opposite.
-When $\ell$ has access to \THIS{}
-and occurs in an extension $E$,
-it is a compile-time error if $D$ is an instance member,
-and the name of $D$ is not $n$.
-% No access to this.
-When $\ell$ does not have access to \THIS,
-it is a compile-time error if $D$ is an instance member.
-% An instance variable initializer is in the body scope, so it is
-% actually possible for $D$ to be an instance member here.
+If $D$ is an instance member,
+it is a compile-time error if $\ell$ does not have access to \THIS.
 \EndCase
 
 \LMHash{}%
 \Case{$D$ does not exist}
-If $\ell$ does not have access to \THIS{}
-(\ref{classes}),
-a compile-time error occurs.
+It is a compile-time error if $\ell$ does not have access to \THIS{}
+(\ref{classes}).
 \EndCase
 
 \rationale{%
@@ -15940,25 +15923,8 @@ and we could say that this ``pair'' shadows $s$:%
 \}
 \end{dartCode}
 
-% At this point we know that
-% - $D$ does not exist, but $\ell$ has access to `this` and the interface of
-%   the enclosing class / of the on-type of the enclosing extension has
-%   a member named $n$, or
-% - $D$ exists and has name $n$, and $\ell$ cannot access `this`, or
-% - $\ell$ occurs in a class $C$, $D$ exists, its name can be different from
-%   $n$, but $\ell$ has access to `this`, and the interface of $C$ has a
-%   member named $n$, or
-% - $\ell$ occurs in an extension $E$, $D$ exists and is a static or instance
-%   member with the name $n$ (and access to `this` exists in the latter case),
-%   or
-% - $D$ exists and is a local variable named \id, and $n$ is \code{\id=}.
-%
-% The lookup yields \PrependThisValue iff $\ell$ has access to `this` and
-% $D$ does not exist or $D$ is an instance member of a class or an applicable
-% extension member.
-
 \LMHash{}%
-If no error occurred,
+In the second and last step, if no error occurred,
 proceed as described in the first applicable case from the following list:
 
 \begin{itemize}
@@ -15967,8 +15933,10 @@ proceed as described in the first applicable case from the following list:
   the lexical lookup yields \PrependThisValue.
   \commentary{%
     In this case it is guaranteed that $\ell$ has access to \THIS,
-    and there is a class or extension instance member
-    with the requested name.%
+    and $n$ will be treated as \code{\THIS.$n$}.
+    But errors may still occur, e.g.,
+    because there is no member of the interface of \THIS{} named $n$,
+    and also no accessible and applicable extension method.%
   }
 \item
   Consider the case where $D$ is a formal type parameter declaration
@@ -15985,7 +15953,8 @@ proceed as described in the first applicable case from the following list:
   a class or mixin $A$.
   The lexical lookup then yields \PrependThisValue.
   \commentary{%
-    In this case it is guaranteed that $\ell$ has access to \THIS.%
+    In this case it is guaranteed that $\ell$ has access to \THIS,
+    but some errors may still occur.%
   }
 \item
   % Cases covered here: $D$ is

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -15828,7 +15828,7 @@ it is understood that the lookup is performed from
 the location of the given occurrence of \id.
 
 \LMHash{}%
-Let \DefineSymbol{S} be the innermost lexical scope containing $\ell$
+Let $S$ be the innermost lexical scope containing $\ell$
 which has a declaration with basename \id.
 In the case where $S$ has
 a declaration named \id{} as well as a declaration named \code{\id=},

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -15853,22 +15853,41 @@ the following errors apply:
   It is a compile-time error if $\ell$ does not have access to \THIS{}
   (\ref{classes}).
 \item
-  When $\ell$ has access to \THIS{}
-  it is a compile-time error if $\ell$ occurs in
-  a class \DefineSymbol{C} and
-  the interface of $C$ does not have a member named $n$;
-  and it is a compile-time error if $\ell$ occurs in
-  an extension \DefineSymbol{E},
-  and the interface of the \ON{} type of $E$ does not have a member named $n$.
-  \commentary{%
-    So it is an error if there is no member with the right basename at all,
-    and also if there is one such member,
-    but it is a non-setter and we are looking for a setter,
-    or vice versa.%
-  }
+  Consider the case where $\ell$ has access to \THIS,
+  and $\ell$ occurs in a class \DefineSymbol{C}.
+  If the interface of $C$ has a member named $n$,
+  let \DefineSymbol{s} be the member signature of said member.
+  Otherwise, if there is an accessible extension $E$
+  such that $C$ matches the \ON{} type of $E$
+  and $E$ has an instance member named $n$,
+  let $S$ be the member signature of said member.
+  Otherwise, a compile-time error occurs.
+\item
+  \BlindDefineSymbol{E, T}%
+  Consider the case where $\ell$ has access to \THIS,
+  and $\ell$ occurs in an extension $E$ with \ON{} type $T$.
+  If the interface of $T$ has a member named $n$,
+  let \DefineSymbol{s} be the member signature of said member.
+  Otherwise, if there is an accessible extension $E_1$
+  such that $T$ matches the \ON{} type of $E_1$
+  and $E_1$ has an instance member named $n$,
+  let $s$ be the member signature of said member.
+  Otherwise, a compile-time error occurs.
 \end{itemize}
 \vspace{-2ex}
 \EndCase
+
+\commentary{%
+So it is an error if there is no member with the right basename at all,
+and no applicable extension member.  
+It is also an error if there is one such member,
+but it is a non-setter and we are looking for a setter,
+or vice versa.%
+}
+
+\LMHash{}%
+We refer to the member signature $s$ specified in the two cases above as the
+\Index{member signature found by lexical lookup}.
 
 % Even when we have found a declaration, it may have the wrong name.
 \LMHash{}%
@@ -15958,16 +15977,10 @@ Now proceed as described in the first applicable case from the following list:
 
 \begin{itemize}
 \item
-  When $D$ does not exist:
-  If $\ell$ occurs in a class \DefineSymbol{C},
-  the lexical lookup yields the member signature of
-  the member of the interface of $C$
-  which has the name $n$.
-  If $\ell$ occurs in an extension \DefineSymbol{E}
-  with \ON{} type \DefineSymbol{T_{on}},
-  the lexical lookup yields the member signature of
-  the member of the interface of $T_{on}$
-  which has the name $n$.
+  When $D$ does not exist,
+  the lexical lookup yields the
+  member signature found by lexical lookup
+  (\ref{lexicalLookup}).
   \commentary{%
     In this case it is guaranteed that $\ell$ occurs inside
     the body of an instance member or a generative constructor,

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -15860,7 +15860,7 @@ the following errors apply:
   Otherwise, if there is an accessible extension $E$
   such that $C$ matches the \ON{} type of $E$
   and $E$ has an instance member named $n$,
-  let $S$ be the member signature of said member.
+  let $s$ be the member signature of said member.
   Otherwise, a compile-time error occurs.
 \item
   \BlindDefineSymbol{E, T}%

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -50,6 +50,8 @@
 %   on itself).
 % - Add the error for a type alias $F$ used in an instance creation etc., when
 %   $F$ expands to a type variable.
+% - Correct lexical lookup rules to include implicit extension method
+%   invocation.
 %
 % 2.7
 % - Rename non-terminals `<...Definition>` to `<...Declaration>` (e.g., it is
@@ -16032,15 +16034,16 @@ Note that a lexical lookup will never yield a declaration of
 an instance member.
 In each case where it is determined that there is no error
 and an instance member is the result of the lookup,
-the member signature from the interface of the enclosing class is yielded.
+the special value \PrependThisValue{} is yielded.
 
 The reason for this is that there may not be a declaration, e.g.,
 in the case where $D$ does not exist,
 but the interface of the class has the required member
 because more than one superinterface has the same member signature
-for the given name.
-So, for uniformity, we always report that an instance member must be used
-by yielding the member signature.%
+for the given name,
+or an extension method is applicable.
+So, for uniformity,
+in these situations we always report that \THIS{} should be added.%
 }
 
 

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -12382,8 +12382,8 @@ When the lexical lookup of \id{} yields an import prefix,
 a compile-time error occurs.
 \EndCase
 
-\Case{Lexical lookup yields a member signature}
-When the lexical lookup of \id{} yields a member signature,
+\Case{Lexical lookup yields \PrependThisValue}
+When the lexical lookup of \id{} yields \PrependThisValue,
 $i$ is treated as
 (\ref{notation})
 the ordinary method invocation
@@ -12392,9 +12392,10 @@ the ordinary method invocation
 
 \commentary{%
 This occurs when the lexical lookup has determined that
-$i$ must invoke an instance member,
+$i$ must invoke an instance member of a class or an extension,
 and the location of $i$ can access \THIS{},
-and the interface of the enclosing class has a member named \id.
+and the interface of the enclosing class has a member named \id,
+or there is an applicable extension with such a member.
 Both the static analysis and evaluation proceeds with
 \code{\THIS.$i$},
 so there is no need to further specify the treatment of $i$.%
@@ -14538,7 +14539,7 @@ Perform a lexical lookup of \code{\id=} from the location of \id.
   Otherwise, a compile-time error occurs,
   unless the static type of $e$ is assignable to the parameter type of $D$.
 \item
-  When the lexical lookup yields a member signature,
+  When the lexical lookup yields \PrependThisValue,
   $a$ is treated as
   (\ref{notation})
   \code{\THIS.\id{} = $e$}.
@@ -14546,7 +14547,8 @@ Perform a lexical lookup of \code{\id=} from the location of \id.
   \commentary{%
     In this case it is known that $a$ has access to \THIS{}
     (\ref{classes}),
-    and the interface of the enclosing class has a member named \code{\id=}.
+    and the interface of the enclosing class has a member named \code{\id=},
+    or there is an applicable extension with a member named \code{\id=}.
     Both the static analysis and evaluation proceeds with
     \code{\THIS.\id{} = $e$},
     so there is no need to further specify the treatment of $a$.%
@@ -14570,7 +14572,7 @@ Perform a lexical lookup of \code{\id=} from the location of \id.
 
 \begin{itemize}
 \item
-  In the case where the lexical lookup yielded
+  In the case where the lexical lookup yields
   a declaration $D$ of a local variable $v$,
   (\commentary{which may be a formal parameter}),
   the expression $e$ is evaluated to an object $o$,
@@ -14598,7 +14600,7 @@ Perform a lexical lookup of \code{\id=} from the location of \id.
 \item
   \commentary{%
     The case where the lexical lookup of \code{\id=}
-    yields a member signature cannot occur,
+    yields \PrependThisValue{} cannot occur,
     because that case is treated as
     \code{\THIS.\id{} = $e$},
     whose evaluation is specified elsewhere.%
@@ -15769,7 +15771,11 @@ it may look up a name $n$ of the form \id{} as well as of the form \code{\id=}.
 
 \LMHash{}%
 A lexical lookup yields a result which is
-a declaration, an import prefix, or a member signature.
+a declaration, an import prefix,
+or the special value
+\Index{\PrependThisValue},
+which indicates that the lookup should be transformed into
+a member access on \THIS{}.
 A lexical lookup can not fail
 (\commentary{so it also makes no sense to say that it succeeds}):
 a compile-time error may occur during the lexical lookup,
@@ -15855,39 +15861,31 @@ the following errors apply:
 \item
   Consider the case where $\ell$ has access to \THIS,
   and $\ell$ occurs in a class \DefineSymbol{C}.
-  If the interface of $C$ has a member named $n$,
-  let \DefineSymbol{s} be the member signature of said member.
-  Otherwise, if there is an accessible extension $E$
+  A compile-time error occurs
+  if the interface of $C$ does not have a member named $n$,
+  and there is no accessible extension $E$
   such that $C$ matches the \ON{} type of $E$
-  and $E$ has an instance member named $n$,
-  let $s$ be the member signature of said member.
-  Otherwise, a compile-time error occurs.
+  and $E$ has an instance member named $n$.
 \item
   \BlindDefineSymbol{E, T}%
   Consider the case where $\ell$ has access to \THIS,
   and $\ell$ occurs in an extension $E$ with \ON{} type $T$.
-  If the interface of $T$ has a member named $n$,
-  let \DefineSymbol{s} be the member signature of said member.
-  Otherwise, if there is an accessible extension $E_1$
+  A compile-time error occurs
+  if the interface of $T$ does not have a member named $n$,
+  and there is no accessible extension $E_1$
   such that $T$ matches the \ON{} type of $E_1$
-  and $E_1$ has an instance member named $n$,
-  let $s$ be the member signature of said member.
-  Otherwise, a compile-time error occurs.
+  and $E_1$ has an instance member named $n$.
 \end{itemize}
 \vspace{-2ex}
 \EndCase
 
 \commentary{%
-So it is an error if there is no member with the right basename at all,
-and no applicable extension member.  
+So it is an error if there is no member with the right basename,
+and there is also no applicable extension member with the right basename.
 It is also an error if there is one such member,
 but it is a non-setter and we are looking for a setter,
 or vice versa.%
 }
-
-\LMHash{}%
-We refer to the member signature $s$ specified in the two cases above as the
-\Index{member signature found by lexical lookup}.
 
 % Even when we have found a declaration, it may have the wrong name.
 \LMHash{}%
@@ -15969,8 +15967,9 @@ and we could say that this ``pair'' shadows $s$:%
 %   or
 % - $D$ exists and is a local variable named \id, and $n$ is \code{\id=}.
 %
-% The lookup yields a member signature iff $\ell$ has access to `this` and
-% $D$ does not exist or $D$ is an instance member of a class.
+% The lookup yields \PrependThisValue iff $\ell$ has access to `this` and
+% $D$ does not exist or $D$ is an instance member of a class or an applicable
+% extension member.
 
 \LMHash{}%
 Now proceed as described in the first applicable case from the following list:
@@ -15979,12 +15978,11 @@ Now proceed as described in the first applicable case from the following list:
 \item
   When $D$ does not exist,
   the lexical lookup yields the
-  member signature found by lexical lookup
-  (\ref{lexicalLookup}).
+  special value \PrependThisValue.
   \commentary{%
-    In this case it is guaranteed that $\ell$ occurs inside
-    the body of an instance member or a generative constructor,
-    and said member exists.%
+    In this case it is guaranteed that $\ell$ has access to \THIS,
+    and there is a class or extension instance member
+    with the requested name.%
   }
 \item
   Consider the case where $D$ is a formal type parameter declaration
@@ -15999,12 +15997,11 @@ Now proceed as described in the first applicable case from the following list:
 \item
   Consider the case where $D$ is an instance member declaration in
   a class $C$.
-  The lexical lookup then yields the member signature named $n$
-  in the interface of $C$.
+  The lexical lookup then yields \PrependThisValue.
   \commentary{%
-    It is again guaranteed that $\ell$ occurs inside
-    the body of an instance member or generative constructor of $C$,
-    and that said member exists.%
+    It is again guaranteed that $\ell$ has access to \THIS,
+    and there is a class instance member or an applicable extension member
+    with the requested name.%
   }
 \item
   % Cases covered here: $D$ is
@@ -16205,10 +16202,10 @@ in such a way that the type of $p$ is not used.%
 \EndCase
 
 \LMHash{}%
-\Case{Lexical lookup yields a member signature}
+\Case{Lexical lookup yields \PrependThisValue}
 In this case the lexical lookup
 (\ref{lexicalLookup})
-for \id{} yields a member signature $s$.
+for \id{} yields \PrependThisValue.
 %
 In this situation $e$ is treated as
 (\ref{notation})
@@ -16304,7 +16301,7 @@ will evaluate the import prefix.
 \EndCase
 
 \LMHash{}%
-\Case{Lexical lookup yields a member signature}
+\Case{Lexical lookup yields \PrependThisValue}
 This situation cannot arise,
 because this only occurs when $e$ is treated as
 \code{\THIS.\id},


### PR DESCRIPTION
The current specification of lexical lookup specifies a compile-time error in certain cases where it should specify that a name `$n$` is instead transformed into `\THIS.$n$` (which is an identifier reference or a part of an unqualified function invocation). This PR fixes that.

Note that lexical lookup yields a member signature as a "signal to caller" that the expression should have `\THIS{}` prepended. The static analysis will then proceed from scratch on the transformed expression, and this will allow us to detect that it is a regular getter/method invocation on `\THIS{}` or an implicit extension getter/method invocation.

Update: The information about _which_ member signature was yielded by a lookup was ignored (we just proceed with `this.id` resp. `this.id<...>(...)`), so I changed the lookup to yield a special value `PREPEND_THIS`.