### PR TITLE
Update the grammar to allow augmenting all types of constructors

### DIFF
--- a/working/augmentation-libraries/feature-specification.md
+++ b/working/augmentation-libraries/feature-specification.md
@@ -604,9 +604,9 @@ declaration ::= 'external' factoryConstructorSignature
   | 'augment'? 'covariant' 'late'? varOrType initializedIdentifierList
   | 'augment'? 'late'? 'final' type? initializedIdentifierList
   | 'augment'? 'late'? varOrType initializedIdentifierList
-  | redirectingFactoryConstructorSignature
-  | constantConstructorSignature (redirection | initializers)?
-  | constructorSignature (redirection | initializers)?
+  | 'augment'? redirectingFactoryConstructorSignature
+  | 'augment'? constantConstructorSignature (redirection | initializers)?
+  | 'augment'? constructorSignature (redirection | initializers)?
 ```
 
 **TODO: Define the grammar for the various `augment super` expressions.**


### PR DESCRIPTION
Allow augmenting constructors with all the non-standard types of constructors (redirecting factories or regular constructors and const constructors).

Fixes https://github.com/dart-lang/language/issues/2136