### PR TITLE
fix analyzer issues, add sdk constraints

### DIFF
--- a/accepted/2.3/spread-collections/benchmarks/.gitignore
+++ b/accepted/2.3/spread-collections/benchmarks/.gitignore
@@ -1,1 +1,3 @@
 /out
+.dart_tool/
+.packages

--- a/accepted/2.3/spread-collections/benchmarks/pubspec.yaml
+++ b/accepted/2.3/spread-collections/benchmarks/pubspec.yaml
@@ -1,3 +1,4 @@
 name: benchmarks
+publish_to: none
 environment:
   sdk: ">=2.3.0 <3.0.0"

--- a/accepted/2.3/spread-collections/benchmarks/pubspec.yaml
+++ b/accepted/2.3/spread-collections/benchmarks/pubspec.yaml
@@ -1,1 +1,3 @@
 name: benchmarks
+environment:
+  sdk: ">=2.3.0 <3.0.0"

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,3 @@
+analyzer:
+  exclude:
+    - accepted/2.3/spread-collections/examples/**

--- a/specification/.gitignore
+++ b/specification/.gitignore
@@ -8,3 +8,5 @@ dartLangSpec*.pdf
 dartLangSpec*.toc
 *-hash.tex
 *-list.txt
+.dart_tool/
+.packages

--- a/specification/pubspec.yaml
+++ b/specification/pubspec.yaml
@@ -1,7 +1,7 @@
 name: scripts
 publish_to: none
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.10.0 <3.0.0"
 dependencies: 
   convert: ^3.0.1
   crypto: ^3.0.1

--- a/specification/pubspec.yaml
+++ b/specification/pubspec.yaml
@@ -1,0 +1,7 @@
+name: scripts
+environment:
+  sdk: ">=2.12.0 <3.0.0"
+dependencies: 
+  convert: ^3.0.1
+  crypto: ^3.0.1
+  utf: ^0.9.0+5

--- a/specification/pubspec.yaml
+++ b/specification/pubspec.yaml
@@ -1,4 +1,5 @@
 name: scripts
+publish_to: none
 environment:
   sdk: ">=2.12.0 <3.0.0"
 dependencies: 

--- a/specification/scripts/addlatexhash.dart
+++ b/specification/scripts/addlatexhash.dart
@@ -111,7 +111,7 @@ normalizeWhitespace(line) {
 multilineNormalize(lines) {
   var afterBlankLines = false; // Does [line] succeed >0 empty lines?
   var afterCommentLines = false; // Does [line] succeed >0 commentOnly lines?
-  var newLines = new List();
+  var newLines = [];
   for (var line in lines) {
     if (afterBlankLines && afterCommentLines) {
       // Previous line was both blank and a comment: not possible.
@@ -193,7 +193,7 @@ sispIsDartEnd(line) => line.contains(dartCodeEndRE);
 /// and "interesting" lines may be characterized by [analysisFunc] via
 /// the returned event object.
 findEvents(lines, analyzer) {
-  var events = new List();
+  var events = [];
   for (var line in lines) {
     var event = analyzer.analyze(line);
     if (event != null) events.add(event);
@@ -540,7 +540,7 @@ main([args]) {
 
   // Perform single-line normalization.
   var inDartCode = false;
-  var normalizedLines = new List();
+  var normalizedLines = [];
 
   for (var line in lines) {
     if (sispIsDartBegin(line)) {


### PR DESCRIPTION
When opening up the language repo in an IDE that analyzes the dir (and not just open files), previously it would pollute the problem view with over 600 issues.

This fixes all of those by:
- Adding analyzer excludes for some examples which are meant to be standalone snippets and not fully valid code
- Updating the pubspec in the 2.3 spec benchmarks dir to have an sdk constraint (to disable null safety)
- Adding a pubspec to the `specification` dir so that the scripts dir in it is valid
- Fixing up some deprecation warnings