### PR TITLE
Api cleanup: remove Scope class and allow for unnamed types 

### DIFF
--- a/working/macros/api/builders.dart
+++ b/working/macros/api/builders.dart
@@ -83,9 +83,8 @@ abstract class ClassDeclarationBuilder
 /// The api used by [Macro] to get a [TypeDeclaration] for any given
 /// [TypeAnnotation].
 abstract class TypeIntrospector {
-  /// TODO: Figure out how to deal with `FutureOr<T>`, function types, and
-  /// other non-nominal types.
-  Future<TypeDeclaration> resolve(TypeAnnotation annotation);
+  /// Resolves a [NamedTypeAnnotation] to its declaration.
+  Future<TypeDeclaration> resolve(NamedTypeAnnotation annotation);
 }
 
 /// The base class for builders in the definition phase. These can convert

--- a/working/macros/api/code.dart
+++ b/working/macros/api/code.dart
@@ -1,51 +1,36 @@
-/// A scope in which to resolve a chunk of code.
-///
-/// TODO: Specify more what these mean, what fields are available (if any), etc.
-abstract class Scope {}
-
 /// The base class representing an arbitrary chunk of Dart code, which may or
 /// may not be syntactically or semantically valid yet.
 class Code {
-  /// The scope in which to resolve anything from [parts] that does not have its
-  /// own scope already defined.
-  final Scope? scope;
-
   /// All the chunks of [Code] or raw [String]s that comprise this [Code]
   /// object.
   final List<Object> parts;
 
-  Code.fromString(String code, {this.scope}) : parts = [code];
+  Code.fromString(String code) : parts = [code];
 
-  Code.fromParts(this.parts, {this.scope});
+  Code.fromParts(this.parts);
 }
 
 /// A piece of code representing a syntactically valid declaration.
 class DeclarationCode extends Code {
-  DeclarationCode.fromString(String code, {Scope? scope})
-      : super.fromString(code, scope: scope);
+  DeclarationCode.fromString(String code) : super.fromString(code);
 
-  DeclarationCode.fromParts(List<Object> parts, {Scope? scope})
-      : super.fromParts(parts, scope: scope);
+  DeclarationCode.fromParts(List<Object> parts) : super.fromParts(parts);
 }
 
 /// A piece of code representing a syntactically valid element.
 ///
 /// Should not include any trailing commas,
 class ElementCode extends Code {
-  ElementCode.fromString(String code, {Scope? scope})
-      : super.fromString(code, scope: scope);
+  ElementCode.fromString(String code) : super.fromString(code);
 
-  ElementCode.fromParts(List<Object> parts, {Scope? scope})
-      : super.fromParts(parts, scope: scope);
+  ElementCode.fromParts(List<Object> parts) : super.fromParts(parts);
 }
 
 /// A piece of code representing a syntactically valid expression.
 class ExpressionCode extends Code {
-  ExpressionCode.fromString(String code, {Scope? scope})
-      : super.fromString(code, scope: scope);
+  ExpressionCode.fromString(String code) : super.fromString(code);
 
-  ExpressionCode.fromParts(List<Object> parts, {Scope? scope})
-      : super.fromParts(parts, scope: scope);
+  ExpressionCode.fromParts(List<Object> parts) : super.fromParts(parts);
 }
 
 /// A piece of code representing a syntactically valid function body.
@@ -55,31 +40,25 @@ class ExpressionCode extends Code {
 ///
 /// Both arrow and block function bodies are allowed.
 class FunctionBodyCode extends Code {
-  FunctionBodyCode.fromString(String code, {Scope? scope})
-      : super.fromString(code, scope: scope);
+  FunctionBodyCode.fromString(String code) : super.fromString(code);
 
-  FunctionBodyCode.fromParts(List<Object> parts, {Scope? scope})
-      : super.fromParts(parts, scope: scope);
+  FunctionBodyCode.fromParts(List<Object> parts) : super.fromParts(parts);
 }
 
 /// A piece of code representing a syntactically valid identifier.
 class IdentifierCode extends Code {
-  IdentifierCode.fromString(String code, {Scope? scope})
-      : super.fromString(code, scope: scope);
+  IdentifierCode.fromString(String code) : super.fromString(code);
 
-  IdentifierCode.fromParts(List<Object> parts, {Scope? scope})
-      : super.fromParts(parts, scope: scope);
+  IdentifierCode.fromParts(List<Object> parts) : super.fromParts(parts);
 }
 
 /// A piece of code identifying a named argument.
 ///
 /// This should not include any trailing commas.
 class NamedArgumentCode extends Code {
-  NamedArgumentCode.fromString(String code, {Scope? scope})
-      : super.fromString(code, scope: scope);
+  NamedArgumentCode.fromString(String code) : super.fromString(code);
 
-  NamedArgumentCode.fromParts(List<Object> parts, {Scope? scope})
-      : super.fromParts(parts, scope: scope);
+  NamedArgumentCode.fromParts(List<Object> parts) : super.fromParts(parts);
 }
 
 /// A piece of code identifying a syntactically valid function parameter.
@@ -92,22 +71,18 @@ class NamedArgumentCode extends Code {
 /// construct and combine these together in a way that creates valid parameter
 /// lists.
 class ParameterCode extends Code {
-  ParameterCode.fromString(String code, {Scope? scope})
-      : super.fromString(code, scope: scope);
+  ParameterCode.fromString(String code) : super.fromString(code);
 
-  ParameterCode.fromParts(List<Object> parts, {Scope? scope})
-      : super.fromParts(parts, scope: scope);
+  ParameterCode.fromParts(List<Object> parts) : super.fromParts(parts);
 }
 
 /// A piece of code representing a syntactically valid statement.
 ///
 /// Should always end with a semicolon.
 class StatementCode extends Code {
-  StatementCode.fromString(String code, {Scope? scope})
-      : super.fromString(code, scope: scope);
+  StatementCode.fromString(String code) : super.fromString(code);
 
-  StatementCode.fromParts(List<Object> parts, {Scope? scope})
-      : super.fromParts(parts, scope: scope);
+  StatementCode.fromParts(List<Object> parts) : super.fromParts(parts);
 }
 
 extension Join<T extends Code> on List<T> {

--- a/working/macros/api/introspection.dart
+++ b/working/macros/api/introspection.dart
@@ -1,37 +1,48 @@
 import 'code.dart';
 
-/// An unresolved reference to a type.
+/// The base class for an unresolved reference to a type.
 ///
-/// These can be resolved to a [TypeDeclaration] using the `builder` classes
-/// depending on the phase a macro is running in.
+/// See the subtypes [FunctionTypeAnnotation] and [NamedTypeAnnotation].
 abstract class TypeAnnotation {
   /// Whether or not the type annotation is explicitly nullable (contains a
   /// trailing `?`)
   bool get isNullable;
 
+  /// A [Code] object representation of this type annotation.
+  Code get code;
+}
+
+/// The base class for function type declarations.
+abstract class FunctionTypeAnnotation implements TypeAnnotation {
+  /// The return type of this function.
+  TypeAnnotation get returnType;
+
+  /// The positional parameters for this function.
+  Iterable<ParameterDeclaration> get positionalParameters;
+
+  /// The named parameters for this function.
+  Iterable<ParameterDeclaration> get namedParameters;
+
+  /// The type parameters for this function.
+  Iterable<TypeParameterDeclaration> get typeParameters;
+}
+
+/// An unresolved reference to a type.
+///
+/// These can be resolved to a [TypeDeclaration] using the `builder` classes
+/// depending on the phase a macro is running in.
+abstract class NamedTypeAnnotation implements TypeAnnotation {
   /// The name of the type as it exists in the type annotation.
   String get name;
-
-  /// The scope in which the type annotation appeared in the program.
-  ///
-  /// This can be used to construct an [IdentifierCode] that refers to this type
-  /// regardless of the context in which it is emitted.
-  Scope get scope;
 
   /// The type arguments, if applicable.
   Iterable<TypeAnnotation> get typeArguments;
 }
 
-//// The base class for all declarations.
+/// The base class for all declarations.
 abstract class Declaration {
-  /// The name of this type declaration
+  /// The name of this declaration.
   String get name;
-
-  /// The scope in which this type declaration is defined.
-  ///
-  /// This can be used to construct an [IdentifierCode] that refers to this type
-  /// regardless of the context in which it is emitted.
-  Scope get scope;
 }
 
 /// A declaration that defines a new type in the program.
@@ -128,10 +139,7 @@ abstract class FieldDeclaration implements VariableDeclaration {
 }
 
 /// Parameter introspection information.
-abstract class ParameterDeclaration {
-  /// The name of the parameter.
-  String get name;
-
+abstract class ParameterDeclaration implements Declaration {
   /// The type of this parameter.
   TypeAnnotation get type;
 
@@ -148,7 +156,7 @@ abstract class ParameterDeclaration {
 }
 
 /// Type parameter introspection information.
-abstract class TypeParameterDeclaration {
+abstract class TypeParameterDeclaration implements Declaration {
   /// The bounds for this type parameter, if it has any.
   TypeAnnotation? get bounds;
 }

--- a/working/macros/example/data_class.dart
+++ b/working/macros/example/data_class.dart
@@ -68,7 +68,7 @@ class _AutoConstructor implements ClassDeclarationsMacro {
             ? ''
             : Code.fromParts([' = ', param.defaultValue!]);
         parts.add(Code.fromParts([
-          '\n$requiredKeyword${param.type.toCode()} ${param.name}',
+          '\n$requiredKeyword${param.type.code} ${param.name}',
           defaultValue,
           ',',
         ]));
@@ -79,7 +79,7 @@ class _AutoConstructor implements ClassDeclarationsMacro {
             ? ''
             : Code.fromParts([' = ', param.defaultValue!]);
         parts.add(Code.fromParts([
-          '\n$requiredKeyword${param.type.toCode()} ${param.name}',
+          '\n$requiredKeyword${param.type.code} ${param.name}',
           defaultValue,
           ',',
         ]));
@@ -123,7 +123,7 @@ class _CopyWith implements ClassDeclarationsMacro {
     var namedParams = [
       for (var field in allFields)
         ParameterCode.fromString(
-            '${field.type.toCode()}${field.type.isNullable ? '' : '?'} '
+            '${field.type.code}${field.type.isNullable ? '' : '?'} '
             '${field.name}'),
     ];
     var args = [
@@ -132,12 +132,12 @@ class _CopyWith implements ClassDeclarationsMacro {
             '${field.name}: ${field.name} ?? this.${field.name}'),
     ];
     builder.declareInClass(DeclarationCode.fromParts([
-      clazz.instantiate().toCode(),
+      clazz.instantiate().code,
       ' copyWith({',
       ...namedParams.joinAsCode(', '),
       ',})',
       // TODO: We assume this constructor exists, but should check
-      '=> ', clazz.instantiate().toCode(), '(',
+      '=> ', clazz.instantiate().code, '(',
       ...args.joinAsCode(', '),
       ', );',
     ]));
@@ -195,7 +195,7 @@ external bool operator==(Object other);'''));
         ExpressionCode.fromString('this.${field.name} == other.${field.name}'),
     ].joinAsCode(' && ');
     equalsBuilder.augment(FunctionBodyCode.fromParts([
-      ' => other is ${clazz.instantiate().toCode()} && ',
+      ' => other is ${clazz.instantiate().code} && ',
       ...equalityExprs,
       ';',
     ]));
@@ -256,8 +256,4 @@ extension _<T> on Iterable<T> {
       if (test(item)) return item;
     }
   }
-}
-
-extension _ToCode on TypeAnnotation {
-  Code toCode() => Code.fromString(this.name, scope: this.scope);
 }


### PR DESCRIPTION
- Drops the Scope class
- Drops the field from the `Code` class and subclasses
- Made `TypeAnnotation` a base class with two subtypes `FunctionTypeAnnotation` and `NamedTypeAnnotation`
- Also added a `code` getter to `TypeAnnotation` which converts it to a `Code` object.
  - Is this actually feasible to produce always? Should this api move to a `builder` class?