### PR TITLE
Adjust `primitive operator ==` to `primitive equality`, and include `hashCode`

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -38,6 +38,8 @@
 % Dec 2022
 % - Change the definition of the type function 'flatten' to resolve soundness
 %   issue, cf. SDK issue #49396.
+% - Change 'primitive operator ==' to 'primitive equality', and include
+%   constraints on `hashCode` corresponding to the ones we have on `==`.
 %
 % 2.15
 % - Allow generic instantiation of expressions with a generic function type
@@ -3233,39 +3235,40 @@ because this is an invocation of a function object
 \end{dartCode}
 
 
-\subsubsection{The Operator `=='}
+\subsubsection{The Operator `==' and Primitive Equality}
 \LMLabel{theOperatorEqualsEquals}
 
 \LMHash{}%
 The operator \lit{==} is used implicitly in certain situations,
 and in particular constant expressions
 (\ref{constants})
-give rise to constraints on that operator.
-In order to specify these constraints just once we introduce the notion of a
-% Neither \syntax nor \lit works, so we fall back to `\code{==}'.
-\IndexCustom{primitive operator `\code{==}'}{%
-  operator `\code{==}'!primitive}:
+give rise to constraints on that operator,
+as well as on the getter \code{hashCode}.
+In order to specify these constraints just once we introduce the notion of
+\Index{primitive equality}:
 
 \begin{itemize}
 \item Every instance of type \code{int} and \code{String}
-  has a primitive operator \lit{==}.
+  has primitive equality.
 \item Every instance of type \code{Symbol}
   which was originally obtained by evaluation of a literal symbol or
   a constant invocation of a constructor of the \code{Symbol} class
-  has a primitive operator \lit{==}.
+  has primitive equality.
 \item Every instance of type \code{Type}
   which was originally obtained by evaluating a constant type literal
   (\ref{dynamicTypeSystem})
-  has a primitive operator \lit{==}.
-\item An instance $o$ has a primitive operator \lit{==}
+  has primitive equality.
+\item An instance $o$ has primitive equality
   if the dynamic type of $o$ is a class $C$,
-  and $C$ has a primitive operator \lit{==}.
-\item The class \code{Object} has a primitive operator \lit{==}.
-\item A class $C$ has a primitive operator \lit{==}
+  and $C$ has primitive equality.
+\item The class \code{Object} has primitive equality.
+\item A class $C$ has primitive equality
   if it does not have an implementation of the operator \lit{==}
+  that overrides the one inherited from \code{Object},
+  and it does not have an implementation of the getter \code{hashCode}
   that overrides the one inherited from \code{Object}.
   \commentary{%
-  In particular, the following have a primitive operator \lit{==}:
+  In particular, the following have primitive equality:
   The null object (\ref{null}),
   function objects obtained by function closurization of
   a static method or a top-level function
@@ -3282,10 +3285,11 @@ In order to specify these constraints just once we introduce the notion of a
 \end{itemize}
 
 \LMHash{}%
-When we say that the operator \lit{==} of a given instance or class
-\IndexCustom{is not primitive}{operator `\code{==}'!is not primitive},
+When we say that a given instance or class
+\IndexCustom{does not have primitive equality}{%
+  primitive equality!does not have},
 it means that it is not true that said instance or class
-has a primitive operator \lit{==}.
+has primitive equality.
 
 
 \subsection{Getters}
@@ -10911,8 +10915,8 @@ It is a compile-time error if
 a collection literal element in a constant set literal
 is not a constant expression.
 It is a compile-time error if
-the operator \lit{==} of an element expression in a constant set literal
-is not primitive
+an element in a constant set literal
+does not have primitive equality
 (\ref{theOperatorEqualsEquals}).
 It is a compile-time error if two elements of a constant set literal are equal
 according to their \lit{==} operator
@@ -11107,8 +11111,8 @@ which means that \CONST{} modifiers need not be specified explicitly.%
 It is a compile-time error
 if a collection literal element in a constant map literal is not constant.
 It is a compile-time error if
-the operator \lit{==} of a key in a constant map literal
-is not primitive
+a key in a constant map literal
+does not have primitive equality
 (\ref{theOperatorEqualsEquals}).
 It is a compile-time error if two keys of a constant map literal are equal
 according to their \lit{==} operator
@@ -17893,8 +17897,8 @@ and are independent of any type annotations.%
 }
 
 \LMHash{}%
-It is a compile-time error if the operator \lit{==} of class $C$
-is not primitive
+It is a compile-time error if the class $C$
+does not have primitive equality
 (\ref{theOperatorEqualsEquals}).
 
 \rationale{%

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -3242,46 +3242,66 @@ because this is an invocation of a function object
 The operator \lit{==} is used implicitly in certain situations,
 and in particular constant expressions
 (\ref{constants})
-give rise to constraints on that operator,
-as well as on the getter \code{hashCode}.
+give rise to constraints on that operator.
+The situation is similar with the getter \code{hashCode}.
 In order to specify these constraints just once we introduce the notion of
-\Index{primitive equality}:
+\Index{primitive equality}.
+
+\rationale{%
+Certain constant expressions are known to have a value
+whose equality is primitive.
+This is useful to know because it allows
+the value of equality expressions
+and the value of invocations of \code{hashCode}
+to be computed at compile-time.
+In particular, this can be used to build
+constant collections at compile-time,
+and it can be used to check that
+all elements in a constant set are distinct,
+and all keys in a constant map are distinct.%
+}
 
 \begin{itemize}
-\item Every instance of type \code{int} and \code{String}
+\item The null object has primitive equality
+  (\ref{null}).
+\item Every instance of type \code{bool}, \code{int}, and \code{String}
   has primitive equality.
 \item Every instance of type \code{Symbol}
   which was originally obtained by evaluation of a literal symbol or
   a constant invocation of a constructor of the \code{Symbol} class
   has primitive equality.
-\item Every instance of type \code{Type}
+\item
+  %% TODO(eernst): With Dart 2.15, we need to mention `List<int>` here,
+  %% unless 'constant type literal' includes that case.
+  Every instance of type \code{Type}
   which was originally obtained by evaluating a constant type literal
   (\ref{dynamicTypeSystem})
   has primitive equality.
-\item An instance $o$ has primitive equality
-  if the dynamic type of $o$ is a class $C$,
-  and $C$ has primitive equality.
-\item The class \code{Object} has primitive equality.
-\item A class $C$ has primitive equality
-  if it does not have an implementation of the operator \lit{==}
-  that overrides the one inherited from \code{Object},
-  and it does not have an implementation of the getter \code{hashCode}
-  that overrides the one inherited from \code{Object}.
-  \commentary{%
-  In particular, the following have primitive equality:
-  The null object (\ref{null}),
-  function objects obtained by function closurization of
-  a static method or a top-level function
-  (\ref{functionClosurization}),
-  instances of type \code{bool}
-  (\ref{booleans}),
-  and instances obtained by evaluation of a list literal
+\item
+  Let $o$ be an object obtained by evaluation of a list literal
   (\ref{lists}),
   a map literal
   (\ref{maps}), or
   a set literal
-  (\ref{sets}).%
-  }
+  (\ref{sets}),
+  then $o$ has primitive equality.
+\item
+  A function object obtained by function closurization of
+  a static method or a top-level function
+  (\ref{functionClosurization})
+  has primitive equality.
+\item
+  An instance $o$ has primitive equality
+  if the dynamic type of $o$ is a class $C$,
+  and $C$ has primitive equality.
+\item
+  The class \code{Object} has primitive equality.
+\item
+  A class $C$ has primitive equality
+  if it does not have an implementation of the operator \lit{==}
+  that overrides the one inherited from \code{Object},
+  and it does not have an implementation of the getter \code{hashCode}
+  that overrides the one inherited from \code{Object}.
 \end{itemize}
 
 \LMHash{}%
@@ -8688,8 +8708,11 @@ It is a compile-time error for a class to extend, mix in or implement
 \code{Null}.
 The \code{Null} class extends the \code{Object} class
 and declares no methods except those also declared by \code{Object}.
-In particular, the \code{Null} class does not override the \lit{==} operator
-inherited from the \code{Object} class.
+
+\commentary{%
+The null object has primitive equality
+(\ref{theOperatorEqualsEquals}).%
+}
 
 \LMHash{}%
 The static type of \NULL{} is the \code{Null} type.
@@ -8840,9 +8863,10 @@ and there are no other objects that implement \code{bool}.
 It is a compile-time error for a class to
 extend, mix in or implement \code{bool}.
 
-\LMHash{}%
-The \code{bool} class does not override the \lit{==} operator inherited from
-the \code{Object} class.
+\commentary{%
+The \TRUE{} and \FALSE{} objects have primitive equality
+(\ref{theOperatorEqualsEquals}).%
+}
 
 \LMHash{}%
 Invoking the getter \code{runtimeType} on a boolean value returns
@@ -13019,9 +13043,12 @@ corresponding to the signature in the function declaration $f$,
 using the current bindings of type variables, if any.
 There does not exist a function type $F'$ which is a proper subtype of $F$
 such that $C$ is a subtype of $F'$.
-If $f$ denotes a static method or top-level function,
-class $C$ does not override the \lit{==} operator
-inherited from the \code{Object} class.
+
+\commentary{%
+If $f$ is a static method or a top-level function
+then $o$ has primitive equality
+(\ref{theOperatorEqualsEquals}).%
+}
 
 \commentary{%
 In other words, $C$ has the freedom to be a proper subtype of


### PR DESCRIPTION
This PR updates the language specification such that the notion of having a 'primitive operator `==`' is replaced by the notion of having 'primitive equality', and it adds constraints on the objects and classes such that they only have primitive equality if they satisfy some constraints on operator `==` (same as before) and on `hashCode` (which is new).

The point is that we wish to maintain that equality as a whole (involving operator `==` as well as `hashCode`) can be relied upon to have a behavior which is known by language processing tools (such as compilers and analyzers). The rules of today (before this PR) allow `hashCode` to be overridden arbitrarily, and this implies that constant sets and non-constant hash sets would have different semantics in the case where the overridden `hashCode` is inconsistent with operator `==`, which seems to be a mal-feature for everybody.
