### PR TITLE
Make it explicit that "let $S$ be a class" can go via a type alias

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -20458,6 +20458,15 @@ and $T$ is not regular-bounded.
 \}
 \end{dartCode}
 
+\LMHash{}%
+When we use phrases like `let $S$ be a class' or `assume that $S$ is a mixin',
+it is understood that this includes the case where
+$S$ is a \synt{typeName} denoting a type alias, or
+$S$ is a parameterized type of the form
+\syntax{<typeName> <typeArguments>}
+where the type name denotes a type alias,
+and the transitive alias expansion of $S$ denotes a class respectively a mixin.
+
 
 \subsection{Subtypes}
 \LMLabel{subtypes}


### PR DESCRIPTION
It is currently specified in the section `Type Aliases` of the language specification that it is an error if a type alias expands to a type variable and it is used as a mixin. So type aliases expanding to a mixin are already covered.

However, it is not specified at various usage locations that type aliases are included. They _are_ mentioned in connection with `extends` and `implements` and `with`, but, for instance, not in the section about mixin application.

This PR adds a paragraph where it is stated that it is in general implied that a term `$S$` can be a type alias that transitively expands to a class when we say things like "let `$S$` be a class".
