### PR TITLE
Support implicit extension method tearoffs

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -6018,7 +6018,7 @@ which is unlikely to be desirable.%
 \LMLabel{implicitExtensionInvocations}
 
 \LMHash{}%
-Instance members of an extension can be invoked implicitly
+Instance members of an extension can be invoked or closurized implicitly
 (\commentary{without mentioning the name of the extension}),
 as if they were instance members of the receiver of
 the given member invocation.


### PR DESCRIPTION
I just noticed that the current specification wording does _not_ clearly allow for an implicit tearoff of an extension method. This PR adds a single word in the section about implicit extension member invocation, to make it explicit that this case is included.