### PR TITLE
Adjust nnbd spec to allow a const factory in a class with a late final variable

### DIFF
--- a/accepted/2.12/nnbd/feature-specification.md
+++ b/accepted/2.12/nnbd/feature-specification.md
@@ -609,7 +609,7 @@ a prefix `await` expression that is not nested inside of another function
 expression.
 
 It is an error for a class with a generative `const` constructor to have a 
-`late final` instance variable without an initializing expression.
+`late final` instance variable.
 
 It is not a compile time error to write to a `final` non-local or instance
 variable if that variable is declared `late` and does not have an initializer.

--- a/accepted/2.12/nnbd/feature-specification.md
+++ b/accepted/2.12/nnbd/feature-specification.md
@@ -604,8 +604,8 @@ It is an error for the initializer expression of a `late` local variable to use
 a prefix `await` expression that is not nested inside of another function
 expression.
 
-It is an error for a class with a `const` constructor to have a `late final`
-instance variable.
+It is an error for a class with a generative `const` constructor to have a 
+`late final` instance variable.
 
 It is not a compile time error to write to a `final` non-local or instance
 variable if that variable is declared `late` and does not have an initializer.

--- a/accepted/2.12/nnbd/feature-specification.md
+++ b/accepted/2.12/nnbd/feature-specification.md
@@ -6,6 +6,10 @@ Status: Draft
 
 ## CHANGELOG
 
+2021.07.28
+  - Allow a constant factory constructor in a class with a late final instance
+    variable.
+
 2020.12.30
   - Remove the warning for overrides with different default values.
   - Specify canonicalization of type literals.

--- a/accepted/2.12/nnbd/feature-specification.md
+++ b/accepted/2.12/nnbd/feature-specification.md
@@ -609,7 +609,7 @@ a prefix `await` expression that is not nested inside of another function
 expression.
 
 It is an error for a class with a generative `const` constructor to have a 
-`late final` instance variable.
+`late final` instance variable without an initializing expression.
 
 It is not a compile time error to write to a `final` non-local or instance
 variable if that variable is declared `late` and does not have an initializer.


### PR DESCRIPTION
Cf. issue https://github.com/dart-lang/language/issues/1763. It looks like we can allow a const factory constructor (which is then necessarily redirecting) in a class that has a late final instance variable.

There will be an implementation effort (it is currently, correctly according to the spec, reported as an error).