### PR TITLE
Fix placement of metadata in required named parameters

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -1986,7 +1986,8 @@ Optional parameters may be specified and provided with default values.
 <defaultFormalParameter> ::= <normalFormalParameter> (`=' <expression>)?
 
 <defaultNamedParameter> ::= \gnewline{}
-  \REQUIRED? <normalFormalParameter> ((`=' | `:') <expression>)?
+  <metadata> \REQUIRED? <normalFormalParameterNoMetadata>
+  ((`=' | `:') <expression>)?
 \end{grammar}
 
 The form \syntax{<normalFormalParameter> `:' <expression>}


### PR DESCRIPTION
Without this I believe the grammar specifies that the `required` keyword appears before metadata.

If this change doesn't get the LaTex right and it would be easier to just make the change yourself than to explain to me what to do I won't be offended if you just close the PR.