### PR TITLE
add initial macro expansion protocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@
 *.vcxproj.filters
 /*.vcxproj.user
 *.stamp
+.dart_tool
+.packages
 
 # Gyp generated files
 *.xcodeproj

--- a/working/macros/api/builders.dart
+++ b/working/macros/api/builders.dart
@@ -27,7 +27,7 @@ abstract class TypeComparator {
   /// Returns true if [leftType] is a subtype of [rightType].
   bool isSubtypeOf(TypeAnnotation leftType, TypeAnnotation rightType);
 
-  /// Retruns true if [leftType] is an identical type to [rightType].
+  /// Returns true if [leftType] is an identical type to [rightType].
   bool isExactly(TypeAnnotation leftType, TypeAnnotation rightType);
 }
 

--- a/working/macros/api/builders.dart
+++ b/working/macros/api/builders.dart
@@ -22,21 +22,24 @@ abstract class TypeBuilder implements Builder {
   void declareType(DeclarationCode typeDeclaration);
 }
 
-/// The api used by [Macro]s to contribute new (non-type)
-/// declarations to the current library.
-///
-/// Can also be used to do subtype checks on types.
-abstract class DeclarationBuilder implements Builder {
-  /// Adds a new regular declaration to the surrounding library.
-  ///
-  /// Note that type declarations are not supported.
-  Declaration declareInLibrary(DeclarationCode declaration);
-
+/// The interface for checking if a type implements another type.
+abstract class TypeComparator {
   /// Returns true if [leftType] is a subtype of [rightType].
   bool isSubtypeOf(TypeAnnotation leftType, TypeAnnotation rightType);
 
   /// Retruns true if [leftType] is an identical type to [rightType].
   bool isExactly(TypeAnnotation leftType, TypeAnnotation rightType);
+}
+
+/// The api used by [Macro]s to contribute new (non-type)
+/// declarations to the current library.
+///
+/// Can also be used to do subtype checks on types.
+abstract class DeclarationBuilder implements Builder, TypeComparator {
+  /// Adds a new regular declaration to the surrounding library.
+  ///
+  /// Note that type declarations are not supported.
+  void declareInLibrary(DeclarationCode declaration);
 }
 
 /// The api used by [Macro]s to contribute new members to a class.

--- a/working/macros/api/builders.dart
+++ b/working/macros/api/builders.dart
@@ -24,7 +24,13 @@ abstract class TypeBuilder implements Builder {
 /// macro expansion.
 abstract class TypeResolver {
   /// Resolves [typeAnnotation] to a [StaticType].
-  StaticType resolve(TypeAnnotation typeAnnotation);
+  ///
+  /// Throws an error if the type annotation cannot be resolved. This should
+  /// only happen in the case of incomplete or invalid programs, but macros
+  /// may be asked to run in this state during the development cycle. It is
+  /// helpful for users if macros provide a best effort implementation in that
+  /// case or handle the error in a useful way.
+  Future<StaticType> resolve(TypeAnnotation typeAnnotation);
 }
 
 /// The api used to introspect on a [ClassDeclaration].

--- a/working/macros/api/expansion_protocol.dart
+++ b/working/macros/api/expansion_protocol.dart
@@ -46,7 +46,8 @@ abstract class MacroExecutor {
   Future<MacroExecutionResult> executeDeclarationsPhase(
       MacroInstanceIdentifier macro,
       Declaration declaration,
-      TypeComparator typeComparator);
+      TypeComparator typeComparator,
+      ClassIntrospector classIntrospector);
 
   /// Runs the definitions phase for [macro] on a given [declaration].
   ///
@@ -69,11 +70,11 @@ abstract class MacroExecutor {
 /// All argument instances must be of type [Code] or a built-in value type that
 /// is serializable (num, bool, String, null, etc).
 class Arguments {
-  final List<Object?> positionalArgs;
+  final List<Object?> positional;
 
-  final Map<String, Object?> namedArgs;
+  final Map<String, Object?> named;
 
-  Arguments(this.positionalArgs, this.namedArgs);
+  Arguments(this.positional, this.named);
 }
 
 /// An opaque identifier for a macro class, retrieved by

--- a/working/macros/api/expansion_protocol.dart
+++ b/working/macros/api/expansion_protocol.dart
@@ -1,5 +1,3 @@
-import 'package:package_config/package_config.dart';
-
 import 'builders.dart';
 import 'code.dart';
 import 'introspection.dart';
@@ -12,10 +10,6 @@ import 'introspection.dart';
 /// during macro discovery and expansion, and unifies how augmentation libraries
 /// are produced.
 abstract class MacroExecutor {
-  /// Creating an executor will require at least a package config, in order to
-  /// resolve macros by URI.
-  MacroExecutor(PackageConfig packageConfig);
-
   /// Invoked when an implementation discovers a new macro definition in a
   /// library, and prepares this executor to run the macro.
   ///

--- a/working/macros/api/expansion_protocol.dart
+++ b/working/macros/api/expansion_protocol.dart
@@ -11,7 +11,7 @@ import 'introspection.dart';
 /// are produced.
 abstract class MacroExecutor {
   /// Invoked when an implementation discovers a new macro definition in a
-  /// library, and prepares this executor to run the macro.
+  /// [library] with [name], and prepares this executor to run the macro.
   ///
   /// May be invoked more than once for the same macro, which will cause the
   /// macro to be re-loaded. Previous [MacroClassIdentifier]s and
@@ -93,12 +93,17 @@ abstract class MacroExecutionResult {
   Iterable<DeclarationCode> get imports;
 
   /// Any augmentations that should be applied as a result of executing a macro.
-  Iterable<DeclarationCode> get agumentations;
+  Iterable<DeclarationCode> get augmentations;
 }
 
 /// Each of the different macro execution phases.
 enum Phase {
-  types, // Only new types are added in this phase
-  declarations, // New non-type declarations are added in this phase
-  defintions, // This phase allows augmenting existing declarations
+  /// Only new types are added in this phase.
+  types,
+
+  /// New non-type declarations are added in this phase.
+  declarations,
+
+  /// This phase allows augmenting existing declarations.
+  defintions,
 }

--- a/working/macros/api/expansion_protocol.dart
+++ b/working/macros/api/expansion_protocol.dart
@@ -14,7 +14,7 @@ import 'introspection.dart';
 abstract class MacroExecutor {
   /// Creating an executor will require at least a package config, in order to
   /// resolve macros by URI.
-  MacroExpander(PackageConfig packageConfig);
+  MacroExecutor(PackageConfig packageConfig);
 
   /// Invoked when an implementation discovers a new macro definition in a
   /// library, and prepares this executor to run the macro.

--- a/working/macros/api/expansion_protocol.dart
+++ b/working/macros/api/expansion_protocol.dart
@@ -10,7 +10,7 @@ import 'introspection.dart';
 ///
 /// This class more clearly defines the role of a Dart language implementation
 /// during macro discovery and expansion, and unifies how augmentation libraries
-/// are produced, as well as how (and where) they are written to disk.
+/// are produced.
 abstract class MacroExecutor {
   /// Creating an executor will require at least a package config, in order to
   /// resolve macros by URI.

--- a/working/macros/api/expansion_protocol.dart
+++ b/working/macros/api/expansion_protocol.dart
@@ -40,7 +40,7 @@ abstract class MacroExecutor {
   Future<MacroExecutionResult> executeDeclarationsPhase(
       MacroInstanceIdentifier macro,
       Declaration declaration,
-      TypeComparator typeComparator,
+      TypeResolver typeResolver,
       ClassIntrospector classIntrospector);
 
   /// Runs the definitions phase for [macro] on a given [declaration].
@@ -49,9 +49,9 @@ abstract class MacroExecutor {
   Future<MacroExecutionResult> executeDefinitionsPhase(
       MacroInstanceIdentifier macro,
       Declaration declaration,
-      TypeComparator typeComparator,
+      TypeResolver typeResolver,
       ClassIntrospector classIntrospector,
-      TypeIntrospector typeIntrospector);
+      TypeDeclarationResolver typeDeclarationResolver);
 
   /// Combines multiple [MacroExecutionResult]s into a single library
   /// augmentation file, and returns a [String] representing that file.

--- a/working/macros/api/expansion_protocol.dart
+++ b/working/macros/api/expansion_protocol.dart
@@ -1,0 +1,109 @@
+import 'package:package_config/package_config.dart';
+
+import 'builders.dart';
+import 'code.dart';
+import 'introspection.dart';
+
+/// The interface used by Dart language implementations, in order to load
+/// and execute macros, as well as produce library augmentations from those
+/// macro applications.
+///
+/// This class more clearly defines the role of a Dart language implementation
+/// during macro discovery and expansion, and unifies how augmentation libraries
+/// are produced, as well as how (and where) they are written to disk.
+abstract class MacroExecutor {
+  /// Creating an executor will require at least a package config, in order to
+  /// resolve macros by URI.
+  MacroExpander(PackageConfig packageConfig);
+
+  /// Invoked when an implementation discovers a new macro definition in a
+  /// library, and prepares this executor to run the macro.
+  ///
+  /// May be invoked more than once for the same macro, which will cause the
+  /// macro to be re-loaded. Previous [MacroClassIdentifier]s and
+  /// [MacroInstanceIdentifier]s given for this macro will be invalid after
+  /// that point and should be discarded.
+  ///
+  /// Throws an exception if the macro fails to load.
+  Future<MacroClassIdentifier> loadMacro(Uri library, String name);
+
+  /// Creates an instance of [macroClass] in the executor, and returns an
+  /// identifier for that instance.
+  ///
+  /// Throws an exception if an instance is not created.
+  Future<MacroInstanceIdentifier> instantiateMacro(
+      MacroClassIdentifier macroClass, String constructor, Arguments arguments);
+
+  /// Runs the type phase for [macro] on a given [declaration].
+  ///
+  /// Throws an exception if there is an error executing the macro.
+  Future<MacroExecutionResult> executeTypesPhase(
+      MacroInstanceIdentifier macro, Declaration declaration);
+
+  /// Runs the declarations phase for [macro] on a given [declaration].
+  ///
+  /// Throws an exception if there is an error executing the macro.
+  Future<MacroExecutionResult> executeDeclarationsPhase(
+      MacroInstanceIdentifier macro,
+      Declaration declaration,
+      TypeComparator typeComparator);
+
+  /// Runs the definitions phase for [macro] on a given [declaration].
+  ///
+  /// Throws an exception if there is an error executing the macro.
+  Future<MacroExecutionResult> executeDefinitionsPhase(
+      MacroInstanceIdentifier macro,
+      Declaration declaration,
+      TypeComparator typeComparator,
+      ClassIntrospector classIntrospector,
+      TypeIntrospector typeIntrospector);
+
+  /// Combines multiple [MacroExecutionResult]s into a single library
+  /// augmentation file, and returns a [String] representing that file.
+  Future<String> buildAugmentationLibrary(
+      Iterable<MacroExecutionResult> macroResults);
+}
+
+/// The arguments passed to a macro constructor.
+///
+/// All argument instances must be of type [Code] or a built-in value type that
+/// is serializable (num, bool, String, null, etc).
+class Arguments {
+  final List<Object?> positionalArgs;
+
+  final Map<String, Object?> namedArgs;
+
+  Arguments(this.positionalArgs, this.namedArgs);
+}
+
+/// An opaque identifier for a macro class, retrieved by
+/// [MacroExecutor.loadMacro].
+///
+/// Used to execute or reload this macro in the future.
+abstract class MacroClassIdentifier {}
+
+/// An opaque identifier for an instance of a macro class, retrieved by
+/// [MacroExecutor.instantiateMacro].
+///
+/// Used to execute or reload this macro in the future.
+abstract class MacroInstanceIdentifier {}
+
+/// A summary of the results of running a macro in a given phase.
+///
+/// All modifications are expressed in terms of library augmentation
+/// declarations.
+abstract class MacroExecutionResult {
+  /// Any library imports that should be added to support the code used in
+  /// the augmentations.
+  Iterable<DeclarationCode> get imports;
+
+  /// Any augmentations that should be applied as a result of executing a macro.
+  Iterable<DeclarationCode> get agumentations;
+}
+
+/// Each of the different macro execution phases.
+enum Phase {
+  types, // Only new types are added in this phase
+  declarations, // New non-type declarations are added in this phase
+  defintions, // This phase allows augmenting existing declarations
+}

--- a/working/macros/api/introspection.dart
+++ b/working/macros/api/introspection.dart
@@ -72,8 +72,12 @@ abstract class TypeDeclaration implements Declaration {
   ///
   /// If [isNullable] is `true`, then this type will behave as if it has a
   /// trailing `?`.
+  ///
+  /// Throws an exception if the type could not be instantiated, typically due
+  /// to one of the type arguments not matching the bounds of the corresponding
+  /// type parameter.
   Future<StaticType> instantiate(
-      {List<StaticType> typeArguments, bool isNullable = false});
+      {required List<StaticType> typeArguments, required bool isNullable});
 }
 
 /// Class (and enum) introspection information.

--- a/working/macros/api/introspection.dart
+++ b/working/macros/api/introspection.dart
@@ -45,10 +45,10 @@ abstract class NamedTypeAnnotation implements TypeAnnotation {
 /// compared to other static types.
 abstract class StaticType {
   /// Returns true if this is a subtype of [other].
-  bool isSubtypeOf(StaticType other);
+  Future<bool> isSubtypeOf(StaticType other);
 
   /// Returns true if this is an identical type to [other].
-  bool isExactly(StaticType other);
+  Future<bool> isExactly(StaticType other);
 }
 
 /// A subtype of [StaticType] representing types that can be resolved by name
@@ -69,7 +69,11 @@ abstract class TypeDeclaration implements Declaration {
   Iterable<TypeParameterDeclaration> get typeParameters;
 
   /// Create a static type representing this type with [typeArguments].
-  StaticType instantiate({List<StaticType> typeArguments});
+  ///
+  /// If [isNullable] is `true`, then this type will behave as if it has a
+  /// trailing `?`.
+  Future<StaticType> instantiate(
+      {List<StaticType> typeArguments, bool isNullable = false});
 }
 
 /// Class (and enum) introspection information.

--- a/working/macros/api/introspection.dart
+++ b/working/macros/api/introspection.dart
@@ -39,6 +39,24 @@ abstract class NamedTypeAnnotation implements TypeAnnotation {
   Iterable<TypeAnnotation> get typeArguments;
 }
 
+/// The interface representing a resolved type.
+///
+/// Resolved types understand exactly what type they represent, and can be
+/// compared to other static types.
+abstract class StaticType {
+  /// Returns true if this is a subtype of [other].
+  bool isSubtypeOf(StaticType other);
+
+  /// Returns true if this is an identical type to [other].
+  bool isExactly(StaticType other);
+}
+
+/// A subtype of [StaticType] representing types that can be resolved by name
+/// to a concrete declaration.
+abstract class NamedStaticType implements StaticType {
+  String get name;
+}
+
 /// The base class for all declarations.
 abstract class Declaration {
   /// The name of this declaration.
@@ -50,8 +68,8 @@ abstract class TypeDeclaration implements Declaration {
   /// The type parameters defined for this type declaration.
   Iterable<TypeParameterDeclaration> get typeParameters;
 
-  /// Create a type annotation representing this type with [typeArguments].
-  TypeAnnotation instantiate({List<TypeAnnotation> typeArguments});
+  /// Create a static type representing this type with [typeArguments].
+  StaticType instantiate({List<StaticType> typeArguments});
 }
 
 /// Class (and enum) introspection information.

--- a/working/macros/pubspec.yaml
+++ b/working/macros/pubspec.yaml
@@ -1,0 +1,6 @@
+name: macro_proposal
+publish_to: none
+dev_dependencies:
+  package_config: ^2.0.0
+environment:
+  sdk: ">=2.12.0 <3.0.0"

--- a/working/macros/pubspec.yaml
+++ b/working/macros/pubspec.yaml
@@ -1,6 +1,4 @@
 name: macro_proposal
 publish_to: none
-dev_dependencies:
-  package_config: ^2.0.0
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
This adds a `MacroExecutor` interface which is intended for use by language frontends (cfe, analyzer) in order to load and execute macros, as well as create library augmention files.

This should help more clearly define the role of a frontend when it comes to macros (discovery and introspection), as well as provide a unified api for producing the final library augmentations.

It does not actually write files though, we still need to figure out how we want to coordinate that part, and make sure that the CFE and analyzer can consistently talk about these files.

This also allows for multiple different implementations in terms of how macros are actually loaded and executed, without the frontends having to know about them.

Followup PR here https://github.com/dart-lang/language/pull/2022 which starts an implementation using `IsolateMirror.loadUri`.