### PR TITLE
Update pre-null-safety spec with new null safety sections

### DIFF
--- a/specification/dart.sty
+++ b/specification/dart.sty
@@ -466,7 +466,7 @@
   \FunctionTypeAllRequired{#1}{ }{X}{B}{s}{T}{n}}
 
 \newcommand{\FunctionTypeNamedStdArgCr}[1]{%
-  \FunctionTypeNamedArgCr{#1}{ }{X}{B}{s}{T}{n}{x}{k}{r}}
+  \FunctionTypeNamedArgCr{#1}{ }{X}{B}{s}{T}{n}{x}{k}}
 
 % Same as \FunctionTypeAllRequiredStd except that it includes a newline, hence
 % suitable for function types that are too long to fit in one line.

--- a/specification/dart.sty
+++ b/specification/dart.sty
@@ -394,6 +394,16 @@
 \newcommand{\FunctionTypePositionalStdCr}[1]{%
   \FunctionTypePositional{#1}{\\}{X}{B}{s}{T}{n}{k}}
 
+% Used to specify function type parameter lists with named optionals.
+% Arguments: Parameter type, number of required parameters,
+% name of optional parameters, number of optional parameters,
+% name of `required` symbol.
+\newcommand{\FunctionTypeNamedArguments}[5]{%
+  \List{#1}{1}{#2},\ \{\TripleList{#5}{#1}{#3}{{#2}+1}{{#2}+{#4}}\}}
+  
+\newcommand{\FunctionTypeNamedArgumentsStd}{%
+  \FunctionTypeNamedArguments{T}{n}{x}{k}{r}}
+
 % Used to specify function types with named parameters:
 % Arguments: Return type, spacer, type parameter name, bound name,
 %   number of type parameters, parameter type, number of required parameters,
@@ -454,6 +464,9 @@
 % "R Function<X1 extends B1, .. Xs extends Bs>(T1, T2, .. Tn)".
 \newcommand{\FunctionTypeAllRequiredStd}[1]{%
   \FunctionTypeAllRequired{#1}{ }{X}{B}{s}{T}{n}}
+
+\newcommand{\FunctionTypeNamedStdArgCr}[1]{%
+  \FunctionTypeNamedArgCr{#1}{ }{X}{B}{s}{T}{n}{x}{k}{r}}
 
 % Same as \FunctionTypeAllRequiredStd except that it includes a newline, hence
 % suitable for function types that are too long to fit in one line.

--- a/specification/dart.sty
+++ b/specification/dart.sty
@@ -346,7 +346,7 @@
 % "T1, .. Tn, {rn+1 Tn+1 xn+1, .. rn+k Tn+k xn+k}".
 \newcommand{\FunctionTypeNamedParameters}[5]{%
   \List{#1}{1}{#2},\ \{\TripleList{#5}{#1}{#3}{{#2}+1}{{#2}+{#4}}\}}
-  
+
 % Variant of \FunctionTypeNamedParameters that uses the standard symbols,
 % that is, a list of function type parameter declarations with named
 % parameters which uses the symbols that we prefer to use for that purpose
@@ -400,7 +400,7 @@
 % name of `required` symbol.
 \newcommand{\FunctionTypeNamedArguments}[5]{%
   \List{#1}{1}{#2},\ \{\TripleList{#5}{#1}{#3}{{#2}+1}{{#2}+{#4}}\}}
-  
+
 \newcommand{\FunctionTypeNamedArgumentsStd}{%
   \FunctionTypeNamedArguments{T}{n}{x}{k}{r}}
 

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -21133,7 +21133,8 @@ All further interpretation of URIs is implementation dependent.
 \LMLabel{types}
 
 \LMHash{}%
-Dart supports static typing based on interface types.
+Dart supports static typing based on interface types
+(\ref{interfaceTypes}).
 
 \rationale{%
   The type system is sound in the sense that
@@ -23830,15 +23831,13 @@ because the alternatives are ambiguous or complex.%
 
 \LMHash{}%
 We define the auxiliary function \NominalTypeDepthName{}
-on interface types and \code{Object?} as follows:
+on interface types as follows:
 
 \begin{itemize}
 \item
-  \DefEquals{\NominalTypeDepth{Object?}}{0}.
-\item
-  \DefEquals{\NominalTypeDepth{Object}}{1}.
-\item
-  \DefEquals{\NominalTypeDepth{Null}}{1}.
+  % We could make it 1 rather than 0, to "reserve space" for `Object?`,
+  % but this function is never used with `Object?` anyway.
+  \DefEquals{\NominalTypeDepth{Object}}{0}.
 \item
   Let $T$ be a class or a mixin,
   and let $M$ be the set of immediate superinterfaces of $T$.
@@ -23846,10 +23845,6 @@ on interface types and \code{Object?} as follows:
   where $d$ is
   $\metavar{max}\,\{\;\NominalTypeDepth{$S$}\;|\;S\;\in M\;\}$.
 \end{itemize}
-
-\commentary{%
-
-}
 
 \LMHash{}%
 \BlindDefineSymbol{I, J, M}%
@@ -24239,7 +24234,7 @@ Let $T$ be a type, and let $T'$ be the transitive alias expansion of $T$
 (\ref{typedef}).
 We say that $T$ is an \Index{interface type} if{}f
 $T'$ is of the form \code{$C$<\List{T}{1}{k}>},
-where $C$ denotes a class different from \code{Never},
+where $C$ denotes a class different from \code{Never} and \code{Null},
 or $C$ denotes a mixin.
 
 \commentary{%
@@ -24247,13 +24242,14 @@ or $C$ denotes a mixin.
   Non-generic classes are included because we can have $k = 0$.
 
   In particular, the following types are \emph{not} interface types:
-  \VOID, \DYNAMIC, \FUNCTION, \code{FutureOr<$T$>} for any $T$, \code{Never},
+  \VOID, \DYNAMIC, \FUNCTION, \code{FutureOr<$T$>} for any $T$,
+  \code{Never}, \code{Null},
   any function type, any type variable, any intersection type,
   and any type of the form \code{$T$?}.
 
-  Conversely, built-in classes
-  like \code{Object}, \code{Null}, \code{num}, \code{int},
-  \code{String}, and \code{Exception} are interface types,
+  Conversely, built-in classes like, e.g.,
+  \code{Object}, \code{num}, \code{int}, \code{String}, and \code{Exception}
+  are interface types,
   and so are
   \code{Future<$T$>}, \code{Stream<$T$>}, \code{Iterable<$T$>},
   \code{List<$T$>}, \code{Map<$S$,\,\,$T$}, and \code{Set<$T$>},

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -21864,9 +21864,6 @@ However, their subtype relations are specified without restrictions.
 \newcommand{\SrnRightTop}{2}
 \newcommand{\SrnLeftTop}{3}
 \newcommand{\SrnBottom}{4}
-%\newcommand{\SrnRightObjectOne}{} Redundant
-%\newcommand{\SrnRightObjectTwo}{} Redundant
-%\newcommand{\SrnRightObjectThree}{} Redundant
 \newcommand{\SrnRightObjectFour}{5}
 \newcommand{\SrnNullOne}{6}
 % \newcommand{\SrnNullTwo}{} Redundant
@@ -22424,12 +22421,12 @@ the set of direct superinterfaces of $C$
     %% in \ref{mixinApplication} is incorrect, and also that it will need to
     %% be rewritten completely for the integration of the new mixin construct.
     The case where the superclass is a mixin application is covered via
-    the equivalence with a declaration
-    of a regular (possibly generic) superclass
+    the equivalence with a declaration of
+    a regular (possibly generic) superclass
     (\ref{mixinApplication}),
     and this means that there may be multiple subtype steps from
     a given class declaration to the class specified in an \EXTENDS{} clause.
-\end{itemize}%
+  \end{itemize}%
 }
 
 \subsubsection{Additional Subtyping Concepts}
@@ -22481,7 +22478,8 @@ if{}f $T$ is not nullable.
   Nullable types are types which are
   definitively known to include the null object,
   regardless of the value of any type variables.
-  This is equivalent to the syntactic criterion that $T$ is any of:
+  If $T'$ is the transitive alias expansion (\ref{typedef}) of $T$
+  then this is equivalent to the syntactic criterion that $T'$ is any of:
 
   \begin{itemize}[itemsep=-0.5ex]
   \item \VOID.
@@ -22503,13 +22501,14 @@ if{}f $T$ is not non-nullable.
   Non-nullable types are types which are definitively known to
   \emph{not} include the null object,
   regardless of the value of any type variables.
-  This is equivalent to the syntactic criterion that $T$ is any of:
+  If $T'$ is the transitive alias expansion (\ref{typedef}) of $T$
+  then this is equivalent to the syntactic criterion that $T$ is any of:
 
   \begin{itemize}[itemsep=-0.5ex]
   \item \code{Never}.
   \item Any function type.
   \item The type \FUNCTION.
-  \item Any interface type except \code{Null}.
+  \item Any interface type.
   \item \code{FutureOr<$S$>}, for any non-nullable type $S$.
   \item Any type variable $X$ whose bound is non-nullable.
   \item Any type of the form \code{$X$\,\&\,$S$}, where
@@ -22871,10 +22870,11 @@ where $T_r$ is determined as follows:
 
   \noindent
   then $T_r$ is
-  \FunctionTypePositional{R_0}{ }{X}{B}{s}{R}{n}{k}
+  \FunctionTypePositional{T'\!_0}{ }{X}{B'\!}{s}{T'\!}{n}{k}
 
   \noindent
-  where $R_i$ is \NormalizedTypeOf{$T_i$} for $i \in 0 .. n+k$.
+  where $T'\!_i$ is \NormalizedTypeOf{$T_i$} for $i \in 0 .. n+k$
+  and $B'\!_i$ is \NormalizedTypeOf{$B_i$} for $i \in 1 .. s$.
 \item If $T_u$ is of the form
   \FunctionTypeNamedStd{T_0}
 
@@ -22882,10 +22882,11 @@ where $T_r$ is determined as follows:
   where $r_j$ is either \REQUIRED{} or empty
   then $T_r$ is
   \noindent
-  \FunctionTypeNamed{R_0}{ }{X}{B}{s}{R}{n}{x}{k}{r}
+  \FunctionTypeNamed{T'\!_0}{ }{X}{B'\!}{s}{T'\!}{n}{x}{k}
 
   \noindent
-  where $R_i$ is \NormalizedTypeOf{$T_i$} for $i \in 0 .. n+k$.
+  where $T'\!_i$ is \NormalizedTypeOf{$T_i$} for $i \in 0 .. n+k$
+  and $B'\!_i$ is \NormalizedTypeOf{$B_i$} for $i \in 0 .. s$.
 \end{itemize}
 
 \commentary{%
@@ -23224,8 +23225,8 @@ to parameter type declarations,
 which is defined as follows.
 Assume that $P_1$ and $P_2$ are two formal parameter type declarations
 with declared type $T_1$ respectively $T_2$,
-such that both are positional or both are named,
-with the same name \DefineSymbol{n}.
+such that both are positional,
+or both are named and have the same name \DefineSymbol{n}.
 Then \UpperBoundType{$P_1$}{$P_2$} (respectively \LowerBoundType{$P_1$}{$P_2$})
 is the formal parameter declaration $P$,
 with the following proporties:
@@ -23244,7 +23245,8 @@ with the following proporties:
   }
 \item
   $P$ is named if $P_1$ and $P_2$ are named.
-  In this case, the name of $P$ is $n$.
+  In this case, the name of $P$ is $n$
+  (\commentary{which is also the name of $P_1$ and $P_2$}).
   $P$ is marked with the modifier \REQUIRED{}
   if both $P_1$ and $P_2$ have this modifier
   (respectively, if either $P_1$ or $P_2$ has this modifier).
@@ -23423,22 +23425,25 @@ The function \UpperBoundTypeName{} is defined as follows.
 
   \noindent
   \code{$T_1$\,\FUNCTION<$X_1$\,\EXTENDS\,$B_{11}$,\,\ldots,\,$X_m$\,%
-    \EXTENDS\,$B_{1m}$>($P_{11}$,\,\ldots,\,$P_{1k}$)}
+    \EXTENDS\,$B_{1m}$>($P_{11}$,\,\ldots[\ldots\,$P_{1k}$])}
 
   \noindent
   \code{$T_2$\,\FUNCTION<$X_1$\,\EXTENDS\,$B_{21}$,\,\ldots,\,$X_m$\,%
-    \EXTENDS\,$B_{2m}$>($P_{21}$,\,\ldots,\,$P_{2l}$)}
+    \EXTENDS\,$B_{2m}$>($P_{21}$,\,\ldots[\ldots\,$P_{2l}$])}
 
   \noindent
   such that each $B_{1i}$ and $B_{2i}$ are types with the same canonical syntax,
-  and both have the same number of required positional parameters.
+  and both $U_1$ or $U_2$ have
+  the same number of required positional parameters.
+  In the case where $U_1$ or $U_2$ has no optional positional parameters,
+  the brackets are omitted.
   Let $q$ be $\metavar{min}(k, l)$,
   let $T_3$ be \UpperBoundType{$T_1$}{$T_2$},
-  let $B_{3i}$ be $B_{1i}$, and
+  let $B_{3i}$ be $B_{1i}$, and finally
   let $P_{3i}$ be \LowerBoundType{$P_{1i}$}{$P_{2i}$}.
-  Then \DefEquals{\UpperBoundType{$U_1$}{$U_2$}}{%
+  Then \DefEqualsNewline{\UpperBoundType{$U_1$}{$U_2$}}{%
     \code{$T_3$\,\FUNCTION<$X_1$\,\EXTENDS\,$B_{31}$,\,\ldots,\,$X_m$\,%
-      \EXTENDS\,$B_{3m}$>($P_{31}$,\,\ldots,\,$P_{3q}$)}}.
+      \EXTENDS\,$B_{3m}$>($P_{31}$,\,\ldots[\ldots\,$P_{3q}$])}}.
 
   \commentary{%
     This case includes non-generic function types by allowing $m$ to be zero.%
@@ -23496,8 +23501,11 @@ The function \UpperBoundTypeName{} is defined as follows.
 %%
 %% TODO(eernst), for review: Why do we not have a rule for
 %% \UpperBoundType{T1 Function(P1..Pm, [...])}{T2 Function(P1..Pk, {...}}}
-%% = T3 Function(R1..Rk), where the left operand has at least k parameters,
-%% plus the converse?
+%% = T3 Function(R1..Rk), where the left operand has at least k parameters
+%% and every named parameter of the right operand is optional (plus the
+%% same rule with operands swapped)?
+%% Motivation: Some expressions of type `Function` would then have a more
+%% precise type, and programs would be safer (a tiny bit, at least).
 %%
 \item
   \DefEquals{\UpperBoundType{$S_1$ \FUNCTION<\ldots>(\ldots)}{%
@@ -23861,7 +23869,7 @@ Let $M_n$ be the set
 $\{\;T\;|\;T\,\in\,M\;\wedge\;\NominalTypeDepth{$T$}\,=\,n\,\}$
 for any natural number $n$.
 Let $q$ be the largest number such that $M_q$ has cardinality one.
-Such a number must exist because $M_0$ is $\{\code{Object?}\}$.
+Such a number must exist because $M_0$ is $\{\code{Object}\}$.
 The least upper bound of $I$ and $J$ is then the sole element of $M_q$.
 
 
@@ -24094,7 +24102,7 @@ The invariant occurrences are treated as described explicitly below.
     the least closure of $S$ with respect to $L$ is
 
     \noindent
-    \FunctionTypeNamed{U_0}{ }{X}{B}{s}{U}{n}{x}{k}{r}
+    \FunctionTypeNamed{U_0}{ }{X}{B}{s}{U}{n}{x}{k}
 
     \noindent
     where
@@ -24109,7 +24117,7 @@ The invariant occurrences are treated as described explicitly below.
     the greatest closure of $S$ with respect to $L$ is
 
     \noindent
-    \FunctionTypeNamed{U_0}{ }{X}{B}{s}{U}{n}{x}{k}{r}
+    \FunctionTypeNamed{U_0}{ }{X}{B}{s}{U}{n}{x}{k}
 
     \noindent
     where $U_0$ is the greatest closure of $T_0$ with respect to $L$,
@@ -24165,15 +24173,17 @@ where \FreeContext{} is treated as a type variable.
 \LMLabel{typesBoundedByTypes}
 
 \LMHash{}%
-For a given type $T_0$, we introduce the notion of a
-\IndexCustom{$T_0$ bounded type}{type!T0 bounded}:
-$T_0$ itself is $T_0$ bounded;
-if $B$ is $T_0$ bounded and
+For a given type $T$, we introduce the notion of a
+% `T bounded` at the end should have been `$T$ bounded`, but makeindex
+% seems to be unable to allow math mode in that position.
+\IndexCustom{$T$ bounded type}{type!T bounded}:
+$T$ itself is $T$ bounded;
+if $B$ is $T$ bounded and
 $X$ is a type variable with bound $B$
-then $X$ is $T_0$ bounded;
-finally, if $B$ is $T_0$ bounded and
+then $X$ is $T$ bounded;
+finally, if $B$ is $T$ bounded and
 $X$ is a type variable
-then $X \& B$ is $T_0$ bounded.
+then $X \& B$ is $T$ bounded.
 
 \LMHash{}%
 In particular, a
@@ -24187,11 +24197,11 @@ Similarly for a
 \LMHash{}%
 A
 \IndexCustom{function-type bounded type}{type!function-type bounded}
-is a type $T$ which is $T_0$ bounded where $T_0$ is a function type
+is a type $S$ which is $T$ bounded where $T$ is a function type
 (\ref{functionTypes}).
-A function-type bounded type $T$ has an
+A function-type bounded type $S$ has an
 \Index{associated function type}
-which is the unique function type $T_0$ such that $T$ is $T_0$ bounded.
+which is the unique function type $T$ such that $S$ is $T$ bounded.
 
 
 \subsection{Class Building Types}
@@ -24252,7 +24262,7 @@ or $C$ denotes a mixin.
   are interface types,
   and so are
   \code{Future<$T$>}, \code{Stream<$T$>}, \code{Iterable<$T$>},
-  \code{List<$T$>}, \code{Map<$S$,\,\,$T$}, and \code{Set<$T$>},
+  \code{List<$T$>}, \code{Map<$S$,\,\,$T$>}, and \code{Set<$T$>},
   for any $S$ and $T$.%
 }
 
@@ -25438,9 +25448,11 @@ At each location where a local variable can be referred
 \commentary{%
   (e.g., as an expression, or as the left hand side of an assignment)%
 },
-the variable has a status as being
-\IndexCustom{definitely assigned}{local variable!definitely assigned} or
-\IndexCustom{definitely unassigned}{local variable!definitely unassigned}.
+the variable can be
+\IndexCustom{definitely assigned}{local variable!definitely assigned},
+and it can be
+\IndexCustom{definitely unassigned}{local variable!definitely unassigned},
+and it can be neither.
 
 \commentary{%
   The precise flow analysis which determines this status at each location
@@ -25693,15 +25705,16 @@ and to \NonNullType{$T$} in the \FALSE{} continuation.
 
 %% TODO(eernst), for review: The null safety spec says that `T?` is
 %% promoted to `T`, but implementations _do_ promote `X extends int?` to
-%% `X & int`. So I've specified the latter. This is also more consistent
-%% with the approach used with `==`.
+%% `X & int`. So we may be able to specify something which will yield
+%% slightly more precise types, and which is more precisely the implemented
+%% behavior.
 \LMHash{}%
 A check of the form \code{$v$\,\,!=\,\,\NULL},
 \code{\NULL\,\,!=\,\,$v$},
 or \code{$v$\,\,\IS\,\,$T$}
-where $v$ has type $T$ at $\ell$
+where $v$ has static type $T?$ at $\ell$
 promotes the type of $v$
-to \NonNullType{$T$} in the \TRUE{} continuation,
+to $T$ in the \TRUE{} continuation,
 and to \code{Null} in the \FALSE{} continuation.
 
 \commentary{%

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -23544,7 +23544,7 @@ The function \UpperBoundTypeName{} is defined as follows.
   \DefEquals{\UpperBoundType{$T_1$}{$T_2$}}{T_2},
   if \SubtypeNE{T_1}{T_2}.
 
-  \commentary{
+  \commentary{%
     In this and in the following cases, both types must be interface types.%
   }
 \item
@@ -23801,7 +23801,7 @@ The function \LowerBoundType{$T_1$}{$T_2$} is defined as follows.
   \DefEquals{\LowerBoundType{$T_1$}{$T_2$}}{\code{Never}}, otherwise.
 \end{itemize}
 
-\rationale{
+\rationale{%
 The rules defining \UpperBoundTypeName{} and \LowerBoundTypeName{}
 are somewhat redundant in that they explicitly specify
 a lot of pairs of symmetric cases.
@@ -25672,6 +25672,7 @@ independently of the control flow.
 }
 
 \LMHash{}%
+\BlindDefineSymbol{\ell, v}%
 Let $\ell$ be a location,
 and let $v$ be a local variable which is in scope at $\ell$.
 Assume that $\ell$ occurs after the declaration of $v$.
@@ -25695,34 +25696,33 @@ are the following:
 
 \LMHash{}%
 In particular,
-a check of the form \code{$v$\,\,==\,\,\NULL},
-\code{\NULL\,\,==\,\,$v$},
-or \code{$v$\,\,\IS\,\,Null}
+an expression of the form \code{$v$\,\,==\,\,\NULL} or
+\code{\NULL\,\,==\,\,$v$}
 where $v$ has type $T$ at $\ell$
 promotes the type of $v$
-to \code{Null} in the \TRUE{} continuation,
-and to \NonNullType{$T$} in the \FALSE{} continuation.
+to \NonNullType{$T$} in the \FALSE{} continuation;
+and an expression of the form \code{$v$\,\,!=\,\,\NULL} or
+\code{\NULL\,\,!=\,\,$v$}
+where $v$ has static type $T$ at $\ell$
+promotes the type of $v$
+to \NonNullType{$T$} in the \TRUE{} continuation.
 
-%% TODO(eernst), for review: The null safety spec says that `T?` is
-%% promoted to `T`, but implementations _do_ promote `X extends int?` to
-%% `X & int`. So we may be able to specify something which will yield
-%% slightly more precise types, and which is more precisely the implemented
-%% behavior.
 \LMHash{}%
-A check of the form \code{$v$\,\,!=\,\,\NULL},
-\code{\NULL\,\,!=\,\,$v$},
-or \code{$v$\,\,\IS\,\,$T$}
-where $v$ has static type $T?$ at $\ell$
+Similarly, a type test of the form \code{$v$\,\,\IS\,\,$T$}
 promotes the type of $v$
 to $T$ in the \TRUE{} continuation,
-and to \code{Null} in the \FALSE{} continuation.
+and a type check of the form \code{$v$\,\,\AS\,\,$T$}
+promotes the type of $v$
+to $T$ in the continuation where the expression evaluated to an object
+(\commentary{that is, it did not throw}).
 
 \commentary{%
   The resulting type of $v$ may be the obvious one, e.g.,
   \code{$v$\,\,=\,\,1} may promote $v$ to \code{int},
   but it may also give rise to a demotion
-  (changing the type of $v$ to a supertype of the type of $v$ at $\ell$),
-  and it may have no effect on the type of $v$
+  (changing the type of $v$ to a supertype of the type of $v$ at $\ell$
+  and potentially promoting it to some other type of interest).
+  It may also have no effect on the type of $v$
   (e.g., when the static type of $e$ is not a type of interest).
   These details will be specified in a future version of this specification.
 
@@ -26025,6 +26025,7 @@ The following algorithm computes the same relation as
 the one which is specified in Fig.~\ref{fig:subtypeRules}.
 It shows that Dart subtyping relationships can be decided
 with good performance.
+This section is not normative.
 
 \LMHash{}%
 The algorithm must be performed such that the first case that matches

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -23134,7 +23134,7 @@ of two or more types.
   then the standard lower bound is guaranteed to be a subtype of $L$,
   The standard lower bound is in any case guaranteed to be
   a subtype of both operands.
-  
+
   The standard upper and lower bounds are intended to compute
   the least upper bound respectively the greatest lower bound whenever possible,
   and otherwise to deliver an approximation thereof.
@@ -23182,7 +23182,7 @@ of two or more types.
   results which are suboptimal in the sense that
   we can rather easily find a better approximation of the
   least upper bound or the greatest lower bound.
-  
+
   In all other cases,
   the standard upper and lower bound are computed recursively,
   based on the structure of the type,
@@ -25803,7 +25803,7 @@ that it has been resolved to denote.
 
 \LMHash{}%
 Moreover, it is assumed that
-type inference and instantiation to bound has taken place 
+type inference and instantiation to bound has taken place
 such that none of the types enountered are raw.
 
 \LMHash{}%

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -12,6 +12,7 @@
 \usepackage[T1]{fontenc}
 \usepackage{makeidx}
 \usepackage{tocloft}
+\usepackage{enumitem}
 \makeindex
 \title{Dart Programming Language Specification\\
 {6th edition draft}\\
@@ -11943,6 +11944,7 @@ We define the auxiliary function
 as follows, using the first applicable case:
 
 \begin{itemize}
+
 \item If $T$ is \code{$X$\,\&\,$S$}
   for some type variable $X$ and type $S$ then
 
@@ -22418,17 +22420,16 @@ the set of direct superinterfaces of $C$
     that exists between two parameterized types based on $C$ and $D$.
     %
     %% TODO(eernst): Note that the specification of how to pass type arguments
-    %% in \ref{mixinApplication} is incorrect, and also that it will need to be
-    %% rewritten completely for the integration of the new mixin construct.
+    %% in \ref{mixinApplication} is incorrect, and also that it will need to
+    %% be rewritten completely for the integration of the new mixin construct.
     The case where the superclass is a mixin application is covered via
-    the equivalence with a declaration of
-    a regular (possibly generic) superclass
+    the equivalence with a declaration
+    of a regular (possibly generic) superclass
     (\ref{mixinApplication}),
     and this means that there may be multiple subtype steps from
     a given class declaration to the class specified in an \EXTENDS{} clause.
 \end{itemize}%
 }
-
 
 \subsubsection{Additional Subtyping Concepts}
 \LMLabel{additionalSubtypingConcepts}
@@ -22462,6 +22463,2061 @@ In this case we also say that the type $T$ is \Index{assignable} to $S$.
   expressions of type \DYNAMIC{} are treated
   as if the compiler would implicitly insert a downcast whenever needed,
   in order to make the program type correct.%
+}
+
+
+\subsection{Type Nullability}
+\LMLabel{typeNullability}
+
+\LMHash{}%
+We say that a type $T$ is \IndexCustom{nullable}{type!nullable}
+if{}f \SubtypeNE{\code{Null}}{T},
+and that $T$ is
+\IndexCustom{potentially non-nullable}{type!potentially non-nullable}
+if{}f $T$ is not nullable.
+
+\commentary{%
+  Nullable types are types which are
+  definitively known to include the null object,
+  regardless of the value of any type variables.
+  This is equivalent to the syntactic criterion that $T$ is any of:
+
+  \begin{itemize}[itemsep=-0.5ex]
+  \item \VOID.
+  \item \DYNAMIC.
+  \item \code{Null}.
+  \item \code{$S$?}, for any type $S$.
+  \item \code{FutureOr<$S$>}, for any nullable type $S$.
+  \end{itemize}%
+}
+
+\LMHash{}%
+We say that a type $T$ is \Index{non-nullable}
+if{}f \SubtypeNE{T}{\code{Object}},
+and that $T$ is
+\IndexCustom{potentially nullable}{type!potentially nullable}
+if{}f $T$ is not non-nullable.
+
+\commentary{%
+  Non-nullable types are types which are definitively known to
+  \emph{not} include the null object,
+  regardless of the value of any type variables.
+  This is equivalent to the syntactic criterion that $T$ is any of:
+
+  \begin{itemize}[itemsep=-0.5ex]
+  \item \code{Never}.
+  \item Any function type.
+  \item The type \FUNCTION.
+  \item Any interface type except \code{Null}.
+  \item \code{FutureOr<$S$>}, for any non-nullable type $S$.
+  \item Any type variable $X$ whose bound is non-nullable.
+  \item Any type of the form \code{$X$\,\&\,$S$}, where
+    $X$ is a type variable and $S$ is non-nullable.
+  \end{itemize}%
+}
+
+\commentary{%
+  Some types are neither nullable nor non-nullable.
+  For example, a type variable $X$ whose bound is nullable, say \code{int?},
+  is neither nullable nor non-nullable:
+  If the value of $X$ is \code{int} then it does not include the null object,
+  and hence $X$ cannot be a nullable type.
+  Conversely, if the value of $X$ is \code{int?}\ or \code{Null}
+  then it \emph{does} include the null object,
+  so it cannot be non-nullable.
+
+  It follows that all four concepts are distinct:
+  The given type $X$ is potentially nullable, but not nullable,
+  and $X$ is also potentially non-nullable, but not non-nullable.%
+}
+
+\LMHash{}%
+We define a function \NonNullTypeName,
+which maps a type $T$ to the corresponding non-nullable type,
+to the extent said non-nullable type is expressible.
+
+\commentary{%
+  For example, \code{int?}\ is mapped to \code{int},
+  a non-nullable result,
+  but \DYNAMIC{} is mapped to \DYNAMIC,
+  even though that is still a nullable type.
+  If $X$ is a type variable whose bound is nullable,
+  \code{FutureOr<$X$>?}\ is mapped to \code{FutureOr<$X$>},
+  which is still a potentially nullable type.
+  We cannot map it to \code{FutureOr<\NonNullType{$X$}>}
+  because that would be unsound:
+  An expression of type \code{FutureOr<$X$>?}
+  may evaluate to an instance of \code{Future<$X$>} (which is not \NULL),
+  but \code{Future<$X$>} might not be a subtype
+  of \code{FutureOr<\NonNullType{$X$}>}.
+  Also, this could introduce an intersection type which is a type argument,
+  and that violates the constraints on intersection types
+  (\ref{intersectionTypes}),
+  so it is lucky that we don't need it.%
+}
+
+\begin{itemize}
+\item
+  \DefEquals{\NonNullType{Null}}{\code{Never}}.
+\item
+  \DefEquals{\NonNullType{$T$?}}{\NonNullType{$T$}},
+  for any type $T$.
+\item
+  \DefEquals{\NonNullType{$X$}}{\code{$X$\,\&\,\NonNullType{$B$}}},
+  where $X$ is a type variable with bound $B$,
+  such that $\NonNullType{$B$} \not= B$.
+\item
+  \DefEquals{\NonNullType{$X$\,\&\,$T$}}{\code{$X$\,\&\,\NonNullType{$T$}}},
+  for any type $T$.
+\item
+  Otherwise, \DefEquals{\NonNullType{$T$}}{T},
+  for any type $T$.
+\end{itemize}
+
+\LMHash{}%
+Let $T$ be a potentially nullable type such that
+\NormalizedTypeOf{$T$} is neither \DYNAMIC{} nor \VOID.
+The \IndexCustom{interface}{interface!of potentially nullable type}
+of $T$ is the interface of \code{Object}.
+
+\commentary{%
+  For example, even though \code{$e_1$.isEven} is allowed
+  when the type of $e_1$ is \code{int},
+  \code{$e_2$.isEven} is a compile-time error
+  when the type of $e_2$ is \code{int?}\ or
+  a type variable $X$ whose bound is \code{int?}.%
+}
+
+
+\subsection{Functions Dealing with Extreme Types}
+\LMLabel{functionsDealingWithExtremeTypes}
+
+\LMHash{}%
+This section defines several helper functions that are concerned with
+the characterization and computation of types near the top or the bottom
+of the subtype graph.
+
+\LMHash{}%
+The functions are syntactic in nature such that termination is obvious.
+In particular, they do not rely on subtyping.
+In each of these function definitions,
+the first applicable case must be used.
+
+\LMHash{}%
+The \Index{\TopMergeTypeName} of two types computes
+a canonical type which represents both of them,
+in the case where they are structurally identical
+modulo the choice among top types.
+It is defined as follows:
+
+\begin{itemize}
+\item \DefEquals{\TopMergeType{Object?}{Object?}}{\code{Object?}}.
+\item \DefEquals{\TopMergeType{\DYNAMIC}{\DYNAMIC}}{\code{\DYNAMIC}}.
+\item \DefEquals{\TopMergeType{\VOID}{\VOID}}{\code{\VOID}}.
+\item \DefEquals{\TopMergeType{Object?}{\VOID}}{\code{Object?}}, and\\
+  \DefEquals{\TopMergeType{\VOID}{Object?}}{\code{Object?}}.
+\item \DefEquals{\TopMergeType{Object?}{\DYNAMIC}}{\code{Object?}}, and\\
+  \DefEquals{\TopMergeType{\DYNAMIC}{Object?}}{\code{Object?}}.
+\item \DefEquals{\TopMergeType{\DYNAMIC}{\VOID}}{\code{Object?}}, and\\
+  \DefEquals{\TopMergeType{\VOID}{\DYNAMIC}}{\code{Object?}}
+\item \DefEquals{\TopMergeType{$T$?}{$S$?}}{\code{\TopMergeType{$T$}{$S$}?}}.
+\item For all other types, the function is applied recursively.
+
+  \commentary{%
+    E.g.
+    $\TopMergeType{$C$<$T$>}{$C$<$S$>} = \code{$C$<\TopMergeType{$T$}{$S$}>}$,
+    and\\
+    $\TopMergeType{\FUNCTION($T$)}{\FUNCTION($S$)} =\\
+    \code{\FUNCTION(\TopMergeType{$T$}{$S$})}$.%
+  }
+\end{itemize}
+
+\commentary{%
+  Note that \TopMergeTypeName{} is not defined for
+  types which are structurally different,
+  apart from being or containing different top types.
+  When \TopMergeTypeName{} is used in this specification,
+  each case where \TopMergeTypeName{} is undefined
+  is handled explicitly.%
+}
+
+\rationale{%
+  \TopMergeTypeName{} yields \code{Object?}\ in the case where
+  the arguments differ in the choice of top types.
+  This reflects the intention that the resulting type should yield
+  a high degree of static type safety.%
+}
+
+\commentary{%
+  For instance, \TopMergeTypeName{} is used during the computation of
+  the interface of a class member which is declared
+  in multiple superinterfaces.
+  If a class $C$ inherits a method $m$ that accepts
+  an argument of type \code{List<\DYNAMIC>} from one superinterface,
+  and another method $m$ that accepts
+  an argument of type \code{List<\VOID>}
+  from another superinterface,
+  the parameter will have type \code{List<Object?>} in $C$,
+  and this will ensure a more strict static typing by default than, say,
+  \code{List<\DYNAMIC>}.%
+}
+
+\LMHash{}%
+\TopMergeTypeName{} of more than two types is defined by taking
+\TopMergeTypeName{} of the first two,
+and then recursively taking \TopMergeTypeName{} of the rest.
+\commentary{The ordering of the arguments makes no difference.}
+
+\LMHash{}%
+The \Index{\IsTopTypeName} predicate is true for any type which is in
+the equivalence class of top types.
+It is a syntactic characterization of top types
+(\ref{superBoundedTypes}).
+
+\begin{itemize}
+\item \DefEquals{\IsTopType{$T$?}}{\IsTopType{$T$} \vee \IsObjectType{$T$}}.
+\item \DefEquals{\IsTopType{\DYNAMIC}}{\metavar{true}}.
+\item \DefEquals{\IsTopType{\VOID}}{\metavar{true}}.
+\item \DefEquals{\IsTopType{FutureOr<$T$>}}{\IsTopType{$T$}}.
+\item \DefEquals{\IsTopType{$T$}}{\metavar{false}}, otherwise.
+\end{itemize}
+
+\noindent
+The \Index{\IsObjectTypeName} predicate is true if{}f
+the argument is a subtype and a supertype of \code{Object}.
+
+\begin{itemize}
+\item \DefEquals{\IsObjectType{Object}}{\metavar{true}}.
+\item \DefEquals{\IsObjectType{FutureOr<$T$>}}{\IsObjectType{$T$}}.
+\item \DefEquals{\IsObjectType{$T$}}{\metavar{false}}, otherwise.
+\end{itemize}
+
+\noindent
+The \Index{\IsBottomTypeName} predicate is true if{}f
+the argument is a subtype of \code{Never}.
+
+\begin{itemize}
+\item \DefEquals{\IsBottomType{Never}}{\metavar{true}}.
+\item \DefEquals{\IsBottomType{$X$\,\,\&\,\,$T$}}{\IsBottomType{$T$}}.
+\item \DefEquals{\IsBottomType{$X$\,\,\EXTENDS\,\,$T$}}{\IsBottomType{$T$}}.
+\item \DefEquals{\IsBottomType{$T$}}{\metavar{false}}, otherwise.
+\end{itemize}
+
+\noindent
+The \Index{\IsNullTypeName} predicate is true if{}f
+the argument is a subtype and a supertype of \code{Null}.
+
+\begin{itemize}
+\item \DefEquals{\IsNullType{Null}}{\metavar{true}}.
+\item \DefEquals{\IsNullType{$T$?}}{\IsNullType{$T$} \vee \IsBottomType{$T$}}.
+\item \DefEquals{\IsNullType{$T$}}{\metavar{false}}, otherwise.
+\end{itemize}
+
+\noindent
+The \Index{\IsMoreTopTypeName} predicate defines a total order on
+top and \code{Object} types.
+
+\begin{itemize}
+\item \DefEquals{\IsMoreTopType{\VOID}{$T$}}{\metavar{true}}.
+\item \DefEquals{\IsMoreTopType{$T$}{\VOID}}{\metavar{false}}.
+\item \DefEquals{\IsMoreTopType{\DYNAMIC}{$T$}}{\metavar{true}}.
+\item \DefEquals{\IsMoreTopType{$T$}{\DYNAMIC}}{\metavar{false}}.
+\item \DefEquals{\IsMoreTopType{Object}{$T$}}{\metavar{true}}.
+\item \DefEquals{\IsMoreTopType{$T$}{Object}}{\metavar{false}}.
+\item \DefEquals{\IsMoreTopType{$T$?}{$S$?}}{\IsMoreTopType{$T$}{$S$}}.
+\item \DefEquals{\IsMoreTopType{$T$}{$S$?}}{\metavar{true}}.
+\item \DefEquals{\IsMoreTopType{$T$?}{$S$}}{\metavar{false}}.
+\item \DefEquals{\IsMoreTopType{FutureOr<$T$>}{FutureOr<$S$>}}{%
+  \IsMoreTopType{$T$}{$S$}}.
+\end{itemize}
+
+\noindent
+The \Index{\IsMoreBottomTypeName} predicate defines an almost total order on
+bottom and \code{Null} types.
+\commentary{%
+  This does not consistently order
+  two different type variables with the same bound.%
+}
+
+\begin{itemize}
+\item \DefEquals{\IsMoreBottomType{Never}{$T$}}{\metavar{true}}.
+\item \DefEquals{\IsMoreBottomType{$T$}{Never}}{\metavar{false}}.
+\item \DefEquals{\IsMoreBottomType{Null}{$T$}}{\metavar{true}}.
+\item \DefEquals{\IsMoreBottomType{$T$}{Null}}{\metavar{false}}.
+\item \DefEquals{\IsMoreBottomType{$T$?}{$S$?}}{\IsMoreBottomType{$T$}{$S$}}.
+\item \DefEquals{\IsMoreBottomType{$T$}{$S$?}}{\metavar{true}}.
+\item \DefEquals{\IsMoreBottomType{$T$?}{$S$}}{\metavar{false}}.
+\item \DefEquals{\IsMoreBottomType{$X$\,\,\&\,\,$T$}{$Y$\,\,\&\,\,$S$}}{%
+  \IsMoreBottomType{$T$}{$S$}}.
+\item \DefEquals{\IsMoreBottomType{$X$\,\,\&\,\,$T$}{$S$}}{\metavar{true}}.
+\item \DefEquals{\IsMoreBottomType{$S$}{$X$\,\,\&\,\,$T$}}{\metavar{false}}.
+\item \DefEquals{%
+  \IsMoreBottomType{$X$\,\,\EXTENDS\,\,$T$}{$Y$\,\,\EXTENDS\,\,$S$}}{%
+  \IsMoreBottomType{$T$}{$S$}}.
+\end{itemize}
+
+
+\subsection{Type Normalization}
+\LMLabel{typeNormalization}
+
+\LMHash{}%
+This section specifies a function that normalizes Dart types.
+In this section it is assumed that type inference
+(\ref{typeInference})
+and instantiation to bound
+(\ref{instantiationToBound})
+have taken place,
+and that no type under consideration is a compile-time error.
+
+\LMHash{}%
+For the definitions below, we need the following concept:
+An \IndexCustom{atomic type}{type!atomic}
+is a term derived from \synt{typeName}
+that denotes a type which is not a type alias.
+
+\commentary{%
+  For instance, \DYNAMIC{} is an atomic type,
+  and so is \code{prefix.MyClass},
+  if it denotes a class,
+  but \code{List<int>} and \code{\VOID\,\,\FUNCTION()} are not atomic.%
+}
+
+\LMHash{}%
+Some Dart types are mutual subtypes,
+but are not considered to be the same type.
+Other Dart types are mutual subtypes,
+even though they have a different syntactic structure.
+Type normalization erases the latter distinction.
+
+\commentary{%
+  For instance, \DYNAMIC{} and \code{Object?}\ are subtypes of each other,
+  but they are not considered to be the same type.
+  This is useful because it allows us to treat two expressions very differently
+  even though the set of objects that they could evaluate to
+  is exactly the same.
+
+  Similarly, \code{FutureOr<Object>} and \code{Object} are mutual subtypes,
+  and so are \code{Never} and a type variable $X$ whose bound is \code{Never}.
+
+  The normalization which is described here will preserve
+  distinctions like the former (such as \DYNAMIC{} and \code{Object?}),
+  and it will eliminate distinctions like the latter
+  (such as \code{Never} and $X$).
+
+  In particular, \SubtypeNE{S}{T} and \SubtypeNE{T}{S} holds if and only if
+  \NormalizedTypeOf{$T$} has
+  the same canonical syntax as \NormalizedTypeOf{$S$}
+  (\ref{standardUpperBoundsAndStandardLowerBounds}),
+  modulo replacement of atomic top types
+  (e.g., \code{List<C<\DYNAMIC>{}>} and \code{List<myPrefix.C<\VOID>{}>}).%
+}
+
+\LMHash{}%
+The function \Index{\NormalizedTypeOfName} is then defined as follows:
+\BlindDefineSymbol{T_a, T_u, T_r}%
+Let $T_a$ be a type
+(\commentary{where `a' stands for `argument'}).
+Let $T_u$ be the transitive alias expansion of $T_a$
+(\commentary{`u' for `unaliased'}, \ref{typedef}).
+Then \DefEquals{\NormalizedTypeOf{$T_a$}}{T_r}
+(\commentary{`r' for result}),
+where $T_r$ is determined as follows:
+
+\begin{itemize}
+\item
+  If $T_u$ is atomic then $T_r$ is $T_u$.
+\item If $T_u$ is of the form \code{FutureOr<$T$>}
+  then let $S$ be \NormalizedTypeOf{$T$} and then:
+  \begin{itemize}
+  \item If $S$ is a top type or \code{Object} then $T_r$ is $S$.
+  \item If $S$ is \code{Never} then $T_r$ is \code{Future<Never>}.
+  \item If $S$ is \code{Null} then $T_r$ is \code{Future<Null>?}.
+  \item Otherwise, $T_r$ is \code{FutureOr<S>}.
+  \end{itemize}
+\item If $T_u$ is of the form \code{$T$?}\ then
+  let $S$ be \NormalizedTypeOf{$T$} and then:
+  \begin{itemize}
+  \item If $S$ is a top type then $T_r$ is $S$.
+  \item If $S$ is \code{Never} or \code{Null} then
+    $T_r$ is \code{Null}.
+  \item If $S$ is \code{FutureOr<$R$>} where $R$ is nullable then
+    $T_r$ is $S$.
+  \item If $S$ is \code{$R$?}\ for some $R$ then $T_r$ is \code{$R$?}.
+  \item Otherwise, $T_r$ is \code{$S$?}.
+  \end{itemize}
+\item If $T_u$ is a type variable $X$ with bound $B$ then:
+  \begin{itemize}
+  \item If $B$ is \code{Never} then $T_r$ is \code{Never}.
+  \item If $B$ is a type variable $Y$
+    and \NormalizedTypeOf{$Y$} is \code{Never}
+    then $T_r$ is \code{Never}.
+  \item Otherwise, $T_r$ is $X$.
+  \end{itemize}
+\item If $T_u$ is of the form \code{$X$\,\&\,$T$}
+  where $X$ is a type variable with bound $B$
+  then let $S$ be \NormalizedTypeOf{$T$} and then:
+  \begin{itemize}
+  \item If $S$ is \code{Never} then $T_r$ is \code{Never}.
+  \item If $S$ is $X$ or a top type then $T_r$ is $X$.
+  \item If \SubtypeNE{\NormalizedTypeOf{$B$}}{S} then $T_r$ is $X$.
+  \item Otherwise, $T_r$ is \code{$X$\,\&\,$S$}.
+  \end{itemize}
+\item If $T_u$ is of the form \code{$C$<\List{T}{1}{k}>}
+  then $T_r$ is \code{$C$<\List{R}{1}{k}>},
+  where $R_i$ is \NormalizedTypeOf{$T_i$}, for $i \in 1 .. k$.
+\item If $T_u$ is of the form
+  \FunctionTypePositionalStd{T_0}
+
+  \noindent
+  then $T_r$ is
+  \FunctionTypePositional{R_0}{ }{X}{B}{s}{R}{n}{k}
+
+  \noindent
+  where $R_i$ is \NormalizedTypeOf{$T_i$} for $i \in 0 .. n+k$.
+\item If $T_u$ is of the form
+  \FunctionTypeNamedStd{T_0}
+
+  \noindent
+  where $r_j$ is either \REQUIRED{} or empty
+  then $T_r$ is
+  \noindent
+  \FunctionTypeNamed{R_0}{ }{X}{B}{s}{R}{n}{x}{k}{r}
+
+  \noindent
+  where $R_i$ is \NormalizedTypeOf{$T_i$} for $i \in 0 .. n+k$.
+\end{itemize}
+
+\commentary{%
+  There is currently no place in the type system
+  where normalization can apply to intersection types
+  (\code{$X$\,\&\,$T$}).
+  The rule is included here for completeness.
+  Normalization is based on the following reductions:
+}
+
+\begin{displaymath}
+  \begin{array}{l@{\quad\mapsto\quad}l}
+    \code{T??} & \code{T?}\\
+    \code{\VOID?} & \code{\VOID}\\
+    \code{\DYNAMIC?} & \code{\DYNAMIC}\\
+    \code{Null?} & \code{Null}\\
+    \code{Never?} & \code{Null}\\
+    \code{$X$\,\,\EXTENDS\,\,Never} & \code{Never}\\
+    \code{FutureOr<$T$>} & \code{$T$}%
+    \mbox{, if \SubtypeNE{\code{Future<$T$>}}{T}}\\
+    \code{FutureOr<$T$>} & \code{Future<$T$>}%
+    \mbox{, if \SubtypeNE{T}{\code{Future<$T$>}}}\\
+    \code{$X$\,\,\&\,\,$T$} & \code{$T$}\mbox{, if \SubtypeNE{T}{X}}\\
+    \code{$X$\,\,\&\,\,$T$} & \code{$X$}\mbox{, if \SubtypeNE{X}{T}}
+  \end{array}
+\end{displaymath}
+
+
+\subsection{The Canonical Syntax of Types}
+\LMLabel{theCanonicalSyntaxOfTypes}
+
+\LMHash{}%
+Concrete syntax denoting types gives rise to several difficulties
+when used to determine static semantic properties,
+like subtyping relationships
+(\ref{subtypes})
+or standard bounds
+(\ref{standardUpperBoundsAndStandardLowerBounds}).
+This section describes how to overcome those difficulties
+by means of a canonical syntactic form for types.
+
+\commentary{%
+  In particular, the phrases `same type' and `identical syntax'
+  deserves some extra scrutiny.
+  If a library $L$ imports the libraries $L_1$ and $L_2$
+  (where $L_1$ and $L_2$ are not the same library),
+  and both $L_1$ and $L_2$ declare a class \code{C},
+  then the syntax \code{C} may occur as a type during static analysis of $L$
+  in situations where it refers to two distinct types.
+
+  For instance, $L_1$ could declare a variable \code{v}
+  of type \code{C}-in-$L_1$,
+  and $L_2$ could declare a function
+  \code{\VOID\,foo(C\,\,c)\,\,\{\}}
+  which uses the type \code{C}-in-$L_2$,
+  and $L$ could contain the expression \code{foo(v)}.
+
+  Note that even though it would be a compile-time error to use \code{C} in $L$
+  (because it is ambiguous),
+  it is not an error to have an expression like \code{foo(v)},
+  and the static analysis of this expression must handle the name clash.%
+}
+
+\rationale{%
+  This shows that concrete syntax behaves in such a manner that it is
+  unsafe to consider two types as the same type,
+  based on the fact that they are denoted by the same syntax,
+  even during the static analysis of a single expression.
+
+  Similarly, it is incorrect to consider two terms derived from \synt{type}
+  as different types based on the fact that they are syntactically different.
+  They could in fact be the same type,
+  e.g., imported with different import prefixes.
+
+  Consequently, we introduce the notion of the canonical syntax for a type,
+  which has the property that each type has a unique syntactic form.
+  We may then consider this canonical syntactic form
+  as a static semantic value,
+  rather than just a syntactic form which is dependent on
+  its location in the program.%
+}
+
+\LMHash{}%
+The
+\IndexCustom{canonical syntax}{type!canonical syntax of}
+of the types in a given library $L_1$
+and all libraries \List{L}{2}{n} reachable from $L_1$ via
+one or more import links
+is determined as follows.
+First, choose a set of distinct, globally fresh identifiers
+\List{\metavar{prefix}}{1}{n}.
+Then transform each library $L_i$, $i \in 1 .. n$ as follows:
+
+\begin{enumerate}
+\item
+  If $D_T$ is a declaration of a class, mixin, or type alias in $L_i$
+  whose name $n$ is private,
+  and an occurrence of $n$ that resolves to $D$
+  exists in a type alias declaration $D_A$ whose name is non-private,
+  then perform a consistent renaming of
+  all occurrences of $n$ in $L_i$ that resolve to $D_T$
+  to a fresh, non-private identifier.
+  \commentary{%
+    So we make $D_T$ public, because it is being leaked anyway.%
+  }
+\item
+  Add a set of import directives to $L_i$ that imports
+  each of the libraries \List{L}{1}{n} with
+  the corresponding prefix $\metavar{prefix}_j$, $j \in 1 .. n$.
+
+  \commentary{%
+    This means that every library in the set
+    $\{\,\List{L}{1}{n}\,\}$
+    imports every other library in that set,
+    even itself and system libraries like \code{dart:core}.%
+  }
+\item
+  Let \id{} be a non-private type identifier derived from \synt{typeName}
+  that resolves to a library declaration in the library $L_j$
+  in the original program;
+  \id{} is then transformed to \code{$\metavar{prefix}_j$.\id}.
+  Let \code{$p$.\id} be derived from \synt{typeName} such that $p$ is
+  an import prefix in the original program
+  and \id{} is a non-private identifier,
+  and consider the case where \code{$p$.\id} resolves to
+  a library declaration in the library $L_j$ in the original program,
+  for some $j$;
+  \code{$p$.\id} is then transformed to \code{$\metavar{prefix}_j$.\id}.
+\item
+  Replace every type in $L_i$ that denotes a type alias
+  along with its actual type arguments, if any,
+  by its transitive alias expansion
+  (\ref{typedef}).
+  \commentary{%
+    Note that the bodies of type alias declarations
+    already use the new prefixes,
+    so the results of the alias expansion will also use
+    the new prefixes consistently.%
+  }
+\end{enumerate}
+
+\commentary{%
+  This transformation does not change any occurrence of \VOID;
+  \VOID{} is a reserved word, not a type identifier.
+  Also, \code{$\metavar{prefix}_j$.\VOID} would be a syntax error.
+
+  Note that the transformation changes terms derived from \synt{type},
+  but it does not change expressions, or any other program element
+  (except that a \synt{type} can occur in an expression, e.g., \code{<int>[]}).
+  In particular, it does not change type literals
+  (that is, expressions denoting types).
+
+  The transformation also does not change identifiers denoting type variables,
+  because they are never resolved to a library declaration,
+  they are always introduced by a scope which is nested
+  inside the library scope.
+  There is no need to change those identifiers, because
+  no occurrence of such an identifier in the type of an expression
+  denotes a declaration in a different library.%
+}
+
+\rationale{%
+  The only purpose of this transformation is to obtain a
+  location-independent designation of all types,
+  in such a way that each \synt{typeName} resolves to the same declaration
+  before and after the transformation.
+  The program behavior may change due to different values returned from
+  \code{toString()} on reified types,
+  but the transformation is otherwise semantics preserving.%
+}
+
+\LMHash{}%
+Every \synt{type} and type literal in the resulting set of libraries
+is now expressed in a globally unique syntactic form,
+which is the form that we call the
+\IndexCustom{canonical syntax of}{type!canonical syntax of}
+said types.
+
+\LMHash{}%
+When we say that two types $T_1$ and $T_2$ have the
+\IndexCustom{same canonical syntax}{type!same canonical syntax},
+it refers to the situation where the current library
+and all libraries which are reachable via one or more imports
+have been transformed as described above,
+and the resulting canonical syntaxes are identical.
+
+\rationale{%
+  The transformation described here would not be useful in practice
+  (or even possible---we can't edit \code{dart:core}).
+  It only serves to show that we can express types using a syntactic form
+  which is independent of the location.
+  This is in turn needed in order to ensure that operations are well-defined
+  even when they bring syntactic elements from different locations together,
+  such as computations of subtype relationships,
+  and construction of standard upper or lower bounds.
+
+  We could just as well have replaced the concrete syntax by a semantic
+  notion of types,
+  where each entity that denotes a type would be, in some sense,
+  a reference to a specific declaration
+  (this is likely to be the approach used by tool implementations).
+  However, that approach would be somewhat inconvenient in a specification,
+  because we would need to re-build all the structures that the
+  syntax offers.
+  For instance, we would need to support the construction of
+  a semantic type entity for \code{Map<int,\,String>},
+  based on the semantic type entities for
+  \code{int}, \code{String}, and \code{Map},
+  and we would need to support deconstruction of those entities
+  in order to prove things like
+  \SubtypeNE{\code{Map<Never,\,Never>}}{\code{Map<int,\,String>}}.
+  This would give rise to a lot of mechanism that will simply duplicate
+  the structure of the syntax.
+  So we prefer to show that the syntax \emph{can} be location independent,
+  and that's sufficient to make syntax usable as our representation of
+  static semantic types.
+
+  We are basically taking the approach that a static semantic type is
+  an equivalence class of all syntactic elements derived from \synt{type}
+  that have the same canonical syntax.%
+}
+
+
+\subsection{Standard Upper Bounds and Standard Lower Bounds}
+\LMLabel{standardUpperBoundsAndStandardLowerBounds}
+
+\LMHash{}%
+This section specifies how to compute the
+\IndexCustom{standard upper bound}{type!standard upper bound}
+as well as the
+\IndexCustom{standard lower bound}{type!standard lower bound}
+of two or more types.
+
+\rationale{%
+  If the least upper bound $U$ of the given operands exists,
+  then the standard upper bound is guaranteed to be a supertype of $U$.
+  The standard upper bound is in any case guaranteed to be
+  a supertype of both operands.
+  Similarly, if the greatest lower bound $L$ of the given operands exists,
+  then the standard lower bound is guaranteed to be a subtype of $L$,
+  The standard lower bound is in any case guaranteed to be
+  a subtype of both operands.
+  
+  The standard upper and lower bounds are intended to compute
+  the least upper bound respectively the greatest lower bound whenever possible,
+  and otherwise to deliver an approximation thereof.
+}
+
+\commentary{%
+  It is easy to see that some pairs of types do not have a least upper bound,
+  because the set of types which are supertypes of both of them
+  does not have a least element.
+  For example:%
+}
+
+\begin{dartCode}
+\CLASS{} I \{\}
+\CLASS{} J \{\}
+\CLASS{} A \IMPLEMENTS{} I, J \{\}
+\CLASS{} B \IMPLEMENTS{} I, J \{\}
+\end{dartCode}
+
+\commentary{%
+  No \emph{least} upper bound exists for \code{A} and \code{B},
+  because \code{I} and \code{J} are incomparable,
+  and no other supertypes of \code{A} and \code{B}
+  are subtypes of both \code{I} and \code{J}.%
+}
+
+\rationale{%
+  For backward compatibility,
+  the standard upper and lower bounds are computed
+  in the same way as in earlier versions of Dart,
+  in the case where the operands are
+  interface types based on distinct classes
+  (\ref{dartOneStandardUpperBound}).%
+}
+
+\commentary{%
+  For example, \code{List<String>} and \code{Iterable<String>}
+  are handled in this manner,
+  because \code{List} and \code{Iterable} are not the same class.%
+}
+
+\rationale{%
+  Consequently, when such types occur as or in the operands,
+  the standard upper and lower bound algorithms may yield
+  results which are suboptimal in the sense that
+  we can rather easily find a better approximation of the
+  least upper bound or the greatest lower bound.
+  
+  In all other cases,
+  the standard upper and lower bound are computed recursively,
+  based on the structure of the type,
+  which ensures that if the results for all subterms yield an actual
+  least upper bound respectively greatest lower bound,
+  then the overall result will preserve that property.%
+}
+
+\LMHash{}%
+The following general assumptions and rules apply in this section:
+The set of clauses defining each function in this section are ordered,
+i.e., the first clause that matches is the one that must be used.
+If a rule is dealing with type variables,
+then it is assumed that the type variables have been
+consistently renamed to fresh names whenever necessary,
+such that no type variables are captured due to accidental name clashes.
+Finally, it is assumed that all types are denoted by their canonical syntax
+(\ref{theCanonicalSyntaxOfTypes}).
+
+\commentary{%
+  This implies that type aliases have already been fully expanded,
+  and two types are the same if and only if they have the same syntax.%
+}
+
+%% TODO(eernst), for review: Is this the correct associativity of SUB/SLB?
+\LMHash{}%
+We define the
+\Index{standard upper bound}
+of a single type $T$ to be $T$.
+We define the standard upper bound of two types $T_1$ and $T_2$ to be
+\UpperBoundType{$T_1$}{$T_2$}, where \UpperBoundTypeName{} is defined below.
+Finally, we define the standard upper bound
+of \List{T}{1}{n} where $n > 2$
+to be \UpperBoundType{$T_1$}{$T'$},
+where $T'$ is the standard upper bound of \List{T}{2}{n}.
+We define the
+\Index{standard lower bound}
+of one or more types in the same way,
+but using \LowerBoundTypeName{} rather than \UpperBoundTypeName{} everywhere.
+
+\LMHash{}%
+It is at times convenient to be able to apply
+\UpperBoundTypeName{} (respectively \LowerBoundTypeName)
+to parameter type declarations,
+which is defined as follows.
+Assume that $P_1$ and $P_2$ are two formal parameter type declarations
+with declared type $T_1$ respectively $T_2$,
+such that both are positional or both are named,
+with the same name \DefineSymbol{n}.
+Then \UpperBoundType{$P_1$}{$P_2$} (respectively \LowerBoundType{$P_1$}{$P_2$})
+is the formal parameter declaration $P$,
+with the following proporties:
+
+\begin{itemize}
+\item
+  The declared type of $P$ is \UpperBoundType{$T_1$}{$T_2$}
+  (respectively\\
+  \LowerBoundType{$T_1$}{$T_2$}).
+\item
+  $P$ is positional if $P_1$ and $P_2$ are positional.
+  In this case, the name of $P$ is a fresh identifier.
+  \commentary{%
+    Names of positional parameter types are optional in some cases,
+    but using a fresh name is always possible.%
+  }
+\item
+  $P$ is named if $P_1$ and $P_2$ are named.
+  In this case, the name of $P$ is $n$.
+  $P$ is marked with the modifier \REQUIRED{}
+  if both $P_1$ and $P_2$ have this modifier
+  (respectively, if either $P_1$ or $P_2$ has this modifier).
+\end{itemize}
+
+\LMHash{}%
+The function \UpperBoundTypeName{} is defined as follows.
+
+\begin{itemize}
+\item
+  \DefEquals{\UpperBoundType{$T$}{$T$}}{T}.
+\item
+  If \IsTopType{$T_1$} and \IsTopType{$T_2$} then\\[1mm]
+  \DefEquals{\UpperBoundType{$T_1$}{$T_2$}}{%
+    \left\{%
+    \begin{array}{l}
+      T_1\mbox{, if \IsMoreTopType{$T_1$}{$T_2$}.}\\
+      T_2\mbox{, otherwise.}
+    \end{array}
+    \right.%
+  }
+\item
+  \DefEquals{\UpperBoundType{$T_1$}{$T_2$}}{T_i},
+  if \IsTopType{$T_i$}, for each $i \in 1 .. 2$.
+\item
+  If \IsBottomType{$T_1$} and \IsBottomType{$T_2$} then\\[1mm]
+  \DefEquals{\UpperBoundType{$T_1$}{$T_2$}}{%
+    \left\{%
+    \begin{array}{l}
+      T_2\mbox{, if \IsMoreBottomType{$T_1$}{$T_2$}.}\\
+      T_1\mbox{, otherwise.}
+    \end{array}
+    \right.%
+  }
+\item
+  \DefEquals{\UpperBoundType{$T_1$}{$T_2$}}{T_2}, if \IsBottomType{$T_1$}.
+\item
+  \DefEquals{\UpperBoundType{$T_1$}{$T_2$}}{T_1}, if \IsBottomType{$T_2$}.
+\item
+  If \IsNullType{$T_1$} and \IsNullType{$T_2$} then\\[1mm]
+  \DefEquals{\UpperBoundType{$T_1$}{$T_2$}}{%
+    \left\{%
+    \begin{array}{l}
+      T_2\mbox{, if \IsMoreBottomType{$T_1$}{$T_2$}.}\\
+      T_1\mbox{, otherwise.}
+    \end{array}
+    \right.%
+  }
+\item
+  If \IsNullType{$T_1$} then\\[1mm]
+  \DefEquals{\UpperBoundType{$T_1$}{$T_2$}}{%
+    \left\{%
+    \begin{array}{l}
+      T_2\mbox{, if $T_2$ is nullable.}\\
+      \code{$T_2$?}\mbox{, otherwise.}
+    \end{array}
+    \right.%
+  }
+\item
+  If \IsNullType{$T_2$} then\\[1mm]
+  \DefEquals{\UpperBoundType{$T_1$}{$T_2$}}{%
+    \left\{%
+    \begin{array}{l}
+      T_1\mbox{, if $T_1$ is nullable.}\\
+      \code{$T_1$?}\mbox{, otherwise.}
+    \end{array}
+    \right.%
+  }
+\item
+  If \IsObjectType{$T_1$} and \IsObjectType{$T_2$} then\\[1mm]
+  \DefEquals{\UpperBoundType{$T_1$}{$T_2$}}{%
+    \left\{%
+    \begin{array}{l}
+      T_1\mbox{, if \IsMoreTopType{$T_1$}{$T_2$}.}\\
+      T_2\mbox{, otherwise.}
+    \end{array}
+    \right.%
+  }
+\item
+  If \IsObjectType{$T_1$} then\\
+  \DefEquals{\UpperBoundType{$T_1$}{$T_2$}}{%
+    \left\{
+    \begin{array}{l}
+      T_1\mbox{, if $T_2$ is non-nullable.}\\
+      \code{$T_1$?}\mbox{, otherwise.}
+    \end{array}
+    \right.%
+  }
+\item
+  If \IsObjectType{$T_2$} then\\[1mm]
+  \DefEquals{\UpperBoundType{$T_1$}{$T_2$}}{%
+    \left\{%
+    \begin{array}{l}
+      T_2\mbox{, if $T_1$ is non-nullable.}\\
+      \code{$T_2$?}\mbox{, otherwise}
+    \end{array}
+    \right.%
+  }
+\item
+  \DefEquals{\UpperBoundType{$T_1$?}{$T_2$?}}{\code{$T_3$?}},\\
+  where $T_3$ is \UpperBoundType{$T_1$}{$T_2$}.
+\item
+  \DefEquals{\UpperBoundType{$T_1$?}{$T_2$}}{\code{$T_3$?}},\\
+  where $T_3$ is \UpperBoundType{$T_1$}{$T_2$}.
+\item
+  \DefEquals{\UpperBoundType{$T_1$}{$T_2$?}}{\code{$T_3$?}},\\
+  where $T_3$ is \UpperBoundType{$T_1$}{$T_2$}.
+\item
+  Let $X_1$ be a type variable with bound $B_1$.\\[1mm]
+  \DefEquals{\UpperBoundType{$X_1$}{$T_2$}}{%
+    \left\{%
+    \begin{array}{l}
+      T_2\mbox{, if \SubtypeNE{X_1}{T_2}.}\\
+      X_1\mbox{, otherwise and if \SubtypeNE{T_2}{X_1}.}\\
+      \UpperBoundType{$B_{1a}$}{$T_2$}\mbox{,}\\
+      \mbox{\quad{}otherwise.}
+    \end{array}
+    \right.%
+  }\\[1mm]
+  where $B_{1a}$ is the greatest closure of $B_1$ with respect to $X_1$
+  (\ref{leastAndGreatestClosureOfTypes}).
+\item
+  Let $X_1$ be a type variable with bound $B_1$,
+  and $S_1$ a subtype of $B_1$.\\[1mm]
+  \DefEquals{\UpperBoundType{$X_1$\,\&\,$S_1$}{$T_2$}}{%
+    \left\{%
+    \begin{array}{l}
+      %% TODO(eernst), for review: Why do we not have the following instead?
+      % T_2\mbox{, if \SubtypeNE{\code{$X_1$\,\&\,$S_1$}}{T_2}.}\\
+      T_2\mbox{, if \SubtypeNE{X_1}{T_2}.}\\
+      %% TODO(eernst), for review: Why do we not have the following as well?
+      % X_1 \& S_1\mbox{, otherwise and if \SubtypeNE{T_2}{X_1 \& S_1}.}\\
+      X_1\mbox{, otherwise and if \SubtypeNE{T_2}{X_1}.}\\
+      \UpperBoundType{$S_{1a}$}{$T_2$}\mbox{,}\\
+      \mbox{\quad{}otherwise.}
+    \end{array}
+    \right.%
+  }\\[1mm]
+  where $S_{1a}$ is the greatest closure of $S_1$ with respect to $X_1$.
+\item
+  Let $X_2$ be a type variable with bound $B_2$.\\[1mm]
+  \DefEquals{\UpperBoundType{$T_1$}{$X_2$}}{%
+    \left\{%
+    \begin{array}{l}
+      X_2\mbox{, if \SubtypeNE{T_1}{X_2}.}\\
+      T_1\mbox{, otherwise and if \SubtypeNE{X_2}{T_1}.}\\
+      \UpperBoundType{$T_1$}{$B_{2a}$}\mbox{,}\\
+      \mbox{\quad{}otherwise.}
+    \end{array}
+    \right.%
+  }\\[1mm]
+  where $B_{2a}$ is the greatest closure of $B_2$ with respect to $X_2$.
+\item
+  %% TODO(eernst), for review: Consider the same changes as in the converse.
+  Let $X_2$ be a type variable with bound $B_2$,
+  and $S_2$ a subtype of $B_2$.\\[1mm]
+  \DefEquals{\UpperBoundType{$T_1$}{$X_2$\,\&\,$S_2$}}{%
+    \left\{%
+    \begin{array}{l}
+      X_2\mbox{, if \SubtypeNE{T_1}{X_2}.}\\
+      T_1\mbox{, otherwise and if \SubtypeNE{X_2}{T_1}.}\\
+      \UpperBoundType{$T_1$}{$B_{2a}$}\mbox{,}\\
+      \mbox{\quad{}otherwise.}
+    \end{array}
+    \right.%
+  }\\[1mm]
+  where $S_{2a}$ is the greatest closure of $S_2$ with respect to $X_2$.
+\item
+  \DefEquals{\UpperBoundType{$T$ \FUNCTION<\ldots>(\ldots)}{\FUNCTION}}{%
+    \FUNCTION}.
+\item
+  \DefEquals{\UpperBoundType{\FUNCTION}{$T$ \FUNCTION<\ldots>(\ldots)}}{%
+    \FUNCTION}.
+\item
+  Let $U_1$ and $U_2$ be, respectively,
+
+  \noindent
+  \code{$T_1$\,\FUNCTION<$X_1$\,\EXTENDS\,$B_{11}$,\,\ldots,\,$X_m$\,%
+    \EXTENDS\,$B_{1m}$>($P_{11}$,\,\ldots,\,$P_{1k}$)}
+
+  \noindent
+  \code{$T_2$\,\FUNCTION<$X_1$\,\EXTENDS\,$B_{21}$,\,\ldots,\,$X_m$\,%
+    \EXTENDS\,$B_{2m}$>($P_{21}$,\,\ldots,\,$P_{2l}$)}
+
+  \noindent
+  such that each $B_{1i}$ and $B_{2i}$ are types with the same canonical syntax,
+  and both have the same number of required positional parameters.
+  Let $q$ be $\metavar{min}(k, l)$,
+  let $T_3$ be \UpperBoundType{$T_1$}{$T_2$},
+  let $B_{3i}$ be $B_{1i}$, and
+  let $P_{3i}$ be \LowerBoundType{$P_{1i}$}{$P_{2i}$}.
+  Then \DefEquals{\UpperBoundType{$U_1$}{$U_2$}}{%
+    \code{$T_3$\,\FUNCTION<$X_1$\,\EXTENDS\,$B_{31}$,\,\ldots,\,$X_m$\,%
+      \EXTENDS\,$B_{3m}$>($P_{31}$,\,\ldots,\,$P_{3q}$)}}.
+
+  \commentary{%
+    This case includes non-generic function types by allowing $m$ to be zero.%
+  }
+\item
+  Let $U_1$ and $U_2$ be, respectively,
+
+  \noindent
+  \code{$T_1$\,\FUNCTION<$X_1$\,\EXTENDS\,$B_{11}$,\,\ldots,\,$X_m$\,%
+    \EXTENDS\,$B_{1m}$>($P_{11}$,\,\ldots,\,$P_{1k}$,\,$\metavar{Named}_1$)}
+
+  \noindent
+  \code{$T_2$\,\FUNCTION<$X_1$\,\EXTENDS\,$B_{21}$,\,\ldots,\,$X_m$\,%
+    \EXTENDS\,$B_{2m}$>($P_{21}$,\,\ldots,\,$P_{2k}$,\,$\metavar{Named}_2$)}
+
+  \noindent
+  where $\metavar{Named}_j$ declares a non-empty set of named parameters
+  with names $\metavar{NamesOfNamed}_j$, $j \in 1 .. 2$,
+  and consider the case where the following is satisfied:
+
+  \begin{itemize}
+  \item Each $B_{1i}$ and $B_{2i}$ are types with the same canonical syntax.
+  \item For each required entry named $n$ in $\metavar{Named}_1$,
+    $\metavar{Named}_2$ contains an entry named $n$
+    (\commentary{which may or may not be required}).
+  \item For each required entry named $n$ in $\metavar{Named}_2$,
+    $\metavar{Named}_1$ contains an entry named $n$
+    (\commentary{which may or may not be required}).
+  \end{itemize}
+
+  Then \DefEqualsNewline{\UpperBoundType{$U_1$}{$U_2$}}{%
+    \code{$T_3$\,\FUNCTION<$X_1$\,\EXTENDS\,$B_{31}$,\,\ldots,\,$X_m$\,%
+      \EXTENDS\,$B_{3m}$>($P_{31}$,\,\ldots,\,$P_{3k}$,\,$\metavar{Named}_3$)}},
+
+  \noindent
+  where:
+
+  \begin{itemize}
+  \item $T_3$ is \UpperBoundType{$T_1$}{$T_2$}.
+  \item $B_{3i}$ is $B_{1i}$.
+  \item $P_{3i}$ is \LowerBoundType{$P_{1i}$}{$P_{2i}$}.
+  \item $\metavar{Named}_3$ declares the set
+    of named parameter types with the names
+    $\metavar{NamesOfNamed}_1\cap\metavar{NamesOfNamed}_2$,
+    such that for each $P'$ in $\metavar{Named}_3$ with name $n$,
+    where $P'_1 \in \metavar{Named}_1$
+    and $P'_2 \in \metavar{Named}_2$
+    also have the name $n$,
+    $P'$ is \LowerBoundType{$P'_1$}{$P'_2$}.
+  \end{itemize}
+
+  \commentary{%
+    This case includes non-generic function types by allowing $m$ to be zero.%
+  }
+%%
+%% TODO(eernst), for review: Why do we not have a rule for
+%% \UpperBoundType{T1 Function(P1..Pm, [...])}{T2 Function(P1..Pk, {...}}}
+%% = T3 Function(R1..Rk), where the left operand has at least k parameters,
+%% plus the converse?
+%%
+\item
+  \DefEquals{\UpperBoundType{$S_1$ \FUNCTION<\ldots>(\ldots)}{%
+      $S_2$ \FUNCTION<\ldots>(\ldots)}}{\FUNCTION}.
+  \commentary{%
+    This is a catch-all rule for the standard upper bound of two function types:
+    At least one operand in the following cases is not a function type.%
+  }
+\item
+  \DefEqualsNewline{\UpperBoundType{$S$ \FUNCTION<\ldots>(\ldots)}{$T_2$}}{%
+    \UpperBoundType{Object}{$T_2$}}.
+\item
+  \DefEqualsNewline{\UpperBoundType{$T_1$}{$S$ \FUNCTION<\ldots>(\ldots)}}{%
+    \UpperBoundType{$T_1$}{Object}}.
+\item
+  \DefEquals{\UpperBoundType{FutureOr<$T_1$>}{FutureOr<$T_2$>}}{%
+    \code{FutureOr<$T_3$>}},
+  where $T_3$ = \UpperBoundType{$T_1$}{$T_2$}.
+\item
+  \DefEquals{\UpperBoundType{Future<$T_1$>}{FutureOr<$T_2$>}}{%
+    \code{FutureOr<$T_3$>}},
+  where $T_3$ = \UpperBoundType{$T_1$}{$T_2$}.
+\item
+  \DefEquals{\UpperBoundType{FutureOr<$T_1$>}{Future<$T_2$>}}{%
+    \code{FutureOr<$T_3$>}},
+  where $T_3$ = \UpperBoundType{$T_1$}{$T_2$}.
+\item
+  \DefEquals{\UpperBoundType{$T_1$}{FutureOr<$T_2$>}}{%
+    \code{FutureOr<$T_3$>}},
+  where $T_3$ = \UpperBoundType{$T_1$}{$T_2$}.
+\item
+  \DefEquals{\UpperBoundType{FutureOr<$T_1$>}{$T_2$}}{%
+    \code{FutureOr<$T_3$>}},
+  where $T_3$ = \UpperBoundType{$T_1$}{$T_2$}.
+\item
+  \DefEquals{\UpperBoundType{$T_1$}{$T_2$}}{T_2},
+  if \SubtypeNE{T_1}{T_2}.
+
+  \commentary{
+    In this and in the following cases, both types must be interface types.%
+  }
+\item
+  \DefEquals{\UpperBoundType{$T_1$}{$T_2$}}{T_1},
+  if \SubtypeNE{T_2}{T_1}.
+\item
+  \DefEqualsNewline{%
+    \UpperBoundType{$C$<$T_0$, \ldots, $T_n$>}{$C$<$S_0$, \ldots, $S_n$>}}{%
+    \code{$C$<$R_0$, \ldots, $R_n$>}},
+  where $R_i$ is \UpperBoundType{$T_i$}{$S_i$}, $i \in 1 .. n$.
+\item
+  \UpperBoundType{$C_0$<$T_0$, \ldots, $T_n$>}{$C_1$<$S_0$, \ldots, $S_k$>}
+  is determined using the algorithm described below
+  (\ref{dartOneStandardUpperBound}).
+\end{itemize}
+
+\LMHash{}%
+The function \LowerBoundType{$T_1$}{$T_2$} is defined as follows.
+
+\begin{itemize}
+\item
+  \DefEquals{\LowerBoundType{$T$}{$T$}}{T}.
+\item
+  If \IsTopType{$T_1$} and \IsTopType{$T_2$} then\\[1mm]
+  \DefEquals{\LowerBoundType{$T_1$}{$T_2$}}{%
+    \left\{%
+    \begin{array}{l}
+      T_1\mbox{, if \IsMoreTopType{$T_2$}{$T_1$}.}\\
+      T_2\mbox{, otherwise.}
+    \end{array}
+    \right.%
+  }
+\item
+  \DefEquals{\LowerBoundType{$T_1$}{$T_2$}}{T_2}, if \IsTopType{$T_1$}.
+\item
+  \DefEquals{\LowerBoundType{$T_1$}{$T_2$}}{T_1}, if \IsTopType{$T_2$}.
+\item
+  If \IsBottomType{$T_1$} and \IsBottomType{$T_2$} then\\[1mm]
+  \DefEquals{\LowerBoundType{$T_1$}{$T_2$}}{%
+    \left\{%
+    \begin{array}{l}
+      T_1\mbox{, if \IsMoreBottomType{$T_1$}{$T_2$}.}\\
+      T_2\mbox{, otherwise.}
+    \end{array}
+    \right.%
+  }
+\item
+  \DefEquals{\LowerBoundType{$T_1$}{$T_2$}}{T_i},
+  if \IsBottomType{$T_i$}, for each $i \in 1 .. 2$.
+\item
+  If \IsNullType{$T_1$} and \IsNullType{$T_2$} then\\[1mm]
+  \DefEquals{\LowerBoundType{$T_1$}{$T_2$}}{%
+    \left\{%
+    \begin{array}{l}
+      T_1\mbox{, if \IsMoreBottomType{$T_1$}{$T_2$}.}\\
+      T_2\mbox{, otherwise.}
+    \end{array}
+    \right.%
+  }
+\item
+  %% TODO(eernst), for review: The null safety spec uses `Null` as the left
+  %% operand, but implementations seem to use the slightly more general
+  %% \IsNullType{$T_1$}. So I specified that.
+  If \IsNullType{$T_1$} then\\[1mm]
+  \DefEquals{\LowerBoundType{$T_1$}{$T_2$}}{%
+    \left\{%
+    \begin{array}{l}
+      T_1\mbox{, if \SubtypeNE{T_1}{T_2}.}\\
+      \code{Never}\mbox{, otherwise.}
+    \end{array}
+    \right.%
+  }
+\item
+  %% TODO(eernst), for review: The null safety spec uses `Null` as the right
+  %% operand, but implementations seem to use the slightly more general
+  %% \IsNullType{$T_2$}. So I specified that.
+  If \IsNullType{$T_2$} then\\[1mm]
+  \DefEquals{\LowerBoundType{$T_1$}{$T_2$}}{%
+    \left\{%
+    \begin{array}{l}
+      T_2\mbox{, if \SubtypeNE{T_2}{T_1}.}\\
+      \code{Never}\mbox{, otherwise.}
+    \end{array}
+    \right.%
+  }
+\item
+  If \IsObjectType{$T_1$} and \IsObjectType{$T_2$} then\\[1mm]
+  \DefEquals{\LowerBoundType{$T_1$}{$T_2$}}{%
+    \left\{%
+    \begin{array}{l}
+      T_1\mbox{, if \IsMoreTopType{$T_2$}{$T_1$}.}\\
+      T_2\mbox{, otherwise.}
+    \end{array}
+    \right.%
+  }
+\item
+  If \IsObjectType{$T_1$} then\\[1mm]
+  \DefEquals{\LowerBoundType{$T_1$}{$T_2$}}{%
+    \left\{%
+    \begin{array}{l}
+      T_2\mbox{, if $T_2$ is non-nullable.}\\
+      \NonNullType{$T_2$}\mbox{, if \NonNullType{$T_2$} is non-nullable.}\\
+      \code{Never}\mbox{, otherwise.}
+    \end{array}
+    \right.%
+  }
+\item
+  If \IsObjectType{$T_2$} then\\[1mm]
+  \DefEquals{\LowerBoundType{$T_1$}{$T_2$}}{%
+    \left\{%
+    \begin{array}{l}
+      T_1\mbox{, if $T_1$ is non-nullable.}\\
+      \NonNullType{$T_1$}\mbox{, if \NonNullType{$T_1$} is non-nullable.}\\
+      \code{Never}\mbox{, otherwise.}
+    \end{array}
+    \right.%
+  }
+\item
+  \DefEquals{\LowerBoundType{$T_1$?}{$T_2$?}}{\code{$T_3$?}},\\
+  where $T_3$ is \LowerBoundType{$T_1$}{$T_2$}.
+\item
+  \DefEquals{\LowerBoundType{$T_1$?}{$T_2$}}{T_3},\\
+  where $T_3$ is \LowerBoundType{$T_1$}{$T_2$}.
+\item
+  \DefEquals{\LowerBoundType{$T_1$}{$T_2$?}}{T_3},\\
+  where $T_3$ is \LowerBoundType{$T_1$}{$T_2$}.
+%%
+%% Note that we do not need rules like the following (as opposed to the
+%% situation with \UpperBoundTypeName{}), because they are already covered
+%% by the cases below where $T_1$ and $T_2$ are subtypes of each other:
+%%
+%% \DefEquals{\LowerBoundType{$T_1$}{\FUNCTION}}{T_1},
+%%   where $T_1$ is a function type.
+%% \DefEquals{\UpperBoundType{\FUNCTION}{$T_2$}}{T_2},
+%%   where $T_2$ is a function type.
+%%
+\item
+  Let $U_1$ and $U_2$ be, respectively,
+
+  \noindent
+  \code{$T_1$\,\FUNCTION<$X_1$\,\EXTENDS\,$B_{11}$,\,\ldots,\,$X_m$\,%
+    \EXTENDS\,$B_{1m}$>($P_{11}$,\,\ldots,\,$P_{1k}$)}
+
+  \noindent
+  \code{$T_2$\,\FUNCTION<$X_1$\,\EXTENDS\,$B_{21}$,\,\ldots,\,$X_m$\,%
+    \EXTENDS\,$B_{2m}$>($P_{21}$,\,\ldots,\,$P_{2l}$)}
+
+  \noindent
+  such that each $B_{1i}$ and $B_{2i}$ are types with the same canonical syntax.
+  Let $q$ be $\metavar{max}(k, l)$,
+  let $T_3$ be \LowerBoundType{$T_1$}{$T_2$},
+  let $B_{3i}$ be $B_{1i}$, and
+  let $P_{3i}$ be determined as follows:
+
+  \begin{itemize}
+  \item $P_{3i}$ is \UpperBoundType{$P_{1i}$}{$P_{2i}$} for
+    $i \leq \metavar{min}(k, l)$.
+  \item $P_{3i}$ is $P_{1i}$ for $k < i \leq q$, when $k = q$;
+    and $P_{3i}$ is $P_{2i}$ for $l < i \leq q$, when $l = q$.
+  \item $P_{3i}$ is optional if $P_{1i}$ or $P_{2i}$ is optional,
+    or if $\metavar{min}(k, l) < i \leq q$.
+  \end{itemize}
+
+  Then \DefEqualsNewline{\LowerBoundType{$U_1$}{$U_2$}}{%
+    \code{$T_3$\,\FUNCTION<$X_1$\,\EXTENDS\,$B_{31}$,\,\ldots,\,$X_m$\,%
+      \EXTENDS\,$B_{3m}$>($P_{31}$,\,\ldots,\,$P_{3q}$)}}.
+
+  \commentary{%
+    This case includes non-generic function types by allowing $m$ to be zero.%
+  }
+\item
+  Let $U_1$ and $U_2$ be, respectively,
+
+  \noindent
+  \code{$T_1$\,\FUNCTION<$X_1$\,\EXTENDS\,$B_{11}$,\,\ldots,\,$X_m$\,%
+    \EXTENDS\,$B_{1m}$>($P_{11}$,\,\ldots,\,$P_{1k}$,\,$\metavar{Named}_1$)}
+
+  \noindent
+  \code{$T_2$\,\FUNCTION<$X_1$\,\EXTENDS\,$B_{21}$,\,\ldots,\,$X_m$\,%
+    \EXTENDS\,$B_{2m}$>($P_{21}$,\,\ldots,\,$P_{2k}$,\,$\metavar{Named}_2$)}
+
+  \noindent
+  where $\metavar{Named}_j$ declares a non-empty set of named parameters
+  with names $\metavar{NamesOfNamed}_j$, $j \in 1 .. 2$,
+  and consider the case where
+  each $B_{1i}$ and $B_{2i}$ are types with the same canonical syntax.
+  Then \DefEqualsNewline{\LowerBoundType{$U_1$}{$U_2$}}{%U_3}, where $U_3$ is
+  \code{$T_3$\,\FUNCTION<$X_1$\,\EXTENDS\,$B_{31}$,\,\ldots,\,$X_m$\,%
+    \EXTENDS\,$B_{3m}$>($P_{31}$,\,\ldots,\,$P_{3k}$,\,$\metavar{Named}_3$)}},
+
+  \noindent
+  where:
+
+  \begin{itemize}
+  \item $T_3$ is \LowerBoundType{$T_1$}{$T_2$}.
+  \item $B_{3i}$ is $B_{1i}$.
+  \item $P_{3i}$ is \UpperBoundType{$P_{1i}$}{$P_{2i}$}.
+  \item $\metavar{Named}_3$ declares the set
+    of named parameter types with the names
+    $\metavar{NamesOfNamed}_1\cup\metavar{NamesOfNamed}_2$,
+    such that for each $P'$ in $\metavar{Named}_3$ with name $n$,
+    the following is satisfied:
+    \begin{itemize}
+    \item If $\metavar{Named}_1$ declares $P'_1$ with name $n$,
+      and $\metavar{Named}_2$ declares $P'_2$ with name $n$,
+      then $P'$ is \UpperBoundType{$P'_1$}{$P'_2$}.
+    \item Otherwise, if $\metavar{Named}_1$ declares $P'_1$ with name $n$,
+      $P'$ is $P'_1$,
+      except that $P'$ does not have the modifier \REQUIRED.
+      \commentary{$P'_1$ may or may not have that modifier, but $P'$ does not.}
+    \item Otherwise, it is guaranteed that
+      $\metavar{Named}_2$ declares a $P'_2$ with name $n$.
+      In this case $P'$ is $P'_2$,
+      except that $P'$ does not have the modifier \REQUIRED.
+    \end{itemize}
+  \end{itemize}
+
+  \commentary{%
+    This case includes non-generic function types by allowing $m$ to be zero.%
+  }
+\item
+  \DefEquals{%
+    \LowerBoundType{$S_1$ \FUNCTION<\ldots>(\ldots)}{%
+      $S_2$ \FUNCTION<\ldots>(\ldots)}}{%
+    \code{Never}},
+  otherwise.
+  \commentary{%
+    This is a catch-all rule for the standard lower bound of two function types:
+    At least one operand in the following cases is not a function type.%
+  }
+\item
+  \DefEquals{\LowerBoundType{$T_1$}{$T_2$}}{T_1}, if \SubtypeNE{T_1}{T_2}.
+\item
+  \DefEquals{\LowerBoundType{$T_1$}{$T_2$}}{T_2}, if \SubtypeNE{T_2}{T_1}.
+\item
+  \DefEquals{\LowerBoundType{FutureOr<$T_1$>}{FutureOr<$T_2$>}}{%
+    \code{FutureOr<$T_3$>}},\\
+  where $T_3$ is \LowerBoundType{$T_1$}{$T_2$}.
+\item
+  \DefEquals{\LowerBoundType{FutureOr<$T_1$>}{Future<$T_2$>}}{%
+    \code{Future<$T_3$>}},\\
+  where $T_3$ is \LowerBoundType{$T_1$}{$T_2$}.
+\item
+  \DefEquals{\LowerBoundType{Future<$T_1$>}{FutureOr<$T_2$>}}{%
+    \code{Future<$T_3$>}},\\
+  where $T_3$ is \LowerBoundType{$T_1$}{$T_2$}.
+\item
+  \DefEquals{\LowerBoundType{FutureOr<$T_1$>}{$T_2$}}{T_3},\\
+  where $T_3$ is \LowerBoundType{$T_1$}{$T_2$}.
+\item
+  \DefEquals{\LowerBoundType{$T_1$}{FutureOr<$T_2$>}}{T_3},\\
+  where $T_3$ is \LowerBoundType{$T_1$}{$T_2$}.
+\item
+  \DefEquals{\LowerBoundType{$T_1$}{$T_2$}}{\code{Never}}, otherwise.
+\end{itemize}
+
+\rationale{
+The rules defining \UpperBoundTypeName{} and \LowerBoundTypeName{}
+are somewhat redundant in that they explicitly specify
+a lot of pairs of symmetric cases.
+It might be sufficient to add ``and the converse'' to
+the first of any such pair of rules and eliminate the second one,
+or we could introduce meta-level abstraction over this kind of symmetry
+as well as other kinds of redundancy.
+However, we have chosen to tolerate the redundancy,
+because the alternatives are ambiguous or complex.%
+}
+
+
+\subsubsection{The Standard Upper Bound of Distinct Interface Types}
+\LMLabel{dartOneStandardUpperBound}
+
+\rationale{%
+  In order to avoid termination issues known from other languages
+  with the computation of `least upper bound' and similar notions,
+  early versions of Dart adopted a rather simple algorithm.
+  In particular, it does not rely on recursive invocations
+  of the same algorithm on subterms of the operands.
+  This algorithm has been preserved,
+  in order to maintain backward compatibility,
+  in spite of the fact that it may deliver results
+  which are obviously not as tight as they could have been.%
+}
+
+\commentary{%
+  For example, the algorithm yields \code{Object} as
+  the standard upper bound of
+  \code{List<Comparable<int>{}>} and \code{Iterable<int>},
+  but it is easy to see that a tighter upper bound exists, e.g.,
+  \code{Iterable<Comparable<num>{}>}.%
+}
+
+\LMHash{}%
+We define the auxiliary function \NominalTypeDepthName{}
+on interface types and \code{Object?} as follows:
+
+\begin{itemize}
+\item
+  \DefEquals{\NominalTypeDepth{Object?}}{0}.
+\item
+  \DefEquals{\NominalTypeDepth{Object}}{1}.
+\item
+  \DefEquals{\NominalTypeDepth{Null}}{1}.
+\item
+  Let $T$ be a class or a mixin,
+  and let $M$ be the set of immediate superinterfaces of $T$.
+  Then \DefEquals{\NominalTypeDepth{$T$}}{d + 1},
+  where $d$ is
+  $\metavar{max}\,\{\;\NominalTypeDepth{$S$}\;|\;S\;\in M\;\}$.
+\end{itemize}
+
+\commentary{%
+
+}
+
+\LMHash{}%
+\BlindDefineSymbol{I, J, M}%
+The algorithm that determines
+the standard upper bound of two distinct interface types
+works as follows.
+Let $I$ and $J$ be interface types,
+let $M_I$ be the set of superinterfaces of $I$,
+let $M_J$ be the set of superinterfaces of $J$,
+and let $M$ be the set $(\{I\} \cup M_I) \cap (\{J\} \cup M_J)$.
+
+\LMHash{}%
+Let $M_n$ be the set
+$\{\;T\;|\;T\,\in\,M\;\wedge\;\NominalTypeDepth{$T$}\,=\,n\,\}$
+for any natural number $n$.
+Let $q$ be the largest number such that $M_q$ has cardinality one.
+Such a number must exist because $M_0$ is $\{\code{Object?}\}$.
+The least upper bound of $I$ and $J$ is then the sole element of $M_q$.
+
+
+\subsubsection{Standard Upper Bound Issues}
+\LMLabel{standardUpperBoundIssues}
+
+%% TODO(eernst), for review: I kept this here (and updated some parts of it)
+%% in order to ensure that this information is preserved. However, it should
+%% perhaps not be in the specification. Should it actually be turned into
+%% a couple of github issues? In any case, it makes sense to communicate
+%% these properties of the algoritm to anyone who needs to know the language
+%% in full detail, which could justify keeping it here, or including a
+%% reference to some other location where the information is available.
+
+\commentary{%
+  The definition of the standard upper bound for type variables
+  does not guarantee termination.
+  Here is a counterexample:
+}
+
+\begin{dartCode}
+\VOID{} foo<T \EXTENDS{} List<S>, S \EXTENDS{} List<T>>(T x, S y) \{
+  \VAR{} a = (x == y) ? x : y;
+\}
+\end{dartCode}
+
+\rationale{%
+  The algorithm could be changed to use the greatest closure
+  (\ref{leastAndGreatestClosureOfTypes})
+  with respect to all of the type variables declared in the same scope.
+
+  The change has not been introduced at this point
+  because the phenomenon is expected to be very rare.
+  It is a breaking change because the standard upper bound of certain types
+  will be a proper supertype of the results obtained
+  with the current algorithm.%
+}
+
+\commentary{%
+  The current algorithm is asymmetric.
+  There is an equivalence class of top types,
+  and we correctly choose a canonical representative for bare top types
+  using the \IsMoreTopTypeName{} predicate.
+  However, when two different top types are embedded in two mutual subtypes,
+  we don't correctly choose a canonical representative.%
+}
+
+\begin{dartCode}
+\IMPORT{} 'dart:async';
+\\
+\VOID{} main() \{
+  List<FutureOr<Object?>{}> x;
+  List<\DYNAMIC> y;
+
+  var a = (x == y) ? x : y; // List<\DYNAMIC>.
+  var b = (x == y) ? y : x; // List<FutureOr<Object?>{}>.
+\}
+\end{dartCode}
+
+\commentary{%
+  The best solution for this is probably to normalize the types.
+  This is fairly straightforward:
+  We just normalize \code{FutureOr<$T$>} to the normal form of $T$
+  when $T$ is a top type.
+  We can then inductively apply this across the rest of the types.
+  Then, whenever we have mutual subtypes, we just return the normal form.
+  This would be breaking, albeit hopefully only in a minor way.
+
+  A similar treatment would need to be done for the bottom types as well,
+  since there are two equivalences there:
+  A type variable $X$ with bound $T$ is equivalent to \code{Never}
+  if $T$ is equivalent to \code{Never},
+  and \code{FutureOr<Never>} is equivalent to \code{Future<Never>}.%
+}
+
+
+\subsection{Least and Greatest Closure of Types}
+\LMLabel{leastAndGreatestClosureOfTypes}
+
+\LMHash{}%
+This section specifies how type variables can be
+eliminated from a given type $T$
+by computing an upper respectively lower bound of $T$ known as the
+least respectively the greatest closure of $T$.
+
+\commentary{%
+  The greatest closure $T_G$ of a type $T$ differs from
+  instantiation to bound
+  (\ref{instantiationToBound})
+  in several ways.
+  First, instantiation to bound yields a type based on
+  a generic class or type alias $G$,
+  whereas the greatest closure takes a parameterized type,
+  so $T$ has received some actual type arguments
+  and is of the form \code{$G$<\List{T}{1}{s}>}.
+  Next, the greatest closure is an upper bound, i.e.,
+  \SubtypeNE{T}{T_G} is guaranteed.
+  Instantiation to bound on a generic class $G$ will yield a type $T_I$
+  such that \SubtypeNE{\code{$G$<\List{U}{1}{s}>}}{T_I}
+  for all \List{U}{1}{s} such that
+  \code{$G$<\List{U}{1}{s}>} is a regular-bounded type;
+  but in some cases that subtype relationship does not hold,
+  especially with type aliases involving invariance.
+  Also, instantiation to bound uses the declared bounds whenever possible,
+  but the greatest closure uses \code{Object?}\ immediately.
+  For instance, with \code{\CLASS\,\,C<X\,\,\EXTENDS\,\,num> \{\}},
+  the greatest closure of \code{C<$Y$>} with respect to $\{Y\}$ is
+  the super-bounded type \code{C<Object?>},
+  but the instantiation to bound on \code{C} is \code{C<num>}.%
+}
+
+\LMHash{}%
+\BlindDefineSymbol{S, L, X_j, n}%
+Let $S$ be a type and $L$ a set of type variables of the form
+$\{\List{X}{1}{n}\}$.
+
+\LMHash{}%
+We define the
+\IndexCustom{least closure}{type!least closure}
+of $S$ with respect to $L$ to be $S$
+with every covariant occurrence of $X_j$ replaced with \code{Never},
+and every contravariant occurrence of $X_j$ replaced with \code{Object?},
+for each $j \in 1 .. n$.
+The invariant occurrences are treated as described explicitly below.
+
+\LMHash{}%
+Similarly, we define the
+\IndexCustom{greatest closure}{type!greatest closure}
+of $S$ with respect to $L$ to be $S$
+with every covariant occurrence of $X_j$ replaced with \code{Object?},
+and every contravariant occurrence of $X_j$ replaced with \code{Never},
+for each $j \in 1 .. n$.
+The invariant occurrences are treated as described explicitly below.
+
+\begin{itemize}
+\item
+  If $S$ is $X$, where $X$ is a type variable in $L$, then
+  the least closure of $S$ with respect to $L$ is \code{Never},
+  and the greatest closure of $S$ with respect to $L$ is \code{Object?}.
+\item
+  If $S$ does not contain any type variables from $L$
+  (\commentary{%
+    for instance, if $S$ is an atomic type, \ref{typeNormalization}})
+  then the least and greatest closure of $S$ is $S$.
+\item
+  If $S$ is a type of the form $T?$ then
+  \begin{itemize}
+  \item
+    the least closure of $S$ with respect to $L$ is $U?$,
+    where $U$ is the least closure of $T$ with respect to $L$.
+  \item
+    the greatest closure of $S$ with respect to $L$ is $U?$,
+    where $U$ is the greatest closure of $T$ with respect to $L$.
+  \end{itemize}
+\item
+  If $S$ is a type of the form \code{FutureOr<$T$>} then
+  \begin{itemize}
+  \item
+    the least closure of $S$ with respect to $L$ is \code{FutureOr<$U$>},
+    where $U$ is the least closure of $T$ with respect to $L$.
+  \item
+    the greatest closure of $S$ with respect to $L$ is \code{FutureOr<$U$>},
+    where $U$ is the greatest closure of $T$ with respect to $L$.
+  \end{itemize}
+\item
+  If $S$ is an interface type of the type \code{$C$<\List{T}{1}{k}>} then
+  \begin{itemize}
+  \item
+    the least closure of $S$ with respect to $L$ is \code{$C$<\List{U}{1}{k}>},
+    where $U_i$ is the least closure of $T_i$ with respect to $L$,
+    for each $i \in 1 .. k$.
+  \item
+    the greatest closure of $S$ with respect to $L$
+    is \code{$C$<\List{U}{1}{k}>},
+    where $U_i$ is the greatest closure of $T_i$ with respect to $L$,
+    for each $i \in 1 .. k$.
+  \end{itemize}
+\item
+  If $S$ is a type of the form
+
+  \noindent
+  \FunctionTypePositionalStd{T_0}
+
+  \noindent
+  and no type variable in $L$ occurs in any of the $B_j$, $j \in 1 .. s$,
+  then
+  \begin{itemize}
+  \item
+    the least closure of $S$ with respect to $L$ is
+
+    \noindent
+    \FunctionTypePositional{U_0}{\\}{X}{B}{s}{U}{n}{k}
+
+    \noindent
+    where
+    $U_0$ is the least closure of $T_0$ with respect to $L$,
+    $U_j$ is the greatest closure of $T_j$ with respect to $L$
+    for each $j \in 1 .. n + k$.
+    It is assumed that type variables have been consistently renamed
+    if necessary,
+    such that no $X_j$ appears in $L$,
+    for each $j \in 1 .. s$.
+  \item
+    the greatest closure of $S$ with respect to $L$ is
+
+    \noindent
+    \FunctionTypePositional{U_0}{\\}{X}{B}{s}{U}{n}{k}
+
+    \noindent
+    where $U_0$ is the greatest closure of $T_0$ with respect to $L$,
+    $U_j$ is the least closure of $T_j$ with respect to $L$
+    for each $j \in 1 .. n + k$.
+    It is assumed that type variables have been consistently renamed
+    if necessary,
+    such that no $X_j$ appears in $L$,
+    for each $j \in 1 .. s$.
+  \end{itemize}
+\item
+  If $S$ is a type of the form
+
+  \noindent
+  \FunctionTypeNamedStd{T_0}
+
+  \noindent
+  where $r_j$ is derived from \code{\REQUIRED?}, $j \in n + 1 .. n + k$,
+  and no type variable in $L$ occurs in any of the $B_j$, $j \in 1 .. s$,
+  then
+  \begin{itemize}
+  \item
+    the least closure of $S$ with respect to $L$ is
+
+    \noindent
+    \FunctionTypeNamed{U_0}{ }{X}{B}{s}{U}{n}{x}{k}{r}
+
+    \noindent
+    where
+    $U_0$ is the least closure of $T_0$ with respect to $L$,
+    $U_j$ is the greatest closure of $T_j$ with respect to $L$
+    for each $j \in 1 .. n + k$.
+    It is assumed that type variables have been consistently renamed
+    if necessary,
+    such that no $X_j$ appears in $L$,
+    for each $j \in 1 .. s$.
+  \item
+    the greatest closure of $S$ with respect to $L$ is
+
+    \noindent
+    \FunctionTypeNamed{U_0}{ }{X}{B}{s}{U}{n}{x}{k}{r}
+
+    \noindent
+    where $U_0$ is the greatest closure of $T_0$ with respect to $L$,
+    $U_j$ is the least closure of $T_j$ with respect to $L$
+    for each $j \in 1 .. n + k$.
+    It is assumed that type variables have been consistently renamed
+    if necessary,
+    such that no $X_j$ appears in $L$,
+    for each $j \in 1 .. s$.
+  \end{itemize}
+\item
+  If $S$ is a type of one of the forms
+
+  \noindent
+  \FunctionTypePositionalStd{T_0}
+
+  \noindent
+  \FunctionTypeNamedStd{T_0}
+
+  \noindent
+  where $L$ contains one or more free type variables that occur in $B_j$
+  for some $j \in 1 .. s$,
+  then the least closure of $S$ with respect to $L$ is \code{Never},
+  and the greatest closure of $S$ with respect to $L$ is \FUNCTION.
+\end{itemize}
+
+\LMHash{}%
+A \Index{type schema} is a type where
+\FreeContext{} may occur as if it were a type variable.
+
+\commentary{%
+  For example, \code{List<\FreeContext>} and \code{int} are type schemas.
+  Type schemas are used to express and propagate constraints on types
+  during type inference
+  (\ref{typeInference}).%
+}
+
+\LMHash{}%
+Let $P$ be a type schema.
+We define the least and greatest closure of $P$
+with respect to \FreeContext{} and a set of type variables $L$ as
+the least and greatest closure with respect to $L \cup \{\FreeContext\}$,
+where \FreeContext{} is treated as a type variable.
+
+\commentary{%
+  Note that the least closure of a type schema is always a subtype of
+  any type which matches the schema, and the greatest closure of a type
+  schema is always a supertype of any type which matches the schema.%
+}
+
+
+\subsection{Types Bounded by Types}
+\LMLabel{typesBoundedByTypes}
+
+\LMHash{}%
+For a given type $T_0$, we introduce the notion of a
+\IndexCustom{$T_0$ bounded type}{type!T0 bounded}:
+$T_0$ itself is $T_0$ bounded;
+if $B$ is $T_0$ bounded and
+$X$ is a type variable with bound $B$
+then $X$ is $T_0$ bounded;
+finally, if $B$ is $T_0$ bounded and
+$X$ is a type variable
+then $X \& B$ is $T_0$ bounded.
+
+\LMHash{}%
+In particular, a
+\IndexCustom{\DYNAMIC{} bounded type}{type!dynamic bounded}
+is either \DYNAMIC{} itself
+or a type variable whose bound is \DYNAMIC{} bounded,
+or an intersection whose second operand is \DYNAMIC{} bounded.
+Similarly for a
+\IndexCustom{\FUNCTION{} bounded type}{type!function bounded}.
+
+\LMHash{}%
+A
+\IndexCustom{function-type bounded type}{type!function-type bounded}
+is a type $T$ which is $T_0$ bounded where $T_0$ is a function type
+(\ref{functionTypes}).
+A function-type bounded type $T$ has an
+\Index{associated function type}
+which is the unique function type $T_0$ such that $T$ is $T_0$ bounded.
+
+
+\subsection{Class Building Types}
+\LMLabel{classBuildingTypes}
+
+\LMHash{}%
+Some types known as
+\IndexCustom{class building types}{type!class building}
+can be used in specific contexts where a class is required
+(\commentary{e.g., when specifying a superinterface of a class}).
+We say that a type $T$ is a class building type
+if none of the following criteria is satisfied:
+
+\begin{itemize}
+\item $T$ is \VOID{} (\ref{typeVoid}).
+\item $T$ is \DYNAMIC{} (\ref{typeDynamic}).
+\item $T$ is \code{FutureOr<$S$>} for some type $S$ (\ref{typeFutureOr}).
+\item
+  % TODO(eernst): If we introduce sealed classes we will have an item
+  % for those, and we may wish to rephrase this.
+  $T$ is \code{Never}, \code{Null}, \code{num}, \code{int}, \code{double},
+  \code{bool}, or \code{String}.
+\item $T$ is \code{$S$?} for some type $S$.
+\item $T$ is a type variable (\ref{generics}).
+\item $T$ is a function type (\ref{functionTypes}).
+\item $T$ is a type alias whose transitive alias expansion
+  (\ref{typedef}) does not denote a class.
+\item $T$ is an enumerated type (\ref{enums}).
+\item $T$ is a deferred type (\ref{staticTypes}).
+\end{itemize}
+
+
+\subsection{Interface Types}
+\LMLabel{interfaceTypes}
+
+\LMHash{}%
+Interface types can be used to access
+a specific set of instance members.
+Let $T$ be a type, and let $T'$ be the transitive alias expansion of $T$
+(\ref{typedef}).
+We say that $T$ is an \Index{interface type} if{}f
+$T'$ is of the form \code{$C$<\List{T}{1}{k}>},
+where $C$ denotes a class different from \code{Never},
+or $C$ denotes a mixin.
+
+\commentary{%
+  Note that \List{T}{1}{k} can be arbitrary types.
+  Non-generic classes are included because we can have $k = 0$.
+
+  In particular, the following types are \emph{not} interface types:
+  \VOID, \DYNAMIC, \FUNCTION, \code{FutureOr<$T$>} for any $T$, \code{Never},
+  any function type, any type variable, any intersection type,
+  and any type of the form \code{$T$?}.
+
+  Conversely, built-in classes
+  like \code{Object}, \code{Null}, \code{num}, \code{int},
+  \code{String}, and \code{Exception} are interface types,
+  and so are
+  \code{Future<$T$>}, \code{Stream<$T$>}, \code{Iterable<$T$>},
+  \code{List<$T$>}, \code{Map<$S$,\,\,$T$}, and \code{Set<$T$>},
+  for any $S$ and $T$.%
+}
+
+
+\subsection{Intersection Types}
+\LMLabel{intersectionTypes}
+
+\LMHash{}%
+Dart supports a very limited notion of intersection types.
+They only occur at compile-time, i.e., they are not reified at run time.
+They arise during static analysis,
+but cannot be specified directly in source code.
+They only admit a left operand which is a type variable.
+The right operand is required to be a subtype of
+the bound of said type variable.
+
+\commentary{%
+  An intersection type will never occur as a nested type, that is,
+  it never occurs as or in
+  an actual type argument in a parameterized type,
+  a parameter type or a return type in a function type,
+  a type parameter bound,
+  as the right operand of another intersection type,
+  or as the operand of the nullable type operator \lit{?}.%
+}
+
+\LMHash{}%
+Assume that $X$ is a type variable with bound $B$,
+and $T$ is a type such that \SubtypeNE{T}{B}.
+We then use the syntax \code{$X$\,\&\,$T$} to designate the intersection type
+that intersects $X$ and $T$.
+
+\commentary{%
+  Note again that \code{$X$\,\&\,$T$} cannot occur in source code,
+  but it can emerge as the type of an expression.
+  Intersection types in Dart are used to hold the information that
+  the object which is the value of a specific variable
+  has a type which is a type variable $X$ with bound $B$,
+  and it is also known to have some other type $T$ which is
+  a subtype of $B$.%
+}
+
+\LMHash{}%
+Let $S$ be a type of the form \code{$X$\,\&\,$T$}.
+The \IndexCustom{interface}{interface!of intersection type}
+of $S$ is the interface of $T$.
+
+
+\subsection{Type Never}
+\LMLabel{typeNever}
+
+\LMHash{}%
+The system library \code{dart:core} exports a type named \code{Never}.
+No object has a dynamic type which is \code{Never} or a subtype thereof.
+
+\commentary{%
+  In other words, \code{Never} is the empty type.
+  \code{Never} is a subtype of every other type in Dart
+  (\ref{subtypeRules}).%
+}
+
+\rationale{%
+  \code{Never} is a useful type for several reasons:
+  It can be used to indicate that
+  the evaluation of an expression will never complete normally,
+  e.g., because it calls a function that always throws.
+  This allows for a more precise control flow analysis.
+
+  Also, \code{Never} can be used to express some extreme types:
+  For instance, the object \code{\CONST\,\,<Never>[]} can be used
+  in any situation where a \code{List<$T$>} is required,
+  for any $T$ whatsoever.
+  Similarly, a variable of type \code{Object?\,\,\FUNCTION(Never)}
+  can be used to hold any function that accepts a single, positional argument.%
+}
+
+\LMHash{}%
+% Note that we are not even checking invocations of members of `Object`
+% statically, so `(throw 0).noSuchMethod(1);` is OK. The analyzer will
+% actually hint that `(1)` is dead code, so it isn't accepted silently.
+Every member access
+\commentary{%
+  (such as calling a method, operator, or getter, or tearing off a method)%
+}
+on a receiver whose static type is \code{Never}
+is treated by the static analysis as producing a result of type \code{Never}.
+Invoking an expression of type \code{Never} as a function
+is treated by the static analysis as producing a result of type \code{Never}.
+In both cases, no syntactically correct list of actual arguments is an error
+\commentary{%
+  (except of course that individual expressions in that list
+  could have errors)%
+}.
+
+\commentary{%
+  Hence, with a receiver whose static type is \code{Never},
+  it is not an error to invoke any method, setter, or getter, or to
+  tear off any method.
+  In other words, \code{Never} is considered to have all members,
+  with all signatures.
+
+  Implementations that provide feedback about dead or unreachable code
+  are encouraged to indicate
+  that arguments passed to any such invocation
+  will not be evaluated at run time,
+  and similarly for any arguments passed to an expression of type \code{Never}
+  which is invoked as a function.%
+}
+
+
+\subsection{Type Null}
+\LMLabel{typeNull}
+
+\LMHash{}%
+The system library \code{dart:core} exports a type named \code{Null}.
+There is exactly one object whose dynamic type is \code{Null},
+and that is the null object
+(\ref{null}).
+
+\commentary{%
+  In other words, \code{Null} is a singleton type.
+  Apart from top types
+  (\ref{superBoundedTypes}),
+  \code{Null} is a subtype of all types of the form \code{$T$?},
+  and of all types $S$ such that \futureOrBase{S} is
+  a top type or a type of the form \code{$T$?}.
+  The only non-trivial subtypes of \code{Null} are
+  \code{Never} and subtypes of \code{Never}
+  (\ref{subtypeRules}).%
+}
+
+\LMHash{}%
+Attempting to instantiate \code{Null} causes a \Error{compile-time error}.
+It is a \Error{compile-time error} for a class to extend, mix in or implement
+\code{Null}.
+The \code{Null} class declares exactly the same members
+with the same signatures as the class \code{Object}.
+
+\commentary{%
+  The \code{Null} class has a primitive \lit{==} operator
+  (\ref{theOperatorEqualsEquals}).%
+}
+
+\rationale{%
+  \code{Null} is mainly used implicitly in
+  a type of the form \code{$T$?}\ for some $T$.
+  If $e$ is an expression of type \code{$T$?}\ that evaluates to an object $o$,
+  then $o$ can be an instance of a subtype of $T$,
+  or it can be the null object.
+  The latter situation is commonly interpreted to mean that
+  the computation did not yield a result.
+  In this sense, \code{Null} can be considered to model
+  the property of being optional.%
+}
+
+
+\subsection{Type Type}
+\LMLabel{typeType}
+
+\LMHash{}%
+The Dart runtime supports a very limited kind of introspective reflection
+for all programs
+\commentary{(that is, without including any reflection support mechanisms)}.
+In particular, evaluation of a type literal as an expression yields
+an object whose run-time type is a subtype of the built-in type \code{Type}.
+System libraries may deliver such objects as well.
+In particular, the getter \code{runtimeType} on \code{Object}
+returns a reified type for the run-time type of the receiver.
+
+\LMHash{}%
+If an object $o$ is obtained in this manner
+as a reification of the type $T$,
+we say that $o$ is a \Index{reified type},
+and we say that $o$ \IndexCustom{reifies}{type!reifies} $T$.
+
+\LMHash{}%
+We define what it means for two types to be the same as follows:
+Let $T_1$ and $T_2$ be types.
+Let $U_j$ be the transitive alias expansion
+(\ref{typedef}) of $T_j$, for $j \in 1 .. 2$,
+and let $S_j$ be \NormalizedTypeOf{$U_j$}, for $j \in 1 .. 2$
+(\ref{typeNormalization}).
+We then say that $T_1$ and $T_2$ are the \Index{same type}
+if{}f $S_1$ and $S_2$ are have the same canonical syntax
+(\ref{standardUpperBoundsAndStandardLowerBounds}).
+
+\LMHash{}%
+A reified type identifies the underlying type in the sense that
+it supports equality tests with other reified types as follows.
+Let $o_1$ and $o_2$ be reified types that reify $T_1$ respectively $T_2$,
+and let $o_3$ be an object which is not a reified type.
+Let $v_j$ be a fresh variable bound to $o_j$, for $j \in 1 .. 3$.
+It is then guaranteed that \code{$v_1$ == $v_2$} evaluates to \TRUE{}
+if{}f $T_1$ and $T_2$ are the same type as defined above.
+Conversely, \code{$v_1$ == $v_3$} evaluates to \FALSE.
+
+\commentary{%
+  Note that we do not equate primitive top types.
+  For example,
+  reified types reifying \code{List<\VOID>} and \code{List<\DYNAMIC>}
+  are not equal.
+  However, a type variable which is declared by a function type
+  is treated as if it were consistently renamed to a fresh name,
+  thus making types identical if possible
+  (also known as alpha equivalence).
+  For example:%
+}
+
+\begin{dartCode}
+\TYPEDEF{} F = \VOID{} \FUNCTION{}<X>(X);
+\TYPEDEF{} G = \VOID{} \FUNCTION{}<Y>(Y);
+\\
+\VOID{} main() \{
+  print(F == G); // \comment{Prints 'true'.}
+\}
+\end{dartCode}
+
+\commentary{%
+  Note that reified types have a primitive operator \lit{==}
+  (\ref{theOperatorEqualsEquals}).
+  This property cannot be assumed for arbitrary expressions of type \code{Type}.
+  For instance, we can declare
+  \code{\CLASS\,\,MyType\,\,\EXTENDS\,\,Type \{\ldots\}}
+  and override operator \lit{==}.%
+}
+
+\LMHash{}%
+Let $e_1$ and $e_2$ be constant expressions
+(\ref{constants})
+evaluating to $o_1$ respectively $o_2$,
+which are reified types reifying the types $T_1$ respecively $T_2$.
+Let $v_1$ and $v_2$ be fresh variables bound to $o_1$ respectively $o_2$.
+We then have \code{identical($v_1$, $v_2$)} if{}f
+\code{$v_1$\,\,==\,\,$v_2$}.
+
+\commentary{%
+  In other words, constant reified types are canonicalized.
+  For runtime implementations which implement identity by choosing a
+  canonical representative for the equivalence class of equal instances,
+  the choice of what type object to canonicalize to is not
+  observable in the language.
+}
+
+\rationale{%
+  As mentioned at the beginning of this section,
+  reified types support a very limited kind of introspective reflection.
+  In particular, we can compare reified types for equality,
+  and in the case where two reified types are equal
+  it is known that they reify types which are subtypes of each other
+  (that is, they are ``the same type'' with respect to subtyping).
+  But we cannot compare reified types for any inequality, that is,
+  we cannot determine whether one is a subtype of the other.
+  It is also impossible to deconstruct a reified type.
+  E.g., we cannot obtain the reified type for \code{$T$}
+  by performing operations on a given reified type for \code{List<$T$>}.
+
+  This design was chosen in order to ensure that Dart programs
+  do not incur the substantial implications in terms of
+  program size and run-time performance
+  that are very difficult to avoid
+  when a more powerful form of reflection is supported.%
 }
 
 
@@ -22527,8 +24583,8 @@ it instead uses \code{Object} as superclass.
 
 \LMHash{}%
 If a class or mixin declaration implements \FUNCTION, it has no effect.
-It is as if the \FUNCTION{} was removed from the \IMPLEMENTS{} clause
-(and if it's the only implemented interface, the entire clause is removed).
+The \IMPLEMENTS{} clause is treated as if \FUNCTION{} were removed
+(and if it is the only implemented interface, the entire clause is removed).
 The resulting class or mixin interface
 does not have \FUNCTION{} as a superinterface.
 
@@ -22540,16 +24596,16 @@ that clause has no effect, the resulting class also does not
 implement \FUNCTION.
 \commentary{%
   The \FUNCTION{} class declares no concrete instance members,
-  so the mixin application creates a sub-class of
-  the superclass with no new members and no new interfaces.%
+  so the mixin application creates a sub-class
+  of the superclass with no new members and no new interfaces.%
 }
 
 \rationale{%
   Since using \FUNCTION{} in these ways has no effect, it would be
   reasonable to disallow it completely, like we do extending, implementing or
   mixing in types like \code{int} or \code{String}.
-  For backwards compatibility with Dart 1 programs,
-  the syntax is allowed to remain, even if it has no effect.
+  The syntax is allowed to remain for now for backwards compatibility,
+  even though it has no effect.
   Tools may choose to warn users that their code has no effect.%
 }
 
@@ -23338,109 +25394,335 @@ the actual value of $B$ in that context.
 }
 
 
-\subsubsection{Least Upper Bounds}
-\LMLabel{leastUpperBounds}
-
-% TODO(eernst): This section has been updated to take generic functions
-% into account, but no other changes have been performed. Hence, we still
-% need to update this section to use Dart 2 rules for LUB.
+\section{Type Inference}
+\LMLabel{typeInference}
 
 \LMHash{}%
-% does this diverge in some cases?
-Given two interfaces $I$ and $J$,
-let $S_I$ be the set of superinterfaces of $I$,
-let $S_J$ be the set of superinterfaces of $J$
-and let $S = (\{I\} \cup S_I) \cap (\{J\} \cup S_J)$.
-Furthermore,
-we define $S_n = \{T | T \in S \wedge depth(T) = n\}$ for any finite $n$
-where $depth(T)$ is the number of steps in the longest inheritance path
-from $T$ to \code{Object}.
-%TODO(lrn): Specify: "inheritance path" is a path in the superinterface graph.
-Let $q$ be the largest number such that $S_q$ has cardinality one,
-which must exist because $S_0$ is $\{\code{Object}\}$.
-The least upper bound of $I$ and $J$ is the sole element of $S_q$.
+This specification does not yet specify type inference in Dart.\!\footnote{%
+A preliminary specification is available at
+\url{https://github.com/dart-lang/language/blob/master/resources/type-system/inference.md}.%
+}
+A future version of this specification will include that topic.
 
 \LMHash{}%
-The least upper bound of \DYNAMIC{} and any type $T$ is \DYNAMIC.
-The least upper bound of \VOID{} and any type $T \ne \DYNAMIC{}$ is \VOID.
-The least upper bound of $\bot$ and any type $T$ is $T$.
-Let $U$ be a type variable with upper bound $B$.
-The least upper bound of $U$ and a type $T \ne \bot$ is
-the least upper bound of $B$ and $T$.
+In other parts of this specification,
+type inference is generally assumed to have taken place already.
+However, commentary is used in several locations to give some informal
+information about the effects of type inference.
+
+
+\section{Flow Analysis}
+\LMLabel{flowAnalysis}
+
+%% TODO(eernst): Come flow analysis, rewrite this section entirely.
+\LMHash{}%
+This specification does not fully specify the flow analysis in Dart,
+but a future version of it will do so.\!\footnote{%
+A preliminary specification is available at
+\url{https://github.com/dart-lang/language/blob/master/resources/type-system/flow-analysis.md}.%
+}
+In this section we specify a few concepts and special cases
+in the flow analysis
+that do not depend on the detailed control flow,
+so as to enable the rest of the specification to refer to information
+obtained during this analysis.
 
 \LMHash{}%
-The least upper bound operation is commutative and idempotent,
-but it is not associative.
+The flow analysis provides information about reachability of code,
+about the definite assignment status of each local variable,
+and about type test related events in the control flow
+that determine type promotion of local variables.
 
-% Function types
 
-%% TODO(eernst): This section should use the new syntax for function types
-%% (\FunctionTypePositionalStd{} etc.); these updates are made by CL 84908.
+\subsection{Definite Assignment}
+\LMLabel{definiteAssignment}
 
 \LMHash{}%
-The least upper bound of a function type and an interface type $T$ is
-the least upper bound of \FUNCTION{} and $T$.
-Let $F$ and $G$ be function types.
-If $F$ and $G$ differ in their number of required parameters,
-then the least upper bound of $F$ and $G$ is \FUNCTION.
-Otherwise:
-
-\begin{itemize}
-\item If
-
-\noindent
-\code{$F = $ <$X_1\ B_1, \ldots,\ X_s\ B_s$>($T_1, \ldots,\ T_r,\ $[$T_{r+1}, \ldots,\ T_n$]) $ \rightarrow T_0$} and
-
-\noindent
-\code{$G = $ <$X_1\ B_1, \ldots,\ X_s\ B_s$>($S_1, \ldots,\ S_r,\ $[$S_{r+1}, \ldots,\ S_k$]) $ \rightarrow S_0$}
-
-\noindent
-where $k \le n$ then the least upper bound of $F$ and $G$ is
-
-\noindent
-\code{<$X_1\ B_1, \ldots,\ X_s\ B_s$>($L_1, \ldots,\ L_r,\ $[$L_{r+1}, \ldots,\ L_k$]) $ \rightarrow L_0$}
-
-\noindent
-where $L_i$ is the least upper bound of $T_i$ and $S_i, i \in 0 .. k$.
-\item If
-
-\noindent
-\code{$F = $ <$X_1\ B_1, \ldots,\ X_s\ B_s$>($T_1, \ldots,\ T_r,\ $[$T_{r+1}, \ldots,\ T_n$]) $ \rightarrow T_0$},
-
-\noindent
-\code{$G = $ <$X_1\ B_1, \ldots,\ X_s\ B_s$>($S_1, \ldots,\ S_r,\ $\{ \ldots{} \}) $ \rightarrow S_0$}
-
-\noindent
-then the least upper bound of $F$ and $G$ is
-
-\noindent
-\code{<$X_1\ B_1, \ldots,\ X_s\ B_s$>($L_1, \ldots,\ L_r$) $ \rightarrow L_0$}
-
-\noindent
-where $L_i$ is the least upper bound of $T_i$ and $S_i, i \in 0 .. r$.
-\item If
-
-\noindent
-\code{$F = $ <$X_1\ B_1, \ldots,\ X_s\ B_s$>($T_1, \ldots,\ T_r,\ $\{$T_{r+1}\ p_{r+1}, \ldots,\ T_f\ p_f$\}) $ \rightarrow T_0$},
-
-\noindent
-\code{$G = $ <$X_1\ B_1, \ldots,\ X_s\ B_s$>($S_1, \ldots,\ S_r,\ $\{$S_{r+1}\ q_{r+1}, \ldots,\ S_g\ q_g$\}) $ \rightarrow S_0$}
-
-then let
-$\{x_m, \ldots, x_n\} = \{p_{r+1}, \ldots, p_f\} \cap \{q_{r+1}, \ldots, q_g\}$
-and let $X_j$ be the least upper bound of the types of $x_j$ in $F$ and
-$G, j \in m .. n$.
-Then the least upper bound of $F$ and $G$ is
-
-\noindent
-\code{<$X_1\ B_1, \ldots,\ X_s\ B_s$>($L_1, \ldots,\ L_r,\ $\{$X_m\ x_m, \ldots,\ X_n\ x_n$\}) $ \rightarrow L_0$}
-
-where $L_i$ is the least upper bound of $T_i$ and $S_i, i \in 0 .. r$
-\end{itemize}
+At each location where a local variable can be referred
+\commentary{%
+  (e.g., as an expression, or as the left hand side of an assignment)%
+},
+the variable has a status as being
+\IndexCustom{definitely assigned}{local variable!definitely assigned} or
+\IndexCustom{definitely unassigned}{local variable!definitely unassigned}.
 
 \commentary{%
-  Note that the non-generic case is covered by using $s = 0$,
-  in which case the type parameter declarations are omitted (\ref{generics}).%
+  The precise flow analysis which determines this status at each location
+  will be specified in a future version of this specification.
+  The intuition is that
+  when a local variable $v$ is definitely assigned at a given location $\ell$
+  then it is guaranteed that $v$ is bound to an object
+  if and when the execution reaches $\ell$.
+  Similarly, if $v$ is definitely unassigned at location $\ell$
+  then it is guaranteed that $v$ is unbound
+  if and when the execution reaches $\ell$.
+  It is possible for a local variable to be
+  both not definitely assigned and not definitely unassigned,
+  namely, in the situation where
+  it is not statically known whether the variable is bound or unbound.%
+}
+
+\LMHash{}%
+A local variable $v$ is definitely assigned and not definitely unassigned
+at any location where $v$ is in scope,
+in the following cases:
+
+\begin{itemize}
+\item $v$ is a formal parameter.
+\item $v$ has an initializing expression.
+  \commentary{%
+    In this case $v$ may or may not be \LATE, that makes no difference.%
+  }
+\item $v$ occurs in a \synt{forStatement} of the form
+  \code{\FOR\,\,($D$\,\,\IN\,\,$e$)\,\,$S$} where $D$ declares $v$.
+  (\ref{for-in}).
+\end{itemize}
+
+\LMHash{}%
+Moreover, if $v$ is a local variable that occurs in
+a \synt{forStatement} of the form
+\code{\FOR\,\,($v$\,\,\IN\,\,$e$)\,\,$S$},
+then $v$ is definitely assigned and not definitely unassigned
+at the beginning of $S$.
+
+\LMHash{}%
+We say that a local variable is
+\IndexCustom{potentially assigned}{local variable!potentially assigned}
+if it is not definitely unassigned,
+and that a local variable is
+\IndexCustom{potentially unassigned}{local variable!potentially unassigned}
+if it is not definitely assigned.
+
+
+\subsection{Type Promotion}
+\LMLabel{typePromotion}
+
+\LMHash{}%
+Each local variable $v$ has a declared type $T$
+(\ref{localVariableDeclaration}),
+and it has a type $S$, defined below, which is a subtype of $T$.
+Type promotion refers to the situation where $S$ is different from $T$.
+
+\commentary{%
+  Intuitively, this is the kind of situation where
+  knowledge about the code which has been executed
+  justifies giving the local variable a ``better'' type
+  than the declared type.
+  Type promotion is also sometimes known as `occurrence typing'.
+
+  For example, if \code{x} is declared as \code{int?\,\,x;} and we know
+  that it was updated by the assignment \code{x\,=\,1} most recently,
+  or we know that \code{x\,\,\IS\,\,int} evaluated to \TRUE,
+  then we can give \code{x} the type \code{int} rather than \code{int?}.%
+}
+
+\LMHash{}%
+Type promotion relies on information from flow analysis.
+Flow analysis yields various kinds of information,
+including a non-empty
+\IndexCustom{stack of types of interest}{%
+  local variable!stack of types of interest}
+for each local variable $v$,
+and for each location $\ell$ where $v$ is in scope.
+The top of the stack of types of interest for $v$ at $\ell$ is the
+\IndexCustom{type}{local variable!type}
+of $v$ at $\ell$.
+We say that the type of $v$ has been
+\IndexCustom{promoted}{type!promoted}
+to $S$ at a location $\ell$,
+when the type of $v$ at $\ell$ is $S$,
+and $S$ is a proper subtype of the declared type of $v$.
+
+\rationale{%
+  We use the term `the type of $v$' to denote the complex typing property
+  which is associated with a control flow analysis and
+  a location dependent notion of type promotion,
+  and we use `the declared type of $v$' to denote the much simpler concept of
+  the type associated with $v$ based on its declaration alone.
+  It might seem much more natural to use `the type of $v$' to denote the latter,
+  and something like `the promoted type of $v$' to denote the former.
+
+  However, we would then have a terminology where
+  `the static type of an expression $e$'
+  should be defined to mean `the promoted type of $e$'
+  in the case where $e$ is a local variable,
+  and `the static type of $e$' in all other cases,
+  and we would need to talk about `the promoted type of $v$'
+  in a large number of locations where we currently
+  use `the type of $v$'.
+
+  So the chosen terminology allows us to confine the explicit reference to
+  the special typing properties of local variables:
+  they are the only expressions that may have different
+  types at different locations in the same scope,
+  except that other expressions may of course contain local variables
+  and hence get different types at different locations.
+  This yields a simpler and more consistent terminology
+  concerning the static type of an expression in general.%
+}
+
+\LMHash{}%
+Let $M$ be the set of types that occur in
+the stack of types of interest for $v$ at a location $\ell$.
+A \Index{type of interest} for $v$ at $\ell$
+is a type which is a member of $M$,
+or the type \NonNullType{$U$},
+where the type $U$ is a member of $M$.
+
+\commentary{%
+  In particular, if $T?$ is a type of interest
+  then $T$ is also a type of interest.%
+}
+
+\commentary{%
+  The flow analysis will be specified in
+  a future version of this specification.
+  Among other things, the flow analysis determines how to compute
+  the stack of types of interest for each local variable $v$
+  at a given location $\ell$,
+  based on the same properties of locations
+  that are immediate predecessors of $\ell$
+  in the control flow graph,
+  ending in the declaration of $v$.
+  At this point we just specify the initial step,
+  and the situations where promotion may occur.%
+}
+
+\LMHash{}%
+The initial stack of types of interest for $v$ has exactly one element,
+namely the declared type
+(\ref{localVariableDeclaration}).
+This is the stack of types of interest
+for the declaring occurrence of the name of $v$
+\commentary{%
+  (i.e., the very first time the variable is mentioned, \ref{variables})%
+}.
+
+\LMHash{}%
+If a local variable $v$ has an initializing expression
+and does not have the modifier \FINAL,
+%% As per the null safety feature spec we should have the following,
+%% (because variables with 'implicit initializers' are exactly for-in
+%% iteration variables), but the implementations do _not_ promote in
+%% this case, so we might need a breaking change process:
+%
+% or if the variable is declared by $D$ in a \synt{forStatement}
+% of the form \code{\FOR\,\,($D$\,\,\IN\,\,$e$)\,\,$S$},
+then the declaration of $v$ is treated as an assignment
+for the purposes of promotion.
+
+\commentary{%
+  This has no effect in the case where $v$
+  does not have an explicit declared type,
+  e.g., \code{\VAR\,\,x\,\,=\,\,$e$;},
+  because the declared type will then
+  already be exactly the static type of the initializing expression.
+  However, it does promote the type of \code{x}
+  in a situation like the following:%
+}
+
+\begin{dartCode}
+\VOID test() \{
+  int? x = 3; // \comment{\code{x} has declared type \code{int?}}.
+  x.isEven; // \comment{Valid, \code{x} has been promoted to \code{int}}.
+  x = null; // \comment{Valid, demotes \code{x} to the declared type.}
+\}
+\end{dartCode}
+
+\LMHash{}%
+There is one special case,
+arising from the fact that intersection types
+are subject to many restrictions
+(\ref{intersectionTypes}).
+Consider the situation
+where the declaration of a local variable $v$ is of the form
+\code{\LATE?\,\,\VAR\,\,$v$ = $e$;}
+where the static type of $e$ is of the form \code{$X$\,\&\,\,$T$}
+where $X$ is a type variable.
+In this situation, the declared type of $v$ is \code{X}
+(\ref{localVariableDeclaration}),
+but the type \code{$X$\,\&\,\,$T$} is added to the stack of types of interest,
+and the type of $v$ is immediately promoted to \code{$X$\,\&\,\,$T$}.
+
+\commentary{%
+  Note that \code{$X$\,\&\,\,$T$} is not otherwise automatically a
+  type of interest just because $X$ is a type of interest.
+  In particular, if $w$ is declared as
+  \code{\LATE?\,\,$X$\,\,$w$ = $e$;}
+  where the static type of $e$ is \code{$X$\,\&\,\,$T$},
+  the type of $w$ is \emph{not} promoted to \code{$X$\,\&\,\,$T$}.%
+}
+
+\LMHash{}%
+We now mention the locations where promotion may occur
+independently of the control flow.
+
+\commentary{%
+  We might say that these promotions are ``atomic'',
+  and all other promotions are derived from these,
+  and from the control flow.%
+}
+
+\LMHash{}%
+Let $\ell$ be a location,
+and let $v$ be a local variable which is in scope at $\ell$.
+Assume that $\ell$ occurs after the declaration of $v$.
+The expressions that give rise to promotion or demotion
+of the type of $v$ at $\ell$
+are the following:
+
+\begin{itemize}
+\item A type test of the form \code{$v$\,\,\IS\,\,$T$}.
+\item A type check of the form \code{$v$\,\,\AS\,\,$T$}.
+\item An assignment of the form \code{$v$\,\,=\,\,$e$}
+  where the static type of $e$ is a type of interest for $v$ at $\ell$,
+  and similarly for compound assignments
+  (\ref{compoundAssignment})
+  including \lit{??=}.
+\item An equality test of the form \code{$v$\,\,==\,\,$e$} or
+  \code{$e$\,\,==\,\,$v$}, where $e$ is \NULL,
+  optionally wrapped in one or more parentheses,
+  and similarly for \lit{!=}.
+\end{itemize}
+
+\LMHash{}%
+In particular,
+a check of the form \code{$v$\,\,==\,\,\NULL},
+\code{\NULL\,\,==\,\,$v$},
+or \code{$v$\,\,\IS\,\,Null}
+where $v$ has type $T$ at $\ell$
+promotes the type of $v$
+to \code{Null} in the \TRUE{} continuation,
+and to \NonNullType{$T$} in the \FALSE{} continuation.
+
+%% TODO(eernst), for review: The null safety spec says that `T?` is
+%% promoted to `T`, but implementations _do_ promote `X extends int?` to
+%% `X & int`. So I've specified the latter. This is also more consistent
+%% with the approach used with `==`.
+\LMHash{}%
+A check of the form \code{$v$\,\,!=\,\,\NULL},
+\code{\NULL\,\,!=\,\,$v$},
+or \code{$v$\,\,\IS\,\,$T$}
+where $v$ has type $T$ at $\ell$
+promotes the type of $v$
+to \NonNullType{$T$} in the \TRUE{} continuation,
+and to \code{Null} in the \FALSE{} continuation.
+
+\commentary{%
+  The resulting type of $v$ may be the obvious one, e.g.,
+  \code{$v$\,\,=\,\,1} may promote $v$ to \code{int},
+  but it may also give rise to a demotion
+  (changing the type of $v$ to a supertype of the type of $v$ at $\ell$),
+  and it may have no effect on the type of $v$
+  (e.g., when the static type of $e$ is not a type of interest).
+  These details will be specified in a future version of this specification.
+
+  Every non-trivial type of control flow determines the control flow graph,
+  and the control flow graph determines which of the above
+  may or must have occurred at $\ell$,
+  and hence gives rise to the stack of types of interest of $v$ at $\ell$,
+  which in turn determines the type of $v$ at $\ell$.
+  This part of the flow analysis will also be specified in the future.%
 }
 
 

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -16341,8 +16341,9 @@ unless any of the following are true:
 \LMHash{}%
 It is a compile-time error if
 the static type of $e_1$ may not be assigned to \code{bool}.
-The static type of $c$ is the least upper bound (\ref{leastUpperBounds}) of
-the static type of $e_2$ and the static type of $e_3$.
+The static type of $c$ is the least upper bound
+(\ref{standardUpperBoundsAndStandardLowerBounds})
+of the static type of $e_2$ and the static type of $e_3$.
 
 
 \subsection{If-null Expressions}
@@ -16367,8 +16368,9 @@ Otherwise evaluate $e_2$ to an object $r$,
 and then $e$ evaluates to $r$.
 
 \LMHash{}%
-The static type of $e$ is the least upper bound (\ref{leastUpperBounds}) of
-the static type of $e_1$ and the static type of $e_2$.
+The static type of $e$ is the least upper bound
+(\ref{standardUpperBoundsAndStandardLowerBounds})
+of the static type of $e_1$ and the static type of $e_2$.
 
 
 \subsection{Logical Boolean Expressions}
@@ -21858,6 +21860,9 @@ However, their subtype relations are specified without restrictions.
   It causes no problems that these rules will not be used
   in their full generality.%
 }
+Every other form of type may occur during static analysis
+as well as during execution,
+and the subtype relationship is always determined in the same way.
 
 % Subtype Rule Numbering
 \newcommand{\SrnReflexivity}{1}

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -2096,7 +2096,7 @@ OR
       that the returned object will not be used
       (\ref{return}).%
     }
-  \item The function is asynchronous, \flatten{T} is not \VOID,
+  \item The function is asynchronous, \Flatten{T} is not \VOID,
     and it would have been a compile-time error
     to declare the function with the body
     \code{\ASYNC{} \{ \RETURN{} $e$; \}}
@@ -11883,7 +11883,7 @@ $F$ in the following cases, using the first applicable case:
   \commentary{%
     There is no rule for the case where $T$ is of the form \code{$X$\,\&\,$S$}
     because this will never occur
-    (this concept is only used in \flattenName, which is defined below).%
+    (this concept is only used in \FlattenName, which is defined below).%
   }
 \end{itemize}
 
@@ -11940,7 +11940,7 @@ we say that $T$ does not derive a future type.
 
 \LMHash{}%
 We define the auxiliary function
-\IndexCustom{\flatten{T}}{flatten(t)@\emph{flatten}$(T)$}
+\IndexCustom{\Flatten{T}}{flatten(t)@\emph{flatten}$(T)$}
 as follows, using the first applicable case:
 
 \begin{itemize}
@@ -11950,24 +11950,24 @@ as follows, using the first applicable case:
 
   \begin{itemize}
   \item if $S$ derives a future type $U$
-    then \DefEquals{\flatten{T}}{\code{\flatten{U}}}.
+    then \DefEquals{\Flatten{T}}{\code{\Flatten{U}}}.
   \item otherwise,
-    \DefEquals{\flatten{T}}{\code{\flatten{X}}}.
+    \DefEquals{\Flatten{T}}{\code{\Flatten{X}}}.
   \end{itemize}
 
 \item If $T$ derives a future type \code{Future<$S$>}
   or \code{FutureOr<$S$>}
-  then \DefEquals{\flatten{T}}{S}.
+  then \DefEquals{\Flatten{T}}{S}.
 
 \item If $T$ derives a future type \code{Future<$S$>?}\ or
-  \code{FutureOr<$S$>?}\ then \DefEquals{\flatten{T}}{\code{$S$?}}.
+  \code{FutureOr<$S$>?}\ then \DefEquals{\Flatten{T}}{\code{$S$?}}.
 
-\item Otherwise, \DefEquals{\flatten{T}}{T}.
+\item Otherwise, \DefEquals{\Flatten{T}}{T}.
 \end{itemize}
 
 \rationale{%
   This definition guarantees that for any type $T$,
-  \code{$T <:$ FutureOr<$\flatten{T}$>}. The proof is by induction on the
+  \code{$T <:$ FutureOr<$\Flatten{T}$>}. The proof is by induction on the
   structure of $T$:
 
   \begin{itemize}
@@ -11976,21 +11976,21 @@ as follows, using the first applicable case:
     \begin{itemize}
     \item if $S$ derives a future type $U$,
       then \code{$T <: S$} and \code{$S <: U$}, so \code{$T <: U$}.
-      By the induction hypothesis, \code{$U <:$ FutureOr<$\flatten{U}$>}.
-      Since \code{$\flatten{T} = \flatten{U}$} in this case, it follows that
-      \code{$U <:$ FutureOr<$\flatten{T}$>}, and so
-      \code{$T <:$ FutureOr<$\flatten{T}$>}.
+      By the induction hypothesis, \code{$U <:$ FutureOr<$\Flatten{U}$>}.
+      Since \code{$\Flatten{T} = \Flatten{U}$} in this case, it follows that
+      \code{$U <:$ FutureOr<$\Flatten{T}$>}, and so
+      \code{$T <:$ FutureOr<$\Flatten{T}$>}.
     \item otherwise, \code{$T <: X$}.
-      By the induction hypothesis, \code{$X <:$ FutureOr<$\flatten{X}$>}.
-      Since \code{$\flatten{T} = \flatten{X}$} in this case, it follows that
-      \code{$U <:$ FutureOr<$\flatten{T}$>}, and so
-      \code{$T <:$ FutureOr<$\flatten{T}$>}.
+      By the induction hypothesis, \code{$X <:$ FutureOr<$\Flatten{X}$>}.
+      Since \code{$\Flatten{T} = \Flatten{X}$} in this case, it follows that
+      \code{$U <:$ FutureOr<$\Flatten{T}$>}, and so
+      \code{$T <:$ FutureOr<$\Flatten{T}$>}.
     \end{itemize}
 
   \item If $T$ derives a future type \code{Future<$S$>}
     or \code{FutureOr<$S$>}, then, since \code{Future<$S$> $<:$ FutureOr<$S$>},
-    it follows that \code{$T <:$ FutureOr<$S$>}. Since \code{$\flatten{T} = S$}
-    in this case, it follows that \code{$T <:$ FutureOr<$\flatten{T}$>}.
+    it follows that \code{$T <:$ FutureOr<$S$>}. Since \code{$\Flatten{T} = S$}
+    in this case, it follows that \code{$T <:$ FutureOr<$\Flatten{T}$>}.
 
   \item If $T$ derives a future type \code{Future<$S$>?} or
     \code{FutureOr<$S$>?}, then, since \code{Future<$S$>? $<:$ FutureOr<$S$>?},
@@ -11998,13 +11998,13 @@ as follows, using the first applicable case:
     \code{FutureOr<$S$>? $<:$ FutureOr<$S$?>} for any type $S$
     (this can be shown using the union type subtype rules and from
     \code{Future<$S$> $<:$ Future<$S$?>} by covariance), so by transivitity,
-    \code{$T <:$ FutureOr<$S$?>}. Since \code{$\flatten{T} = S$?} in this case,
-    it follows that \code{$T <:$ FutureOr<$\flatten{T}$>}.
+    \code{$T <:$ FutureOr<$S$?>}. Since \code{$\Flatten{T} = S$?} in this case,
+    it follows that \code{$T <:$ FutureOr<$\Flatten{T}$>}.
 
-  \item Otherwise, \code{$\flatten{T} = T$}, so
-    \code{FutureOr<$\flatten{T}$> $=$ FutureOr<$T$>}. Since
+  \item Otherwise, \code{$\Flatten{T} = T$}, so
+    \code{FutureOr<$\Flatten{T}$> $=$ FutureOr<$T$>}. Since
     \code{$T <:$ FutureOr<$T$>}, it follows that
-    \code{$T <:$ FutureOr<$\flatten{T}$>}.
+    \code{$T <:$ FutureOr<$\Flatten{T}$>}.
   \end{itemize}
 }
 
@@ -12039,7 +12039,7 @@ The static type of a function literal of the form
 
 \noindent
 is
-\FunctionTypePositionalStdCr{\code{Future<\flatten{T_0}>}},
+\FunctionTypePositionalStdCr{\code{Future<\Flatten{T_0}>}},
 
 \noindent
 where $T_0$ is the static type of $e$.
@@ -12075,7 +12075,7 @@ The static type of a function literal of the form
 
 \noindent
 is
-\FunctionTypeNamedStdCr{\code{Future<\flatten{T_0}>}},
+\FunctionTypeNamedStdCr{\code{Future<\Flatten{T_0}>}},
 
 \noindent
 where $T_0$ is the static type of $e$.
@@ -16891,13 +16891,13 @@ completes.
 \BlindDefineSymbol{a, e, S}%
 Let $a$ be an expression of the form \code{\AWAIT\,\,$e$}.
 Let $S$ be the static type of $e$.
-The static type of $a$ is then \flatten{S}
+The static type of $a$ is then \Flatten{S}
 (\ref{functionExpressions}).
 
 \LMHash{}%
 Evaluation of $a$ proceeds as follows:
 First, the expression $e$ is evaluated to an object $o$.
-Let \DefineSymbol{T} be \flatten{S}.
+Let \DefineSymbol{T} be \Flatten{S}.
 If the run-time type of $o$ is a subtype of \code{Future<$T$>},
 then let \DefineSymbol{f} be $o$;
 otherwise let $f$ be the result of creating
@@ -16918,7 +16918,7 @@ $a$ throws $x$ and $t$
 If $f$ completes with an object $v$, $a$ evaluates to $v$.
 
 \rationale{%
-  The use of \flattenName{} to find $T$
+  The use of \FlattenName{} to find $T$
   and hence determine the dynamic type test
   implies that we await a future in every case where this choice is sound.%
 }
@@ -16935,7 +16935,7 @@ If $f$ completes with an object $v$, $a$ evaluates to $v$.
   However, the second kind could be a \code{Future<Object?>}.
   This object isn't a \code{Future<Object>}, and it isn't \NULL,
   so it \emph{must} be considered to be in the second group.
-  Nevertheless, \flatten{\code{FutureOr<Object>?}} is \code{Object?},
+  Nevertheless, \Flatten{\code{FutureOr<Object>?}} is \code{Object?},
   so we \emph{will} await a \code{Future<Object?>}.
   We have chosen this semantics because it was the smallest breaking change
   relative to the semantics in earlier versions of Dart,
@@ -19382,7 +19382,7 @@ Consider the case where $f$ is an asynchronous non-generator function
 %
 % Returning without an object is only ok for async-"voidy" return types.
 It is a compile-time error if $s$ is \code{\RETURN;},
-unless \flatten{T}
+unless \Flatten{T}
 (\ref{functionExpressions})
 is \VOID, \DYNAMIC, or \code{Null}.
 %
@@ -19395,26 +19395,26 @@ is \VOID, \DYNAMIC, or \code{Null}.
 % Returning with an object in an void async function only ok
 % when that value is async-"voidy".
 It is a compile-time error if $s$ is \code{\RETURN{} $e$;},
-\flatten{T} is \VOID,
-and \flatten{S} is neither \VOID, \DYNAMIC, nor \code{Null}.
+\Flatten{T} is \VOID,
+and \Flatten{S} is neither \VOID, \DYNAMIC, nor \code{Null}.
 %
 % Returning async-void in a "non-async-voidy" function is an error.
 It is a compile-time error if $s$ is \code{\RETURN{} $e$;},
-\flatten{T} is neither \VOID, \DYNAMIC, nor \code{Null},
-and \flatten{S} is \VOID.
+\Flatten{T} is neither \VOID, \DYNAMIC, nor \code{Null},
+and \Flatten{S} is \VOID.
 %
 % Otherwise, returning an un-deasync-assignable value is an error.
 It is a compile-time error if $s$ is \code{\RETURN{} $e$;},
-\flatten{S} is not \VOID,
-and \code{Future<\flatten{S}>} is not assignable to $T$.
+\Flatten{S} is not \VOID,
+and \code{Future<\Flatten{S}>} is not assignable to $T$.
 
 \commentary{%
-  Note that \flatten{T} cannot be \VOID, \DYNAMIC, or \code{Null}
+  Note that \Flatten{T} cannot be \VOID, \DYNAMIC, or \code{Null}
   in the last case,
   because then \code{Future<$U$>} is assignable to $T$ for \emph{all} $U$.
   In particular, when $T$ is \code{FutureOr<Null>}
   (which is equivalent to \code{Future<Null>}),
-  \code{Future<\flatten{S}>} is assignable to $T$ for all $S$.
+  \code{Future<\Flatten{S}>} is assignable to $T$ for all $S$.
   This means that no compile-time error is raised,
   but \emph{only} the null object (\ref{null})
   or an instance of \code{Future<Null>}
@@ -19426,7 +19426,7 @@ and \code{Future<\flatten{S}>} is not assignable to $T$.
 
   An error will not be raised if $f$ has no declared return type,
   since the return type would be \DYNAMIC,
-  and \code{Future<\flatten{S}>} is assignable to \DYNAMIC{} for all $S$.
+  and \code{Future<\Flatten{S}>} is assignable to \DYNAMIC{} for all $S$.
   However, an asynchronous non-generator function
   that declares a return type which is not ``voidy''
   must return an expression explicitly.%
@@ -19477,7 +19477,7 @@ Let $S$ be the run-time type of $o$ and
 let $T$ be the actual return type of $f$
 (\ref{actualTypes}).
 If the body of $f$ is marked \ASYNC{} (\ref{functions})
-and $S$ is a subtype of \code{Future<\flatten{T}>}
+and $S$ is a subtype of \code{Future<\Flatten{T}>}
 then let $r$ be the result of evaluating \code{await $v$}
 where $v$ is a fresh variable bound to $o$.
 Otherwise let $r$ be $o$.

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -24218,7 +24218,7 @@ if none of the following criteria is satisfied:
 \item $T$ is a type variable (\ref{generics}).
 \item $T$ is a function type (\ref{functionTypes}).
 \item $T$ is a type alias whose transitive alias expansion
-  (\ref{typedef}) does not denote a class.
+  (\ref{typedef}) does not denote a type building type.
 \item $T$ is an enumerated type (\ref{enums}).
 \item $T$ is a deferred type (\ref{staticTypes}).
 \end{itemize}


### PR DESCRIPTION
This PR was created by deleting the sections from `Subtypes` to (but not including) `Reference` plus the appendix `Algorithmic Subtyping`, and inserting the section `Subtypes` from the null safety update branch plus all the following sections until (but not including) `Reference`, plus the new version of the appendix `Algorithmic Subtyping`.

The point is that this PR introduces a large chunk of the new material related to null safety which is introduced into the language specification, and it does not include all the small changes to sections that are mostly the same as before (those changes will be submitted as other PRs later on). In other words, the text before `Subtyping` is unchanged (apart from the fixes mentioned below), and references from the new material to any location before `Subtyping` may thus very well refer to obsolete language.

A couple of other updates were necessary in order to make the result LaTeX'able:

- `dart.sty` was updated to be the version used with the null safety PR (the new version includes a number of declarations that are used by the material about null safety).
- `dartLangSpec.tex` was updated to use `\Delta` rather than `\Gamma` to denote a type variable environment (that's the common notation; we previously used `\Gamma`, but that's typically a "term" variable environment, so `\Delta` would be less confusing for readers who also read research papers involving type systems).
- `\RawFunctionTypeNamed` was updated to allow for the `required` modifier; a couple of changes were necessary in sections before `Subtyping` in order to make dartLangSpec.tex LaTeX'able again, but this only involved adding the new LaTeX macro argument `{r}`, further updates will take place later on (this update just updates stuff from `Subtyping` and out).
- The symbol used to indicate that a word or phrase is being defined was changed from `\diamond` to `\triangle`, because `\triangle` is now also used over `=` in order to indicate that a certain term of the form `A = B` defines `A`.
- Compile-time errors are now also indicated in the margin (using an `\ominus` symbol, similar to the symbolic traffic sign meaning "No entrance"), this symbol is used in the new material, that is, nowhere before section `Subtyping`; for instance, it occurs in section `Type Null`.

Unfortunately, the diff algorithm in git (and, probably, almost any diff algorithm) does not quite understand that the operation performed here is "delete two big chunks of text and insert replacements that are mostly new material", but it does seem to get on track after a while.