### PR TITLE
Make argument to `WeakRef` constuctor non-nullable

### DIFF
--- a/working/1847 - FinalizationRegistry/proposal.md
+++ b/working/1847 - FinalizationRegistry/proposal.md
@@ -207,22 +207,25 @@ abstract class FinalizationRegistry<FT> {
 ///
 /// A _weak_ reference to the [target] object which may be cleared
 /// (set to reference `null` instead) at any time
-/// where there is no other ways for the program to access the target object.
+/// when there is no other ways for the program to access the target object.
 ///
 /// _The referenced object may be garbage collected when the only reachable
 /// references to it are weak._
 ///
-/// Not all objects are supported as targets for weak references. [WeakRef]
-/// constructor and [WeakRef.target] will reject any object that is not
+/// Not all objects are supported as targets for weak references. 
+/// The [WeakRef] constructor will reject any object that is not
 /// supported as an [Expando] key.
 abstract class WeakRef<T extends Object> {
-  /// Create a [WeakRef] pointing to the given [target], which must be
-  /// an object supported as an [Expando] key.
+  /// Create a [WeakRef] pointing to the given [target].
+  /// 
+  /// The [target] must be an object supported as an [Expando] key.
   external factory WeakRef(T target);
 
-  /// The current object weakly referenced by [this]. Is either [null] or
-  /// an object supported as an [Expando] key.
-  abstract T? target;
+  /// The current object weakly referenced by [this], if any.
+  /// 
+  /// The value os either the object supplied in the constructor,
+  /// or `null` if the weak reference has been cleared.
+  T? get target;
 }
 
 typedef WeakMap = Expando;


### PR DESCRIPTION
Do we want to support a `null` argument to the `WeakRef` constructor?

It shouldn't work since `null` is not a valid `Expando` key, so I'd expect it to throw.
There is one use-case: To create an already-empty `WeakRef` which is usable as a default-value, but then I'd prefer to just have a `static const WeakRef<Never> empty = ...;` constant which starts out empty, or have a separate `WeakRef.empty()` constructor, not to make `null` meaningful.

Also fixed a typo.