### PR TITLE
Change symbolLiteral to match actual implementation, clean up reserved words formatting

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -8975,10 +8975,10 @@ a valid declaration name or a valid library name in a Dart program.
 
 \LMHash{}%
 A symbol literal \code{\#\id} where \id{} is an identifier
-that does not begin with an underscore (`\code{\_}'),
+that does not begin with an underscore (`\code{\_}') or \VOID{}
 evaluates to an instance of \code{Symbol}
-representing the identifier \id.
-All occurrences of \code{\#\id} evaluate to the same instance
+representing the identifier \id respectively \VOID.
+All occurrences of such symbol literals evaluate to the same instance
 \commentary{(symbol instances are canonicalized)},
 and no other symbol literals evaluate to that \code{Symbol} instance
 or to a \code{Symbol} instance that is equal

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -8966,34 +8966,28 @@ the concatenation of the strings $s_0$, $r_1$, \ldots, $r_n$, and $s_n$.
 \LMHash{}%
 A \IndexCustom{symbol literal}{literal!symbol}
 denotes a name that would be either
-a valid declaration name or a valid library name in a Dart program.
+a valid declaration name, a valid library name, or \VOID.
 
 \begin{grammar}
 <symbolLiteral> ::=
-  `#' (<operator> | <identifier> (`.' <identifier>)* | \VOID{})
+  `#' (<identifier> (`.' <identifier>)* | <operator> | \VOID)
 \end{grammar}
 
 \LMHash{}%
-A symbol literal \code{\#\id} where \id{} is an identifier
-that does not begin with an underscore (`\code{\_}') or \VOID{}
-evaluates to an instance of \code{Symbol}
-representing the identifier \id respectively \VOID.
-All occurrences of such symbol literals evaluate to the same instance
-\commentary{(symbol instances are canonicalized)},
-and no other symbol literals evaluate to that \code{Symbol} instance
-or to a \code{Symbol} instance that is equal
-(according to the \lit{==} operator \ref{equality}) to that instance.
+The static type of a symbol literal is \code{Symbol}.
 
 \LMHash{}%
-A symbol literal \code{\#$\id.\id_2\ldots\id_n$}
-where $\id{} \ldots \id_n$ are identifiers
+Let \id{} be an identifier that does not begin with an underscore
+(`\code{\_}').
+The symbol literal \code{\#\id}
+evaluates to an instance of \code{Symbol}
+representing the identifier \id.
+
+\LMHash{}%
+A symbol literal \code{\#$\id_1$.$\id_2$.$\cdots$.$\id_n$}
+where \List{\id}{1}{n} are identifiers
 evaluates to an instance of \code{Symbol}
 representing that particular sequence of identifiers.
-All occurrences of \code{\#$\id.\id_2\ldots\id_n$}
-with the same sequence of identifiers
-evaluate to the same instance,
-and no other symbol literals evaluate to that \code{Symbol} instance
-or to a \code{Symbol} instance that is \lit{==} to that instance.
 \commentary{%
 This kind of symbol literal denotes the name of a library declaration,
 as specified in a \synt{libraryName}.
@@ -9002,20 +8996,39 @@ if some of its identifiers begin with an underscore.%
 }
 
 \LMHash{}%
-A symbol literal \code{\#\metavar{operator}} evaluates to
-an instance of \code{Symbol}
+A symbol literal \code{\#\metavar{op}}
+where \metavar{op} is derived from \synt{operator}
+evaluates to an instance of \code{Symbol}
 representing that particular operator name.
-All occurrences of \code{\#\metavar{operator}} evaluate to the same instance,
-and no other symbol literals evaluate to that \code{Symbol} instance
-or to a \code{Symbol} instance that is \lit{==} to that instance.
 
 \LMHash{}%
-A symbol literal \code{\#\_\id}, evaluates to an instance of \code{Symbol}
+The symbol literal \code{\#void}
+evaluates to an instance of \code{Symbol}
+representing the reserved word \VOID.
+
+\LMHash{}%
+Assume that the term $t$ is an identifier \id{}
+that does not start with an underscore,
+that $t$ is \VOID,
+that $t$ is a period separated sequence of identifiers
+\code{$id_1$.$id_2$.$\cdots$.$id_n$},
+or that $t$ is derived from \synt{operator}.
+Any two occurrences of \code{\#t} evaluate to the same object
+(\commentary{that is, symbol instances are canonicalized}),
+and no other symbol literals evaluate to that object,
+nor to a \code{Symbol} instance that is equal to that object
+according to the \lit{==} operator
+(\ref{equality}).
+
+\LMHash{}%
+A symbol literal \code{\#\_\id} where \id{} is an identifier
+evaluates to an instance of \code{Symbol}
 representing the private identifier \code{\_\id} of the containing library.
 All occurrences of \code{\#\_\id} \emph{in the same library} evaluate to
-the same instance,
-and no other symbol literals evaluate to that \code{Symbol} instance
-or to a \code{Symbol} instance that is \lit{==} to that instance.
+the same object,
+and no other symbol literals evaluate to the same object,
+nor to a \code{Symbol} instance that is equal to that object
+according to the \lit{==} operator.
 
 \LMHash{}%
 The objects created by symbol literals all override
@@ -9048,9 +9061,6 @@ reflective code easier to read and write.
 The fact that symbols are easy to type and can often act as
 convenient substitutes for enums are secondary benefits.%
 }
-
-\LMHash{}%
-The static type of a symbol literal is \code{Symbol}.
 
 
 \subsection{Collection Literals}

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -8969,13 +8969,16 @@ denotes a name that would be either
 a valid declaration name or a valid library name in a Dart program.
 
 \begin{grammar}
-<symbolLiteral> ::= `#' (<operator> | (<identifier> (`.' <identifier>)*))
+<symbolLiteral> ::= `#' (<operator> | <symbolIdentifier> (`.' <symbolIdentifier>)*)
+
+<symbolIdentifier> ::= <identifier> | <reservedWord>
 \end{grammar}
 
 \LMHash{}%
-A symbol literal \code{\#\id} where \id{} is an identifier
+A symbol literal \code{\#\id} where \id{} is a symbol identifier
 that does not begin with an underscore (`\code{\_}'),
-evaluates to an instance of \code{Symbol} representing the identifier \id.
+evaluates to an instance of \code{Symbol}
+representing the symbol identifier \id.
 All occurrences of \code{\#\id} evaluate to the same instance
 \commentary{(symbol instances are canonicalized)},
 and no other symbol literals evaluate to that \code{Symbol} instance
@@ -8984,9 +8987,11 @@ or to a \code{Symbol} instance that is equal
 
 \LMHash{}%
 A symbol literal \code{\#$\id.\id_2\ldots\id_n$}
-where $\id{} \ldots \id_n$ are identifiers,
-evaluates to an instance of \code{Symbol} representing that particular sequence of identifiers.
-All occurrences of \code{\#$\id.\id_2\ldots\id_n$} with the same sequence of identifiers
+where $\id{} \ldots \id_n$ are symbol identifiers
+evaluates to an instance of \code{Symbol}
+representing that particular sequence of symbol identifiers.
+All occurrences of \code{\#$\id.\id_2\ldots\id_n$}
+with the same sequence of identifiers
 evaluate to the same instance,
 and no other symbol literals evaluate to that \code{Symbol} instance
 or to a \code{Symbol} instance that is \lit{==} to that instance.
@@ -8998,7 +9003,8 @@ if some of its identifiers begin with an underscore.%
 }
 
 \LMHash{}%
-A symbol literal \code{\#\metavar{operator}} evaluates to an instance of \code{Symbol}
+A symbol literal \code{\#\metavar{operator}} evaluates to
+an instance of \code{Symbol}
 representing that particular operator name.
 All occurrences of \code{\#\metavar{operator}} evaluate to the same instance,
 and no other symbol literals evaluate to that \code{Symbol} instance
@@ -9007,7 +9013,8 @@ or to a \code{Symbol} instance that is \lit{==} to that instance.
 \LMHash{}%
 A symbol literal \code{\#\_\id}, evaluates to an instance of \code{Symbol}
 representing the private identifier \code{\_\id} of the containing library.
-All occurrences of \code{\#\_\id} \emph{in the same library} evaluate to the same instance,
+All occurrences of \code{\#\_\id} \emph{in the same library} evaluate to
+the same instance,
 and no other symbol literals evaluate to that \code{Symbol} instance
 or to a \code{Symbol} instance that is \lit{==} to that instance.
 
@@ -16048,6 +16055,13 @@ An \Index{identifier expression} consists of a single identifier; it provides ac
 
 <qualifiedName> ::= <typeIdentifier> `.' <identifier>
   \alt <typeIdentifier> `.' <typeIdentifier> `.' <identifier>
+
+<LETTER> ::= `a' .. `z'
+  \alt `A' .. `Z'
+
+<DIGIT> ::= `0' .. `9'
+
+<WHITESPACE> ::= (`\\t' | ` ' | <NEWLINE>)+
 \end{grammar}
 
 \LMHash{}%
@@ -21424,17 +21438,28 @@ At any point in the tokenization process, the longest possible token is recogniz
 \LMLabel{reservedWords}
 
 \LMHash{}%
-A \Index{reserved word} may not be used as an identifier; it is a compile-time error if a reserved word is used where an identifier is expected.
+A \Index{reserved word} can only be used in the syntactic positions
+specified by the grammar.
+In particular, a compile-time error occurs if a reserved word is used
+where an identifier is expected.
 
-\ASSERT{}, \BREAK{}, \CASE{}, \CATCH{}, \CLASS{}, \CONST{}, \CONTINUE{}, \DEFAULT{}, \DO{}, \ELSE{}, \ENUM{}, \EXTENDS{}, \FALSE{}, \FINAL{}, \FINALLY{}, \FOR{}, \IF{}, \IN{}, \IS{}, \NEW{}, \NULL{}, \RETHROW, \RETURN{}, \SUPER{}, \SWITCH{}, \THIS{}, \THROW{}, \TRUE{}, \TRY{}, \VAR{}, \VOID{}, \WHILE{}, \WITH{}.
+\commentary{%
+Note that reserved words occur bold and unquoted in grammar rules
+(e.g., \ASSERT{})
+even though the consistent notation would use quotes
+(e.g., \lit{assert}).
+This notational abuse occurs because we believe
+it makes the grammar rules more readable.%
+}
 
 \begin{grammar}
-<LETTER> ::= `a' .. `z'
-  \alt `A' .. `Z'
-
-<DIGIT> ::= `0' .. `9'
-
-<WHITESPACE> ::= (`\\t' | ` ' | <NEWLINE>)+
+<reservedWord> ::= \ASSERT{} | \BREAK{} | \CASE{} | \CATCH{} |
+    \CLASS{} | \CONST{} | \CONTINUE{}
+  \alt\hspace{-3mm} \DEFAULT{} | \DO{} | \ELSE{} | \ENUM{} | \EXTENDS{} |
+    \FALSE{} | \FINAL{} | \FINALLY{} | \FOR{} | \IF{} | \IN{} | \IS{}
+  \alt\hspace{-3mm} \NEW{} | \NULL{} | \RETHROW{} | \RETURN{} | \SUPER{} |
+    \SWITCH{} | \THIS{} | \THROW{} | \TRUE{} | \TRY{}
+  \alt\hspace{-3mm} \VAR{} | \VOID{} | \WHILE{} | \WITH{}
 \end{grammar}
 
 

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -8969,16 +8969,15 @@ denotes a name that would be either
 a valid declaration name or a valid library name in a Dart program.
 
 \begin{grammar}
-<symbolLiteral> ::= `#' (<operator> | <symbolIdentifier> (`.' <symbolIdentifier>)*)
-
-<symbolIdentifier> ::= <identifier> | <reservedWord>
+<symbolLiteral> ::=
+  `#' (<operator> | <identifier> (`.' <identifier>)* | \VOID{})
 \end{grammar}
 
 \LMHash{}%
-A symbol literal \code{\#\id} where \id{} is a symbol identifier
+A symbol literal \code{\#\id} where \id{} is an identifier
 that does not begin with an underscore (`\code{\_}'),
 evaluates to an instance of \code{Symbol}
-representing the symbol identifier \id.
+representing the identifier \id.
 All occurrences of \code{\#\id} evaluate to the same instance
 \commentary{(symbol instances are canonicalized)},
 and no other symbol literals evaluate to that \code{Symbol} instance
@@ -8987,9 +8986,9 @@ or to a \code{Symbol} instance that is equal
 
 \LMHash{}%
 A symbol literal \code{\#$\id.\id_2\ldots\id_n$}
-where $\id{} \ldots \id_n$ are symbol identifiers
+where $\id{} \ldots \id_n$ are identifiers
 evaluates to an instance of \code{Symbol}
-representing that particular sequence of symbol identifiers.
+representing that particular sequence of identifiers.
 All occurrences of \code{\#$\id.\id_2\ldots\id_n$}
 with the same sequence of identifiers
 evaluate to the same instance,


### PR DESCRIPTION
This CL changes symbol literals to allow `#void`, because we have allowed that for several years.

We have had the test `tests/corelib/symbol_reserved_word_test.dart` since 2014, but it is badly flawed. In particular, it is a multi-test, but it tests many cases where a compile-time error is expected using `//# ...: continued`, which means that the test will pass as long as at least one of the desired compile-time errors occur. However, some parts of the test have been executed in a meaningful manner, so we do have a history of behavior from this test. The analyzer has no current failures on this test, so it's a non-breaking change to specify the behavior that it actually tests.

I've changed the test to express the intent stated in comments in that file (https://dart-review.googlesource.com/c/sdk/+/195503). In particular, it is no longer a multi-test, which fixes the logical error.

However, the test claims that `#void` and `const Symbol('void')` should not be a compile-time error, and that `new Symbol('void')` should not be a run-time error. This is the change which is reflected by this PR.

`#void.foo` is flagged as an error by the analyzer and expected to be an error (so it's not a breaking change to keep considering this to be an error). It does change the reason: `#void` is accepted, and `.foo` is a member access on that symbol, so the error is now that `Symbol` does not have a `foo`. However, that's not a breaking change.

`#foo.void` was a syntax error and remains a syntax error.

The remaining part of `symbol_reserved_word_test.dart` tests that `#word` is an error whenever `word` is a reserved word, and that is also true after this PR.

I have no idea why `#void` was allowed (even though the spec never said so), but I suspect that it could be because that symbol occurs somewhere in the result of an invocation of a `dart:mirrors` method. In any case, it seems safe and non-breaking to add support for `#void` and keep all the other reserved words an error.

Finally, this PR cleans up the formatting of the reserved words and moves a couple of lexical rules away from section 'Reserved Words' and into the section where the only reference to those rules occurs.