### PR TITLE
Specify that C.m, C.m() cannot invoke an extension method

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -30,6 +30,8 @@
 % - Allow generic instantiation of expressions with a generic function type
 %   (until now, it was an error unless the expression denoted a declaration).
 % - Allow generic instantiation of the `call` method of a function object.
+% - Disallow `TypeLiteral.extensionMethod()`, in line with the error for
+%   `int.toString()`.
 %
 % 2.14
 % - Add constraint on type of parameter which is covariant-by-declaration in
@@ -6045,9 +6047,10 @@ An implicit extension member invocation occurs
 for a member invocation $i$
 (\ref{memberInvocations})
 with receiver $r$ and corresponding member name $m$ if{}f
-(1) the interface of the static type of $r$ does not have a member
+(1) $r$ is not a type literal,
+(2) the interface of the static type of $r$ does not have a member
 whose basename is the basename of $m$,
-and (2) there exists a unique most specific
+and (3) there exists a unique most specific
 (\ref{extensionSpecificity})
 extension denoted by $E$ which is accessible
 (\ref{extensionAccessibility})
@@ -13654,16 +13657,30 @@ and the static type of $i$ is as specified there.
 
 \LMHash{}%
 It is a compile-time error to invoke any of the methods of class \code{Object}
-on a constant type literal that is immediately followed by the token `.'\,.
+on a type literal that is immediately followed by the token `.' (a period).
 
 \rationale{%
-The reason for the latter is that this syntax is reserved for
-invocation of static methods.
+The reason for this rule is that this syntax is reserved for
+invocation of static members.
+Invocation of a static member of a class, mixin, or extension
+uses said entity as a \emph{namespace},
+not as an actual class, mixin, or extension.
+In particular, the syntactic receiver is not evaluated
+to an object---that would not even be possible for an extension.%
+}
+
+\commentary{%
 For instance, \code{int.toString()} is similar to
-\code{C.someStaticMethod()}, and
-it would be confusing if just a couple of expressions of this form
-were instance method invocations.
-If needed, \code{(int).toString()} may be used instead.%
+\code{C.someStaticMethod()}, and it would be confusing
+if the former would evaluate the receiver and call an instance method,
+and the latter (which is much more common and useful)
+would use the type literal as a namespace.
+If needed, \code{(int).toString()} may be used instead.
+
+As a natural consequence of this rule,
+a type literal cannot be the receiver in
+an implicit invocation of an extension method
+(\ref{implicitExtensionInvocations}).%
 }
 
 \LMHash{}%

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -13676,7 +13676,7 @@ to an object---that would not even be possible for an extension.%
 An member access on a type literal 
 (e.g., \code{C.id()}, \code{C.id}, or \code{C?.id()}),
 always treats the declaration denoted by the literal as
-a namespace for accessing static members.
+a namespace for accessing static members or constructors.
 For instance, \code{int.toString()} is an error
 because \code{int} does not declare a static member named \code{toString}.
 It will not evaluate \code{int} to a \code{Type} object

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -30,8 +30,8 @@
 % - Allow generic instantiation of expressions with a generic function type
 %   (until now, it was an error unless the expression denoted a declaration).
 % - Allow generic instantiation of the `call` method of a function object.
-% - Disallow `TypeLiteral.extensionMethod()`, in line with the error for
-%   `int.toString()`.
+% - Clarify that `TypeLiteral.extensionMethod()` is an error, in line with the
+%   error for `int.toString()`.
 %
 % 2.14
 % - Add constraint on type of parameter which is covariant-by-declaration in
@@ -13656,12 +13656,15 @@ considering $F$ to be the static type of the function to call,
 and the static type of $i$ is as specified there.
 
 \LMHash{}%
-It is a compile-time error to invoke any of the methods of class \code{Object}
-on a type literal that is immediately followed by the token `.' (a period).
+It is a compile-time error to invoke an instance method on a type literal
+that is immediately followed by the token `.' (a period).
+\commentary{
+For instance, \code{int.toString()} is an error.%
+}
 
 \rationale{%
-The reason for this rule is that this syntax is reserved for
-invocation of static members.
+The reason for this rule is that member access on a type literal
+is reserved for invocation of static members.
 Invocation of a static member of a class, mixin, or extension
 uses said entity as a \emph{namespace},
 not as an actual class, mixin, or extension.
@@ -13670,14 +13673,19 @@ to an object---that would not even be possible for an extension.%
 }
 
 \commentary{%
-For instance, \code{int.toString()} is similar to
-\code{C.someStaticMethod()}, and it would be confusing
-if the former would evaluate the receiver and call an instance method,
-and the latter (which is much more common and useful)
-would use the type literal as a namespace.
-If needed, \code{(int).toString()} may be used instead.
+An member access on a type literal 
+(e.g., \code{C.id()}, \code{C.id}, or \code{C?.id()}),
+always treats the declaration denoted by the literal as
+a namespace for accessing static members.
+For instance, \code{int.toString()} is an error
+because \code{int} does not declare a static member named \code{toString}.
+It will not evaluate \code{int} to a \code{Type} object
+and then call its \code{toString} instance method.
+To do that, you can use \code{(int).toString()}.
+Note that cascades are different:
+they \emph{always} evaluate their receiver to an object first.
 
-As a natural consequence of this rule,
+As a natural consequence,
 a type literal cannot be the receiver in
 an implicit invocation of an extension method
 (\ref{implicitExtensionInvocations}).%


### PR DESCRIPTION
It has been an error for years to use `int.toString()` to call the `Object` instance method `toString` on an instance of `Type`. This syntax ("`<typeLiteral> '.' <memberAccess>`") is reserved for static member access.

It is inconsistent if we allow the same syntax to invoke an extension method (because an extension method will always be dominated by an instance method on the static type of the receiver, and hence extension methods are presumed to _always_ be invoked in a situation where we could also invoke an instance method).

The current specification wording does not make this obvious, and you could argue that it allows for `int.myExtensionMethod()` to invoke an extension method on `Type`.

This PR makes it explicit and unambiguous that it is not possible to implicitly call an extension method on a type literal.