### PR TITLE
Fix broken link in `optional-semicolons-prototype`

### DIFF
--- a/resources/optional-semicolons-prototype.md
+++ b/resources/optional-semicolons-prototype.md
@@ -1,7 +1,7 @@
 This is a quick write-up of the investigation I did around optional semicolons
 after writing the [Terminating Tokens][] proposal.
 
-[terminating tokens]: https://github.com/dart-lang/language/tree/master/working/terminating-tokens
+[terminating tokens]: https://github.com/dart-lang/language/tree/master/inactive/terminating-tokens.md
 
 That proposal was a thorough experiment to see if it's possible to make
 semicolons optional with a minimum of breakage to existing code. I think the


### PR DESCRIPTION
[Terminating Tokens](https://github.com/dart-lang/language/blob/9daaad1d2103dcb7ad91f3ebf27a878c13fca985/inactive/terminating-tokens.md) was moved from working to inactive in #1024 but the links were not updated.