### PR TITLE
Correct typo about extension specificity

### DIFF
--- a/accepted/2.7/static-extension-methods/feature-specification.md
+++ b/accepted/2.7/static-extension-methods/feature-specification.md
@@ -293,7 +293,7 @@ extension SmartList<T> on List<T> {
   x.doTheSmartThing(print);
 ```
 
-Here both the extensions apply, but the `SmartList` extension is more specific than the `SmartIterable` extension because `List<dynamic>` &lt;: `Iterable<dynamic>`.
+Here both the extensions apply, but the `SmartList` extension is more specific than the `SmartIterable` extension because `List<int>` &lt;: `Iterable<int>`.
 
 Example:
 

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -6207,7 +6207,7 @@ when multiple applicable extensions are available.%
 \commentary{%
 Here both of the extensions apply,
 but \code{ExtendList} is more specific than \code{ExtendIterable} because
-\SubtypeNE{\code{List<dynamic>}}{\code{Iterable<dynamic>}}.%
+\SubtypeNE{\code{List<int>}}{\code{Iterable<int>}}.%
 }
 
 \begin{dartCode}


### PR DESCRIPTION
One of the examples about extension specificity gives an incorrect reason for why one is more specific than the other, this PR fixes that.