### PR TITLE
Macros: add Resource class specification for reading external resources

### DIFF
--- a/working/macros/feature-specification.md
+++ b/working/macros/feature-specification.md
@@ -350,7 +350,7 @@ part files?
 Lastly, since macros must return synchronously, we only expose a synchronous
 API for reading resources.
 
-The specific API is as follows:
+The specific API is as follows, and would only be available at compile time:
 
 ```dart
 /// A read-only resource API for use in macro implementation code.

--- a/working/macros/feature-specification.md
+++ b/working/macros/feature-specification.md
@@ -389,21 +389,19 @@ class Resource {
 
 #### Resource Invalidation
 
+Resources that are read should be treated as source inputs to the program, and
+should invalidate the parts of the program that depended on them when they
+change.
+
 When a resource is read during compilation, it should either be cached for
 subsequent reads to use or a hash of its contents stored. No two macros should
 ever see different contents for the same resource, within the same build.
 
-When a resource does change on disk, then all libraries containing macros that
-read that resource should be invalidated on subsequent builds/analysis of the
-app.
-
-Hot reload itself should not need to track resources since it is handed fully
-compiled kernel files (with macros already applied).
-
 This implies that the compilers will need to be keeping track of which
 resources have been read, and adding a dependency on those resources to the
 library. The compilers (or tools invoking the compilers) will then need to
-watch these resource files in the same way that they watch source files today.
+watch these resource files for changes in the same way that they watch source
+files today.
 
 This also includes tracking when resources are created or destroyed - so for
 instance calling any method on a `Resource` should add a dependency on the

--- a/working/macros/feature-specification.md
+++ b/working/macros/feature-specification.md
@@ -327,7 +327,7 @@ block macros from reading resources outside the scope of the original program.
 
 In order to distinguish whether a resource is "in scope", we use the package
 config file. Specifically, we allow access to any resource that exists under
-the root uri of any package in the current package config. Note that this may
+the root URI of any package in the current package config. Note that this may
 include resources outside of the `lib` directory of a package - even for
 package dependencies - depending on how the package config file is configured.
 
@@ -337,14 +337,14 @@ is outside the scope of the program. **TODO**: Evaluate whether this
 restriction is problematic for any current compilation strategies, such as in
 bazel, and if so consider alternatives.
 
-Resources are read via a [Uri][]. This may be a `package:` uri, or an absolute
-uri of any other form as long as it exists under the root uri of some package
+Resources are read via a [Uri][]. This may be a `package:` URI, or an absolute
+uri of any other form as long as it exists under the root URI of some package
 listed in the package config.
 
-It is also intuitive for macros to accept a relative uri for resources. In
-order to support this macros should compute the absolute uri from the current
-libraries uri. This uri is accessible by introspecting on the library of the
-declaration that a macro is applied to. **TODO**: Support for relative uris in
+It is also intuitive for macros to accept a relative URI for resources. In
+order to support this macros should compute the absolute URI from the current
+libraries URI. This URI is accessible by introspecting on the library of the
+declaration that a macro is applied to. **TODO**: Support for relative URIs in
 part files?
 
 Lastly, since macros must return synchronously, we only expose a synchronous
@@ -355,7 +355,7 @@ The specific API is as follows, and would only be available at compile time:
 ```dart
 /// A read-only resource API for use in macro implementation code.
 class Resource {
-  /// Either a `package:` uri, or an absolute uri which is under the root of
+  /// Either a `package:` URI, or an absolute URI which is under the root of
   /// one or more packages in the current package config.
   final Uri uri;
 

--- a/working/macros/feature-specification.md
+++ b/working/macros/feature-specification.md
@@ -390,7 +390,7 @@ This also includes tracking when resources are created or destroyed - so for
 instance calling any method on a `Resource` should add a dependency on the
 `uri` of that resource, whether it exists or not.
 
-##### build_runner implementation
+##### build_runner
 
 In build_runner we run the compiler in a special directory and we only copy
 over the files we know will be read (transitive dart files). How would we
@@ -400,7 +400,7 @@ read by the compiler?
 It is likely that we would need some special configuration from the users here
 to make this work, at least a general glob of available resources for a package.
 
-##### bazel implementation
+##### bazel
 
 No additional complications, resources will need to be provided as data inputs
 to the dart_library targets though.


### PR DESCRIPTION
Here is my WIP specification for how external resources can be loaded.

Note that it is vague enough to allow for reading `http` and potentially custom multi-root resources. This adds some general flexibility for the future, for instance if we wanted to run a compiler in a browser and load sources through http uris. In that case loading resources from http uris that fall under one of those package roots would be allowed.

I am a bit concerned about symlinks in general here still, I would love to hear thoughts on that.

Note that this also means macros can't load resources if there is no package config at all. So standalone dart scripts wouldn't be able to use macros that load resources, unless we carved out some sort of a special exception for this case.