### PR TITLE
Clarify override error for inherited member with non-covariant parameter

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -5222,21 +5222,20 @@ if{}f the following criteria are all satisfied:
   (\ref{superBoundedTypes}).
 
   \commentary{%
-    This requirement can actually be violated:
-    If $m$ is the signature of a concrete member declaration
-    inherited from a superclass $S$ into a class $C$,
-    a parameter $p$ may not be covariant-by-declaration
-    even though the parameter corresponding to $p$ in a superinterface of $C$
-    is covariant-by-declaration.
-    In this case the inherited member fails to be a correct override
-    of the member in that superinterface
-    (unless $p$ has a top type, where the covariance cannot cause unsoundness).
-
-    Otherwise, when $m$ is the member signature of a declaration in a class $C$
+    This requirement is satisfied in the typical case, but not in all cases:
+    When $m$ is the member signature of a declaration in a class $C$
     and $m'$ is a member signature from a superinterface of $C$,
     this requirement will never fail.
     This is because $p$ is automatically and implicitly covariant-by-declaration
     whenever $p'$ is covariant-by-declaration.
+
+    However, if $m$ is the signature of a concrete member declaration
+    inherited from a superclass $S$ into a class $C$,
+    a parameter $p$ may not be covariant-by-declaration
+    even though $p'$ is covariant-by-declaration.
+    In this case the inherited member fails to be a correct override
+    of the member in that superinterface
+    (unless $p$ has a top type, where the covariance cannot cause unsoundness).
   }
 \item
   %% TODO(eernst): Come nnbd, this warning is removed.

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -5216,26 +5216,16 @@ if{}f the following criteria are all satisfied:
     This is a built-in property of the function type subtype rules.
   }
 
-  If $p'$ is a formal parameter in $m'$ which is covariant-by-declaration,
-  the corresponding parameter $p$ in $m$ must also be covariant-by-declaration
-  unless the type of $p$ is a top type
-  (\ref{superBoundedTypes}).
-
   \commentary{%
-    This requirement is satisfied in the typical case, but not in all cases:
-    When $m$ is the member signature of a declaration in a class $C$
-    and $m'$ is a member signature from a superinterface of $C$,
-    this requirement will never fail.
-    This is because $p$ is automatically and implicitly covariant-by-declaration
-    whenever $p'$ is covariant-by-declaration.
-
-    However, if $m$ is the signature of a concrete member declaration
+    Note that if $m$ is the signature of a concrete member declaration
     inherited from a superclass $S$ into a class $C$,
     a parameter $p$ may not be covariant-by-declaration
     even though $p'$ is covariant-by-declaration.
-    In this case the inherited member fails to be a correct override
-    of the member in that superinterface
-    (unless $p$ has a top type, where the covariance cannot cause unsoundness).
+    In this case, for soundness, there may be a need to perform
+    a dynamic type check on the actual argument passed to $p$,
+    which is not performed by the inherited implementation.
+    An implementation may choose to generate a forwarding method
+    to ensure that the required type check is performed.
   }
 \item
   %% TODO(eernst): Come nnbd, this warning is removed.

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -34,6 +34,8 @@
 % - Change grammar to enable non-function type aliases. Correct rule for
 %   invoking `F.staticMethod()` where `F` is a type alias.
 % - Add missing error for cyclic redirecting generative constructor.
+% - Clarify the treatment of `covariant` parameters in the interface of a class
+%   that inherits an implementation where those parameters are not covariant.
 %
 % 2.8 - 2.10
 % - Change several warnings to compile-time errors, matching the actual
@@ -5221,9 +5223,10 @@ if{}f the following criteria are all satisfied:
     so that modifier need not be present syntactically in $D$.
   }
 
-  It is a compile-time error if $m'$ has a parameter
-  with the modifier \COVARIANT,
-  and the corresponding parameter in $m$ does not have that modifier.
+  If $p'$ is a formal parameter in $m'$ that has the modifier \COVARIANT,
+  the corresponding parameter $p$ in $m$ must also have the modifier \COVARIANT,
+  unless the type of $p$ is a top type
+  (\ref{superBoundedTypes}).
 
   \commentary{%
     This can only occur in the case where $m$ is the signature of

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -5216,16 +5216,26 @@ if{}f the following criteria are all satisfied:
     This is a built-in property of the function type subtype rules.
   }
 
+  If $p'$ is a formal parameter in $m'$ which is covariant-by-declaration,
+  the corresponding parameter $p$ in $m$ must also be covariant-by-declaration
+  unless the type of $p$ is a top type
+  (\ref{superBoundedTypes}).
+
   \commentary{%
-    Note that if $m$ is the signature of a concrete member declaration
+    This requirement is satisfied in the typical case, but not in all cases:
+    When $m$ is the member signature of a declaration in a class $C$
+    and $m'$ is a member signature from a superinterface of $C$,
+    this requirement will never fail.
+    This is because $p$ is automatically and implicitly covariant-by-declaration
+    whenever $p'$ is covariant-by-declaration.
+
+    However, if $m$ is the signature of a concrete member declaration
     inherited from a superclass $S$ into a class $C$,
     a parameter $p$ may not be covariant-by-declaration
     even though $p'$ is covariant-by-declaration.
-    In this case, for soundness, there may be a need to perform
-    a dynamic type check on the actual argument passed to $p$,
-    which is not performed by the inherited implementation.
-    An implementation may choose to generate a forwarding method
-    to ensure that the required type check is performed.
+    In this case the inherited member fails to be a correct override
+    of the member in that superinterface
+    (unless $p$ has a top type, where the covariance cannot cause unsoundness).
   }
 \item
   %% TODO(eernst): Come nnbd, this warning is removed.

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -5250,11 +5250,12 @@ if{}f the following criteria are all satisfied:
 
 \commentary{%
 Note that a parameter which is covariant-by-declaration
-must have a type which is subject to one more check
+must have a type which satisfies one more requirement,
+relative to the corresponding parameters in all superinterfaces,
+both direct and indirect
 (\ref{instanceMethods}).
-We cannot cover that property here,
-because it is concerned with declarations in all superinterfaces,
-whereas the notion of a correct member override is only concerned with
+We cannot make that requirement a part of the notion of correct overrides,
+because correct overrides are only concerned with
 the relation to a single superinterface.%
 }
 

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -5204,28 +5204,42 @@ if{}f the following criteria are all satisfied:
   $F$ must then be a subtype of $F'$.
 
   \commentary{%
-  The subtype requirement ensures that argument list shapes
-  that are admissible for an invocation of a method with signature $m'$
-  are also admissible for an invocation of a method with signature $m$.
-  For instance, $m'$ may accept 2 or 3 positional arguments,
-  and $m$ may accept 1, 2, 3, or 4 positional arguments, but not vice versa.
-  This is a built-in property of the function type subtype rules.
-  %
-  Note that a member signature differs from
-  an underlying syntactic declaration $D$ in a class $C$.
-  In particular,
-  a parameter in a member signature has the modifier \COVARIANT{}
-  if and only if the parameter is covariant-by-declaration
-  (\ref{covariantParameters}),
-  and that may be the case due to declarations in a supertype of $C$,
-  so that modifier need not be present in $D$.
-  %
-  There is an additional potential compile-time error associated with
-  a parameter which is covariant-by-declaration
-  (\ref{instanceMethods}).
-  But we cannot cover that here as a property of member overrides,
-  because it is concerned with declarations in all superinterfaces,
-  indirect as well as direct.%
+    The subtype requirement ensures that argument list shapes
+    that are admissible for an invocation of a method with signature $m'$
+    are also admissible for an invocation of a method with signature $m$.
+    For instance, $m'$ may accept 2 or 3 positional arguments,
+    and $m$ may accept 1, 2, 3, or 4 positional arguments, but not vice versa.
+    This is a built-in property of the function type subtype rules.
+
+    Note that a member signature differs from
+    an underlying syntactic declaration $D$ in a class $C$.
+    In particular,
+    a parameter in a member signature has the modifier \COVARIANT{}
+    if and only if the parameter is covariant-by-declaration
+    (\ref{covariantParameters}),
+    and that may be the case due to declarations in a supertype of $C$,
+    so that modifier need not be present syntactically in $D$.
+  }
+
+  It is a compile-time error if $m'$ has a parameter
+  with the modifier \COVARIANT,
+  and the corresponding parameter in $m$ does not have that modifier.
+
+  \commentary{%
+    This can only occur in the case where $m$ is the signature of
+    a concrete member declaration inherited from a superclass.
+    Otherwise, if $m$ needs to be a correct override of $m'$ then
+    $m'$ is already a member of a superinterface of the enclosing class
+    of the declaration whose signature is $m$.
+    Every \COVARIANT{} parameter of $m'$ is then also \COVARIANT{} in $m$,
+    with or without an explicit occurrence of the modifier \COVARIANT.
+
+    There is one additional potential compile-time error associated with
+    a parameter which is covariant-by-declaration
+    (\ref{instanceMethods}).
+    We cannot cover that error here as a property of member overrides,
+    because it is concerned with declarations in all superinterfaces,
+    indirect as well as direct.%
   }
 \item
   If $m$ and $m'$ are both methods,

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -5195,13 +5195,15 @@ if{}f the following criteria are all satisfied:
 \begin{itemize}
 \item
   $m$ and $m'$ are both methods, both getters, or both setters.
-  % We cannot have a setter and a method, say, because they cannot have
-  % the same name. However, we must _allow_ $m$ and $m'$ to be two setters.
+\item
+  If $m$ and $m'$ are both getters:
+  The return type of $m$ must be a subtype of the return type of $m'$.
 \item
   If $m$ and $m'$ are both methods or both setters:
   Let $F$ be the function type of $m$
   except that the parameter type is the built-in class \code{Object}
-  for each parameter of $m$ which has the modifier \COVARIANT.
+  for each parameter of $m$ which is covariant-by-declaration
+  (\ref{covariantParameters}).
   Let $F'$ be the function type of $m'$.
   $F$ must then be a subtype of $F'$.
 
@@ -5212,49 +5214,49 @@ if{}f the following criteria are all satisfied:
     For instance, $m'$ may accept 2 or 3 positional arguments,
     and $m$ may accept 1, 2, 3, or 4 positional arguments, but not vice versa.
     This is a built-in property of the function type subtype rules.
-
-    Note that a member signature differs from
-    an underlying syntactic declaration $D$ in a class $C$.
-    In particular,
-    a parameter in a member signature has the modifier \COVARIANT{}
-    if and only if the parameter is covariant-by-declaration
-    (\ref{covariantParameters}),
-    and that may be the case due to declarations in a supertype of $C$,
-    so that modifier need not be present syntactically in $D$.
   }
 
-  If $p'$ is a formal parameter in $m'$ that has the modifier \COVARIANT,
-  the corresponding parameter $p$ in $m$ must also have the modifier \COVARIANT,
+  If $p'$ is a formal parameter in $m'$ which is covariant-by-declaration,
+  the corresponding parameter $p$ in $m$ must also be covariant-by-declaration
   unless the type of $p$ is a top type
   (\ref{superBoundedTypes}).
 
   \commentary{%
-    This can only occur in the case where $m$ is the signature of
-    a concrete member declaration inherited from a superclass.
-    Otherwise, if $m$ needs to be a correct override of $m'$ then
-    $m'$ is already a member of a superinterface of the enclosing class
-    of the declaration whose signature is $m$.
-    Every \COVARIANT{} parameter of $m'$ is then also \COVARIANT{} in $m$,
-    with or without an explicit occurrence of the modifier \COVARIANT.
+    This requirement can actually be violated:
+    If $m$ is the signature of a concrete member declaration
+    inherited from a superclass $S$ into a class $C$,
+    a parameter $p$ may not be covariant-by-declaration
+    even though the parameter corresponding to $p$ in a superinterface of $C$
+    is covariant-by-declaration.
+    In this case the inherited member fails to be a correct override
+    of the member in that superinterface
+    (unless $p$ has a top type, where the covariance cannot cause unsoundness).
 
-    There is one additional potential compile-time error associated with
-    a parameter which is covariant-by-declaration
-    (\ref{instanceMethods}).
-    We cannot cover that error here as a property of member overrides,
-    because it is concerned with declarations in all superinterfaces,
-    indirect as well as direct.%
+    Otherwise, when $m$ is the member signature of a declaration in a class $C$
+    and $m'$ is a member signature from a superinterface of $C$,
+    this requirement will never fail.
+    This is because $p$ is automatically and implicitly covariant-by-declaration
+    whenever $p'$ is covariant-by-declaration.
   }
 \item
+  %% TODO(eernst): Come nnbd, this warning is removed.
   If $m$ and $m'$ are both methods,
   $p$ is an optional parameter of $m$,
   $p'$ is the parameter of $m'$ corresponding to $p$,
   $p$ has default value $d$ and $p'$ has default value $d'$,
   then $d$ and $d'$ must be identical,
   or a static warning occurs.
-\item
-  If $m$ and $m'$ are both getters:
-  The return type of $m$ must be a subtype of the return type of $m'$.
 \end{itemize}
+
+\commentary{%
+Note that a parameter which is covariant-by-declaration
+must have a type which is subject to one more check
+(\ref{instanceMethods}).
+We cannot cover that property here,
+because it is concerned with declarations in all superinterfaces,
+whereas the notion of a correct member override is only concerned with
+the relation to a single superinterface.%
+}
 
 
 \section{Mixins}


### PR DESCRIPTION
This PR updates the language specification to make it explicit that it is a compile-time error for a member signature _m_ to override another member signature _m2_ if the latter has a parameter which is covariant-by-declaration, and the former does not have that.

This error is independent of the function types of the method signatures, so let's consider an example where the function types are identical (so it's trivially a correct member override in that respect):

```dart
class A { num foo(num n) => 1.1; }
abstract class B { num foo(covariant num x); }
class C extends A with B {} // Error
```

Here, `C` is an error because its interface has a member signature `num foo(covariant num)`, but it has an implementation with signature `num foo(num)` (inherited from `A`), and the `covariant` property is missing. (Note that we're talking about member signatures, and `covariant` is always explicit in a member signature, as opposed to syntactic declarations where it may be present implicitly, because it is present in a superinterface.)

The point is that the inherited method implementation `A.foo` doesn't "magically" get a parameter which is covariant-by-declaration just because it's inherited by `C`.