### PR TITLE
Macros: Add a concept of "macro libraries"

### DIFF
--- a/working/macros/feature-specification.md
+++ b/working/macros/feature-specification.md
@@ -582,7 +582,7 @@ modifier on the library directive: `macro library my_macro;`.
   applications when the original library is imported.
 - The library containing the Macro interfaces and APIs is itself a macro
   library. This makes it only useful to import from other macro libraries, and
-  ensures its apis never leak unexpectedly into runtime apps.
+  ensures its APIs never leak unexpectedly into runtime apps.
 
 In this way, macros (and their imports) have no effect on the final program
 beyond the code that they generate. It also draws a clear distinction between


### PR DESCRIPTION
This introduces a new concept of a `macro` library, which gives us maximum predictability in terms of tree shaking of macros themselves from the final program. These can still be used just like normal libraries from a user perspective, and the extra boilerplate is just one keyword in the macro library itself. 