### PR TITLE
Post-hoc review response for #1468

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -19698,7 +19698,7 @@ then we say that
 %% possible enhancement for the future, and a non breaking change.
 
 \LMHash{}%
-Let $D$ be a type alias delaration,
+Let $D$ be a type alias declaration,
 and let $M$ be the transitive closure of
 the type alias declarations that $D$ depends on.
 A compile-time error occurs if $D \in M$.

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -19822,6 +19822,7 @@ Let $D$ be a type alias declaration of the form
 \code{\TYPEDEF{} $F$<\TypeParametersStd> = $T$;}
 
 \noindent
+where $s > 0$.
 \BlindDefineSymbol{Y_j}%
 Let \List{Y}{1}{s} be fresh type variables,
 assumed to satisfy the bounds of $D$.


### PR DESCRIPTION
Small adjustments to the language specification, as a follow-up on #1468.