### PR TITLE
Specify callable object closurization

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -14,7 +14,7 @@
 \makeindex
 \title{Dart Programming Language Specification\\
 {6th edition draft}\\
-{\large Version 2.13-dev}}
+{\large Version 2.15-dev}}
 \author{}
 
 % For information about Location Markers (and in particular the

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -12783,7 +12783,7 @@ $i$ is treated as
 the ordinary invocation
 
 \noindent
-\code{$e_f$.call<$A_1, \ldots,\ A_r$>($a_1, \ldots,\ a_n,\ x_{n+1}$: $a_{n+1}, \ldots,\ x_{n+k}$: $a_{n+k}$)}.
+\code{$e_f$.\CALL<$A_1, \ldots,\ A_r$>($a_1, \ldots,\ a_n,\ x_{n+1}$: $a_{n+1}, \ldots,\ x_{n+k}$: $a_{n+k}$)}.
 
 \LMHash{}%
 Otherwise, the static analysis of $i$ is performed as specified
@@ -14088,7 +14088,8 @@ or it is an expression of the form \code{\SUPER.\id}
 \Case{Implicit}
 Let $e$ be an expression whose static type is
 an interface type that has a method named \CALL.
-In the case where the context type for $e$ is a function type,
+In the case where the context type for $e$ is a function type
+or the type \FUNCTION,
 $e$ is treated as \code{$e$.\CALL}.
 
 \commentary{%
@@ -14096,8 +14097,8 @@ This means that a ``callable object'' may be treated as a function
 that supports a mechanism similar to function closurization
 (\ref{functionClosurization})
 by desugaring it to a method closurization on \CALL.
-It is required that it is statically known that it is a callable object,
-and that the context type requires a function.%
+This only occurs when it is statically known that it is a callable object,
+and when the context type requires a function.%
 }
 \EndCase
 

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -2294,7 +2294,7 @@ Let $u$ be the run-time type of a function object $o$ obtained by
 function closurization
 (\ref{functionClosurization})
 or instance method closurization
-(\ref{ordinaryMethodClosurization})
+(\ref{instanceMethodClosurization})
 applied to $F$,
 and let $t$ be the actual type corresponding to $T$
 at the occasion where $o$ was created
@@ -2947,7 +2947,7 @@ with the signature taken from the interface of $C$,
 and with the same default value for each optional parameter.
 It can be invoked in an ordinary invocation and in a superinvocation,
 and when $m$ is a method it can be closurized
-(\ref{ordinaryMethodClosurization})
+(\ref{instanceMethodClosurization})
 using a property extraction
 (\ref{propertyExtraction}).
 
@@ -12878,7 +12878,7 @@ respectively to the function literal $f$ considered as a function declaration.
 % identical even if not required, e.g., local functions with no free variables.
 \IndexCustom{Closurization}{closurization}
 denotes instance method closurization
-(\ref{ordinaryMethodClosurization})
+(\ref{instanceMethodClosurization})
 as well as function closurization,
 and it is also used as a shorthand for either of them
 when there is no ambiguity.
@@ -13989,7 +13989,7 @@ A property extraction can be either:
 \begin{enumerate}
 \item An instance method closurization,
   which converts a method into a function object
-  (\ref{ordinaryMethodClosurization}).
+  (\ref{instanceMethodClosurization}).
   Or
 \item A getter invocation, which returns
   the result of invoking of a getter method
@@ -14167,7 +14167,7 @@ Let $f$ be the result of looking up (\ref{lookup}) method
 \id{} in $o$ with respect to the current library $L$.
 If method lookup succeeds then $i$ evaluates to
 the closurization of method $f$ on object $o$
-(\ref{ordinaryMethodClosurization}).
+(\ref{instanceMethodClosurization}).
 
 \commentary{%
 Note that $f$ is never an abstract method,
@@ -14276,12 +14276,11 @@ does not have a concrete member named \id.%
 }
 
 
-\subsubsection{Ordinary Method Closurization}
-\LMLabel{ordinaryMethodClosurization}
+\subsubsection{Instance Method Closurization}
+\LMLabel{instanceMethodClosurization}
 
 \LMHash{}%
-This section specifies the dynamic semantics of
-ordinary member closurizations.
+This section specifies the dynamic semantics of instance method closurizations.
 
 \commentary{%
 Note that the non-generic case is covered implicitly using $s = 0$,
@@ -14490,7 +14489,7 @@ and optional positional parameters
 
 \commentary{%
 Note that a super closurization is an instance method closurization,
-as defined in (\ref{ordinaryMethodClosurization}).%
+as defined in (\ref{instanceMethodClosurization}).%
 }
 
 \LMHash{}%
@@ -14568,7 +14567,7 @@ if and only if $o_1$ and $o_2$ is the same object.
 Generic method instantiation is a mechanism that yields
 a non-generic function object,
 based on a property extraction which denotes an instance method closurization
-(\ref{ordinaryMethodClosurization}, \ref{superClosurization}).
+(\ref{instanceMethodClosurization}, \ref{superClosurization}).
 
 \commentary{%
 It is a mechanism which is very similar to instance method closurization,

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -30,8 +30,8 @@
 % - Allow generic instantiation of expressions with a generic function type
 %   (until now, it was an error unless the expression denoted a declaration).
 % - Allow generic instantiation of the `call` method of a function object.
-% - Add support for desugaring `f` as `f.call`, thus enabling "function
-%   closurization for callable objects".
+% - Add support for function closurization for callable objects, in the sense
+%   that `o` is desugared as `o.call` when the context type is a function type.
 %
 % 2.14
 % - Add constraint on type of parameter which is covariant-by-declaration in

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -30,6 +30,8 @@
 % - Allow generic instantiation of expressions with a generic function type
 %   (until now, it was an error unless the expression denoted a declaration).
 % - Allow generic instantiation of the `call` method of a function object.
+% - Add support for desugaring `f` as `f.call`, thus enabling "function
+%   closurization for callable objects".
 %
 % 2.14
 % - Add constraint on type of parameter which is covariant-by-declaration in
@@ -2292,7 +2294,7 @@ Let $u$ be the run-time type of a function object $o$ obtained by
 function closurization
 (\ref{functionClosurization})
 or instance method closurization
-(\ref{ordinaryMemberClosurization})
+(\ref{ordinaryMethodClosurization})
 applied to $F$,
 and let $t$ be the actual type corresponding to $T$
 at the occasion where $o$ was created
@@ -2945,7 +2947,7 @@ with the signature taken from the interface of $C$,
 and with the same default value for each optional parameter.
 It can be invoked in an ordinary invocation and in a superinvocation,
 and when $m$ is a method it can be closurized
-(\ref{ordinaryMemberClosurization})
+(\ref{ordinaryMethodClosurization})
 using a property extraction
 (\ref{propertyExtraction}).
 
@@ -12876,7 +12878,7 @@ respectively to the function literal $f$ considered as a function declaration.
 % identical even if not required, e.g., local functions with no free variables.
 \IndexCustom{Closurization}{closurization}
 denotes instance method closurization
-(\ref{ordinaryMemberClosurization})
+(\ref{ordinaryMethodClosurization})
 as well as function closurization,
 and it is also used as a shorthand for either of them
 when there is no ambiguity.
@@ -12925,7 +12927,7 @@ are canonicalized.%
 }
 
 
-\subsubsection{Generic Function Instantiation}
+\subsection{Generic Function Instantiation}
 \LMLabel{genericFunctionInstantiation}
 
 %% TODO(eernst): The specification of generic function instantiation relies
@@ -13987,7 +13989,7 @@ A property extraction can be either:
 \begin{enumerate}
 \item An instance method closurization,
   which converts a method into a function object
-  (\ref{ordinaryMemberClosurization}).
+  (\ref{ordinaryMethodClosurization}).
   Or
 \item A getter invocation, which returns
   the result of invoking of a getter method
@@ -13999,7 +14001,8 @@ Function objects derived from members via closurization
 are colloquially known as tear-offs.%
 }
 
-Property extraction can be either conditional or unconditional.
+\LMHash{}%
+Property extraction comes in several forms, as described below.
 
 \LMHash{}%
 \Case{Conditional}
@@ -14081,6 +14084,23 @@ or it is an expression of the form \code{\SUPER.\id}
 (\ref{superGetterAccessAndMethodClosurization}).
 \EndCase
 
+\LMHash{}%
+\Case{Implicit}
+Let $e$ be an expression whose static type is
+an interface type that has a method named \CALL.
+In the case where the context type for $e$ is a function type,
+$e$ is treated as \code{$e$.\CALL}.
+
+\commentary{%
+This means that a ``callable object'' may be treated as a function
+that supports a mechanism similar to function closurization
+(\ref{functionClosurization})
+by desugaring it to a method closurization on \CALL.
+It is required that it is statically known that it is a callable object,
+and that the context type requires a function.%
+}
+\EndCase
+
 
 \subsubsection{Getter Access and Method Extraction}
 \LMLabel{getterAccessAndMethodExtraction}
@@ -14146,7 +14166,7 @@ Let $f$ be the result of looking up (\ref{lookup}) method
 \id{} in $o$ with respect to the current library $L$.
 If method lookup succeeds then $i$ evaluates to
 the closurization of method $f$ on object $o$
-(\ref{ordinaryMemberClosurization}).
+(\ref{ordinaryMethodClosurization}).
 
 \commentary{%
 Note that $f$ is never an abstract method,
@@ -14255,8 +14275,8 @@ does not have a concrete member named \id.%
 }
 
 
-\subsubsection{Ordinary Member Closurization}
-\LMLabel{ordinaryMemberClosurization}
+\subsubsection{Ordinary Method Closurization}
+\LMLabel{ordinaryMethodClosurization}
 
 \LMHash{}%
 This section specifies the dynamic semantics of
@@ -14469,7 +14489,7 @@ and optional positional parameters
 
 \commentary{%
 Note that a super closurization is an instance method closurization,
-as defined in (\ref{ordinaryMemberClosurization}).%
+as defined in (\ref{ordinaryMethodClosurization}).%
 }
 
 \LMHash{}%
@@ -14547,7 +14567,7 @@ if and only if $o_1$ and $o_2$ is the same object.
 Generic method instantiation is a mechanism that yields
 a non-generic function object,
 based on a property extraction which denotes an instance method closurization
-(\ref{ordinaryMemberClosurization}, \ref{superClosurization}).
+(\ref{ordinaryMethodClosurization}, \ref{superClosurization}).
 
 \commentary{%
 It is a mechanism which is very similar to instance method closurization,


### PR DESCRIPTION
This PR adds a new case to the set of possible 'property extraction' expressions: Implicit property extraction. It occurs where an expression `e` has a static type as a callable object, and the context type is a function type. In this case we desugar `e` into `e.call`. Note that this will also serve as the first step in a generic function instantiation, because it is still true that the context type is a function type also in the case where `e.call` isn't assignable to that context type (but we can fix it by means of an implicit instantiation).

Smaller corrections:

The subsubsection about generic function instantiation was turned into a subsection: It used to be the case that a generic function instantiation would necessarily include a function closurization as a sub-action. This is no longer true, we can perform the generic instantiation on an existing function object. This means that the generic instantiation material should no longer be a subsection of 'Function Closurization', it's a stand-alone feature.

Subtitle uses version 2.15-dev, not 2.13-dev.

Note that this change is _not_ expected to give rise to any implementation efforts. The following works today already:

```dart
class A { call() {}}
void f(void Function() g) => print(g);
void main() => f(A());
```
