### PR TITLE
Corrected the version number of the stable spec to 2.10 (there is no 2.11)

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -14,7 +14,7 @@
 \makeindex
 \title{Dart Programming Language Specification\\
 {5th edition}\\
-{\large Version 2.11.0}}
+{\large Version 2.10}}
 \author{}
 
 % For information about Location Markers (and in particular the
@@ -26,7 +26,7 @@
 %
 % Significant changes to the specification.
 %
-% 2.8 - 2.11
+% 2.8 - 2.10
 % - Change several warnings to compile-time errors, matching the actual
 %   behavior of tools.
 % - Eliminate error for library name conflicts in imports and exports.
@@ -43,7 +43,7 @@
 % - Integrate the specification of extension methods into this document.
 % - Specify identifier references denoting extension members.
 % - Remove a few null safety features, to enable publishing a stable
-%   version of the specification which is purely about Dart 2.11.
+%   version of the specification which is purely about Dart 2.10.
 % - Reorganize specification of type aliases to be in section 'Type Aliases'
 %   (this used to be both there, and in 'Generics').
 % - Clarify the cyclicity error for type aliases ("F is not allowed to depend


### PR DESCRIPTION
The stable language specification does not include null safety, so it should have a language version number which is lower than 2.12. The most recent stable version with that property is 2.10 (there was no 2.11), so this PR makes that correction.