### PR TITLE
Correct `part of` syntax

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -19558,7 +19558,7 @@ may be found.
 \begin{grammar}
 <partDirective> ::= <metadata> \PART{} <uri> `;'
 
-<partHeader> ::= <metadata> \PART{} \OF{} <identifier> (`.' <identifier>)* `;'
+<partHeader> ::= <metadata> \PART{} \OF{} (<dottedIdentifierList> | <uri>) `;'
 
 <partDeclaration> ::= <partHeader> <topLevelDeclaration>* <EOF>
 \end{grammar}
@@ -19573,7 +19573,8 @@ as discussed in Sect.~\ref{librariesAndScripts}.%
 
 \LMHash{}%
 A \Index{part header} begins with \PART{} \OF{} followed by
-the name of the library the part belongs to.
+the name of the library the part belongs to,
+or a \synt{uri} denoting said library.
 A part declaration consists of a part header followed by
 a sequence of top-level declarations.
 


### PR DESCRIPTION
Tiny bug fix, cf. https://github.com/dart-lang/sdk/issues/45916:

The specification currently allows for a `part of` directive where the enclosing library is specified using `<identifier> ('.' <identifier>)*`, but not using `<uri>`. The latter is intended to work, and it has been working in all tools for a while, and this PR just brings the specification up to date.