### PR TITLE
Fix several double word typos, cf. dart-lang/language#1682

### DIFF
--- a/accepted/2.1/super-mixins/mixin-inference.md
+++ b/accepted/2.1/super-mixins/mixin-inference.md
@@ -101,7 +101,7 @@ set exists, then it is an error.  Note that for well-formed programs, the only
 free type variables in the `Ti` must by definition be drawn from the type
 parameters to the enclosing class of the mixin application. Hence it follows
 both that the `Ti` are well-formed types in the scope of the mixin application,
-and that the the `Xi` do not occur free in the `Ti` since we have assumed that
+and that the `Xi` do not occur free in the `Ti` since we have assumed that
 classes are suitably renamed to avoid capture.
 
 Let `[X0 extends B0, ..., Xj extends Bj]` be a set of type variable bounds such

--- a/accepted/2.12/nnbd/feature-specification.md
+++ b/accepted/2.12/nnbd/feature-specification.md
@@ -273,7 +273,7 @@ For example, `{ a?[b]:c }` can be parsed either as a set literal or a map
 literal, depending on whether the `?` is interpreted as part of a null aware
 subscript or as part of a conditional expression.  Whenever there is a sequence
 of tokens which may be parsed either as a conditional expression or as two
-expressions separated by a colon, the first of which is a a null aware
+expressions separated by a colon, the first of which is a null aware
 subscript, parsers shall choose to parse as a conditional expression.
 
 
@@ -1169,7 +1169,7 @@ First, _L_ is compiled as a library as specified above.
 Then, the top-level function defined by `main`
 in the exported namespace of _L_ is invoked as follows:
 
-If `main` can be called with with two positional arguments,
+If `main` can be called with two positional arguments,
 it is invoked with the following two actual arguments:
 
 - An object whose run-time type implements `List<String>`.

--- a/accepted/2.3/control-flow-collections/implementation-plan.md
+++ b/accepted/2.3/control-flow-collections/implementation-plan.md
@@ -19,7 +19,7 @@ flag][]. Tools must be passed the flag
 
 While this feature is under development, individual tools may have incomplete or
 changing implementations behind the flag. When all tools have completely
-implemented the feature, the the feature will be enabled by default, and the
+implemented the feature, the feature will be enabled by default, and the
 flag removed in a stable release.
 
 ### Tests

--- a/accepted/2.5/constant-update-2018/implementation-plan.md
+++ b/accepted/2.5/constant-update-2018/implementation-plan.md
@@ -24,7 +24,7 @@ to users.
 
 While developing, individual tools may have incomplete implementations behind the flag.
 When all tools have completely implemented the feature,
-the the feature will be enabled, and the flag removed, in a stable release.
+the feature will be enabled, and the flag removed, in a stable release.
 
 
 ### Phase 0 (Prerequisite)

--- a/accepted/2.5/contravariant-superinterface-2018/feature-specification.md
+++ b/accepted/2.5/contravariant-superinterface-2018/feature-specification.md
@@ -45,7 +45,7 @@ whose corresponding parameter type is `int`.
 
 Note that the heap invariant is violated during execution at the point
 where `a` is initialized, even though the program has no error according
-the the existing rules (before the inclusion of this feature).
+to the existing rules (before the inclusion of this feature).
 
 The underlying issue is that the contravariant usage of a type variable in
 a superinterface creates a twisted subtype lattice where `B` "goes in one

--- a/accepted/2.7/static-extension-methods/feature-specification.md
+++ b/accepted/2.7/static-extension-methods/feature-specification.md
@@ -265,7 +265,7 @@ Let *i* be a member invocation with target expression `e` and corresponding memb
 
 1. The `E2` extension is declared in a platform library and the `E1` extension is not, or
 2. either both or neither are declared in platform libraries and
-3. *T<sub>1</sub>* is a subtype of of *T<sub>2</sub>* and either
+3. *T<sub>1</sub>* is a subtype of *T<sub>2</sub>* and either
 4. not vice versa, or
 5. the instantiate-to-bounds `on` type of `E1` is a subtype of the instantiate-to-bounds `on` type of `E2` and not vice versa.
 

--- a/accepted/2.7/static-extension-methods/implementation-plan.md
+++ b/accepted/2.7/static-extension-methods/implementation-plan.md
@@ -19,7 +19,7 @@ flag][]. Tools must be passed the flag
 
 While this feature is under development, individual tools may have incomplete or
 changing implementations behind the flag. When all tools have completely
-implemented the feature, the the feature will be enabled by default, and the
+implemented the feature, the feature will be enabled by default, and the
 flag removed in a stable release.
 
 ### Tests

--- a/accepted/2.7/static-extension-methods/old/feature-specification-draft14.md
+++ b/accepted/2.7/static-extension-methods/old/feature-specification-draft14.md
@@ -246,7 +246,7 @@ Let *i* be a member invocation with target expression `e` and corresponding memb
 
 1. The `E2` extension is declared in a platform library and the `E1` extension is not, or
 2. either both or neither are declared in platform libraries and
-3. *T<sub>1</sub>* is a subtype of of *T<sub>2</sub>* and either
+3. *T<sub>1</sub>* is a subtype of *T<sub>2</sub>* and either
 4. not vice versa, or
 5. the instantiate-to-bounds `on` type of `E1` is a subtype of the instantiate-to-bounds `on` type of `E2` and not vice versa.
 

--- a/accepted/2.7/static-extension-methods/old/lrn-strawman.md
+++ b/accepted/2.7/static-extension-methods/old/lrn-strawman.md
@@ -305,7 +305,7 @@ Bar<num, num> bar = Bar<int, double>();
 main() { var list = bar.baz(); }
 ```
 
-The static type of `list` will be `List<num>`, that much is certain. However, we can't bind `T` at run-time to _the_ run-time type argument of `Bar` because there are two values. We _do not_ want to compute the least-upper-bound of the two two run-time types. We also do not want to fail at run-time. That doesn't really leave us with any good solution except using the static type.
+The static type of `list` will be `List<num>`, that much is certain. However, we can't bind `T` at run-time to _the_ run-time type argument of `Bar` because there are two values. We _do not_ want to compute the least-upper-bound of the two run-time types. We also do not want to fail at run-time. That doesn't really leave us with any good solution except using the static type.
 
 The problem with this example was ambiguity. We cannot extract _the_ run-time type argument when the type variable occurs more than once in the type constraint list. We _can_ if it occurs exactly once.
 

--- a/accepted/README.md
+++ b/accepted/README.md
@@ -1,7 +1,7 @@
 # Accepted language features
 
 This directory holds feature specifications, implementation plan documents, etc.
-for accepted Dart language changes changes. 
+for accepted Dart language changes. 
 
 For the full Dart Language Specification, please see our homepage:
 https://www.dartlang.org/guides/language/spec

--- a/accepted/future-releases/constructor-tearoffs/feature-specification.md
+++ b/accepted/future-releases/constructor-tearoffs/feature-specification.md
@@ -381,7 +381,7 @@ The grammar changes necessary for these changes will be provided separately (lik
 
 ## Summary
 
-We allow `TypeName.name` and `TypeName<typeArgs>.name`, when not followed by a type argument list or function argument list, as expressions which creates tear-offs of the the constructor `TypeName.name`.  The `TypeName` can refer to a class declaration or to a type alias declaration which aliases a class.
+We allow `TypeName.name` and `TypeName<typeArgs>.name`, when not followed by a type argument list or function argument list, as expressions which creates tear-offs of the constructor `TypeName.name`.  The `TypeName` can refer to a class declaration or to a type alias declaration which aliases a class.
 
 ```dart
 typedef ListList<T> = List<List<T>>;

--- a/accepted/future-releases/small-features-21Q1/implementation-plan.md
+++ b/accepted/future-releases/small-features-21Q1/implementation-plan.md
@@ -19,7 +19,7 @@ flag][]. Tools must be passed the flag
 
 While this feature is under development, individual tools may have incomplete or
 changing implementations behind the flag. When all tools have completely
-implemented the feature, the the feature will be enabled by default, and the
+implemented the feature, the feature will be enabled by default, and the
 flag removed in a stable release.
 
 ### "triple-shift" Experimental flag

--- a/archive/feature-specifications/covariant-overrides.md
+++ b/archive/feature-specifications/covariant-overrides.md
@@ -146,7 +146,7 @@ For a covariant parameter, the override rule is that its type must be
 either a supertype or a subtype of the type declared for the corresponding
 parameter in each of the directly or indirectly overridden declarations.
 
-*For a parameter which is not covariant, the override rule is is unchanged:
+*For a parameter which is not covariant, the override rule is unchanged:
 its type must be a supertype of the type declared for the corresponding
 parameter in each directly overridden declaration. This includes the
 typical case where the type does not change, because any type is a
@@ -445,7 +445,7 @@ can be implemented, and both choices provide a certain amount of protection
 against tightening types by accident. We have chosen the permissive variant,
 and it is always possible to make a linter require a stricter one.
 
-For a regular (non-covariant) parameter, the override rule is is unchanged:
+For a regular (non-covariant) parameter, the override rule is unchanged:
 its type must be a supertype of the type declared for the same parameter in
 each directly overridden declaration. This includes the typical case where the
 type does not change, because any type is a supertype of itself.

--- a/archive/feature-specifications/generalized-void.md
+++ b/archive/feature-specifications/generalized-void.md
@@ -208,7 +208,7 @@ the type void is treated as being the built-in class `Object`.
 
 *Dart 1.x does not support generic function types dynamically, because they
 are erased to regular function types during compilation. Hence there is no
-need to specify the the typing relations for generic function types. In
+need to specify the typing relations for generic function types. In
 Dart 2, the subtype relationship for generic function types follows from
 the rule that the type void is treated as `Object`.*
 

--- a/archive/feature-specifications/instantiate-to-bound.md
+++ b/archive/feature-specifications/instantiate-to-bound.md
@@ -8,7 +8,7 @@
 
 Based on [this description](https://github.com/dart-lang/sdk/issues/27526#issuecomment-260021397) by leafp@.
 
-**This document** is an informal specification of the the instantiate to
+**This document** is an informal specification of the instantiate to
 bound mechanism in Dart 2. The feature described here, *instantiate to
 bound*, makes it possible to omit some or all actual type arguments in some
 types using generic classes. The missing type arguments will be added

--- a/archive/feature-specifications/mixin-inference.md
+++ b/archive/feature-specifications/mixin-inference.md
@@ -123,7 +123,7 @@ set exists, then it is an error.  Note that for well-formed programs, the only
 free type variables in the `Ti` must by definition be drawn from the type
 parameters to the enclosing class of the mixin application. Hence it follows
 both that the `Ti` are well-formed types in the scope of the mixin application,
-and that the the `Xi` do not occur free in the `Ti` since we have assumed that
+and that the `Xi` do not occur free in the `Ti` since we have assumed that
 classes are suitably renamed to avoid capture.
 
 Let `[X0 extends B0, ..., Xj extends Bj]` be a set of type variable bounds such

--- a/doc/life_of_a_language_feature.md
+++ b/doc/life_of_a_language_feature.md
@@ -38,7 +38,7 @@ Proposals may be iterated on in-place.
 
 As mentioned, alternative proposals should have their own issue and writeup.
 
-All proposals should be linked from and link to the the 'request' for
+All proposals should be linked from and link to the 'request' for
 the user problem/feature request they are trying to address.
 
 ### External (outside of the language team) feedback

--- a/resources/type-system/flow-analysis.md
+++ b/resources/type-system/flow-analysis.md
@@ -258,7 +258,7 @@ We also make use of the following auxiliary functions:
   where `r2` is `r` with `true` pushed as the top element of the stack.
 
 - `drop(M)`, where `M = FlowModel(r, VM)` is defined as `FlowModel(r1, VM)`
-  where where `r` is of the form `n0::r1`.  This is the flow model which drops
+  where `r` is of the form `n0::r1`.  This is the flow model which drops
   the reachability information encoded in the top entry in the stack.
 
 - `unsplit(M)`, where `M = FlowModel(r, VM)` is defined as `M1 = FlowModel(r1,

--- a/resources/type-system/inference.md
+++ b/resources/type-system/inference.md
@@ -1006,7 +1006,7 @@ propagation?
   signature.
   - In general, if the function signature is compatible with the context type,
     take any available information from the context.  If the function signature
-    is not compatible, this this should always be a type error anyway, so
+    is not compatible, this should always be a type error anyway, so
     implementations should be free to choose the best error recovery path.
   - The monomorphic case can be treated as a degenerate case of the polymorphic
     rule

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -2539,7 +2539,7 @@ unless each of them has parameters and types such that they satisfy
 the corresponding member signature.
 But when there is a non-trivial \code{noSuchMethod} it is allowed
 to leave some members unimplemented,
-and it is allowed to to have a \code{noSuchMethod} forwarder which does not
+and it is allowed to have a \code{noSuchMethod} forwarder which does not
 satisfy the class interface
 (in which case it will be overridden by another \code{noSuchMethod} forwarder).%
 }


### PR DESCRIPTION
This PR just fixes a bunch of typos where the same word is repeated twice, and the author was unlikely to intend that that word should be repeated.