### PR TITLE
Adjust wording about extension vs. static method conflicts

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -5840,8 +5840,8 @@ Moreover, a compile-time error occurs in the following situations:
 \item $D$ declares a member whose basename is the name of a type parameter
   of $D$.
 \item $D$ declares an instance member or a static member whose basename is
-  \code{hashCode}, \code{noSuchMethod}, \code{runtimeType}, or \code{toString}.
-  Or $D$ declares an operator named \lit{==}.
+  \code{hashCode}, \code{noSuchMethod}, \code{runtimeType}, \code{toString},
+  or \lit{==}.
   \commentary{%
     That is, a member whose basename is also the name of
     an instance member that every object has.%

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -39,6 +39,8 @@
 % - Adjust and clarify simple string interpolation (to allow `'$this'`, which
 %   is already implemented and useful).
 % - Add several lexical rules about identifiers, clarifying different kinds.
+% - Clarify the conflicts between extension members and `Object` instance
+%   members.
 %
 % 2.14
 % - Add constraint on type of parameter which is covariant-by-declaration in
@@ -5837,8 +5839,8 @@ Moreover, a compile-time error occurs in the following situations:
 \item $D$ declares a type parameter named \code{E}.
 \item $D$ declares a member whose basename is the name of a type parameter
   of $D$.
-\item $D$ declares a member (static or not) with the same basename as a
-  member declared by the built-in class \code{Object}.
+\item $D$ declares a member (static or not) with the same basename as an
+  instance member declared by the built-in class \code{Object}.
 \item $D$ declares a constructor.
 \item $D$ declares an instance variable.
 \item $D$ declares an abstract member.

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -5839,8 +5839,13 @@ Moreover, a compile-time error occurs in the following situations:
 \item $D$ declares a type parameter named \code{E}.
 \item $D$ declares a member whose basename is the name of a type parameter
   of $D$.
-\item $D$ declares a member (static or not) with the same basename as an
-  instance member declared by the built-in class \code{Object}.
+\item $D$ declares an instance member or a static member whose basename is
+  \code{hashCode}, \code{noSuchMethod}, \code{runtimeType}, or \code{toString}.
+  Or $D$ declares an operator named \lit{==}.
+  \commentary{%
+    That is, a member whose basename is also the name of
+    an instance member that every object has.%
+  }
 \item $D$ declares a constructor.
 \item $D$ declares an instance variable.
 \item $D$ declares an abstract member.


### PR DESCRIPTION
The section about extensions in the language specification had an imprecise wording about conflicts involving an extension member (static or not) and a member of the class `Object`. This PR clarifies the text: Such conflicts only arise when the member of `Object` is an instance member.