### PR TITLE
Grammar fix: Add support for covariant late final instance variables

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -2409,8 +2409,8 @@ or via mixin applications (\ref{mixinApplication}).
   \alt \STATIC{} \FINAL{} <type>? <staticFinalDeclarationList>
   \alt \STATIC{} \LATE{} \FINAL{} <type>? <initializedIdentifierList>
   \alt \STATIC{} \LATE? <varOrType> <initializedIdentifierList>
-  \alt \COVARIANT{} \LATE? <varOrType> <initializedIdentifierList>
   \alt \COVARIANT{} \LATE{} \FINAL{} <type>? <initializedIdentifierList>
+  \alt \COVARIANT{} \LATE? <varOrType> <initializedIdentifierList>
   \alt \LATE? \FINAL{} <type>? <initializedIdentifierList>
   \alt \LATE? <varOrType> <initializedIdentifierList>
   \alt <redirectingFactoryConstructorSignature>

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -2410,6 +2410,7 @@ or via mixin applications (\ref{mixinApplication}).
   \alt \STATIC{} \LATE{} \FINAL{} <type>? <initializedIdentifierList>
   \alt \STATIC{} \LATE? <varOrType> <initializedIdentifierList>
   \alt \COVARIANT{} \LATE? <varOrType> <initializedIdentifierList>
+  \alt \COVARIANT{} \LATE{} \FINAL{} <type>? <initializedIdentifierList>
   \alt \LATE? \FINAL{} <type>? <initializedIdentifierList>
   \alt \LATE? <varOrType> <initializedIdentifierList>
   \alt <redirectingFactoryConstructorSignature>

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -2409,7 +2409,7 @@ or via mixin applications (\ref{mixinApplication}).
   \alt \STATIC{} \FINAL{} <type>? <staticFinalDeclarationList>
   \alt \STATIC{} \LATE{} \FINAL{} <type>? <initializedIdentifierList>
   \alt \STATIC{} \LATE? <varOrType> <initializedIdentifierList>
-  \alt \COVARIANT{} \LATE{} \FINAL{} <type>? <initializedIdentifierList>
+  \alt \COVARIANT{} \LATE{} \FINAL{} <type>? <identifierList>
   \alt \COVARIANT{} \LATE? <varOrType> <initializedIdentifierList>
   \alt \LATE? \FINAL{} <type>? <initializedIdentifierList>
   \alt \LATE? <varOrType> <initializedIdentifierList>


### PR DESCRIPTION
The current grammar does not allow an instance variable declaration with modifiers `covariant late final`. However, that should be allowed, because a _late_ final variable does have a setter. This PR adds a grammar rule to enable that.

There is no implementation effort, because this construct is already used in `language/nnbd/late/covariant_instance_field_test.dart`, and that test succeeds on all configurations, cf. https://dart-ci.firebaseapp.com/current_results/#/filter=language/nnbd/late/covariant_instance_field_test&showAll.