### PR TITLE
Alternate macro api proposal, less visible phases

### DIFF
--- a/working/macros/api/builders.dart
+++ b/working/macros/api/builders.dart
@@ -1,0 +1,115 @@
+import 'code.dart';
+import 'introspection.dart';
+import 'macros.dart'; // For dart docs :(
+
+abstract class Builder {
+  /// Used to construct a [TypeAnnotation] to a runtime type available to the
+  /// the macro implementation code.
+  ///
+  /// This can be used to emit a reference to it in generated code, or do
+  /// subtype checks (depending on support in the current phase).
+  TypeAnnotation typeAnnotationOf<T>();
+}
+
+/// The api used by [TypeMacro]s to contribute new type declarations to the
+/// current library, and get [TypeAnnotation]s from runtime [Type] objects.
+abstract class TypeBuilder implements Builder {
+  /// Adds a new type declaration to the surrounding library.
+  void addTypeToLibary(DeclarationCode typeDeclaration);
+}
+
+/// The api used by [DeclarationMacro]s to contribute new (non-type)
+/// declarations to the current library.
+///
+/// Can also be used to do subtype checks on types.
+abstract class DeclarationBuilder implements Builder {
+  /// Adds a new regular declaration to the surrounding library.
+  ///
+  /// Note that type declarations are not supported.
+  void addToLibrary(DeclarationCode declaration);
+
+  /// Returns true if [leftType] is a subtype of [rightType].
+  bool isSubtypeOf(TypeAnnotation leftType, TypeAnnotation rightType);
+
+  /// Retruns true if [leftType] is an identical type to [rightType].
+  bool isExactly(TypeAnnotation leftType, TypeAnnotation rightType);
+}
+
+/// The api used by [DeclarationMacro]s to contribute new members to a class.
+abstract class ClassMemberDeclarationBuilder implements DeclarationBuilder {
+  /// Adds a new declaration to the surrounding class.
+  void addToClass(DeclarationCode declaration);
+}
+
+/// The api used to introspect on a [ClassDeclaration].
+abstract class ClassIntrospector {
+  /// The fields available for [clazz].
+  ///
+  /// This may be incomplete if in the declaration phase and additional macros
+  /// are going to run on this class.
+  Stream<FieldDeclaration> fieldsOf(ClassDeclaration clazz);
+
+  /// The methods available so far for the current class.
+  ///
+  /// This may be incomplete if additional declaration macros are running on
+  /// this class.
+  Stream<MethodDeclaration> methodsOf(ClassDeclaration clazz);
+
+  /// The constructors available so far for the current class.
+  ///
+  /// This may be incomplete if additional declaration macros are running on
+  /// this class.
+  Stream<ConstructorDeclaration> constructorsOf(ClassDeclaration clazz);
+
+  /// The class that is directly extended via an `extends` clause.
+  Future<ClassDeclaration?> superclassOf(ClassDeclaration clazz);
+
+  /// All of the classes that are mixed in with `with` clauses.
+  Stream<ClassDeclaration> mixinsOf(ClassDeclaration clazz);
+}
+
+/// The api used by [DeclarationMacro]s to reflect on the currently available
+/// members, superclass, and mixins for a given [ClassDeclaration]
+abstract class ClassDeclarationBuilder
+    implements ClassMemberDeclarationBuilder, ClassIntrospector {}
+
+/// The api used by [DefinitionMacro] to get a [TypeDeclaration] for any given
+/// [TypeAnnotation].
+abstract class TypeIntrospector {
+  Future<TypeDeclaration> typeDeclarationOf(TypeAnnotation annotation);
+}
+
+/// The base class for builders in the definition phase. These can convert
+/// any [TypeAnnotation] into its corresponding [TypeDeclaration], and also
+/// reflect more deeply on those.
+abstract class DefinitionBuilder
+    implements Builder, ClassIntrospector, TypeIntrospector {}
+
+/// The apis used by [DefinitionMacro]s to define the body of a constructor
+/// or wrap the body of an existing constructor with additional statements.
+abstract class ConstructorDefinitionBuilder implements DefinitionBuilder {
+  /// Augments an existing constructor body with [body].
+  ///
+  /// TODO: Link the library augmentations proposal to describe the semantics.
+  void augment({FunctionBodyCode? body, List<Code>? initializers});
+}
+
+/// The apis used by [DefinitionMacro]s to augment functions or methods.
+abstract class FunctionDefinitionBuilder implements DefinitionBuilder {
+  /// Augments the function.
+  ///
+  /// TODO: Link the library augmentations proposal to describe the semantics.
+  void augment(FunctionBodyCode body);
+}
+
+/// The api used by [DefinitionMacro]s to augment a field.
+abstract class FieldDefinitionBuilder implements DefinitionBuilder {
+  /// Augments the field.
+  ///
+  /// TODO: Link the library augmentations proposal to describe the semantics.
+  void augment({
+    DeclarationCode? getter,
+    DeclarationCode? setter,
+    ExpressionCode? initializer,
+  });
+}

--- a/working/macros/api/builders.dart
+++ b/working/macros/api/builders.dart
@@ -78,7 +78,9 @@ abstract class ClassDeclarationBuilder
 /// The api used by [Macro] to get a [TypeDeclaration] for any given
 /// [TypeAnnotation].
 abstract class TypeIntrospector {
-  Future<TypeDeclaration> typeDeclarationOf(TypeAnnotation annotation);
+  /// TODO: Figure out how to deal with `FutureOr<T>`, function types, and
+  /// other non-nominal types.
+  Future<TypeDeclaration> resolve(TypeAnnotation annotation);
 }
 
 /// The base class for builders in the definition phase. These can convert

--- a/working/macros/api/builders.dart
+++ b/working/macros/api/builders.dart
@@ -2,19 +2,10 @@ import 'dart:async';
 
 import 'code.dart';
 import 'introspection.dart';
-import 'macros.dart'; // For dart docs :(
-
-abstract class Builder {
-  /// Used to construct a [TypeAnnotation] to a runtime type available to the
-  /// the macro implementation code.
-  ///
-  /// This can be used to emit a reference to it in generated code, or do
-  /// subtype checks (depending on support in the current phase).
-  TypeAnnotation typeAnnotationOf<T>();
-}
+import 'macros.dart'; // For dart docs.
 
 /// The interface used by [Macro]s to modify the current library.
-abstract class LibraryBuilder {
+abstract class LibraryContext {
   /// Used to contribute new type declarations to this library.
   void buildTypes(FutureOr<void> Function(TypeBuilder) callback);
 
@@ -23,14 +14,14 @@ abstract class LibraryBuilder {
 }
 
 /// The interface used by [FunctionMacro]s to modify the function.
-abstract class FunctionBuilder implements LibraryBuilder {
+abstract class FunctionContext implements LibraryContext {
   /// Used to augment a function definition.
   void buildDefinition(
       FutureOr<void> Function(FunctionDefinitionBuilder) callback);
 }
 
 /// The interface used by [ClassMacro]s to modify the class.
-abstract class ClassBuilder implements LibraryBuilder {
+abstract class ClassContext implements LibraryContext {
   /// Used to contribute new non-type declarations to this library or class.
   @override
   void buildDeclarations(
@@ -43,7 +34,7 @@ abstract class ClassBuilder implements LibraryBuilder {
 
 /// The interface used by all [Macro]s that run on a member of a class, to add
 /// declarations to that class or the surrounding library.
-abstract class ClassMemberBuilder implements LibraryBuilder {
+abstract class ClassMemberContext implements LibraryContext {
   /// Used to contribute new non-type declarations to the surrounding library
   /// or class.
   @override
@@ -52,24 +43,35 @@ abstract class ClassMemberBuilder implements LibraryBuilder {
 }
 
 /// The interface used by [FieldMacro]s to modify the field.
-abstract class FieldBuilder implements ClassMemberBuilder {
+abstract class FieldContext implements ClassMemberContext {
   /// Used to augment a field definition.
   void buildDefinition(
       FutureOr<void> Function(FieldDefinitionBuilder) callback);
 }
 
 /// The interface used by [MethodMacro]s to modify the method.
-abstract class MethodBuilder implements ClassMemberBuilder {
+abstract class MethodContext implements ClassMemberContext {
   /// Used to augment a method definition.
   void buildDefinition(
       FutureOr<void> Function(FunctionDefinitionBuilder) callback);
 }
 
 /// The interface used by [ConstructorMacro]s to modify the constructor.
-abstract class ConstructorBuilder implements ClassMemberBuilder {
+abstract class ConstructorContext implements ClassMemberContext {
   /// Used to augment a constructor definition.
   void buildDefinition(
       FutureOr<void> Function(ConstructorDefinitionBuilder) callback);
+}
+
+/// The base interface used to add declarations to the program as well
+/// as augment existing ones.
+abstract class Builder {
+  /// Used to construct a [TypeAnnotation] to a runtime type available to the
+  /// the macro implementation code.
+  ///
+  /// This can be used to emit a reference to it in generated code, or do
+  /// subtype checks (depending on support in the current phase).
+  TypeAnnotation typeAnnotationOf<T>();
 }
 
 /// The api used by [Macro]s to contribute new type declarations to the
@@ -79,7 +81,7 @@ abstract class TypeBuilder implements Builder {
   void declareType(DeclarationCode typeDeclaration);
 }
 
-/// The api used by [DeclarationMacro]s to contribute new (non-type)
+/// The api used by [Macro]s to contribute new (non-type)
 /// declarations to the current library.
 ///
 /// Can also be used to do subtype checks on types.
@@ -96,7 +98,7 @@ abstract class DeclarationBuilder implements Builder {
   bool isExactly(TypeAnnotation leftType, TypeAnnotation rightType);
 }
 
-/// The api used by [DeclarationMacro]s to contribute new members to a class.
+/// The api used by [Macro]s to contribute new members to a class.
 abstract class ClassMemberDeclarationBuilder implements DeclarationBuilder {
   /// Adds a new declaration to the surrounding class.
   void declareInClass(DeclarationCode declaration);

--- a/working/macros/api/builders.dart
+++ b/working/macros/api/builders.dart
@@ -13,7 +13,66 @@ abstract class Builder {
   TypeAnnotation typeAnnotationOf<T>();
 }
 
-/// The api used by [TypeMacro]s to contribute new type declarations to the
+/// The interface used by [Macro]s to modify the current library.
+abstract class LibraryBuilder {
+  /// Used to contribute new type declarations to this library.
+  void buildTypes(FutureOr<void> Function(TypeBuilder) callback);
+
+  /// Used to contribute new non-type declarations to this library.
+  void buildDeclarations(FutureOr<void> Function(DeclarationBuilder) callback);
+}
+
+/// The interface used by [FunctionMacro]s to modify the function.
+abstract class FunctionBuilder implements LibraryBuilder {
+  /// Used to augment a function definition.
+  void buildDefinition(
+      FutureOr<void> Function(FunctionDefinitionBuilder) callback);
+}
+
+/// The interface used by [ClassMacro]s to modify the class.
+abstract class ClassBuilder implements LibraryBuilder {
+  /// Used to contribute new non-type declarations to this library or class.
+  @override
+  void buildDeclarations(
+      FutureOr<void> Function(ClassDeclarationBuilder) callback);
+
+  /// Used to augment any members in this class.
+  void buildDefinitions(
+      FutureOr<void> Function(ClassDefinitionBuilder) callback);
+}
+
+/// The interface used by all [Macro]s that run on a member of a class, to add
+/// declarations to that class or the surrounding library.
+abstract class ClassMemberBuilder implements LibraryBuilder {
+  /// Used to contribute new non-type declarations to the surrounding library
+  /// or class.
+  @override
+  void buildDeclarations(
+      FutureOr<void> Function(ClassMemberDeclarationBuilder) callback);
+}
+
+/// The interface used by [FieldMacro]s to modify the field.
+abstract class FieldBuilder implements ClassMemberBuilder {
+  /// Used to augment a field definition.
+  void buildDefinition(
+      FutureOr<void> Function(FieldDefinitionBuilder) callback);
+}
+
+/// The interface used by [MethodMacro]s to modify the method.
+abstract class MethodBuilder implements ClassMemberBuilder {
+  /// Used to augment a method definition.
+  void buildDefinition(
+      FutureOr<void> Function(FunctionDefinitionBuilder) callback);
+}
+
+/// The interface used by [ConstructorMacro]s to modify the constructor.
+abstract class ConstructorBuilder implements ClassMemberBuilder {
+  /// Used to augment a constructor definition.
+  void buildDefinition(
+      FutureOr<void> Function(ConstructorDefinitionBuilder) callback);
+}
+
+/// The api used by [Macro]s to contribute new type declarations to the
 /// current library, and get [TypeAnnotation]s from runtime [Type] objects.
 abstract class TypeBuilder implements Builder {
   /// Adds a new type declaration to the surrounding library.

--- a/working/macros/api/builders.dart
+++ b/working/macros/api/builders.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'code.dart';
 import 'introspection.dart';
 import 'macros.dart'; // For dart docs :(
@@ -85,7 +87,29 @@ abstract class TypeIntrospector {
 abstract class DefinitionBuilder
     implements Builder, ClassIntrospector, TypeIntrospector {}
 
-/// The apis used by [DefinitionMacro]s to define the body of a constructor
+/// The apis used by [Macro]s that run on classes, to fill in the definitions
+/// of any external declarations within that class.
+abstract class ClassDefinitionBuilder implements DefinitionBuilder {
+  /// Retrieve a [FieldDefinitionBuilder] for a field by [name].
+  ///
+  /// Throws an [ArgumentError] if there is no field by that name.
+  Future<void> buildField(String name,
+      FutureOr<void> Function(FieldDefinitionBuilder builder) callback);
+
+  /// Retrieve a [FunctionDefinitionBuilder] for a method by [name].
+  ///
+  /// Throws an [ArgumentError] if there is no method by that name.
+  Future<void> buildMethod(String name,
+      FutureOr<void> Function(FunctionDefinitionBuilder builder) callback);
+
+  /// Retrieve a [ConstructorDefinitionBuilder] for a constructor by [name].
+  ///
+  /// Throws an [ArgumentError] if there is no constructor by that name.
+  Future<void> buildConstructor(String name,
+      FutureOr<void> Function(ConstructorDefinitionBuilder builder) callback);
+}
+
+/// The apis used by [Macro]s to define the body of a constructor
 /// or wrap the body of an existing constructor with additional statements.
 abstract class ConstructorDefinitionBuilder implements DefinitionBuilder {
   /// Augments an existing constructor body with [body].
@@ -94,7 +118,7 @@ abstract class ConstructorDefinitionBuilder implements DefinitionBuilder {
   void augment({FunctionBodyCode? body, List<Code>? initializers});
 }
 
-/// The apis used by [DefinitionMacro]s to augment functions or methods.
+/// The apis used by [Macro]s to augment functions or methods.
 abstract class FunctionDefinitionBuilder implements DefinitionBuilder {
   /// Augments the function.
   ///
@@ -102,7 +126,7 @@ abstract class FunctionDefinitionBuilder implements DefinitionBuilder {
   void augment(FunctionBodyCode body);
 }
 
-/// The api used by [DefinitionMacro]s to augment a field.
+/// The api used by [Macro]s to augment a field.
 abstract class FieldDefinitionBuilder implements DefinitionBuilder {
   /// Augments the field.
   ///

--- a/working/macros/api/builders.dart
+++ b/working/macros/api/builders.dart
@@ -26,7 +26,7 @@ abstract class DeclarationBuilder implements Builder {
   /// Adds a new regular declaration to the surrounding library.
   ///
   /// Note that type declarations are not supported.
-  void addToLibrary(DeclarationCode declaration);
+  Declaration addToLibrary(DeclarationCode declaration);
 
   /// Returns true if [leftType] is a subtype of [rightType].
   bool isSubtypeOf(TypeAnnotation leftType, TypeAnnotation rightType);
@@ -68,12 +68,12 @@ abstract class ClassIntrospector {
   Future<List<ClassDeclaration>> mixinsOf(ClassDeclaration clazz);
 }
 
-/// The api used by [DeclarationMacro]s to reflect on the currently available
+/// The api used by [Macro]s to reflect on the currently available
 /// members, superclass, and mixins for a given [ClassDeclaration]
 abstract class ClassDeclarationBuilder
     implements ClassMemberDeclarationBuilder, ClassIntrospector {}
 
-/// The api used by [DefinitionMacro] to get a [TypeDeclaration] for any given
+/// The api used by [Macro] to get a [TypeDeclaration] for any given
 /// [TypeAnnotation].
 abstract class TypeIntrospector {
   Future<TypeDeclaration> typeDeclarationOf(TypeAnnotation annotation);

--- a/working/macros/api/builders.dart
+++ b/working/macros/api/builders.dart
@@ -47,25 +47,25 @@ abstract class ClassIntrospector {
   ///
   /// This may be incomplete if in the declaration phase and additional macros
   /// are going to run on this class.
-  Stream<FieldDeclaration> fieldsOf(ClassDeclaration clazz);
+  Future<List<FieldDeclaration>> fieldsOf(ClassDeclaration clazz);
 
   /// The methods available so far for the current class.
   ///
   /// This may be incomplete if additional declaration macros are running on
   /// this class.
-  Stream<MethodDeclaration> methodsOf(ClassDeclaration clazz);
+  Future<List<MethodDeclaration>> methodsOf(ClassDeclaration clazz);
 
   /// The constructors available so far for the current class.
   ///
   /// This may be incomplete if additional declaration macros are running on
   /// this class.
-  Stream<ConstructorDeclaration> constructorsOf(ClassDeclaration clazz);
+  Future<List<ConstructorDeclaration>> constructorsOf(ClassDeclaration clazz);
 
   /// The class that is directly extended via an `extends` clause.
   Future<ClassDeclaration?> superclassOf(ClassDeclaration clazz);
 
   /// All of the classes that are mixed in with `with` clauses.
-  Stream<ClassDeclaration> mixinsOf(ClassDeclaration clazz);
+  Future<List<ClassDeclaration>> mixinsOf(ClassDeclaration clazz);
 }
 
 /// The api used by [DeclarationMacro]s to reflect on the currently available

--- a/working/macros/api/builders.dart
+++ b/working/macros/api/builders.dart
@@ -17,7 +17,7 @@ abstract class Builder {
 /// current library, and get [TypeAnnotation]s from runtime [Type] objects.
 abstract class TypeBuilder implements Builder {
   /// Adds a new type declaration to the surrounding library.
-  void addTypeToLibary(DeclarationCode typeDeclaration);
+  void declareType(DeclarationCode typeDeclaration);
 }
 
 /// The api used by [DeclarationMacro]s to contribute new (non-type)
@@ -28,7 +28,7 @@ abstract class DeclarationBuilder implements Builder {
   /// Adds a new regular declaration to the surrounding library.
   ///
   /// Note that type declarations are not supported.
-  Declaration addToLibrary(DeclarationCode declaration);
+  Declaration declareInLibrary(DeclarationCode declaration);
 
   /// Returns true if [leftType] is a subtype of [rightType].
   bool isSubtypeOf(TypeAnnotation leftType, TypeAnnotation rightType);
@@ -40,7 +40,7 @@ abstract class DeclarationBuilder implements Builder {
 /// The api used by [DeclarationMacro]s to contribute new members to a class.
 abstract class ClassMemberDeclarationBuilder implements DeclarationBuilder {
   /// Adds a new declaration to the surrounding class.
-  void addToClass(DeclarationCode declaration);
+  void declareInClass(DeclarationCode declaration);
 }
 
 /// The api used to introspect on a [ClassDeclaration].

--- a/working/macros/api/code.dart
+++ b/working/macros/api/code.dart
@@ -10,7 +10,7 @@ class Scope {
 }
 
 /// The base class representing an arbitrary chunk of Dart code, which may or
-/// may not be syntacically or semantically valid yet.
+/// may not be syntactically or semantically valid yet.
 class Code {
   /// The scope in which to resolve anything from [parts] that does not have its
   /// own scope already defined.

--- a/working/macros/api/code.dart
+++ b/working/macros/api/code.dart
@@ -26,31 +26,31 @@ class Code {
 }
 
 /// A piece of code representing a syntactically valid declaration.
-class Declaration extends Code {
-  Declaration.fromString(String code, {Scope? scope})
+class DeclarationCode extends Code {
+  DeclarationCode.fromString(String code, {Scope? scope})
       : super.fromString(code, scope: scope);
 
-  Declaration.fromParts(List<Object> parts, {Scope? scope})
+  DeclarationCode.fromParts(List<Object> parts, {Scope? scope})
       : super.fromParts(parts, scope: scope);
 }
 
 /// A piece of code representing a syntactically valid element.
 ///
 /// Should not include any trailing commas,
-class Element extends Code {
-  Element.fromString(String code, {Scope? scope})
+class ElementCode extends Code {
+  ElementCode.fromString(String code, {Scope? scope})
       : super.fromString(code, scope: scope);
 
-  Element.fromParts(List<Object> parts, {Scope? scope})
+  ElementCode.fromParts(List<Object> parts, {Scope? scope})
       : super.fromParts(parts, scope: scope);
 }
 
 /// A piece of code representing a syntactically valid expression.
-class Expression extends Code {
-  Expression.fromString(String code, {Scope? scope})
+class ExpressionCode extends Code {
+  ExpressionCode.fromString(String code, {Scope? scope})
       : super.fromString(code, scope: scope);
 
-  Expression.fromParts(List<Object> parts, {Scope? scope})
+  ExpressionCode.fromParts(List<Object> parts, {Scope? scope})
       : super.fromParts(parts, scope: scope);
 }
 
@@ -60,31 +60,31 @@ class Expression extends Code {
 /// including modifiers like `async`.
 ///
 /// Both arrow and block function bodies are allowed.
-class FunctionBody extends Code {
-  FunctionBody.fromString(String code, {Scope? scope})
+class FunctionBodyCode extends Code {
+  FunctionBodyCode.fromString(String code, {Scope? scope})
       : super.fromString(code, scope: scope);
 
-  FunctionBody.fromParts(List<Object> parts, {Scope? scope})
+  FunctionBodyCode.fromParts(List<Object> parts, {Scope? scope})
       : super.fromParts(parts, scope: scope);
 }
 
 /// A piece of code representing a syntactically valid identifier.
-class Identifier extends Code {
-  Identifier.fromString(String code, {Scope? scope})
+class IdentifierCode extends Code {
+  IdentifierCode.fromString(String code, {Scope? scope})
       : super.fromString(code, scope: scope);
 
-  Identifier.fromParts(List<Object> parts, {Scope? scope})
+  IdentifierCode.fromParts(List<Object> parts, {Scope? scope})
       : super.fromParts(parts, scope: scope);
 }
 
 /// A piece of code identifying a named argument.
 ///
 /// This should not include any trailing commas.
-class NamedArgument extends Code {
-  NamedArgument.fromString(String code, {Scope? scope})
+class NamedArgumentCode extends Code {
+  NamedArgumentCode.fromString(String code, {Scope? scope})
       : super.fromString(code, scope: scope);
 
-  NamedArgument.fromParts(List<Object> parts, {Scope? scope})
+  NamedArgumentCode.fromParts(List<Object> parts, {Scope? scope})
       : super.fromParts(parts, scope: scope);
 }
 
@@ -97,22 +97,22 @@ class NamedArgument extends Code {
 /// nor between optional or required parameters. It is the job of the user to
 /// construct and combine these together in a way that creates valid parameter
 /// lists.
-class Parameter extends Code {
-  Parameter.fromString(String code, {Scope? scope})
+class ParameterCode extends Code {
+  ParameterCode.fromString(String code, {Scope? scope})
       : super.fromString(code, scope: scope);
 
-  Parameter.fromParts(List<Object> parts, {Scope? scope})
+  ParameterCode.fromParts(List<Object> parts, {Scope? scope})
       : super.fromParts(parts, scope: scope);
 }
 
 /// A piece of code representing a syntactically valid statement.
 ///
 /// Should always end with a semicolon.
-class Statement extends Code {
-  Statement.fromString(String code, {Scope? scope})
+class StatementCode extends Code {
+  StatementCode.fromString(String code, {Scope? scope})
       : super.fromString(code, scope: scope);
 
-  Statement.fromParts(List<Object> parts, {Scope? scope})
+  StatementCode.fromParts(List<Object> parts, {Scope? scope})
       : super.fromParts(parts, scope: scope);
 }
 

--- a/working/macros/api/code.dart
+++ b/working/macros/api/code.dart
@@ -1,0 +1,129 @@
+/// A scope in which to resolve a chunk of code.
+///
+/// TODO: Handle more deeply nested scopes (such as a scope specific to a class
+/// or method body).
+class Scope {
+  /// Identifiers should be resolved as if they existed in this library.
+  final Uri libraryUri;
+
+  Scope(this.libraryUri);
+}
+
+/// The base class representing an arbitrary chunk of Dart code, which may or
+/// may not be syntacically or semantically valid yet.
+class Code {
+  /// The scope in which to resolve anything from [parts] that does not have its
+  /// own scope already defined.
+  final Scope? scope;
+
+  /// All the chunks of [Code] or raw [String]s that comprise this [Code]
+  /// object.
+  final List<Object> parts;
+
+  Code.fromString(String code, {this.scope}) : parts = [code];
+
+  Code.fromParts(this.parts, {this.scope});
+}
+
+/// A piece of code representing a syntactically valid declaration.
+class Declaration extends Code {
+  Declaration.fromString(String code, {Scope? scope})
+      : super.fromString(code, scope: scope);
+
+  Declaration.fromParts(List<Object> parts, {Scope? scope})
+      : super.fromParts(parts, scope: scope);
+}
+
+/// A piece of code representing a syntactically valid element.
+///
+/// Should not include any trailing commas,
+class Element extends Code {
+  Element.fromString(String code, {Scope? scope})
+      : super.fromString(code, scope: scope);
+
+  Element.fromParts(List<Object> parts, {Scope? scope})
+      : super.fromParts(parts, scope: scope);
+}
+
+/// A piece of code representing a syntactically valid expression.
+class Expression extends Code {
+  Expression.fromString(String code, {Scope? scope})
+      : super.fromString(code, scope: scope);
+
+  Expression.fromParts(List<Object> parts, {Scope? scope})
+      : super.fromParts(parts, scope: scope);
+}
+
+/// A piece of code representing a syntactically valid function body.
+///
+/// This includes any and all code after the parameter list of a function,
+/// including modifiers like `async`.
+///
+/// Both arrow and block function bodies are allowed.
+class FunctionBody extends Code {
+  FunctionBody.fromString(String code, {Scope? scope})
+      : super.fromString(code, scope: scope);
+
+  FunctionBody.fromParts(List<Object> parts, {Scope? scope})
+      : super.fromParts(parts, scope: scope);
+}
+
+/// A piece of code representing a syntactically valid identifier.
+class Identifier extends Code {
+  Identifier.fromString(String code, {Scope? scope})
+      : super.fromString(code, scope: scope);
+
+  Identifier.fromParts(List<Object> parts, {Scope? scope})
+      : super.fromParts(parts, scope: scope);
+}
+
+/// A piece of code identifying a named argument.
+///
+/// This should not include any trailing commas.
+class NamedArgument extends Code {
+  NamedArgument.fromString(String code, {Scope? scope})
+      : super.fromString(code, scope: scope);
+
+  NamedArgument.fromParts(List<Object> parts, {Scope? scope})
+      : super.fromParts(parts, scope: scope);
+}
+
+/// A piece of code identifying a syntactically valid function parameter.
+///
+/// This should not include any trailing commas, but may include modifiers
+/// such as `required`, and default values.
+///
+/// There is no distinction here made between named and positional parameters,
+/// nor between optional or required parameters. It is the job of the user to
+/// construct and combine these together in a way that creates valid parameter
+/// lists.
+class Parameter extends Code {
+  Parameter.fromString(String code, {Scope? scope})
+      : super.fromString(code, scope: scope);
+
+  Parameter.fromParts(List<Object> parts, {Scope? scope})
+      : super.fromParts(parts, scope: scope);
+}
+
+/// A piece of code representing a syntactically valid statement.
+///
+/// Should always end with a semicolon.
+class Statement extends Code {
+  Statement.fromString(String code, {Scope? scope})
+      : super.fromString(code, scope: scope);
+
+  Statement.fromParts(List<Object> parts, {Scope? scope})
+      : super.fromParts(parts, scope: scope);
+}
+
+extension Join<T extends Code> on List<T> {
+  /// Joins all the items in [this] with [separator], and returns
+  /// a new list.
+  List<Code> joinAsCode(String separator) => [
+        for (var i = 0; i < length - 1; i++) ...[
+          this[i],
+          Code.fromString(separator),
+        ],
+        last,
+      ];
+}

--- a/working/macros/api/code.dart
+++ b/working/macros/api/code.dart
@@ -1,13 +1,7 @@
 /// A scope in which to resolve a chunk of code.
 ///
-/// TODO: Handle more deeply nested scopes (such as a scope specific to a class
-/// or method body).
-class Scope {
-  /// Identifiers should be resolved as if they existed in this library.
-  final Uri libraryUri;
-
-  Scope(this.libraryUri);
-}
+/// TODO: Specify more what these mean, what fields are available (if any), etc.
+abstract class Scope {}
 
 /// The base class representing an arbitrary chunk of Dart code, which may or
 /// may not be syntactically or semantically valid yet.

--- a/working/macros/api/introspection.dart
+++ b/working/macros/api/introspection.dart
@@ -119,18 +119,29 @@ abstract class FieldDeclaration implements Declaration {
 
   /// The class that defines this method.
   TypeAnnotation get definingClass;
+
+  /// A [Code] object representing the initializer for this field, if present.
+  Code? get initializer;
 }
 
 /// Parameter introspection information.
 abstract class ParameterDeclaration {
-  /// Whether or not this parameter has the `required` keyword.
-  bool get required;
+  /// The name of the parameter.
+  String get name;
 
   /// The type of this parameter.
   TypeAnnotation get type;
 
   /// Whether or not this is a named parameter.
   bool get isNamed;
+
+  /// Whether or not this parameter is either a non-optional positional
+  /// parameter or an optional parameter with the `required` keyword.
+  bool get isRequired;
+
+  /// A [Code] object representing the default value for this parameter, if
+  /// present. Can be used to copy default values to other parameters.
+  Code? get defaultValue;
 }
 
 /// Type parameter introspection information.

--- a/working/macros/api/introspection.dart
+++ b/working/macros/api/introspection.dart
@@ -1,20 +1,20 @@
 import 'code.dart';
 
-/// Type annotation introspection information.
+/// An unresolved reference to a type.
 ///
-/// These can be resolved using the `builder` classes depending on the phase
-/// a macro is running in.
+/// These can be resolved to a [TypeDeclaration] using the `builder` classes
+/// depending on the phase a macro is running in.
 abstract class TypeAnnotation {
-  /// Whether or not the type reference is explicitly nullable (contains a
+  /// Whether or not the type annotation is explicitly nullable (contains a
   /// trailing `?`)
   bool get isNullable;
 
   /// The name of the type as it exists in the type annotation.
   String get name;
 
-  /// The scope in which the type reference appeared in the program.
+  /// The scope in which the type annotation appeared in the program.
   ///
-  /// This can be used to construct an [Identifier] that refers to this type
+  /// This can be used to construct an [IdentifierCode] that refers to this type
   /// regardless of the context in which it is emitted.
   Scope get scope;
 
@@ -22,33 +22,38 @@ abstract class TypeAnnotation {
   Iterable<TypeAnnotation> get typeArguments;
 }
 
-/// Generic declaration introspection information.
+//// The base class for all declarations.
 abstract class Declaration {
-  /// Whether this declaration has an `abstract` modifier.
-  bool get isAbstract;
-
-  /// Whether this declaration has an `external` modifier.
-  bool get isExternal;
-
-  /// The name of this declaration as it appears in the code.
+  /// The name of this type declaration
   String get name;
 
-  /// Emits a piece of code that concretely refers to the same type that is
-  /// referred to by [this], regardless of where in the program it is placed.
+  /// The scope in which this type declaration is defined.
   ///
-  /// Effectively, this type reference has a custom scope (equal to [scope])
-  /// instead of the standard lexical scope.
-  Code get reference;
-
-  /// The scope in which the type reference appeared in the program.
+  /// This can be used to construct an [IdentifierCode] that refers to this type
+  /// regardless of the context in which it is emitted.
   Scope get scope;
+}
+
+/// A declaration that defines a new type in the program.
+abstract class TypeDeclaration implements Declaration {
+  /// The type parameters defined for this type declaration.
+  Iterable<TypeParameterDeclaration> get typeParameters;
+
+  /// Create a type annotation representing this type with [typeArguments].
+  TypeAnnotation instantiate({List<TypeAnnotation> typeArguments});
 }
 
 /// Class (and enum) introspection information.
 ///
 /// Information about fields, methods, and constructors must be retrieved from
 /// the `builder` objects.
-abstract class ClassDeclaration implements Declaration {
+abstract class ClassDeclaration implements TypeDeclaration {
+  /// Whether this class has an `abstract` modifier.
+  bool get isAbstract;
+
+  /// Whether this class has an `external` modifier.
+  bool get isExternal;
+
   /// The `extends` type annotation, if present.
   TypeAnnotation? get superclass;
 
@@ -59,56 +64,77 @@ abstract class ClassDeclaration implements Declaration {
   Iterable<TypeAnnotation> get mixins;
 
   /// All the type arguments, if applicable.
-  Iterable<TypeParameter> get typeParameters;
+  Iterable<TypeParameterDeclaration> get typeParameters;
 }
-
-/// Enum introspection information.
-abstract class EnumDeclaration implements Declaration {}
 
 /// Function introspection information.
 abstract class FunctionDeclaration implements Declaration {
+  /// Whether this function has an `abstract` modifier.
+  bool get isAbstract;
+
+  /// Whether this function has an `external` modifier.
+  bool get isExternal;
+
+  /// Whether this function is actually a getter.
   bool get isGetter;
 
+  /// Whether this function is actually a setter.
   bool get isSetter;
 
+  /// The return type of this function.
   TypeAnnotation get returnType;
 
-  Iterable<Parameter> get positionalParameters;
+  /// The positional parameters for this function.
+  Iterable<ParameterDeclaration> get positionalParameters;
 
-  Iterable<Parameter> get namedParameters;
+  /// The named parameters for this function.
+  Iterable<ParameterDeclaration> get namedParameters;
 
-  Iterable<TypeParameter> get typeParameters;
+  /// The type parameters for this function.
+  Iterable<TypeParameterDeclaration> get typeParameters;
 }
 
-/// Method introspection information for [TypeMacro]s.
+/// Method introspection information.
 abstract class MethodDeclaration implements FunctionDeclaration {
+  /// The class that defines this method.
   TypeAnnotation get definingClass;
 }
 
-/// Constructor introspection information for [TypeMacro]s.
+/// Constructor introspection information.
 abstract class ConstructorDeclaration implements MethodDeclaration {
+  /// Whether or not this is a factory constructor.
   bool get isFactory;
 }
 
 /// Field introspection information ..
 abstract class FieldDeclaration implements Declaration {
+  /// Whether this function has an `abstract` modifier.
+  bool get isAbstract;
+
+  /// Whether this function has an `external` modifier.
+  bool get isExternal;
+
+  /// Type type of this field.
   TypeAnnotation get type;
 
+  /// The class that defines this method.
   TypeAnnotation get definingClass;
 }
 
 /// Parameter introspection information.
-abstract class Parameter {
-  String get name;
-
+abstract class ParameterDeclaration {
+  /// Whether or not this parameter has the `required` keyword.
   bool get required;
 
+  /// The type of this parameter.
   TypeAnnotation get type;
+
+  /// Whether or not this is a named parameter.
+  bool get isNamed;
 }
 
 /// Type parameter introspection information.
-abstract class TypeParameter {
+abstract class TypeParameterDeclaration {
+  /// The bounds for this type parameter, if it has any.
   TypeAnnotation? get bounds;
-
-  String get name;
 }

--- a/working/macros/api/introspection.dart
+++ b/working/macros/api/introspection.dart
@@ -1,0 +1,114 @@
+import 'code.dart';
+
+/// Type annotation introspection information.
+///
+/// These can be resolved using the `builder` classes depending on the phase
+/// a macro is running in.
+abstract class TypeAnnotation {
+  /// Whether or not the type reference is explicitly nullable (contains a
+  /// trailing `?`)
+  bool get isNullable;
+
+  /// The name of the type as it exists in the type annotation.
+  String get name;
+
+  /// The scope in which the type reference appeared in the program.
+  ///
+  /// This can be used to construct an [Identifier] that refers to this type
+  /// regardless of the context in which it is emitted.
+  Scope get scope;
+
+  /// The type arguments, if applicable.
+  Iterable<TypeAnnotation> get typeArguments;
+}
+
+/// Generic declaration introspection information.
+abstract class Declaration {
+  /// Whether this declaration has an `abstract` modifier.
+  bool get isAbstract;
+
+  /// Whether this declaration has an `external` modifier.
+  bool get isExternal;
+
+  /// The name of this declaration as it appears in the code.
+  String get name;
+
+  /// Emits a piece of code that concretely refers to the same type that is
+  /// referred to by [this], regardless of where in the program it is placed.
+  ///
+  /// Effectively, this type reference has a custom scope (equal to [scope])
+  /// instead of the standard lexical scope.
+  Code get reference;
+
+  /// The scope in which the type reference appeared in the program.
+  Scope get scope;
+}
+
+/// Class (and enum) introspection information.
+///
+/// Information about fields, methods, and constructors must be retrieved from
+/// the `builder` objects.
+abstract class ClassDeclaration implements Declaration {
+  /// The `extends` type annotation, if present.
+  TypeAnnotation? get superclass;
+
+  /// All the `implements` type annotations.
+  Iterable<TypeAnnotation> get implements;
+
+  /// All the `with` type annotations.
+  Iterable<TypeAnnotation> get mixins;
+
+  /// All the type arguments, if applicable.
+  Iterable<TypeParameter> get typeParameters;
+}
+
+/// Enum introspection information.
+abstract class EnumDeclaration implements Declaration {}
+
+/// Function introspection information.
+abstract class FunctionDeclaration implements Declaration {
+  bool get isGetter;
+
+  bool get isSetter;
+
+  TypeAnnotation get returnType;
+
+  Iterable<Parameter> get positionalParameters;
+
+  Iterable<Parameter> get namedParameters;
+
+  Iterable<TypeParameter> get typeParameters;
+}
+
+/// Method introspection information for [TypeMacro]s.
+abstract class MethodDeclaration implements FunctionDeclaration {
+  TypeAnnotation get definingClass;
+}
+
+/// Constructor introspection information for [TypeMacro]s.
+abstract class ConstructorDeclaration implements MethodDeclaration {
+  bool get isFactory;
+}
+
+/// Field introspection information ..
+abstract class FieldDeclaration implements Declaration {
+  TypeAnnotation get type;
+
+  TypeAnnotation get definingClass;
+}
+
+/// Parameter introspection information.
+abstract class Parameter {
+  String get name;
+
+  bool get required;
+
+  TypeAnnotation get type;
+}
+
+/// Type parameter introspection information.
+abstract class TypeParameter {
+  TypeAnnotation? get bounds;
+
+  String get name;
+}

--- a/working/macros/api/macros.dart
+++ b/working/macros/api/macros.dart
@@ -37,6 +37,9 @@ abstract class ClassMacro extends Macro {
   @override
   external void buildDeclarations(
       FutureOr<void> Function(ClassDeclarationBuilder) callback);
+
+  external void buildDefinitions(
+      FutureOr<void> Function(ClassDefinitionBuilder) callback);
 }
 
 /// The interface for [Macro]s that can be applied to fields.

--- a/working/macros/api/macros.dart
+++ b/working/macros/api/macros.dart
@@ -1,0 +1,119 @@
+import 'builders.dart';
+import 'introspection.dart';
+
+/// The marker interface for all types of macros.
+abstract class Macro {}
+
+/// The marker interface for macros that are allowed to contribute new type
+/// declarations into the program.
+///
+/// These macros run before all other types of macros.
+///
+/// In exchange for the power to add new type declarations, these macros have
+/// limited introspections capabilities, since new types can be added in this
+/// phase you cannot follow type references back to their declarations.
+abstract class TypeMacro implements Macro {}
+
+/// The marker interface for macros that are allowed to contribute new
+/// declarations to the program, including both top level and class level
+/// declarations.
+///
+/// These macros run after [TypeMacro]s, but before [DefinitionMacro]s.
+///
+/// These macros can resolve type annotations to specific declarations, and
+/// inspect type hierarchies, but they cannot inspect the declarations on those
+/// type annotations, since new declarations could still be added in this phase.
+abstract class DeclarationMacro implements Macro {}
+
+/// The marker interface for macros that are only allowed to implement or wrap
+/// existing declarations in the program. They cannot introduce any new
+/// declarations that are visible to the program, but are allowed to add
+/// declarations that only they can see.
+///
+/// These macros run after all other types of macros.
+///
+/// These macros can fully reflect on the program since the static shape is
+/// fully definied by the time they run.
+abstract class DefinitionMacro implements Macro {}
+
+/// The interface for [TypeMacro]s that can be applied to classes.
+abstract class ClassTypeMacro implements TypeMacro {
+  void visitClassType(ClassDeclaration type, TypeBuilder builder);
+}
+
+/// The interface for [DeclarationMacro]s that can be applied to classes.
+abstract class ClassDeclarationMacro implements DeclarationMacro {
+  void visitClassDeclaration(
+      ClassDeclaration declaration, ClassDeclarationBuilder builder);
+}
+
+/// The interface for [TypeMacro]s that can be applied to fields.
+abstract class FieldTypeMacro implements TypeMacro {
+  void visitFieldType(FieldDeclaration field, TypeBuilder builder);
+}
+
+/// The interface for [DeclarationMacro]s that can be applied to fields.
+abstract class FieldDeclarationMacro implements DeclarationMacro {
+  void visitFieldDeclaration(
+      FieldDeclaration declaration, ClassDeclarationBuilder builder);
+}
+
+/// The interface for [DefinitionMacro]s that can be applied to fields.
+abstract class FieldDefinitionMacro implements DefinitionMacro {
+  void visitFieldDefinition(
+      FieldDeclaration definition, FieldDefinitionBuilder builder);
+}
+
+/// The interface for [TypeMacro]s that can be applied to top level functions
+/// or methods.
+abstract class FunctionTypeMacro implements TypeMacro {
+  void visitFunctionType(FunctionDeclaration type, TypeBuilder builder);
+}
+
+/// The interface for [DeclarationMacro]s that can be applied to top level
+/// functions or methods.
+abstract class FunctionDeclarationMacro implements DeclarationMacro {
+  void visitFunctionDeclaration(
+      FunctionDeclaration declaration, DeclarationBuilder builder);
+}
+
+/// The interface for [DefinitionMacro]s that can be applied to top level
+/// functions or methods.
+abstract class FunctionDefinitionMacro implements DefinitionMacro {
+  void visitFunctionDefinition(
+      FunctionDeclaration definition, FunctionDefinitionBuilder builder);
+}
+
+/// The interface for [TypeMacro]s that can be applied to methods.
+abstract class MethodTypeMacro implements TypeMacro {
+  void visitMethodType(MethodDeclaration type, TypeBuilder builder);
+}
+
+/// The interface for [DeclarationMacro]s that can be applied to methods.
+abstract class MethodDeclarationMacro implements DeclarationMacro {
+  void visitMethodDeclaration(
+      MethodDeclaration declaration, ClassDeclarationBuilder builder);
+}
+
+/// The interface for [DefinitionMacro]s that can be applied to methods.
+abstract class MethodDefinitionMacro implements DefinitionMacro {
+  void visitMethodDefinition(
+      MethodDeclaration definition, FunctionDefinitionBuilder builder);
+}
+
+/// The interface for [TypeMacro]s that can be applied to constructors.
+abstract class ConstructorTypeMacro implements TypeMacro {
+  void visitConstructorType(ConstructorDeclaration type, TypeBuilder builder);
+}
+
+/// The interface for [DeclarationMacro]s that can be applied to constructors.
+abstract class ConstructorDeclarationMacro implements DefinitionMacro {
+  void visitConstructorDeclaration(
+      ConstructorDeclaration declaration, ClassDeclarationBuilder builder);
+}
+
+/// The interface for [DefinitionMacro]s that can be applied to constructors.
+abstract class ConstructorDefinitionMacro implements DefinitionMacro {
+  void visitConstructorDefinition(
+      ConstructorDeclaration definition, ConstructorDefinitionBuilder builder);
+}

--- a/working/macros/api/macros.dart
+++ b/working/macros/api/macros.dart
@@ -4,120 +4,79 @@ import 'builders.dart';
 import 'introspection.dart';
 
 /// The marker interface for all types of macros.
-abstract class Macro {}
+abstract class Macro {
+  const Macro();
 
-/// The marker interface for macros that are allowed to contribute new type
-/// declarations into the program.
-///
-/// These macros run before all other types of macros.
-///
-/// In exchange for the power to add new type declarations, these macros have
-/// limited introspections capabilities, since new types can be added in this
-/// phase you cannot follow type references back to their declarations.
-abstract class TypeMacro implements Macro {}
+  external void buildTypes(FutureOr<void> Function(TypeBuilder) callback);
 
-/// The marker interface for macros that are allowed to contribute new
-/// declarations to the program, including both top level and class level
-/// declarations.
-///
-/// These macros run after [TypeMacro]s, but before [DefinitionMacro]s.
-///
-/// These macros can resolve type annotations to specific declarations, and
-/// inspect type hierarchies, but they cannot inspect the declarations on those
-/// type annotations, since new declarations could still be added in this phase.
-abstract class DeclarationMacro implements Macro {}
-
-/// The marker interface for macros that are only allowed to implement or wrap
-/// existing declarations in the program. They cannot introduce any new
-/// declarations that are visible to the program, but are allowed to add
-/// declarations that only they can see.
-///
-/// These macros run after all other types of macros.
-///
-/// These macros can fully reflect on the program since the static shape is
-/// fully definied by the time they run.
-abstract class DefinitionMacro implements Macro {}
-
-/// The interface for [TypeMacro]s that can be applied to classes.
-abstract class ClassTypeMacro implements TypeMacro {
-  FutureOr<void> visitClassType(ClassDeclaration type, TypeBuilder builder);
+  external void buildDeclarations(
+      FutureOr<void> Function(DeclarationBuilder) callback);
 }
 
-/// The interface for [DeclarationMacro]s that can be applied to classes.
-abstract class ClassDeclarationMacro implements DeclarationMacro {
-  FutureOr<void> visitClassDeclaration(
-      ClassDeclaration declaration, ClassDeclarationBuilder builder);
+/// The interface for [Macro]s that can be applied to any top level function,
+/// instance method, or static method.
+abstract class FunctionMacro extends Macro {
+  const FunctionMacro();
+
+  FutureOr<void> visitFunction(FunctionDeclaration function);
+
+  @override
+  external void buildDeclarations(
+      FutureOr<void> Function(DeclarationBuilder) callback);
+
+  external void buildDefinition(
+      FutureOr<void> Function(FunctionDefinitionBuilder) callback);
 }
 
-/// The interface for [TypeMacro]s that can be applied to fields.
-abstract class FieldTypeMacro implements TypeMacro {
-  FutureOr<void> visitFieldType(FieldDeclaration field, TypeBuilder builder);
+/// The interface for [Macro]s that can be applied to classes.
+abstract class ClassMacro extends Macro {
+  const ClassMacro();
+
+  FutureOr<void> visitClass(ClassDeclaration clazz);
+
+  @override
+  external void buildDeclarations(
+      FutureOr<void> Function(ClassDeclarationBuilder) callback);
 }
 
-/// The interface for [DeclarationMacro]s that can be applied to fields.
-abstract class FieldDeclarationMacro implements DeclarationMacro {
-  FutureOr<void> visitFieldDeclaration(
-      FieldDeclaration declaration, ClassDeclarationBuilder builder);
+/// The interface for [Macro]s that can be applied to fields.
+abstract class FieldMacro extends Macro {
+  const FieldMacro();
+
+  FutureOr<void> visitField(FieldDeclaration field);
+
+  @override
+  external void buildDeclarations(
+      FutureOr<void> Function(ClassMemberDeclarationBuilder) callback);
+
+  external void buildDefinition(
+      FutureOr<void> Function(FieldDefinitionBuilder) callback);
 }
 
-/// The interface for [DefinitionMacro]s that can be applied to fields.
-abstract class FieldDefinitionMacro implements DefinitionMacro {
-  FutureOr<void> visitFieldDefinition(
-      FieldDeclaration definition, FieldDefinitionBuilder builder);
+/// The interface for [Macro]s that can be applied to methods.
+abstract class MethodMacro extends Macro {
+  const MethodMacro();
+
+  FutureOr<void> visitMethod(MethodDeclaration method);
+
+  @override
+  external void buildDeclarations(
+      FutureOr<void> Function(ClassMemberDeclarationBuilder) callback);
+
+  external void buildDefinition(
+      FutureOr<void> Function(FunctionDefinitionBuilder) callback);
 }
 
-/// The interface for [TypeMacro]s that can be applied to top level functions
-/// or methods.
-abstract class FunctionTypeMacro implements TypeMacro {
-  FutureOr<void> visitFunctionType(
-      FunctionDeclaration type, TypeBuilder builder);
-}
+/// The interface for [Macro]s that can be applied to constructors.
+abstract class ConstructorMacro extends Macro {
+  const ConstructorMacro();
 
-/// The interface for [DeclarationMacro]s that can be applied to top level
-/// functions or methods.
-abstract class FunctionDeclarationMacro implements DeclarationMacro {
-  FutureOr<void> visitFunctionDeclaration(
-      FunctionDeclaration declaration, DeclarationBuilder builder);
-}
+  FutureOr<void> visitConstructor(ConstructorDeclaration constructor);
 
-/// The interface for [DefinitionMacro]s that can be applied to top level
-/// functions or methods.
-abstract class FunctionDefinitionMacro implements DefinitionMacro {
-  FutureOr<void> visitFunctionDefinition(
-      FunctionDeclaration definition, FunctionDefinitionBuilder builder);
-}
+  @override
+  external void buildDeclarations(
+      FutureOr<void> Function(ClassMemberDeclarationBuilder) callback);
 
-/// The interface for [TypeMacro]s that can be applied to methods.
-abstract class MethodTypeMacro implements TypeMacro {
-  FutureOr<void> visitMethodType(MethodDeclaration type, TypeBuilder builder);
-}
-
-/// The interface for [DeclarationMacro]s that can be applied to methods.
-abstract class MethodDeclarationMacro implements DeclarationMacro {
-  FutureOr<void> visitMethodDeclaration(
-      MethodDeclaration declaration, ClassDeclarationBuilder builder);
-}
-
-/// The interface for [DefinitionMacro]s that can be applied to methods.
-abstract class MethodDefinitionMacro implements DefinitionMacro {
-  FutureOr<void> visitMethodDefinition(
-      MethodDeclaration definition, FunctionDefinitionBuilder builder);
-}
-
-/// The interface for [TypeMacro]s that can be applied to constructors.
-abstract class ConstructorTypeMacro implements TypeMacro {
-  FutureOr<void> visitConstructorType(
-      ConstructorDeclaration type, TypeBuilder builder);
-}
-
-/// The interface for [DeclarationMacro]s that can be applied to constructors.
-abstract class ConstructorDeclarationMacro implements DefinitionMacro {
-  FutureOr<void> visitConstructorDeclaration(
-      ConstructorDeclaration declaration, ClassDeclarationBuilder builder);
-}
-
-/// The interface for [DefinitionMacro]s that can be applied to constructors.
-abstract class ConstructorDefinitionMacro implements DefinitionMacro {
-  FutureOr<void> visitConstructorDefinition(
-      ConstructorDeclaration definition, ConstructorDefinitionBuilder builder);
+  external void buildDefinition(
+      FutureOr<void> Function(ConstructorDefinitionBuilder) callback);
 }

--- a/working/macros/api/macros.dart
+++ b/working/macros/api/macros.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'builders.dart';
 import 'introspection.dart';
 
@@ -38,82 +40,84 @@ abstract class DefinitionMacro implements Macro {}
 
 /// The interface for [TypeMacro]s that can be applied to classes.
 abstract class ClassTypeMacro implements TypeMacro {
-  void visitClassType(ClassDeclaration type, TypeBuilder builder);
+  FutureOr<void> visitClassType(ClassDeclaration type, TypeBuilder builder);
 }
 
 /// The interface for [DeclarationMacro]s that can be applied to classes.
 abstract class ClassDeclarationMacro implements DeclarationMacro {
-  void visitClassDeclaration(
+  FutureOr<void> visitClassDeclaration(
       ClassDeclaration declaration, ClassDeclarationBuilder builder);
 }
 
 /// The interface for [TypeMacro]s that can be applied to fields.
 abstract class FieldTypeMacro implements TypeMacro {
-  void visitFieldType(FieldDeclaration field, TypeBuilder builder);
+  FutureOr<void> visitFieldType(FieldDeclaration field, TypeBuilder builder);
 }
 
 /// The interface for [DeclarationMacro]s that can be applied to fields.
 abstract class FieldDeclarationMacro implements DeclarationMacro {
-  void visitFieldDeclaration(
+  FutureOr<void> visitFieldDeclaration(
       FieldDeclaration declaration, ClassDeclarationBuilder builder);
 }
 
 /// The interface for [DefinitionMacro]s that can be applied to fields.
 abstract class FieldDefinitionMacro implements DefinitionMacro {
-  void visitFieldDefinition(
+  FutureOr<void> visitFieldDefinition(
       FieldDeclaration definition, FieldDefinitionBuilder builder);
 }
 
 /// The interface for [TypeMacro]s that can be applied to top level functions
 /// or methods.
 abstract class FunctionTypeMacro implements TypeMacro {
-  void visitFunctionType(FunctionDeclaration type, TypeBuilder builder);
+  FutureOr<void> visitFunctionType(
+      FunctionDeclaration type, TypeBuilder builder);
 }
 
 /// The interface for [DeclarationMacro]s that can be applied to top level
 /// functions or methods.
 abstract class FunctionDeclarationMacro implements DeclarationMacro {
-  void visitFunctionDeclaration(
+  FutureOr<void> visitFunctionDeclaration(
       FunctionDeclaration declaration, DeclarationBuilder builder);
 }
 
 /// The interface for [DefinitionMacro]s that can be applied to top level
 /// functions or methods.
 abstract class FunctionDefinitionMacro implements DefinitionMacro {
-  void visitFunctionDefinition(
+  FutureOr<void> visitFunctionDefinition(
       FunctionDeclaration definition, FunctionDefinitionBuilder builder);
 }
 
 /// The interface for [TypeMacro]s that can be applied to methods.
 abstract class MethodTypeMacro implements TypeMacro {
-  void visitMethodType(MethodDeclaration type, TypeBuilder builder);
+  FutureOr<void> visitMethodType(MethodDeclaration type, TypeBuilder builder);
 }
 
 /// The interface for [DeclarationMacro]s that can be applied to methods.
 abstract class MethodDeclarationMacro implements DeclarationMacro {
-  void visitMethodDeclaration(
+  FutureOr<void> visitMethodDeclaration(
       MethodDeclaration declaration, ClassDeclarationBuilder builder);
 }
 
 /// The interface for [DefinitionMacro]s that can be applied to methods.
 abstract class MethodDefinitionMacro implements DefinitionMacro {
-  void visitMethodDefinition(
+  FutureOr<void> visitMethodDefinition(
       MethodDeclaration definition, FunctionDefinitionBuilder builder);
 }
 
 /// The interface for [TypeMacro]s that can be applied to constructors.
 abstract class ConstructorTypeMacro implements TypeMacro {
-  void visitConstructorType(ConstructorDeclaration type, TypeBuilder builder);
+  FutureOr<void> visitConstructorType(
+      ConstructorDeclaration type, TypeBuilder builder);
 }
 
 /// The interface for [DeclarationMacro]s that can be applied to constructors.
 abstract class ConstructorDeclarationMacro implements DefinitionMacro {
-  void visitConstructorDeclaration(
+  FutureOr<void> visitConstructorDeclaration(
       ConstructorDeclaration declaration, ClassDeclarationBuilder builder);
 }
 
 /// The interface for [DefinitionMacro]s that can be applied to constructors.
 abstract class ConstructorDefinitionMacro implements DefinitionMacro {
-  void visitConstructorDefinition(
+  FutureOr<void> visitConstructorDefinition(
       ConstructorDeclaration definition, ConstructorDefinitionBuilder builder);
 }

--- a/working/macros/api/macros.dart
+++ b/working/macros/api/macros.dart
@@ -4,82 +4,36 @@ import 'builders.dart';
 import 'introspection.dart';
 
 /// The marker interface for all types of macros.
-abstract class Macro {
-  const Macro();
-
-  external void buildTypes(FutureOr<void> Function(TypeBuilder) callback);
-
-  external void buildDeclarations(
-      FutureOr<void> Function(DeclarationBuilder) callback);
-}
+abstract class Macro {}
 
 /// The interface for [Macro]s that can be applied to any top level function,
 /// instance method, or static method.
-abstract class FunctionMacro extends Macro {
-  const FunctionMacro();
-
-  FutureOr<void> visitFunction(FunctionDeclaration function);
-
-  @override
-  external void buildDeclarations(
-      FutureOr<void> Function(DeclarationBuilder) callback);
-
-  external void buildDefinition(
-      FutureOr<void> Function(FunctionDefinitionBuilder) callback);
+abstract class FunctionMacro implements Macro {
+  /// Invoked for any function that is annotated with this macro.
+  FutureOr<void> visitFunction(
+      FunctionDeclaration function, FunctionBuilder builder);
 }
 
 /// The interface for [Macro]s that can be applied to classes.
-abstract class ClassMacro extends Macro {
-  const ClassMacro();
-
-  FutureOr<void> visitClass(ClassDeclaration clazz);
-
-  @override
-  external void buildDeclarations(
-      FutureOr<void> Function(ClassDeclarationBuilder) callback);
-
-  external void buildDefinitions(
-      FutureOr<void> Function(ClassDefinitionBuilder) callback);
+abstract class ClassMacro implements Macro {
+  /// Invoked for any class that is annotated with this macro.
+  FutureOr<void> visitClass(ClassDeclaration clazz, ClassBuilder builder);
 }
 
 /// The interface for [Macro]s that can be applied to fields.
-abstract class FieldMacro extends Macro {
-  const FieldMacro();
-
-  FutureOr<void> visitField(FieldDeclaration field);
-
-  @override
-  external void buildDeclarations(
-      FutureOr<void> Function(ClassMemberDeclarationBuilder) callback);
-
-  external void buildDefinition(
-      FutureOr<void> Function(FieldDefinitionBuilder) callback);
+abstract class FieldMacro implements Macro {
+  /// Invoked for any field that is annotated with this macro
+  FutureOr<void> visitField(FieldDeclaration field, FieldBuilder builder);
 }
 
 /// The interface for [Macro]s that can be applied to methods.
-abstract class MethodMacro extends Macro {
-  const MethodMacro();
-
-  FutureOr<void> visitMethod(MethodDeclaration method);
-
-  @override
-  external void buildDeclarations(
-      FutureOr<void> Function(ClassMemberDeclarationBuilder) callback);
-
-  external void buildDefinition(
-      FutureOr<void> Function(FunctionDefinitionBuilder) callback);
+abstract class MethodMacro implements Macro {
+  /// Invoked for any method that is annotated with this macro.
+  FutureOr<void> visitMethod(MethodDeclaration method, MethodBuilder builder);
 }
 
 /// The interface for [Macro]s that can be applied to constructors.
-abstract class ConstructorMacro extends Macro {
-  const ConstructorMacro();
-
+abstract class ConstructorMacro implements Macro {
+  /// Invoked for each constructor annotated with this macro.
   FutureOr<void> visitConstructor(ConstructorDeclaration constructor);
-
-  @override
-  external void buildDeclarations(
-      FutureOr<void> Function(ClassMemberDeclarationBuilder) callback);
-
-  external void buildDefinition(
-      FutureOr<void> Function(ConstructorDefinitionBuilder) callback);
 }

--- a/working/macros/api/macros.dart
+++ b/working/macros/api/macros.dart
@@ -11,29 +11,30 @@ abstract class Macro {}
 abstract class FunctionMacro implements Macro {
   /// Invoked for any function that is annotated with this macro.
   FutureOr<void> visitFunction(
-      FunctionDeclaration function, FunctionBuilder builder);
+      FunctionDeclaration function, FunctionContext context);
 }
 
 /// The interface for [Macro]s that can be applied to classes.
 abstract class ClassMacro implements Macro {
   /// Invoked for any class that is annotated with this macro.
-  FutureOr<void> visitClass(ClassDeclaration clazz, ClassBuilder builder);
+  FutureOr<void> visitClass(ClassDeclaration clazz, ClassContext context);
 }
 
 /// The interface for [Macro]s that can be applied to fields.
 abstract class FieldMacro implements Macro {
   /// Invoked for any field that is annotated with this macro
-  FutureOr<void> visitField(FieldDeclaration field, FieldBuilder builder);
+  FutureOr<void> visitField(FieldDeclaration field, FieldContext context);
 }
 
 /// The interface for [Macro]s that can be applied to methods.
 abstract class MethodMacro implements Macro {
   /// Invoked for any method that is annotated with this macro.
-  FutureOr<void> visitMethod(MethodDeclaration method, MethodBuilder builder);
+  FutureOr<void> visitMethod(MethodDeclaration method, MethodContext context);
 }
 
 /// The interface for [Macro]s that can be applied to constructors.
 abstract class ConstructorMacro implements Macro {
   /// Invoked for each constructor annotated with this macro.
-  FutureOr<void> visitConstructor(ConstructorDeclaration constructor);
+  FutureOr<void> visitConstructor(
+      ConstructorDeclaration constructor, ConstructorContext context);
 }

--- a/working/macros/example/data_class.dart
+++ b/working/macros/example/data_class.dart
@@ -92,7 +92,7 @@ class _AutoConstructor extends ClassMacro {
         parts.add(Code.fromString(')'));
       }
       parts.add(Code.fromString(';'));
-      builder.addToClass(DeclarationCode.fromParts(parts));
+      builder.declareInClass(DeclarationCode.fromParts(parts));
     });
   }
 }
@@ -123,7 +123,7 @@ class _CopyWith extends ClassMacro {
           NamedArgumentCode.fromString(
               '${field.name}: ${field.name} ?? this.${field.name}'),
       ];
-      builder.addToClass(DeclarationCode.fromParts([
+      builder.declareInClass(DeclarationCode.fromParts([
         clazz.instantiate().toCode(),
         ' copyWith({',
         ...namedParams.joinAsCode(', '),
@@ -145,7 +145,7 @@ class _HashCode extends ClassMacro {
   @override
   void visitClass(ClassDeclaration clazz) {
     buildDeclarations((builder) {
-      builder.addToClass(DeclarationCode.fromString('''
+      builder.declareInClass(DeclarationCode.fromString('''
 @override
 external int get hashCode;'''));
     });
@@ -174,7 +174,7 @@ class _Equality extends ClassMacro {
   @override
   void visitClass(ClassDeclaration clazz) {
     buildDeclarations((builder) async {
-      builder.addToClass(DeclarationCode.fromString('''
+      builder.declareInClass(DeclarationCode.fromString('''
 @override
 external bool operator==(Object other);'''));
     });

--- a/working/macros/example/data_class.dart
+++ b/working/macros/example/data_class.dart
@@ -5,27 +5,27 @@ import '../api/code.dart';
 
 const dataClass = _DataClass();
 
-class _DataClass extends ClassMacro {
+class _DataClass implements ClassMacro {
   const _DataClass();
 
   @override
-  void visitClass(ClassDeclaration clazz) {
-    autoConstructor.visitClass(clazz);
-    copyWith.visitClass(clazz);
-    hashCode.visitClass(clazz);
-    equality.visitClass(clazz);
-    toString.visitClass(clazz);
+  void visitClass(ClassDeclaration clazz, ClassBuilder builder) {
+    autoConstructor.visitClass(clazz, builder);
+    copyWith.visitClass(clazz, builder);
+    hashCode.visitClass(clazz, builder);
+    equality.visitClass(clazz, builder);
+    toString.visitClass(clazz, builder);
   }
 }
 
 const autoConstructor = _AutoConstructor();
 
-class _AutoConstructor extends ClassMacro {
+class _AutoConstructor implements ClassMacro {
   const _AutoConstructor();
 
   @override
-  void visitClass(ClassDeclaration clazz) {
-    buildDeclarations((builder) async {
+  void visitClass(ClassDeclaration clazz, ClassBuilder builder) {
+    builder.buildDeclarations((builder) async {
       var constructors = await builder.constructorsOf(clazz);
       if (constructors.any((c) => c.name == '')) {
         throw ArgumentError(
@@ -100,12 +100,12 @@ class _AutoConstructor extends ClassMacro {
 const copyWith = _CopyWith();
 
 // TODO: How to deal with overriding nullable fields to `null`?
-class _CopyWith extends ClassMacro {
+class _CopyWith implements ClassMacro {
   const _CopyWith();
 
   @override
-  void visitClass(ClassDeclaration clazz) {
-    buildDeclarations((builder) async {
+  void visitClass(ClassDeclaration clazz, ClassBuilder builder) {
+    builder.buildDeclarations((builder) async {
       var methods = await builder.methodsOf(clazz);
       if (methods.any((c) => c.name == 'copyWith')) {
         throw ArgumentError(
@@ -139,18 +139,18 @@ class _CopyWith extends ClassMacro {
 
 const hashCode = _HashCode();
 
-class _HashCode extends ClassMacro {
+class _HashCode implements ClassMacro {
   const _HashCode();
 
   @override
-  void visitClass(ClassDeclaration clazz) {
-    buildDeclarations((builder) {
+  void visitClass(ClassDeclaration clazz, ClassBuilder builder) {
+    builder.buildDeclarations((builder) {
       builder.declareInClass(DeclarationCode.fromString('''
 @override
 external int get hashCode;'''));
     });
 
-    buildDefinitions((builder) async {
+    builder.buildDefinitions((builder) async {
       await builder.buildMethod('hashCode', (builder) async {
         var hashCodeExprs = [
           await for (var field in clazz.allFields(builder))
@@ -168,18 +168,18 @@ external int get hashCode;'''));
 
 const equality = _Equality();
 
-class _Equality extends ClassMacro {
+class _Equality implements ClassMacro {
   const _Equality();
 
   @override
-  void visitClass(ClassDeclaration clazz) {
-    buildDeclarations((builder) async {
+  void visitClass(ClassDeclaration clazz, ClassBuilder builder) {
+    builder.buildDeclarations((builder) async {
       builder.declareInClass(DeclarationCode.fromString('''
 @override
 external bool operator==(Object other);'''));
     });
 
-    buildDefinitions((builder) async {
+    builder.buildDefinitions((builder) async {
       await builder.buildMethod('==', (builder) async {
         var equalityExprs = [
           await for (var field in clazz.allFields(builder))
@@ -198,12 +198,12 @@ external bool operator==(Object other);'''));
 
 const toString = _ToString();
 
-class _ToString extends ClassMacro {
+class _ToString implements ClassMacro {
   const _ToString();
 
   @override
-  void visitClass(ClassDeclaration clazz) {
-    buildDeclarations((builder) async {
+  void visitClass(ClassDeclaration clazz, ClassBuilder builder) {
+    builder.buildDeclarations((builder) async {
       builder.declareInClass(DeclarationCode.fromString(
         '''
 @override
@@ -211,7 +211,7 @@ external String toString();''',
       ));
     });
 
-    buildDefinitions((builder) async {
+    builder.buildDefinitions((builder) async {
       await builder.buildMethod('toString', (builder) async {
         var fieldExprs = [
           await for (var field in clazz.allFields(builder))

--- a/working/macros/example/data_class.dart
+++ b/working/macros/example/data_class.dart
@@ -1,0 +1,236 @@
+import '../api/macros.dart';
+import '../api/introspection.dart';
+import '../api/builders.dart';
+import '../api/code.dart';
+
+const dataClass = _DataClass();
+
+class _DataClass implements ClassDeclarationMacro {
+  const _DataClass();
+
+  @override
+  void visitClassDeclaration(
+      ClassDeclaration declaration, ClassDeclarationBuilder builder) {
+    autoConstructor.visitClassDeclaration(declaration, builder);
+    copyWith.visitClassDeclaration(declaration, builder);
+    hashCode.visitClassDeclaration(declaration, builder);
+    equality.visitClassDeclaration(declaration, builder);
+    toString.visitClassDeclaration(declaration, builder);
+  }
+}
+
+const autoConstructor = _AutoConstructor();
+
+class _AutoConstructor implements ClassDeclarationMacro {
+  const _AutoConstructor();
+
+  @override
+  void visitClassDeclaration(
+      ClassDeclaration declaration, ClassDeclarationBuilder builder) async {
+    var constructors = await builder.constructorsOf(declaration);
+    if (constructors.any((c) => c.name == '')) {
+      throw ArgumentError(
+          'Cannot generate an unnamed constructor because one already exists');
+    }
+
+    var parts = [Code.fromString('${declaration.name}({')];
+    // Add all the fields of `declaration` as named parameters.
+    var fields = await builder.fieldsOf(declaration);
+    for (var field in fields) {
+      var requiredKeyword = field.type.isNullable ? '' : 'required ';
+      parts.add(Code.fromString('\n${requiredKeyword}this.${field.name},'));
+    }
+
+    // Add all super constructor parameters as named parameters.
+    var superclass = await builder.superclassOf(declaration);
+    MethodDeclaration? superconstructor;
+    if (superclass != null) {
+      var superconstructor = (await builder.constructorsOf(superclass))
+          .firstWhereOrNull((c) => c.name == '');
+      if (superconstructor == null) {
+        throw ArgumentError(
+            'Super class $superclass of $declaration does not have an unnamed '
+            'constructor');
+      }
+      // We convert positional parameters in the super constructor to named
+      // parameters in this constructor.
+      for (var param in superconstructor.positionalParameters) {
+        var requiredKeyword = param.isRequired ? 'required' : '';
+        var defaultValue = param.defaultValue == null
+            ? ''
+            : Code.fromParts([' = ', param.defaultValue!]);
+        parts.add(Code.fromParts([
+          '\n$requiredKeyword${param.type.toCode()} ${param.name}',
+          defaultValue,
+          ',',
+        ]));
+      }
+      for (var param in superconstructor.namedParameters) {
+        var requiredKeyword = param.isRequired ? '' : 'required ';
+        var defaultValue = param.defaultValue == null
+            ? ''
+            : Code.fromParts([' = ', param.defaultValue!]);
+        parts.add(Code.fromParts([
+          '\n$requiredKeyword${param.type.toCode()} ${param.name}',
+          defaultValue,
+          ',',
+        ]));
+      }
+    }
+    parts.add(Code.fromString('\n})'));
+    if (superconstructor != null) {
+      parts.add(Code.fromString(' : super('));
+      for (var param in superconstructor.positionalParameters) {
+        parts.add(Code.fromString('\n${param.name},'));
+      }
+      if (superconstructor.namedParameters.isNotEmpty) {
+        parts.add(Code.fromString('{'));
+        for (var param in superconstructor.namedParameters) {
+          parts.add(Code.fromString('\n${param.name}: ${param.name},'));
+        }
+        parts.add(Code.fromString('\n}'));
+      }
+      parts.add(Code.fromString(')'));
+    }
+    parts.add(Code.fromString(';'));
+    builder.addToClass(DeclarationCode.fromParts(parts));
+  }
+}
+
+const copyWith = _CopyWith();
+
+// TODO: How to deal with overriding nullable fields to `null`?
+class _CopyWith implements ClassDeclarationMacro {
+  const _CopyWith();
+
+  @override
+  void visitClassDeclaration(
+      ClassDeclaration declaration, ClassDeclarationBuilder builder) async {
+    var methods = await builder.methodsOf(declaration);
+    if (methods.any((c) => c.name == 'copyWith')) {
+      throw ArgumentError(
+          'Cannot generate a copyWith method because one already exists');
+    }
+    var allFields = await declaration.allFields(builder).toList();
+    var namedParams = [
+      for (var field in allFields)
+        ParameterCode.fromString(
+            '${field.type.toCode()}${field.type.isNullable ? '' : '?'} '
+            '${field.name}'),
+    ];
+    var args = [
+      for (var field in allFields)
+        NamedArgumentCode.fromString(
+            '${field.name}: ${field.name}?? this.${field.name}'),
+    ];
+    builder.addToClass(DeclarationCode.fromParts([
+      declaration.instantiate().toCode(),
+      ' copyWith({',
+      ...namedParams.joinAsCode(', '),
+      ',})',
+      // TODO: We assume this constructor exists, but should check
+      '=> ', declaration.instantiate().toCode(), '}(',
+      ...args.joinAsCode(', '),
+      ', );',
+    ]));
+  }
+}
+
+const hashCode = _HashCode();
+
+class _HashCode implements ClassDeclarationMacro {
+  const _HashCode();
+
+  @override
+  void visitClassDeclaration(
+      ClassDeclaration declaration, ClassDeclarationBuilder builder) async {
+    var hashCodeExprs = [
+      await for (var field in declaration.allFields(builder))
+        ExpressionCode.fromString('${field.name}.hashCode')
+    ].joinAsCode(' ^ ');
+
+    builder.addToClass(DeclarationCode.fromParts([
+      '''
+@override
+int get hashCode =>''',
+      ...hashCodeExprs,
+      ';',
+    ]));
+  }
+}
+
+const equality = _Equality();
+
+class _Equality implements ClassDeclarationMacro {
+  const _Equality();
+
+  @override
+  void visitClassDeclaration(
+      ClassDeclaration declaration, ClassDeclarationBuilder builder) async {
+    var equalityExprs = [
+      await for (var field in declaration.allFields(builder))
+        ExpressionCode.fromString('this.${field.name} == other.${field.name}'),
+    ].joinAsCode(' && ');
+
+    builder.addToClass(DeclarationCode.fromParts([
+      '''
+@override
+bool operator==(Object other) =>
+    other is ${declaration.instantiate().toCode()} && ''',
+      ...equalityExprs,
+      ';',
+    ]));
+  }
+}
+
+const toString = _ToString();
+
+class _ToString implements ClassDeclarationMacro {
+  const _ToString();
+
+  @override
+  void visitClassDeclaration(
+      ClassDeclaration declaration, ClassDeclarationBuilder builder) async {
+    var fieldExprs = [
+      await for (var field in declaration.allFields(builder))
+        Code.fromString('  ${field.name}: \${${field.name}}'),
+    ].joinAsCode('\n');
+
+    builder.addToClass(DeclarationCode.fromParts([
+      '''
+@override
+String toString() => """\${${declaration.name}} {
+''',
+      ...fieldExprs,
+      '}""";',
+    ]));
+  }
+}
+
+extension _AllFields on ClassDeclaration {
+  // Returns all fields from all super classes.
+  Stream<FieldDeclaration> allFields(ClassIntrospector introspector) async* {
+    for (var field in await introspector.fieldsOf(this)) {
+      yield field;
+    }
+    var next = await introspector.superclassOf(this);
+    while (next is ClassDeclaration && next.name != 'Object') {
+      for (var field in await introspector.fieldsOf(next)) {
+        yield field;
+      }
+      next = await introspector.superclassOf(next);
+    }
+  }
+}
+
+extension _<T> on Iterable<T> {
+  T? firstWhereOrNull(bool Function(T element) test) {
+    for (var item in this) {
+      if (test(item)) return item;
+    }
+  }
+}
+
+extension _ToCode on TypeAnnotation {
+  Code toCode() => Code.fromString(this.name, scope: this.scope);
+}

--- a/working/macros/example/data_class.dart
+++ b/working/macros/example/data_class.dart
@@ -9,12 +9,12 @@ class _DataClass implements ClassMacro {
   const _DataClass();
 
   @override
-  void visitClass(ClassDeclaration clazz, ClassBuilder builder) {
-    autoConstructor.visitClass(clazz, builder);
-    copyWith.visitClass(clazz, builder);
-    hashCode.visitClass(clazz, builder);
-    equality.visitClass(clazz, builder);
-    toString.visitClass(clazz, builder);
+  void visitClass(ClassDeclaration clazz, ClassContext context) {
+    autoConstructor.visitClass(clazz, context);
+    copyWith.visitClass(clazz, context);
+    hashCode.visitClass(clazz, context);
+    equality.visitClass(clazz, context);
+    toString.visitClass(clazz, context);
   }
 }
 
@@ -24,8 +24,8 @@ class _AutoConstructor implements ClassMacro {
   const _AutoConstructor();
 
   @override
-  void visitClass(ClassDeclaration clazz, ClassBuilder builder) {
-    builder.buildDeclarations((builder) async {
+  void visitClass(ClassDeclaration clazz, ClassContext context) {
+    context.buildDeclarations((builder) async {
       var constructors = await builder.constructorsOf(clazz);
       if (constructors.any((c) => c.name == '')) {
         throw ArgumentError(
@@ -104,8 +104,8 @@ class _CopyWith implements ClassMacro {
   const _CopyWith();
 
   @override
-  void visitClass(ClassDeclaration clazz, ClassBuilder builder) {
-    builder.buildDeclarations((builder) async {
+  void visitClass(ClassDeclaration clazz, ClassContext context) {
+    context.buildDeclarations((builder) async {
       var methods = await builder.methodsOf(clazz);
       if (methods.any((c) => c.name == 'copyWith')) {
         throw ArgumentError(
@@ -143,14 +143,14 @@ class _HashCode implements ClassMacro {
   const _HashCode();
 
   @override
-  void visitClass(ClassDeclaration clazz, ClassBuilder builder) {
-    builder.buildDeclarations((builder) {
+  void visitClass(ClassDeclaration clazz, ClassContext context) {
+    context.buildDeclarations((builder) {
       builder.declareInClass(DeclarationCode.fromString('''
 @override
 external int get hashCode;'''));
     });
 
-    builder.buildDefinitions((builder) async {
+    context.buildDefinitions((builder) async {
       await builder.buildMethod('hashCode', (builder) async {
         var hashCodeExprs = [
           await for (var field in clazz.allFields(builder))
@@ -172,14 +172,14 @@ class _Equality implements ClassMacro {
   const _Equality();
 
   @override
-  void visitClass(ClassDeclaration clazz, ClassBuilder builder) {
-    builder.buildDeclarations((builder) async {
+  void visitClass(ClassDeclaration clazz, ClassContext context) {
+    context.buildDeclarations((builder) async {
       builder.declareInClass(DeclarationCode.fromString('''
 @override
 external bool operator==(Object other);'''));
     });
 
-    builder.buildDefinitions((builder) async {
+    context.buildDefinitions((builder) async {
       await builder.buildMethod('==', (builder) async {
         var equalityExprs = [
           await for (var field in clazz.allFields(builder))
@@ -202,8 +202,8 @@ class _ToString implements ClassMacro {
   const _ToString();
 
   @override
-  void visitClass(ClassDeclaration clazz, ClassBuilder builder) {
-    builder.buildDeclarations((builder) async {
+  void visitClass(ClassDeclaration clazz, ClassContext context) {
+    context.buildDeclarations((builder) async {
       builder.declareInClass(DeclarationCode.fromString(
         '''
 @override
@@ -211,7 +211,7 @@ external String toString();''',
       ));
     });
 
-    builder.buildDefinitions((builder) async {
+    context.buildDefinitions((builder) async {
       await builder.buildMethod('toString', (builder) async {
         var fieldExprs = [
           await for (var field in clazz.allFields(builder))

--- a/working/macros/example/data_class.dart
+++ b/working/macros/example/data_class.dart
@@ -204,7 +204,7 @@ class _ToString extends ClassMacro {
   @override
   void visitClass(ClassDeclaration clazz) {
     buildDeclarations((builder) async {
-      builder.addToClass(DeclarationCode.fromString(
+      builder.declareInClass(DeclarationCode.fromString(
         '''
 @override
 external String toString();''',


### PR DESCRIPTION
In this proposal, there are no explicit classes you implement for each phase, there is only a single class to implement based on the type of declaration you will annotate.

Each of these classes has a single visit method which only gets a declaration argument (no builder). They have external `buildTypes`, `buildDeclarations`, and `buildDefinition` methods. These methods take a callback as an argument, and the callback receives the corresponding builder.

Some advantages of this api are:

- Can have some shared state between phases, managed by local variables in the `visit` method.
- Less complicated class  heirarchy - far fewer classes to understand.
- The phases are less directly exposed, you don't really have to understand them so much any more.

Some disadvantages of this api are:

- Can result in runtime errors if violating phases - you can't call the `buildTypes` method from within the callback passed to `buildDeclarations` for instance. That would violate ordering, and we would have to throw at runtime. We could lint for this though.
- People may try to share state that isn't shareable across phases (for instance store the TypeBuilder and use it in the declaration phase).
- If only implementing one phase there is more boilerplate.