### PR TITLE
Add WIP macro apis to the proposal

### DIFF
--- a/working/macros/api/builders.dart
+++ b/working/macros/api/builders.dart
@@ -1,0 +1,115 @@
+import 'code.dart';
+import 'introspection.dart';
+import 'macros.dart'; // For dart docs :(
+
+abstract class Builder {
+  /// Used to construct a [TypeAnnotation] to a runtime type available to the
+  /// the macro implementation code.
+  ///
+  /// This can be used to emit a reference to it in generated code, or do
+  /// subtype checks (depending on support in the current phase).
+  TypeAnnotation typeAnnotationOf<T>();
+}
+
+/// The api used by [TypeMacro]s to contribute new type declarations to the
+/// current library, and get [TypeAnnotation]s from runtime [Type] objects.
+abstract class TypeBuilder implements Builder {
+  /// Adds a new type declaration to the surrounding library.
+  void addTypeToLibary(DeclarationCode typeDeclaration);
+}
+
+/// The api used by [DeclarationMacro]s to contribute new (non-type)
+/// declarations to the current library.
+///
+/// Can also be used to do subtype checks on types.
+abstract class DeclarationBuilder implements Builder {
+  /// Adds a new regular declaration to the surrounding library.
+  ///
+  /// Note that type declarations are not supported.
+  void addToLibrary(DeclarationCode declaration);
+
+  /// Returns true if [leftType] is a subtype of [rightType].
+  bool isSubtypeOf(TypeAnnotation leftType, TypeAnnotation rightType);
+
+  /// Retruns true if [leftType] is an identical type to [rightType].
+  bool isExactly(TypeAnnotation leftType, TypeAnnotation rightType);
+}
+
+/// The api used by [DeclarationMacro]s to contribute new members to a class.
+abstract class ClassMemberDeclarationBuilder implements DeclarationBuilder {
+  /// Adds a new declaration to the surrounding class.
+  void addToClass(DeclarationCode declaration);
+}
+
+/// The api used to introspect on a [ClassDeclaration].
+abstract class ClassIntrospector {
+  /// The fields available for [clazz].
+  ///
+  /// This may be incomplete if in the declaration phase and additional macros
+  /// are going to run on this class.
+  Stream<FieldDeclaration> fieldsOf(ClassDeclaration clazz);
+
+  /// The methods available so far for the current class.
+  ///
+  /// This may be incomplete if additional declaration macros are running on
+  /// this class.
+  Stream<MethodDeclaration> methodsOf(ClassDeclaration clazz);
+
+  /// The constructors available so far for the current class.
+  ///
+  /// This may be incomplete if additional declaration macros are running on
+  /// this class.
+  Stream<ConstructorDeclaration> constructorsOf(ClassDeclaration clazz);
+
+  /// The class that is directly extended via an `extends` clause.
+  Future<ClassDeclaration?> superclassOf(ClassDeclaration clazz);
+
+  /// All of the classes that are mixed in with `with` clauses.
+  Stream<ClassDeclaration> mixinsOf(ClassDeclaration clazz);
+}
+
+/// The api used by [DeclarationMacro]s to reflect on the currently available
+/// members, superclass, and mixins for a given [ClassDeclaration]
+abstract class ClassDeclarationBuilder
+    implements ClassMemberDeclarationBuilder, ClassIntrospector {}
+
+/// The api used by [DefinitionMacro] to get a [TypeDeclaration] for any given
+/// [TypeAnnotation].
+abstract class TypeIntrospector {
+  Future<TypeDeclaration> typeDeclarationOf(TypeAnnotation annotation);
+}
+
+/// The base class for builders in the definition phase. These can convert
+/// any [TypeAnnotation] into its corresponding [TypeDeclaration], and also
+/// reflect more deeply on those.
+abstract class DefinitionBuilder
+    implements Builder, ClassIntrospector, TypeIntrospector {}
+
+/// The apis used by [DefinitionMacro]s to define the body of a constructor
+/// or wrap the body of an existing constructor with additional statements.
+abstract class ConstructorDefinitionBuilder implements DefinitionBuilder {
+  /// Augments an existing constructor body with [body].
+  ///
+  /// TODO: Link the library augmentations proposal to describe the semantics.
+  void augment({FunctionBodyCode? body, List<Code>? initializers});
+}
+
+/// The apis used by [DefinitionMacro]s to augment functions or methods.
+abstract class FunctionDefinitionBuilder implements DefinitionBuilder {
+  /// Augments the function.
+  ///
+  /// TODO: Link the library augmentations proposal to describe the semantics.
+  void augment(FunctionBodyCode body);
+}
+
+/// The api used by [DefinitionMacro]s to augment a field.
+abstract class FieldDefinitionBuilder implements DefinitionBuilder {
+  /// Augments the field.
+  ///
+  /// TODO: Link the library augmentations proposal to describe the semantics.
+  void augment({
+    DeclarationCode? getter,
+    DeclarationCode? setter,
+    ExpressionCode? initializer,
+  });
+}

--- a/working/macros/api/builders.dart
+++ b/working/macros/api/builders.dart
@@ -47,25 +47,25 @@ abstract class ClassIntrospector {
   ///
   /// This may be incomplete if in the declaration phase and additional macros
   /// are going to run on this class.
-  Stream<FieldDeclaration> fieldsOf(ClassDeclaration clazz);
+  Future<List<FieldDeclaration>> fieldsOf(ClassDeclaration clazz);
 
   /// The methods available so far for the current class.
   ///
   /// This may be incomplete if additional declaration macros are running on
   /// this class.
-  Stream<MethodDeclaration> methodsOf(ClassDeclaration clazz);
+  Future<List<MethodDeclaration>> methodsOf(ClassDeclaration clazz);
 
   /// The constructors available so far for the current class.
   ///
   /// This may be incomplete if additional declaration macros are running on
   /// this class.
-  Stream<ConstructorDeclaration> constructorsOf(ClassDeclaration clazz);
+  Future<List<ConstructorDeclaration>> constructorsOf(ClassDeclaration clazz);
 
   /// The class that is directly extended via an `extends` clause.
   Future<ClassDeclaration?> superclassOf(ClassDeclaration clazz);
 
   /// All of the classes that are mixed in with `with` clauses.
-  Stream<ClassDeclaration> mixinsOf(ClassDeclaration clazz);
+  Future<List<ClassDeclaration>> mixinsOf(ClassDeclaration clazz);
 }
 
 /// The api used by [DeclarationMacro]s to reflect on the currently available

--- a/working/macros/api/code.dart
+++ b/working/macros/api/code.dart
@@ -26,31 +26,31 @@ class Code {
 }
 
 /// A piece of code representing a syntactically valid declaration.
-class Declaration extends Code {
-  Declaration.fromString(String code, {Scope? scope})
+class DeclarationCode extends Code {
+  DeclarationCode.fromString(String code, {Scope? scope})
       : super.fromString(code, scope: scope);
 
-  Declaration.fromParts(List<Object> parts, {Scope? scope})
+  DeclarationCode.fromParts(List<Object> parts, {Scope? scope})
       : super.fromParts(parts, scope: scope);
 }
 
 /// A piece of code representing a syntactically valid element.
 ///
 /// Should not include any trailing commas,
-class Element extends Code {
-  Element.fromString(String code, {Scope? scope})
+class ElementCode extends Code {
+  ElementCode.fromString(String code, {Scope? scope})
       : super.fromString(code, scope: scope);
 
-  Element.fromParts(List<Object> parts, {Scope? scope})
+  ElementCode.fromParts(List<Object> parts, {Scope? scope})
       : super.fromParts(parts, scope: scope);
 }
 
 /// A piece of code representing a syntactically valid expression.
-class Expression extends Code {
-  Expression.fromString(String code, {Scope? scope})
+class ExpressionCode extends Code {
+  ExpressionCode.fromString(String code, {Scope? scope})
       : super.fromString(code, scope: scope);
 
-  Expression.fromParts(List<Object> parts, {Scope? scope})
+  ExpressionCode.fromParts(List<Object> parts, {Scope? scope})
       : super.fromParts(parts, scope: scope);
 }
 
@@ -60,31 +60,31 @@ class Expression extends Code {
 /// including modifiers like `async`.
 ///
 /// Both arrow and block function bodies are allowed.
-class FunctionBody extends Code {
-  FunctionBody.fromString(String code, {Scope? scope})
+class FunctionBodyCode extends Code {
+  FunctionBodyCode.fromString(String code, {Scope? scope})
       : super.fromString(code, scope: scope);
 
-  FunctionBody.fromParts(List<Object> parts, {Scope? scope})
+  FunctionBodyCode.fromParts(List<Object> parts, {Scope? scope})
       : super.fromParts(parts, scope: scope);
 }
 
 /// A piece of code representing a syntactically valid identifier.
-class Identifier extends Code {
-  Identifier.fromString(String code, {Scope? scope})
+class IdentifierCode extends Code {
+  IdentifierCode.fromString(String code, {Scope? scope})
       : super.fromString(code, scope: scope);
 
-  Identifier.fromParts(List<Object> parts, {Scope? scope})
+  IdentifierCode.fromParts(List<Object> parts, {Scope? scope})
       : super.fromParts(parts, scope: scope);
 }
 
 /// A piece of code identifying a named argument.
 ///
 /// This should not include any trailing commas.
-class NamedArgument extends Code {
-  NamedArgument.fromString(String code, {Scope? scope})
+class NamedArgumentCode extends Code {
+  NamedArgumentCode.fromString(String code, {Scope? scope})
       : super.fromString(code, scope: scope);
 
-  NamedArgument.fromParts(List<Object> parts, {Scope? scope})
+  NamedArgumentCode.fromParts(List<Object> parts, {Scope? scope})
       : super.fromParts(parts, scope: scope);
 }
 
@@ -97,22 +97,22 @@ class NamedArgument extends Code {
 /// nor between optional or required parameters. It is the job of the user to
 /// construct and combine these together in a way that creates valid parameter
 /// lists.
-class Parameter extends Code {
-  Parameter.fromString(String code, {Scope? scope})
+class ParameterCode extends Code {
+  ParameterCode.fromString(String code, {Scope? scope})
       : super.fromString(code, scope: scope);
 
-  Parameter.fromParts(List<Object> parts, {Scope? scope})
+  ParameterCode.fromParts(List<Object> parts, {Scope? scope})
       : super.fromParts(parts, scope: scope);
 }
 
 /// A piece of code representing a syntactically valid statement.
 ///
 /// Should always end with a semicolon.
-class Statement extends Code {
-  Statement.fromString(String code, {Scope? scope})
+class StatementCode extends Code {
+  StatementCode.fromString(String code, {Scope? scope})
       : super.fromString(code, scope: scope);
 
-  Statement.fromParts(List<Object> parts, {Scope? scope})
+  StatementCode.fromParts(List<Object> parts, {Scope? scope})
       : super.fromParts(parts, scope: scope);
 }
 

--- a/working/macros/api/code.dart
+++ b/working/macros/api/code.dart
@@ -1,0 +1,129 @@
+/// A scope in which to resolve a chunk of code.
+///
+/// TODO: Handle more deeply nested scopes (such as a scope specific to a class
+/// or method body).
+class Scope {
+  /// Identifiers should be resolved as if they existed in this library.
+  final Uri libraryUri;
+
+  Scope(this.libraryUri);
+}
+
+/// The base class representing an arbitrary chunk of Dart code, which may or
+/// may not be syntacically or semantically valid yet.
+class Code {
+  /// The scope in which to resolve anything from [parts] that does not have its
+  /// own scope already defined.
+  final Scope? scope;
+
+  /// All the chunks of [Code] or raw [String]s that comprise this [Code]
+  /// object.
+  final List<Object> parts;
+
+  Code.fromString(String code, {this.scope}) : parts = [code];
+
+  Code.fromParts(this.parts, {this.scope});
+}
+
+/// A piece of code representing a syntactically valid declaration.
+class Declaration extends Code {
+  Declaration.fromString(String code, {Scope? scope})
+      : super.fromString(code, scope: scope);
+
+  Declaration.fromParts(List<Object> parts, {Scope? scope})
+      : super.fromParts(parts, scope: scope);
+}
+
+/// A piece of code representing a syntactically valid element.
+///
+/// Should not include any trailing commas,
+class Element extends Code {
+  Element.fromString(String code, {Scope? scope})
+      : super.fromString(code, scope: scope);
+
+  Element.fromParts(List<Object> parts, {Scope? scope})
+      : super.fromParts(parts, scope: scope);
+}
+
+/// A piece of code representing a syntactically valid expression.
+class Expression extends Code {
+  Expression.fromString(String code, {Scope? scope})
+      : super.fromString(code, scope: scope);
+
+  Expression.fromParts(List<Object> parts, {Scope? scope})
+      : super.fromParts(parts, scope: scope);
+}
+
+/// A piece of code representing a syntactically valid function body.
+///
+/// This includes any and all code after the parameter list of a function,
+/// including modifiers like `async`.
+///
+/// Both arrow and block function bodies are allowed.
+class FunctionBody extends Code {
+  FunctionBody.fromString(String code, {Scope? scope})
+      : super.fromString(code, scope: scope);
+
+  FunctionBody.fromParts(List<Object> parts, {Scope? scope})
+      : super.fromParts(parts, scope: scope);
+}
+
+/// A piece of code representing a syntactically valid identifier.
+class Identifier extends Code {
+  Identifier.fromString(String code, {Scope? scope})
+      : super.fromString(code, scope: scope);
+
+  Identifier.fromParts(List<Object> parts, {Scope? scope})
+      : super.fromParts(parts, scope: scope);
+}
+
+/// A piece of code identifying a named argument.
+///
+/// This should not include any trailing commas.
+class NamedArgument extends Code {
+  NamedArgument.fromString(String code, {Scope? scope})
+      : super.fromString(code, scope: scope);
+
+  NamedArgument.fromParts(List<Object> parts, {Scope? scope})
+      : super.fromParts(parts, scope: scope);
+}
+
+/// A piece of code identifying a syntactically valid function parameter.
+///
+/// This should not include any trailing commas, but may include modifiers
+/// such as `required`, and default values.
+///
+/// There is no distinction here made between named and positional parameters,
+/// nor between optional or required parameters. It is the job of the user to
+/// construct and combine these together in a way that creates valid parameter
+/// lists.
+class Parameter extends Code {
+  Parameter.fromString(String code, {Scope? scope})
+      : super.fromString(code, scope: scope);
+
+  Parameter.fromParts(List<Object> parts, {Scope? scope})
+      : super.fromParts(parts, scope: scope);
+}
+
+/// A piece of code representing a syntactically valid statement.
+///
+/// Should always end with a semicolon.
+class Statement extends Code {
+  Statement.fromString(String code, {Scope? scope})
+      : super.fromString(code, scope: scope);
+
+  Statement.fromParts(List<Object> parts, {Scope? scope})
+      : super.fromParts(parts, scope: scope);
+}
+
+extension Join<T extends Code> on List<T> {
+  /// Joins all the items in [this] with [separator], and returns
+  /// a new list.
+  List<Code> joinAsCode(String separator) => [
+        for (var i = 0; i < length - 1; i++) ...[
+          this[i],
+          Code.fromString(separator),
+        ],
+        last,
+      ];
+}

--- a/working/macros/api/introspection.dart
+++ b/working/macros/api/introspection.dart
@@ -119,18 +119,29 @@ abstract class FieldDeclaration implements Declaration {
 
   /// The class that defines this method.
   TypeAnnotation get definingClass;
+
+  /// A [Code] object representing the initializer for this field, if present.
+  Code? get initializer;
 }
 
 /// Parameter introspection information.
 abstract class ParameterDeclaration {
-  /// Whether or not this parameter has the `required` keyword.
-  bool get required;
+  /// The name of the parameter.
+  String get name;
 
   /// The type of this parameter.
   TypeAnnotation get type;
 
   /// Whether or not this is a named parameter.
   bool get isNamed;
+
+  /// Whether or not this parameter is either a non-optional positional
+  /// parameter or an optional parameter with the `required` keyword.
+  bool get isRequired;
+
+  /// A [Code] object representing the default value for this parameter, if
+  /// present. Can be used to copy default values to other parameters.
+  Code? get defaultValue;
 }
 
 /// Type parameter introspection information.

--- a/working/macros/api/introspection.dart
+++ b/working/macros/api/introspection.dart
@@ -1,20 +1,20 @@
 import 'code.dart';
 
-/// Type annotation introspection information.
+/// An unresolved reference to a type.
 ///
-/// These can be resolved using the `builder` classes depending on the phase
-/// a macro is running in.
+/// These can be resolved to a [TypeDeclaration] using the `builder` classes
+/// depending on the phase a macro is running in.
 abstract class TypeAnnotation {
-  /// Whether or not the type reference is explicitly nullable (contains a
+  /// Whether or not the type annotation is explicitly nullable (contains a
   /// trailing `?`)
   bool get isNullable;
 
   /// The name of the type as it exists in the type annotation.
   String get name;
 
-  /// The scope in which the type reference appeared in the program.
+  /// The scope in which the type annotation appeared in the program.
   ///
-  /// This can be used to construct an [Identifier] that refers to this type
+  /// This can be used to construct an [IdentifierCode] that refers to this type
   /// regardless of the context in which it is emitted.
   Scope get scope;
 
@@ -22,33 +22,38 @@ abstract class TypeAnnotation {
   Iterable<TypeAnnotation> get typeArguments;
 }
 
-/// Generic declaration introspection information.
+//// The base class for all declarations.
 abstract class Declaration {
-  /// Whether this declaration has an `abstract` modifier.
-  bool get isAbstract;
-
-  /// Whether this declaration has an `external` modifier.
-  bool get isExternal;
-
-  /// The name of this declaration as it appears in the code.
+  /// The name of this type declaration
   String get name;
 
-  /// Emits a piece of code that concretely refers to the same type that is
-  /// referred to by [this], regardless of where in the program it is placed.
+  /// The scope in which this type declaration is defined.
   ///
-  /// Effectively, this type reference has a custom scope (equal to [scope])
-  /// instead of the standard lexical scope.
-  Code get reference;
-
-  /// The scope in which the type reference appeared in the program.
+  /// This can be used to construct an [IdentifierCode] that refers to this type
+  /// regardless of the context in which it is emitted.
   Scope get scope;
+}
+
+/// A declaration that defines a new type in the program.
+abstract class TypeDeclaration implements Declaration {
+  /// The type parameters defined for this type declaration.
+  Iterable<TypeParameterDeclaration> get typeParameters;
+
+  /// Create a type annotation representing this type with [typeArguments].
+  TypeAnnotation instantiate({List<TypeAnnotation> typeArguments});
 }
 
 /// Class (and enum) introspection information.
 ///
 /// Information about fields, methods, and constructors must be retrieved from
 /// the `builder` objects.
-abstract class ClassDeclaration implements Declaration {
+abstract class ClassDeclaration implements TypeDeclaration {
+  /// Whether this class has an `abstract` modifier.
+  bool get isAbstract;
+
+  /// Whether this class has an `external` modifier.
+  bool get isExternal;
+
   /// The `extends` type annotation, if present.
   TypeAnnotation? get superclass;
 
@@ -59,56 +64,77 @@ abstract class ClassDeclaration implements Declaration {
   Iterable<TypeAnnotation> get mixins;
 
   /// All the type arguments, if applicable.
-  Iterable<TypeParameter> get typeParameters;
+  Iterable<TypeParameterDeclaration> get typeParameters;
 }
-
-/// Enum introspection information.
-abstract class EnumDeclaration implements Declaration {}
 
 /// Function introspection information.
 abstract class FunctionDeclaration implements Declaration {
+  /// Whether this function has an `abstract` modifier.
+  bool get isAbstract;
+
+  /// Whether this function has an `external` modifier.
+  bool get isExternal;
+
+  /// Whether this function is actually a getter.
   bool get isGetter;
 
+  /// Whether this function is actually a setter.
   bool get isSetter;
 
+  /// The return type of this function.
   TypeAnnotation get returnType;
 
-  Iterable<Parameter> get positionalParameters;
+  /// The positional parameters for this function.
+  Iterable<ParameterDeclaration> get positionalParameters;
 
-  Iterable<Parameter> get namedParameters;
+  /// The named parameters for this function.
+  Iterable<ParameterDeclaration> get namedParameters;
 
-  Iterable<TypeParameter> get typeParameters;
+  /// The type parameters for this function.
+  Iterable<TypeParameterDeclaration> get typeParameters;
 }
 
-/// Method introspection information for [TypeMacro]s.
+/// Method introspection information.
 abstract class MethodDeclaration implements FunctionDeclaration {
+  /// The class that defines this method.
   TypeAnnotation get definingClass;
 }
 
-/// Constructor introspection information for [TypeMacro]s.
+/// Constructor introspection information.
 abstract class ConstructorDeclaration implements MethodDeclaration {
+  /// Whether or not this is a factory constructor.
   bool get isFactory;
 }
 
 /// Field introspection information ..
 abstract class FieldDeclaration implements Declaration {
+  /// Whether this function has an `abstract` modifier.
+  bool get isAbstract;
+
+  /// Whether this function has an `external` modifier.
+  bool get isExternal;
+
+  /// Type type of this field.
   TypeAnnotation get type;
 
+  /// The class that defines this method.
   TypeAnnotation get definingClass;
 }
 
 /// Parameter introspection information.
-abstract class Parameter {
-  String get name;
-
+abstract class ParameterDeclaration {
+  /// Whether or not this parameter has the `required` keyword.
   bool get required;
 
+  /// The type of this parameter.
   TypeAnnotation get type;
+
+  /// Whether or not this is a named parameter.
+  bool get isNamed;
 }
 
 /// Type parameter introspection information.
-abstract class TypeParameter {
+abstract class TypeParameterDeclaration {
+  /// The bounds for this type parameter, if it has any.
   TypeAnnotation? get bounds;
-
-  String get name;
 }

--- a/working/macros/api/introspection.dart
+++ b/working/macros/api/introspection.dart
@@ -1,0 +1,114 @@
+import 'code.dart';
+
+/// Type annotation introspection information.
+///
+/// These can be resolved using the `builder` classes depending on the phase
+/// a macro is running in.
+abstract class TypeAnnotation {
+  /// Whether or not the type reference is explicitly nullable (contains a
+  /// trailing `?`)
+  bool get isNullable;
+
+  /// The name of the type as it exists in the type annotation.
+  String get name;
+
+  /// The scope in which the type reference appeared in the program.
+  ///
+  /// This can be used to construct an [Identifier] that refers to this type
+  /// regardless of the context in which it is emitted.
+  Scope get scope;
+
+  /// The type arguments, if applicable.
+  Iterable<TypeAnnotation> get typeArguments;
+}
+
+/// Generic declaration introspection information.
+abstract class Declaration {
+  /// Whether this declaration has an `abstract` modifier.
+  bool get isAbstract;
+
+  /// Whether this declaration has an `external` modifier.
+  bool get isExternal;
+
+  /// The name of this declaration as it appears in the code.
+  String get name;
+
+  /// Emits a piece of code that concretely refers to the same type that is
+  /// referred to by [this], regardless of where in the program it is placed.
+  ///
+  /// Effectively, this type reference has a custom scope (equal to [scope])
+  /// instead of the standard lexical scope.
+  Code get reference;
+
+  /// The scope in which the type reference appeared in the program.
+  Scope get scope;
+}
+
+/// Class (and enum) introspection information.
+///
+/// Information about fields, methods, and constructors must be retrieved from
+/// the `builder` objects.
+abstract class ClassDeclaration implements Declaration {
+  /// The `extends` type annotation, if present.
+  TypeAnnotation? get superclass;
+
+  /// All the `implements` type annotations.
+  Iterable<TypeAnnotation> get implements;
+
+  /// All the `with` type annotations.
+  Iterable<TypeAnnotation> get mixins;
+
+  /// All the type arguments, if applicable.
+  Iterable<TypeParameter> get typeParameters;
+}
+
+/// Enum introspection information.
+abstract class EnumDeclaration implements Declaration {}
+
+/// Function introspection information.
+abstract class FunctionDeclaration implements Declaration {
+  bool get isGetter;
+
+  bool get isSetter;
+
+  TypeAnnotation get returnType;
+
+  Iterable<Parameter> get positionalParameters;
+
+  Iterable<Parameter> get namedParameters;
+
+  Iterable<TypeParameter> get typeParameters;
+}
+
+/// Method introspection information for [TypeMacro]s.
+abstract class MethodDeclaration implements FunctionDeclaration {
+  TypeAnnotation get definingClass;
+}
+
+/// Constructor introspection information for [TypeMacro]s.
+abstract class ConstructorDeclaration implements MethodDeclaration {
+  bool get isFactory;
+}
+
+/// Field introspection information ..
+abstract class FieldDeclaration implements Declaration {
+  TypeAnnotation get type;
+
+  TypeAnnotation get definingClass;
+}
+
+/// Parameter introspection information.
+abstract class Parameter {
+  String get name;
+
+  bool get required;
+
+  TypeAnnotation get type;
+}
+
+/// Type parameter introspection information.
+abstract class TypeParameter {
+  TypeAnnotation? get bounds;
+
+  String get name;
+}

--- a/working/macros/api/macros.dart
+++ b/working/macros/api/macros.dart
@@ -1,0 +1,119 @@
+import 'builders.dart';
+import 'introspection.dart';
+
+/// The marker interface for all types of macros.
+abstract class Macro {}
+
+/// The marker interface for macros that are allowed to contribute new type
+/// declarations into the program.
+///
+/// These macros run before all other types of macros.
+///
+/// In exchange for the power to add new type declarations, these macros have
+/// limited introspections capabilities, since new types can be added in this
+/// phase you cannot follow type references back to their declarations.
+abstract class TypeMacro implements Macro {}
+
+/// The marker interface for macros that are allowed to contribute new
+/// declarations to the program, including both top level and class level
+/// declarations.
+///
+/// These macros run after [TypeMacro]s, but before [DefinitionMacro]s.
+///
+/// These macros can resolve type annotations to specific declarations, and
+/// inspect type hierarchies, but they cannot inspect the declarations on those
+/// type annotations, since new declarations could still be added in this phase.
+abstract class DeclarationMacro implements Macro {}
+
+/// The marker interface for macros that are only allowed to implement or wrap
+/// existing declarations in the program. They cannot introduce any new
+/// declarations that are visible to the program, but are allowed to add
+/// declarations that only they can see.
+///
+/// These macros run after all other types of macros.
+///
+/// These macros can fully reflect on the program since the static shape is
+/// fully definied by the time they run.
+abstract class DefinitionMacro implements Macro {}
+
+/// The interface for [TypeMacro]s that can be applied to classes.
+abstract class ClassTypeMacro implements TypeMacro {
+  void visitClassType(ClassDeclaration type, TypeBuilder builder);
+}
+
+/// The interface for [DeclarationMacro]s that can be applied to classes.
+abstract class ClassDeclarationMacro implements DeclarationMacro {
+  void visitClassDeclaration(
+      ClassDeclaration declaration, ClassDeclarationBuilder builder);
+}
+
+/// The interface for [TypeMacro]s that can be applied to fields.
+abstract class FieldTypeMacro implements TypeMacro {
+  void visitFieldType(FieldDeclaration field, TypeBuilder builder);
+}
+
+/// The interface for [DeclarationMacro]s that can be applied to fields.
+abstract class FieldDeclarationMacro implements DeclarationMacro {
+  void visitFieldDeclaration(
+      FieldDeclaration declaration, ClassDeclarationBuilder builder);
+}
+
+/// The interface for [DefinitionMacro]s that can be applied to fields.
+abstract class FieldDefinitionMacro implements DefinitionMacro {
+  void visitFieldDefinition(
+      FieldDeclaration definition, FieldDefinitionBuilder builder);
+}
+
+/// The interface for [TypeMacro]s that can be applied to top level functions
+/// or methods.
+abstract class FunctionTypeMacro implements TypeMacro {
+  void visitFunctionType(FunctionDeclaration type, TypeBuilder builder);
+}
+
+/// The interface for [DeclarationMacro]s that can be applied to top level
+/// functions or methods.
+abstract class FunctionDeclarationMacro implements DeclarationMacro {
+  void visitFunctionDeclaration(
+      FunctionDeclaration declaration, DeclarationBuilder builder);
+}
+
+/// The interface for [DefinitionMacro]s that can be applied to top level
+/// functions or methods.
+abstract class FunctionDefinitionMacro implements DefinitionMacro {
+  void visitFunctionDefinition(
+      FunctionDeclaration definition, FunctionDefinitionBuilder builder);
+}
+
+/// The interface for [TypeMacro]s that can be applied to methods.
+abstract class MethodTypeMacro implements TypeMacro {
+  void visitMethodType(MethodDeclaration type, TypeBuilder builder);
+}
+
+/// The interface for [DeclarationMacro]s that can be applied to methods.
+abstract class MethodDeclarationMacro implements DeclarationMacro {
+  void visitMethodDeclaration(
+      MethodDeclaration declaration, ClassDeclarationBuilder builder);
+}
+
+/// The interface for [DefinitionMacro]s that can be applied to methods.
+abstract class MethodDefinitionMacro implements DefinitionMacro {
+  void visitMethodDefinition(
+      MethodDeclaration definition, FunctionDefinitionBuilder builder);
+}
+
+/// The interface for [TypeMacro]s that can be applied to constructors.
+abstract class ConstructorTypeMacro implements TypeMacro {
+  void visitConstructorType(ConstructorDeclaration type, TypeBuilder builder);
+}
+
+/// The interface for [DeclarationMacro]s that can be applied to constructors.
+abstract class ConstructorDeclarationMacro implements DefinitionMacro {
+  void visitConstructorDeclaration(
+      ConstructorDeclaration declaration, ClassDeclarationBuilder builder);
+}
+
+/// The interface for [DefinitionMacro]s that can be applied to constructors.
+abstract class ConstructorDefinitionMacro implements DefinitionMacro {
+  void visitConstructorDefinition(
+      ConstructorDeclaration definition, ConstructorDefinitionBuilder builder);
+}

--- a/working/macros/api/macros.dart
+++ b/working/macros/api/macros.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'builders.dart';
 import 'introspection.dart';
 
@@ -38,82 +40,84 @@ abstract class DefinitionMacro implements Macro {}
 
 /// The interface for [TypeMacro]s that can be applied to classes.
 abstract class ClassTypeMacro implements TypeMacro {
-  void visitClassType(ClassDeclaration type, TypeBuilder builder);
+  FutureOr<void> visitClassType(ClassDeclaration type, TypeBuilder builder);
 }
 
 /// The interface for [DeclarationMacro]s that can be applied to classes.
 abstract class ClassDeclarationMacro implements DeclarationMacro {
-  void visitClassDeclaration(
+  FutureOr<void> visitClassDeclaration(
       ClassDeclaration declaration, ClassDeclarationBuilder builder);
 }
 
 /// The interface for [TypeMacro]s that can be applied to fields.
 abstract class FieldTypeMacro implements TypeMacro {
-  void visitFieldType(FieldDeclaration field, TypeBuilder builder);
+  FutureOr<void> visitFieldType(FieldDeclaration field, TypeBuilder builder);
 }
 
 /// The interface for [DeclarationMacro]s that can be applied to fields.
 abstract class FieldDeclarationMacro implements DeclarationMacro {
-  void visitFieldDeclaration(
+  FutureOr<void> visitFieldDeclaration(
       FieldDeclaration declaration, ClassDeclarationBuilder builder);
 }
 
 /// The interface for [DefinitionMacro]s that can be applied to fields.
 abstract class FieldDefinitionMacro implements DefinitionMacro {
-  void visitFieldDefinition(
+  FutureOr<void> visitFieldDefinition(
       FieldDeclaration definition, FieldDefinitionBuilder builder);
 }
 
 /// The interface for [TypeMacro]s that can be applied to top level functions
 /// or methods.
 abstract class FunctionTypeMacro implements TypeMacro {
-  void visitFunctionType(FunctionDeclaration type, TypeBuilder builder);
+  FutureOr<void> visitFunctionType(
+      FunctionDeclaration type, TypeBuilder builder);
 }
 
 /// The interface for [DeclarationMacro]s that can be applied to top level
 /// functions or methods.
 abstract class FunctionDeclarationMacro implements DeclarationMacro {
-  void visitFunctionDeclaration(
+  FutureOr<void> visitFunctionDeclaration(
       FunctionDeclaration declaration, DeclarationBuilder builder);
 }
 
 /// The interface for [DefinitionMacro]s that can be applied to top level
 /// functions or methods.
 abstract class FunctionDefinitionMacro implements DefinitionMacro {
-  void visitFunctionDefinition(
+  FutureOr<void> visitFunctionDefinition(
       FunctionDeclaration definition, FunctionDefinitionBuilder builder);
 }
 
 /// The interface for [TypeMacro]s that can be applied to methods.
 abstract class MethodTypeMacro implements TypeMacro {
-  void visitMethodType(MethodDeclaration type, TypeBuilder builder);
+  FutureOr<void> visitMethodType(MethodDeclaration type, TypeBuilder builder);
 }
 
 /// The interface for [DeclarationMacro]s that can be applied to methods.
 abstract class MethodDeclarationMacro implements DeclarationMacro {
-  void visitMethodDeclaration(
+  FutureOr<void> visitMethodDeclaration(
       MethodDeclaration declaration, ClassDeclarationBuilder builder);
 }
 
 /// The interface for [DefinitionMacro]s that can be applied to methods.
 abstract class MethodDefinitionMacro implements DefinitionMacro {
-  void visitMethodDefinition(
+  FutureOr<void> visitMethodDefinition(
       MethodDeclaration definition, FunctionDefinitionBuilder builder);
 }
 
 /// The interface for [TypeMacro]s that can be applied to constructors.
 abstract class ConstructorTypeMacro implements TypeMacro {
-  void visitConstructorType(ConstructorDeclaration type, TypeBuilder builder);
+  FutureOr<void> visitConstructorType(
+      ConstructorDeclaration type, TypeBuilder builder);
 }
 
 /// The interface for [DeclarationMacro]s that can be applied to constructors.
 abstract class ConstructorDeclarationMacro implements DefinitionMacro {
-  void visitConstructorDeclaration(
+  FutureOr<void> visitConstructorDeclaration(
       ConstructorDeclaration declaration, ClassDeclarationBuilder builder);
 }
 
 /// The interface for [DefinitionMacro]s that can be applied to constructors.
 abstract class ConstructorDefinitionMacro implements DefinitionMacro {
-  void visitConstructorDefinition(
+  FutureOr<void> visitConstructorDefinition(
       ConstructorDeclaration definition, ConstructorDefinitionBuilder builder);
 }

--- a/working/macros/example/data_class.dart
+++ b/working/macros/example/data_class.dart
@@ -1,0 +1,236 @@
+import '../api/macros.dart';
+import '../api/introspection.dart';
+import '../api/builders.dart';
+import '../api/code.dart';
+
+const dataClass = _DataClass();
+
+class _DataClass implements ClassDeclarationMacro {
+  const _DataClass();
+
+  @override
+  void visitClassDeclaration(
+      ClassDeclaration declaration, ClassDeclarationBuilder builder) {
+    autoConstructor.visitClassDeclaration(declaration, builder);
+    copyWith.visitClassDeclaration(declaration, builder);
+    hashCode.visitClassDeclaration(declaration, builder);
+    equality.visitClassDeclaration(declaration, builder);
+    toString.visitClassDeclaration(declaration, builder);
+  }
+}
+
+const autoConstructor = _AutoConstructor();
+
+class _AutoConstructor implements ClassDeclarationMacro {
+  const _AutoConstructor();
+
+  @override
+  void visitClassDeclaration(
+      ClassDeclaration declaration, ClassDeclarationBuilder builder) async {
+    var constructors = await builder.constructorsOf(declaration);
+    if (constructors.any((c) => c.name == '')) {
+      throw ArgumentError(
+          'Cannot generate an unnamed constructor because one already exists');
+    }
+
+    var parts = [Code.fromString('${declaration.name}({')];
+    // Add all the fields of `declaration` as named parameters.
+    var fields = await builder.fieldsOf(declaration);
+    for (var field in fields) {
+      var requiredKeyword = field.type.isNullable ? '' : 'required ';
+      parts.add(Code.fromString('\n${requiredKeyword}this.${field.name},'));
+    }
+
+    // Add all super constructor parameters as named parameters.
+    var superclass = await builder.superclassOf(declaration);
+    MethodDeclaration? superconstructor;
+    if (superclass != null) {
+      var superconstructor = (await builder.constructorsOf(superclass))
+          .firstWhereOrNull((c) => c.name == '');
+      if (superconstructor == null) {
+        throw ArgumentError(
+            'Super class $superclass of $declaration does not have an unnamed '
+            'constructor');
+      }
+      // We convert positional parameters in the super constructor to named
+      // parameters in this constructor.
+      for (var param in superconstructor.positionalParameters) {
+        var requiredKeyword = param.isRequired ? 'required' : '';
+        var defaultValue = param.defaultValue == null
+            ? ''
+            : Code.fromParts([' = ', param.defaultValue!]);
+        parts.add(Code.fromParts([
+          '\n$requiredKeyword${param.type.toCode()} ${param.name}',
+          defaultValue,
+          ',',
+        ]));
+      }
+      for (var param in superconstructor.namedParameters) {
+        var requiredKeyword = param.isRequired ? '' : 'required ';
+        var defaultValue = param.defaultValue == null
+            ? ''
+            : Code.fromParts([' = ', param.defaultValue!]);
+        parts.add(Code.fromParts([
+          '\n$requiredKeyword${param.type.toCode()} ${param.name}',
+          defaultValue,
+          ',',
+        ]));
+      }
+    }
+    parts.add(Code.fromString('\n})'));
+    if (superconstructor != null) {
+      parts.add(Code.fromString(' : super('));
+      for (var param in superconstructor.positionalParameters) {
+        parts.add(Code.fromString('\n${param.name},'));
+      }
+      if (superconstructor.namedParameters.isNotEmpty) {
+        parts.add(Code.fromString('{'));
+        for (var param in superconstructor.namedParameters) {
+          parts.add(Code.fromString('\n${param.name}: ${param.name},'));
+        }
+        parts.add(Code.fromString('\n}'));
+      }
+      parts.add(Code.fromString(')'));
+    }
+    parts.add(Code.fromString(';'));
+    builder.addToClass(DeclarationCode.fromParts(parts));
+  }
+}
+
+const copyWith = _CopyWith();
+
+// TODO: How to deal with overriding nullable fields to `null`?
+class _CopyWith implements ClassDeclarationMacro {
+  const _CopyWith();
+
+  @override
+  void visitClassDeclaration(
+      ClassDeclaration declaration, ClassDeclarationBuilder builder) async {
+    var methods = await builder.methodsOf(declaration);
+    if (methods.any((c) => c.name == 'copyWith')) {
+      throw ArgumentError(
+          'Cannot generate a copyWith method because one already exists');
+    }
+    var allFields = await declaration.allFields(builder).toList();
+    var namedParams = [
+      for (var field in allFields)
+        ParameterCode.fromString(
+            '${field.type.toCode()}${field.type.isNullable ? '' : '?'} '
+            '${field.name}'),
+    ];
+    var args = [
+      for (var field in allFields)
+        NamedArgumentCode.fromString(
+            '${field.name}: ${field.name}?? this.${field.name}'),
+    ];
+    builder.addToClass(DeclarationCode.fromParts([
+      declaration.instantiate().toCode(),
+      ' copyWith({',
+      ...namedParams.joinAsCode(', '),
+      ',})',
+      // TODO: We assume this constructor exists, but should check
+      '=> ', declaration.instantiate().toCode(), '}(',
+      ...args.joinAsCode(', '),
+      ', );',
+    ]));
+  }
+}
+
+const hashCode = _HashCode();
+
+class _HashCode implements ClassDeclarationMacro {
+  const _HashCode();
+
+  @override
+  void visitClassDeclaration(
+      ClassDeclaration declaration, ClassDeclarationBuilder builder) async {
+    var hashCodeExprs = [
+      await for (var field in declaration.allFields(builder))
+        ExpressionCode.fromString('${field.name}.hashCode')
+    ].joinAsCode(' ^ ');
+
+    builder.addToClass(DeclarationCode.fromParts([
+      '''
+@override
+int get hashCode =>''',
+      ...hashCodeExprs,
+      ';',
+    ]));
+  }
+}
+
+const equality = _Equality();
+
+class _Equality implements ClassDeclarationMacro {
+  const _Equality();
+
+  @override
+  void visitClassDeclaration(
+      ClassDeclaration declaration, ClassDeclarationBuilder builder) async {
+    var equalityExprs = [
+      await for (var field in declaration.allFields(builder))
+        ExpressionCode.fromString('this.${field.name} == other.${field.name}'),
+    ].joinAsCode(' && ');
+
+    builder.addToClass(DeclarationCode.fromParts([
+      '''
+@override
+bool operator==(Object other) =>
+    other is ${declaration.instantiate().toCode()} && ''',
+      ...equalityExprs,
+      ';',
+    ]));
+  }
+}
+
+const toString = _ToString();
+
+class _ToString implements ClassDeclarationMacro {
+  const _ToString();
+
+  @override
+  void visitClassDeclaration(
+      ClassDeclaration declaration, ClassDeclarationBuilder builder) async {
+    var fieldExprs = [
+      await for (var field in declaration.allFields(builder))
+        Code.fromString('  ${field.name}: \${${field.name}}'),
+    ].joinAsCode('\n');
+
+    builder.addToClass(DeclarationCode.fromParts([
+      '''
+@override
+String toString() => """\${${declaration.name}} {
+''',
+      ...fieldExprs,
+      '}""";',
+    ]));
+  }
+}
+
+extension _AllFields on ClassDeclaration {
+  // Returns all fields from all super classes.
+  Stream<FieldDeclaration> allFields(ClassIntrospector introspector) async* {
+    for (var field in await introspector.fieldsOf(this)) {
+      yield field;
+    }
+    var next = await introspector.superclassOf(this);
+    while (next is ClassDeclaration && next.name != 'Object') {
+      for (var field in await introspector.fieldsOf(next)) {
+        yield field;
+      }
+      next = await introspector.superclassOf(next);
+    }
+  }
+}
+
+extension _<T> on Iterable<T> {
+  T? firstWhereOrNull(bool Function(T element) test) {
+    for (var item in this) {
+      if (test(item)) return item;
+    }
+  }
+}
+
+extension _ToCode on TypeAnnotation {
+  Code toCode() => Code.fromString(this.name, scope: this.scope);
+}


### PR DESCRIPTION
I made a fair number of changes here from the original prototype apis. A lot of this was influenced by subsequent prototypes for actually loading and running macros in a separate isolate - it became clear we will want some asynchronous apis to enable us to split up information into smaller chunks for sending it efficiently to a separate macro expansion isolate.

The major differences are as follows:

- all types in all apis now appear as `TypeAnnotation` objects, and then the builder apis expose operations on those based on the capabilities in that phase.
- the ClassDeclaration api doesn't directly have information about its members - you have to also query separately for those through asynchronous apis on the builder objects.
  - this does feel a bit weird, so we could change it potentially

There are also still some holes I am sure in terms of missing information that we may want to expose for certain objects.

I also ported over the data class macro example to this API.