### PR TITLE
Fix inconsistency in small-features 21Q1 feature spec

### DIFF
--- a/accepted/future-releases/small-features-21Q1/feature-specification.md
+++ b/accepted/future-releases/small-features-21Q1/feature-specification.md
@@ -36,7 +36,7 @@ We currently allow metadata to be a call to a constant constructor:
 @Deprecated("Do not use this thing")
 ```
 
-However, it is not possible to pass type arguments to the constructor invocationn:
+However, it is not possible to pass type arguments to the constructor invocation:
 
 ```dart
 @TypeHelper<int>(42, "The meaning")

--- a/accepted/future-releases/small-features-21Q1/feature-specification.md
+++ b/accepted/future-releases/small-features-21Q1/feature-specification.md
@@ -36,7 +36,7 @@ We currently allow metadata to be a call to a constant constructor:
 @Deprecated("Do not use this thing")
 ```
 
-However, the *grammar* does not allow type arguments, meaning that it's not possible to write:
+However, it is not possible to pass type arguments to the constructor invocationn:
 
 ```dart
 @TypeHelper<int>(42, "The meaning")
@@ -44,7 +44,8 @@ However, the *grammar* does not allow type arguments, meaning that it's not poss
 
 There is no technical reason for this restriction. It was just simpler, and probably didn't seem necessary at the time metadata was introduced. It does now.
 
-There is no change in the grammar, it already allows the type arguments:
+There is no change in the current grammar, it already allows the type arguments,
+and we just need to stop reporting those type arguments as an error:
 
 ```
 <metadatum> ::=


### PR DESCRIPTION
In https://github.com/dart-lang/language/pull/1513 I overlooked that the small-features-21Q1 feature spec says in _one more location_ that we have to change the grammar. This PR fixes that.