### PR TITLE
Add `<metadata>` to parameter types

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -19311,8 +19311,8 @@ but it is the least upper bound of all function types.%
 <normalParameterTypes> ::= \gnewline{}
   <normalParameterType> (`,' <normalParameterType>)*
 
-<normalParameterType> ::= <typedIdentifier>
-  \alt <type>
+<normalParameterType> ::= <metadata> <typedIdentifier>
+  \alt <metadata> <type>
 
 <optionalParameterTypes> ::= <optionalPositionalParameterTypes>
   \alt <namedParameterTypes>
@@ -19323,7 +19323,7 @@ but it is the least upper bound of all function types.%
   `\{' <namedParameterType> (`,' <namedParameterType>)* `,'? `\}'
 
 <namedParameterType> ::=
-  \REQUIRED? <typedIdentifier>
+  <metadata> \REQUIRED? <typedIdentifier>
 
 <typedIdentifier> ::= <type> <identifier>
 \end{grammar}


### PR DESCRIPTION
Tiny grammar change, to align the spec with the impl:

The implementations support metadata on parameter types, e.g., `void Function(@deprecated int)`, and the test `language/metadata/metadata_location_test.dart` already contains test cases for that feature.

The language specification grammar does not allow for metadata in this location, but this is most likely by accident, and the feature does not seem to cause any problems.

Hence, this PR updates the language specification to allow it.
