### PR TITLE
Restore errors about derived mixins

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -5248,7 +5248,7 @@ A mixin describes the difference between a class and its superclass.
 A mixin is either derived from an existing class declaration
 or introduced by a mixin declaration.
 It is a compile-time error to derive a mixin from
-a class that explicitly declares a generative constructor,
+a class that declares a generative constructor,
 or from a class that has a superclass other than \code{Object}.
 
 \LMHash{}%

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -5247,6 +5247,9 @@ if{}f the following criteria are all satisfied:
 A mixin describes the difference between a class and its superclass.
 A mixin is either derived from an existing class declaration
 or introduced by a mixin declaration.
+It is a compile-time error to derive a mixin from
+a class that explicitly declares a generative constructor,
+or from a class that has a superclass other than \code{Object}.
 
 \LMHash{}%
 Mixin application occurs when one or more mixins are mixed into
@@ -5292,8 +5295,6 @@ Let $D$ be a mixin application class declaration of the form
 It is a compile-time error if $S$ is an enumerated type (\ref{enums}).
 It is a compile-time error if any of $M_1, \ldots, M_k$ is an enumerated type
 (\ref{enums}).
-It is a compile-time error if a well formed mixin
-cannot be derived from each of $M_1, \ldots, M_k$.
 
 \LMHash{}%
 The effect of $D$ in library $L$ is to introduce the name $N$ into


### PR DESCRIPTION
Commit 89347169c715d39e5d3e6ae588cd2bdcbb875492 removed two errors from the language specification: It is an error to derive a mixin from a class whose superclass is not `Object`, or a class that explicitly declares a generative constructor. This PR restores those two errors. We do not have the required language design needed in order to lift those restrictions, so they should be restored.

There is no associated implementation effort, the errors have been reported by the CFE and the analyzer all the time.