### PR TITLE
Update enhanced enum feature specification.

### DIFF
--- a/accepted/future-releases/enhanced-enums/feature-specification.md
+++ b/accepted/future-releases/enhanced-enums/feature-specification.md
@@ -66,11 +66,11 @@ must redirect to a generative constructor._
 
 ## Semantics
 
-We change the publicly visible API of the  `Enum` class to be declared as:
+The `Enum` class behaves as if it was declared as:
 
 ```dart
 class Enum {
-  // No default constructor (however we enforce that).
+  // No default constructor.
   external int get index;
   external String toString();
 }
@@ -84,14 +84,15 @@ The semantics of such an enum declaration, *E*, is defined as introducing a (sem
 
 * **Name**: The name of the class *C* and its implicit interface is the name of the `enum` declaration.
 
-* **Superclass**: The superclass of *C* is (seemingly) the `Enum` class, with the mixins declared by *E* applied. _(In practice, the superclass may be another system provided class with implements `Enum`.)_
+* **Superclass**: The superclass of *C* is an implementation-specific built-in class *`EnumImpl`*, with the mixins declared by *E* applied. _(The `EnumImpl` class may be the `Enum` class itself or it may be another class which extends or implements `Enum`, but as seen from a non-platform library the interface of *`EnumImpl`* is the same as that of `Enum`, and its methods work as specified for `Enum` )_
 
-  * If *E* is declared as `enum Name with Mixin1, Mixin2 …` then the superclass of *C* is the mixin application `Enum with Mixin1, Mixin2`.
+  * If *E* is declared as `enum Name with Mixin1, Mixin2 …` then the superclass of *C* is the mixin application <Code>*EnumImpl* with Mixin1, Mixin2</code>.
 
   It’s a **compile-time error** if such a mixin application introduces any instance variables. _We need to be able to call an implementation specific superclass `const` constructor of `Enum`, and a mixin application of a mixin with a field does not make its forwarding constructor `const`. Currently that’s the only restriction, but if we add further restrictions on mixin applications having `const` forwarding constructors, those should also apply here._
 
 * **Superinterfaces**: The immediate superinterfaces of *C* are the interface of the superclass and the interfaces declared by *E*.
-  * If `E` is declares as `enum Name with Mixin1, Mixin2 implements Type1, Type2 { … }` then the immediate superinterfaces of *C* are the interfaces of `Name with Mixin1, Mixin2`, `Type1` and `Type2`.
+  
+  * If `E` is declared as `enum Name with Mixin1, Mixin2 implements Type1, Type2 { … }` then the immediate superinterfaces of *C* are the interfaces of `Name with Mixin1, Mixin2`, `Type1` and `Type2`.
 
 - **Declared members**: For each member declaration of the `enum` declaration *E*, the same member is added to the class *C*. This includes constructors (which must be `const` generative or non-`const` factory constructors.)
 
@@ -142,7 +143,7 @@ If the resulting class would have any naming conflicts, or other compile-time er
 
 If not invalid, the semantics denoted by the `enum` declaration is that class, which we’ll refer to as the *corresponding class* of the `enum` declaration. *(We don’t require the implementation to be exactly such a class declaration, there might be other helper classes involved in the implementation, and different private members, but the publicly visible interface and behavior should match.)*
 
-That is, if the corresponding class of an `enum` declaration is valid, the `enum` declaration introduces the public interface* and *type* of the corresponding class. _There are, however, restrictions on how that class and interface can be used, listed in the next section._
+That is, if the corresponding class of an `enum` declaration is valid, the `enum` declaration introduces the *public interface* and *type* of the corresponding class. _There are, however, restrictions on how that class and interface can be used, listed in the next section._
 
 ### Implementing `Enum` and enum types
 
@@ -258,7 +259,7 @@ enum Plain {
 }
 ```
 
-has corresponding class desugaring similar to:
+would have a corresponding class desugaring of:
 
 ```dart
 class Plain extends Enum {
@@ -288,7 +289,7 @@ mixin EnumIndexOrdering<T extends Enum> on Enum implements Comparable<T> {
 }
 ```
 
-has corresponding class desugaring of:
+would have a  corresponding class desugaring of:
 
 ```dart
 class Ordering extends Enum with EnumIndexOrdering<Ordering> {
@@ -304,8 +305,6 @@ class Ordering extends Enum with EnumIndexOrdering<Ordering> {
   String _$enumToString() => "Ordering.${_$name}";
 }
 ```
-
-
 
 ### Complex, one with everything
 
@@ -364,7 +363,7 @@ enum Complex<T extends Pattern> with EnumComparable<Complex> implements Pattern 
 }
 ```
 
-has corresponding class desugaring of:
+would have a corresponding class desugaring of:
 
 ```dart
 class Complex<T extends Pattern> extends Enum with EnumComparable<Complex>
@@ -424,7 +423,7 @@ enum MySingleton implements Whatever {
 }
 ```
 
-has a corresponding class desugaring of:
+would have a corresponding class desugaring of:
 
 ```dart
 class MySingleton extends Enum implements Whatever {

--- a/accepted/future-releases/enhanced-enums/feature-specification.md
+++ b/accepted/future-releases/enhanced-enums/feature-specification.md
@@ -1,6 +1,6 @@
 # Dart Enhanced Enum Classes
 
-Author: lrn@google.com<br>Version: 1.4<br>Tracking issue [#158](https://github.com/dart-lang/language/issues/158)
+Author: lrn@google.com<br>Version: 1.5<br>Tracking issue [#158](https://github.com/dart-lang/language/issues/158)
 
 This is a formal proposal for a language feature which allows `enum` declarations to declare classes with fields, methods and const constructors initializing those fields. Further, `enum` declarations can implement interfaces and, as an optional feature, apply mixins.
 
@@ -29,9 +29,9 @@ enum Name<T extends Object?> with Mixin1, Mixin2 implements Interface1, Interfac
 where `memberDeclaration*` is almost any sequence of static and instance member declarations, or constructors, 
 with some necessary restrictions specified below.
 
-The `;` after the identifier list is optional if there is nothing else in the declaration, required if there is any member declaration after it. The identifier list may have a trailing comma (like now).
+The `;` after the identifier list is optional if there is nothing else in the declaration (for backwards compatibility), and required if there is any member declaration after it. The identifier list may have a trailing comma in either case (like now).
 
-The superclass of the mixin applications is the `Enum` class (which has an *abstract* `index` getter, so the only valid `super` invocations on that superclass are those valid on `Object`, `super.index` must be an error).
+The superclass of the mixin applications is the `Enum` class (which has a concrete `index` getter and otherwise only the members of `Object`, so the only valid `super` invocations on that superclass are those valid on `Object` and `super.index`).
 
 The grammar of the `enum` declaration becomes:
 
@@ -47,17 +47,15 @@ The grammar of the `enum` declaration becomes:
   | <metadata> <identifier> <typeArguments>? `.' <identifier> <arguments>
 ```
 
-It is a compile-time error if the enum declaration contains any generative constructor which is not `const`.
+It is a **compile-time error** if the enum declaration contains any generative constructor which is not `const`.
 
-_We_ can _allow omitting the `const` on constructors since it’s required, so we could just assume it’s always there. 
-That’s a convenience we can also add at any later point. For now we require it._
+_We_ could _allow omitting the `const` on constructors, since it’s required, so we could just assume it’s always there. That’s a convenience we can also add at any later point. For now we require the `const`._
 
-It is a compile-time error if the initializer list of a non-redirecting generative constructor includes a `super` constructor invocation.
+It is a **compile-time error** if the initializer list of a non-redirecting generative constructor includes a `super` constructor invocation.
 
-_We will introduce the necessary super-invocation ourselves. We could allow `super()`, which will be the constructor of `Enum`, but it's 
-simpler to just disallow it._
+_We will introduce the necessary super-invocation ourselves as an implementation detail. From the user’s perspective, they extend `Enum` which has no public constructors. We could allow `super()`, which would then be a constructor of `Enum`, but it's simpler to just disallow super invocations entirely._
 
-It is a compile-time error to refer to a declared or default generative constructor of an `enum` declaration in any way, other than:
+It is a **compile-time error** to refer to a declared or default generative constructor of an `enum` declaration in any way, other than:
 * As the target of a redirecting generative constructor of the same `enum`, or
 * Implicitly in the enum value declarations of the same `enum`.
 
@@ -68,104 +66,83 @@ must redirect to a generative constructor._
 
 ## Semantics
 
-First we will add a `const Enum();` constructor to the `Enum` class, so that it can validly be a superclass of `enum` classes. _(The `Enum` class currently has a non-`const` default constructor that no-one can use because the class is abstract and cannot be extended, and in practice `enum` classes implement it instead. We now need to, at least pretend to, extend it so that mixins `on Enum` can be applied.)_
-
-The semantics of such an enum declaration is defined as being equivalent to *rewriting into a corresponding class declaration* as follows:
-
-- Declare a class with the same name and type parameters as the `enum` declaration.
-
-- Add `extends Enum`, where `Enum` refers to the type declared in `dart:core`.
-
-- Further add the mixins and interfaces of the `enum` declaration.
-
-- Add `final int index;` and `final String _$name;` instance variable declarations to the class. 
-  (We’ll represent fresh names by prefixing with `_$` here and below, and `int` and `String` both refer to the type declared in `dart:core`).
-
-- For each member declaration:
-
-  - If the member declaration is a (necessarily `const`) generative constructor, 
-    introduce a similar named constructor on the class with a fresh name, 
-    which takes two extra leading positional arguments (`Name.foo(...):...;` &mapsto; `Name._$foo(int .., String .., ...):...`,
-    `Name(...):...;` &mapsto; `Name._$(int .., String .., ...):...`). 
-    If the constructor is non-redirecting, make the two arguments `this.index` and `this._$name`. 
-    If the constructor is redirecting, make them `int _$index` and `String _$name`, 
-    then change the target of the redirection to its corresponding freshly-renamed constructor 
-    and pass `_$index` and `_$name` as two extra initial positional arguments.
-  - Otherwise include the member as written.
-
-- If no generative constructors were declared, and no unnamed factory constructor was added,
-  a default generative constructor `const Name._$(this.index, this._$name);` is added.
-
-- If no `toString` member overriding `Object.toString` was declared or inherited _(from mixin applications)_,
-  A `String toString() => “Name.${_$name}”;` instance method is added.
-
-- For each `<enumEntry>` with name `id` and index *i* in the comma-separated list of enum entries, a static constant is added as follows:
-
-  - `id` &mapsto;  `static const id = Name._$(i, "id");` &mdash; equivalent to `id()`.
-  - `id(args)` &mapsto; `static const id = Name._$(i, "id", args);`
-  - `id<types>(args)` &mapsto; `static const id = Name<types>._$(i, "id", args);`
-  - `id.named(args)` &mapsto; `static const id = Name._$named(i, "id", args);`
-  - `id<types>.named(args)` &mapsto; `static const id = Name<types>._$named(i, "id", args);`
-
-  We expect type inference to be applied to the resulting declarations and generic constructor invocations where necessary,
-  and the type of the constant variable is inferred from the static type of the constant object creation expression.
-
-- A static constant named `values` is added as `static const List<Name> values = [id1, …, idn];`
-  where `id1`…`idn` are the names of the enum entries of the `enum` declaration in source/index order.
-  If `Name` is generic, the `List<Name>` instantiates it to bounds as usual.
-
-If the resulting class would have any naming conflicts, or other compile-time errors, the `enum` declaration is invalid and a compile-time error occurs. Such errors include, but are not limited to:
-
-- Declaring or inheriting (from `Enum` or from a declared mixin or interface) any member with the same basename as an enum value, 
-  or the name `values`, or declaring an enum value with name `values`. _(The introduced static declarations would have a conflict.)_
-
-- Inheriting a member signature with basename `index`, from a mixin or interface, which is not validly overridden by an implementation with signature 
-  `int get index;`. _(The introduced `index` getter would not be a valid implementation of that interface signature.)_
-
-- Inheriting a member signature with basename `toString`, but no implementation, 
-  from a mixin or interface, which is not validly overridden by an implementation with signature 
-  `String toString();`. _(The introduced `toString()` method would not be a valid implementation of that interface signature.)_
-
-- Declaring any members or enum values with basename `index` or `values`.
-
-- Declaring a type parameter on the `enum` which does not have a valid well-bounded or super-bounded instantiate-to-bounds result 
-  (because the introduced `static const List<EnumName> values` requires a valid instantiate-to-bounds result which is at least super-bounded).
-
-- The type parameters of the enum not having a well-bounded instantiate-to-bounds result *and* an enum element omitting the type arguments
-  and not having arguments which valid type arguments can be inferred from (because an implicit `EnumName._$(0, "foo", unrelatedArgs)` 
-  constructor invocation requires an well-bound inferred type arguments for a generic `EnumName` enum).
-
-- Declaring an enum value where the desugared constructor invocation is not a valid `const` generative constructor invocation.
-
-- Referring to a generative constructor of the `enum` exceit in a redirecting generative constructor or the enum values,
-  _(because the constructor is renamed to a fresh name, and only those two occurrences use the new name)._
-
-Otherwise the `enum` declaration has an interface and behavior which is equivalent to that class declaration, which we’ll refer to as the *corresponding class declaration* of the `enum` declaration. *(We don’t require the implementation to be that class declaration, there might be other helper classes involved in the implementation, and different private members, but the publicly visible interface and behavior should match.)*
-
-That is, if the corresponding class declaration of an `enum` declaration is valid, the `enum` declaration introduces the same *public interface* and *type* that the corresponding class declaration would introduce if declared in the same location. _There are, however, restrictions on how that class and interface can be used, listed in the next section._
-
-This `enum` declaration above is therefore defined to behave equivalently to the corresponding class declaration:
+We change the publicly visible API of the  `Enum` class to be declared as:
 
 ```dart
-class Name<T extends Object?> extends Enum with Mixin1, Mixin2 
-    implements Interface1, Interface2 {
-  static const id1 = Name<int>._$(0, "id1", args1);
-  static const id2 = Name<String>._$(1, "id2", args2);
-  static const id3 = Name<bool>._$(2, "id3", args3);
-  static const List<Name> values = [id1, id2, id3];
-
-  final int index;
-  final String _$name;
-
-  Name._$(this.index, this._$name, params) : initList;
-
-  memberDeclarations*
-
-  String toString() => "Name.${_$name}"; // Unless defined by memberDeclarations.
+class Enum {
+  // No default constructor (however we enforce that).
+  external int get index;
+  external String toString();
 }
 ```
 
-Further, the `EnumName` extension in `dart:core` will extract the `_$name` value from any enum value.
+We intend to (at least pretend to) let `enum` classes extend `Enum`, and let mixins and members access the default `index` and `toString()` through `super.`. _(In practice, we may use a different class implementing `Enum` as the superclass, but for checking the validity of `super.index`/`super.toString()`, we analyze against `Enum` itself, so it must have non-abstract implementations.)_
+
+This all makes it look as if `Enum` would be a valid superclass for the mixin applications and methods of the enhanced `enum` class.
+
+The semantics of such an enum declaration, *E*, is defined as introducing a (semantic) *class*, *C*, just like a similar `class` declaration.
+
+* **Name**: The name of the class *C* and its implicit interface is the name of the `enum` declaration.
+
+* **Superclass**: The superclass of *C* is (seemingly) the `Enum` class, with the mixins declared by *E* applied. _(In practice, the superclass may be another system provided class with implements `Enum`.)_
+
+  * If *E* is declared as `enum Name with Mixin1, Mixin2 …` then the superclass of *C* is the mixin application `Enum with Mixin1, Mixin2`.
+
+  It’s a **compile-time error** if such a mixin application introduces any instance variables. _We need to be able to call an implementation specific superclass `const` constructor of `Enum`, and a mixin application of a mixin with a field does not make its forwarding constructor `const`. Currently that’s the only restriction, but if we add further restrictions on mixin applications having `const` forwarding constructors, those should also apply here._
+
+* **Superinterfaces**: The immediate superinterfaces of *C* are the interface of the superclass and the interfaces declared by *E*.
+  * If `E` is declares as `enum Name with Mixin1, Mixin2 implements Type1, Type2 { … }` then the immediate superinterfaces of *C* are the interfaces of `Name with Mixin1, Mixin2`, `Type1` and `Type2`.
+
+- **Declared members**: For each member declaration of the `enum` declaration *E*, the same member is added to the class *C*. This includes constructors (which must be `const` generative or non-`const` factory constructors.)
+
+- **Default constructor**: If no generative constructors were declared, and no unnamed factory constructor was added,
+  a default generative constructor is added:
+
+  ```dart
+  const Name();
+  ```
+  
+  _(This differs from the default constructor of a normal `class` declaration by being constant.)_
+  
+- **Enum values**: For each `<enumEntry>` with name `id` and index *i* in the comma-separated list of enum entries, a constant value is created, and a static constant variable named `id` is created in *C* with that value. All the constant values are associated, in some implementation dependent way, with 
+  
+- their name `id` as a string `"id"`, 
+  - their index *i* as an `int`, and
+  - their `enum` class’s name as a string, `"Name"`,
+  
+  all of which is accessible to the `toString` and `index` member of `Enum`, and to the `EnumName.name` extension getter. The values are computed as follows.
+  
+  - `id` &mapsto; `Name()` (no arguments, equivalent to empty argument list)
+  - `id(args)` &mapsto; `Name(args)`
+  - `id<types>(args)` &mapsto; `Name<types>(args)`
+  - `id.named(args)` &mapsto; `Name._$named(args)`
+  - `id<types>.named(args)` &mapsto; `Name<types>._$named(args)`
+  
+  where `args` are considered as occurring in a `const` context, and it’s a **compile-time error** if they are then not compile-time constants.
+  
+  Type inference is applied to the resulting constructor invocations, with no context type, where necessary, so omitted type arguments to a generic `enum` class are filled in by type inference, using the type of arguments, if any, and then the type of the constant variable is the static type of the constant object creation expression.
+  
+  The objects created here are *not canonicalized* like other constant object creations. _(In practice, the index value is considered part of the object, so no two objects will have the same state.)_
+  
+- **Static `values` list**: If the class does not declare or inherit a member with base-name `values`, a static constant variable named `values` is added as by the declaration  `static const List<Name> values = [id1, …, idn];`
+  where `id1`…`idn` are the names of the enum entries of the `enum` declaration in source/index order.
+  If `Name` is generic, the `List<Name>` instantiates `Name` to its bounds.
+
+
+
+If the resulting class would have any naming conflicts, or other compile-time errors, the `enum` declaration is invalid and a compile-time error occurs. Such errors include, but are not limited to:
+
+- Declaring or inheriting (from `Enum` or from a declared mixin or interface) any member with the same basename as an enum value which is not a static setter. _(The introduced static declarations would have a conflict.)_
+- Declaring or mixing in a member which is not a valid override of a super-interface member declaration, including, but not limited to, the `index` and `toString` members of `Enum`.
+- Declaring or inheriting an member signature with no corresponding implementation. _(For example declaring an abstract `Never get index` or `String toString([int optional])`, but not providing an implementation.)
+- Declaring a type parameter on the `enum` which does not have a valid well-bounded or super-bounded instantiate-to-bounds result *and* not declaring or inheriting a member with base-name `values` _(because the then automatically introduced `static const List<EnumName> values` requires a valid instantiate-to-bounds result which is at least super-bounded, and a value declaration may require a well-bounded instantiation)_.
+- The type parameters of the enum not having a well-bounded instantiate-to-bounds result *and* an enum element omitting the type arguments and not having arguments which valid type arguments can be inferred from (because an implicit `EnumName(0, "foo", unrelatedArgs)`  constructor invocation requires a well-bound inferred type arguments for a generic `EnumName` enum).
+- Using a non-constant expression as argument of an enum value.
+- Declaring a static member and inheriting an instance member with the same base-name.
+
+If not invalid, the semantics denoted by the `enum` declaration is that class, which we’ll refer to as the *corresponding class* of the `enum` declaration. *(We don’t require the implementation to be exactly such a class declaration, there might be other helper classes involved in the implementation, and different private members, but the publicly visible interface and behavior should match.)*
+
+That is, if the corresponding class of an `enum` declaration is valid, the `enum` declaration introduces the public interface* and *type* of the corresponding class. _There are, however, restrictions on how that class and interface can be used, listed in the next section._
 
 ### Implementing `Enum` and enum types
 
@@ -173,9 +150,9 @@ It’s currently a compile-time error for a class to implement, extend or mix-in
 
 Because we want to allow interfaces and mixins that are intended to be applied to `enum` declarations, and therefore to assume `Enum` to be a superclass, we loosen that restriction to:
 
-- It’s a compile-time error if a *non-abstract* class has `Enum` as a superinterface unless it is the corresponding class declaration of an `enum` declaration.
+- It’s a compile-time error if a *non-abstract* class has `Enum` as a superinterface (directly or transitively) unless it is the corresponding class of an `enum` declaration.
 
-- It is a compile-time error if a class implements, extends or mixes-in the class or interface introduced by an `enum` declaration.
+- It is a compile-time error if a class implements, extends or mixes-in the class or interface introduced by an `enum` declaration. _(An enum class can’t be used as a mixin since it is not a `mixin` declaration and the class has a superclass other than `Object`, but we include “mixes-in” for completeness.)_
 
 Those restrictions allows abstract classes (interfaces) which implements `Enum` in order to have the `int index;` getter member available, and it allows `mixin` declarations to use `Enum` as an `on` type because `mixin` declarations cannot be instantiated directly.
 
@@ -187,9 +164,77 @@ The recommended formatting of an `enum` declaration is to format the header (bef
 
 If the enum entries have no arguments, they can be listed on one line where it fits, like they are today.
 
+## Implementation
+
+The specification here does not specify *how* the index and name of an enum is associated with the enum instances. In practice it’s possible to desugar an `enum` declaration to a `class` declaration, as long as the desugaring can access private names from other libraries (`dart:core` in particular).
+
+The existing enums are implemented as desugaring into a class extending a private `_Enum` class which holds the `final int index;` declaration and a `final String _name;` declaration (used by the the `EnumName.name` getter), and both fields are initialized by a constructor. 
+
+In practice, the implementation of the enhanced enums will likely be something similar.
+
+Either first declare `Enum` as:
+
+```dart
+abstract class Enum {
+  Enum._(this.index, this._name);  
+  final int index;
+  final String _name;
+  String _$enumToString();
+  String toString() => _$enumToString();
+}
+```
+
+*or* retain the current `_Enum` class and make that the actual superclass of `enum` classes. Either works, I’ll use `Enum` as the superclass directly in the following.
+
+Then desugar an `enum` declaration to an actual `class` declaration and rewrite every generative constructor of the `enum` declaration to take two extra leading positional arguments. 
+
+The `enum` declaration:
+
+```dart
+enum LogPriority with LogPriorityMixin implements Comparable<LogPriority> {
+  warning(2, "Warning"),
+  error(1, "Error"),
+  log.unknown("Log"),
+  ;
+ 
+  MyEnum(this.priority, this.prefix);
+  MyEnum.unknown(String prefix) : this(-1, prefix);
+    
+  final String prefix;
+  final int priorty;
+  int compareTo(Log other) => priority - other.priority;
+}
+```
+
+would then desugar to something like:
+
+```dart
+class LogPriority extends Enum with LogriorityMixin implements Comparable<LogPriority> {
+  static const warning = MyEnum._$(0, "warning", 2, "Warning");
+  static const error = MyEnum._$(1, "error", 1, "Error");
+  static const log = MyEnum._$unknown(2, "log", "Log");
+  
+  MyEnum._$(int _$index, String _$name, this.priority, this.prefix) 
+        : super(_$index, _$name);
+  MyEnum._$unknown(int _$index, String _$name, String prefix) : 
+        : this._$(_$index, _$name, prefix, -1);
+    
+  final String prefix;
+  final int priorty;
+  int compareTo(Log other) => priority - other.priority;
+    
+  static const List<LogPriority> values = [warning, error, log];
+    
+  // Refers to privates in dart:core.
+  String _$enumToString() => "LogPriority.${_$name}";
+}
+```
+
+In practice, we may choose to have a subclass of `Enum` as the actual superclass of the `enum` class, rather than use `Enum` directly. We’ll have to make sure that it makes no difference wrt. which declarations are valid (at least outside of `dart:core`, and for `enum`s declared inside `dart:core` it’s our own responsibility to not conflict with names used by the enum implementation.)
+
 ## Summary
 
-We let `enum` declarations be much more like classes, just classes with a fixed number of known constant instances. We allow the class to apply mixins (applicable to a supertype of `Enum`) and implement interfaces. We allow any static or instance member declaration, and any generative `const` constructor declaration (so instance variables must be final, including those added by mixins, otherwise the mixin application constructor forwarders to the superclass `const Enum()` constructor won’t be `const`).
+We let `enum` declarations be much more like the classes they are, with the only restriction now being that it’s classes with a fixed number of known constant instances. We allow the class to apply mixins (applicable to a supertype of `Enum`) and implement interfaces. We allow any static or instance member declaration, and any generative `const` constructor declaration (so instance variables must be final, including those added by mixins, otherwise the mixin application constructor forwarders to the superclass `const Enum()` constructor won’t be `const`).
 
 The enum values can call the declared constructors, or the default unnamed zero-argument `const` constructor which is added if no other constructor is declared. The syntax looks like a constructor invocation except that the enum value name replaces the class name. If no type arguments or value arguments are needed, and the constructor invoked is unnamed, the enum value can still be a plain identifier.
 
@@ -213,7 +258,7 @@ enum Plain {
 }
 ```
 
-has corresponding class declaration:
+has corresponding class desugaring similar to:
 
 ```dart
 class Plain extends Enum {
@@ -222,14 +267,45 @@ class Plain extends Enum {
   static const Plain baz = Plain._$(2, "baz");
   static const List<Plain> values = [foo, bar, baz];
 
-  final int index;
-  final String _$name;
+  const Plain._$(int _$index, String_ $name) : super._(_$index, $_name);
 
-  const Plain._$(this.index, this._$name) : super._();
-
-  String toString() => "Plain.${_$name}";
+  // Private names from `dart:core`.
+  String _$enumToString() => "Plain.${_$name}";
 }
 ```
+
+### Simple but comparable
+
+```dart
+enum Ordering with EnumIndexOrdering<Ordering> {
+  zero,
+  few,
+  many;
+}
+
+mixin EnumIndexOrdering<T extends Enum> on Enum implements Comparable<T> {
+  int compareTo(T other) => this.index - other.index;
+}
+```
+
+has corresponding class desugaring of:
+
+```dart
+class Ordering extends Enum with EnumIndexOrdering<Ordering> {
+  static const zero = Ordering._$(0, "zero");
+  static const few = Ordering._$(1, "few");
+  static const many = Ordering._$(2, "many");
+  static const List<Ordering> values = [zero, few, many];
+  
+  // Default constructor desugared:
+  Ordering._$(int _$index, String _$name): super(_$index, _$name);
+  
+  // Private names from `dart:core`.
+  String _$enumToString() => "Ordering.${_$name}";
+}
+```
+
+
 
 ### Complex, one with everything
 
@@ -288,7 +364,7 @@ enum Complex<T extends Pattern> with EnumComparable<Complex> implements Pattern 
 }
 ```
 
-has corresponding class declaration:
+has corresponding class desugaring of:
 
 ```dart
 class Complex<T extends Pattern> extends Enum with EnumComparable<Complex>
@@ -302,13 +378,11 @@ class Complex<T extends Pattern> extends Enum with EnumComparable<Complex>
 
   static final List<Pattern?> _patterns = List<Pattern?>.filled(3, null);
 
-  final int index;
-  final String _$name;
   final String _patternSource;
   final T Function(String) _factory;
 
-  const Complex._$(this.index, this._$name, String pattern, T Function(String) factory)
-      : _patternSource = pattern, _factory = factory, super._();
+  const Complex._$(int _$index, String _$name, String pattern, T Function(String) factory)
+      : _patternSource = pattern, _factory = factory, super._(_$index, _$name);
 
   factory Complex.matching(String text) {
     for (var value in values) {
@@ -332,6 +406,9 @@ class Complex<T extends Pattern> extends Enum with EnumComparable<Complex>
   Match? matchAsPrefix(String input, [int start = 0]) =>
       pattern.matchAsPrefix(input, start);
 
+  // Private names from `dart:core`.
+  String _$enumToString() => "Complex.$_name";
+    
   String toString() => "Complex<$T>($_patternSource)";
 }
 ```
@@ -347,52 +424,21 @@ enum MySingleton implements Whatever {
 }
 ```
 
-has equivalent class
+has a corresponding class desugaring of:
 
 ```dart
 class MySingleton extends Enum implements Whatever {
   static const MySingleton instance = MySingleton._$(0, "instance");
   static const List<MySingleton> values = [instance];
-  final int index;
-  final String _$name;
-  const MySingleton._$(this.index, this._$name, ...) : ..., super._();
+  const MySingleton._$(int _$index, String _$name, ...) : ..., super._(_$index, _$name);
   // Normal class declarations.
-  // toString if needed.
+  
+  // Private names from `dart:core`.
+  String _$enumToString() => "MySingleton.${_$name}";
 }
 ```
 
 There is a chance that people will start using `enum` declarations to declare singleton classes. It has a little overhead, but it’s finite (and the `values` getter can likely be tree-shaken).
-
-## Implementation
-
-The existing enums are implemented as extending a private `_Enum` class which holds the `final int index;` declaration and a `final String _name;` declaration (used by the the `EnumName.name` getter), and both fields are initialized by a constructor.
-
-Since this proposal allows mixin applications which can, potentially, shadow a superclass `index` getter, we likely need to change some parts of the implementation.
-
-- Make the actual implementation class for an `enum` extend `_Enum` instead of `Enum`, and forward the index and name values to the superclass constructor.
-- Not have `index` and `_$name` instance variables in the implementation class.
-
-- Make the `final int index;` field in `_Enum` be private (`final int _index;`).
-- Add an `int get index => this.<dart:core::_index>;` to the actual implementation class for the `enum` to dodge overrides of `index` in mixins. (The `<dart:core::_index>` syntax represents accessing the library private `_index` member from `dart:core` through compiler magic.)
-
-That makes the actual implementation of the `Plain` enum above likely to be something like:
-
-```dart
-class Plain extends _Enum {
-  static const Plain foo = Plain._$(0, "foo");
-  static const Plain bar = Plain._$(1, "bar");
-  static const Plain baz = Plain._$(2, "baz");
-  static const List<Plain> values = [foo, bar, baz];
-
-  const Plain._$(int _$index, String _$name) : super(_$index, _$name);
-
-  int get index => this.<dart:core::_index>;
-
-  String toString() => "Plain.${<date:core::_name>}";
-}
-```
-
-This should allow a reasonable implementation which still supports `EnumName`. We currently implement the `toString` using such compiler-magic to access the `_name` field of `_Enum`, so all we need is to add a similar `index` getter to each enum class.
 
 ## Versions
 
@@ -401,3 +447,4 @@ This should allow a reasonable implementation which still supports `EnumName`. W
 1.2, 2021-10-25: Tweak some wordings and ambiguities.
 1.3, 2021-10-27: Add examples of potential errors in the corresponding class declaration.
 1.4, 2021-10-28: Say that it's an error to refer to generative constructors, and make the `Enum` constructor public.
+1.5, 2021-12-07: Say that `index` and `toString` are inherited from the superclass, `values` is omitted if it would conflict. Rephrase specification in terms of defining a semantic class, not a syntactic one.


### PR DESCRIPTION
State that `index` and `toString` are inherited from `Enum`.
State that `values` is only added if it would not conflict.

Rephrase the definition in terms of an `enum` declaration
introducing a *class*, not a `class` declaration.
Then put the corresponding class declaration into the
"implementation" section as a desugaring, not a specification.