### PR TITLE
Correct <partDeclaration>

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -19773,7 +19773,7 @@ may be found.
 
 <partHeader> ::= <metadata> \PART{} \OF{} (<dottedIdentifierList> | <uri>) `;'
 
-<partDeclaration> ::=\gnewline{}
+<partDeclaration> ::=
   <partHeader> (<metadata> <topLevelDeclaration>)* <EOF>
 \end{grammar}
 

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -41,6 +41,7 @@
 % - Add several lexical rules about identifiers, clarifying different kinds.
 % - Clarify the conflicts between extension members and `Object` instance
 %   members.
+% - Correct <partDeclaration> to include metadata.
 %
 % 2.14
 % - Add constraint on type of parameter which is covariant-by-declaration in
@@ -19772,7 +19773,8 @@ may be found.
 
 <partHeader> ::= <metadata> \PART{} \OF{} (<dottedIdentifierList> | <uri>) `;'
 
-<partDeclaration> ::= <partHeader> <topLevelDeclaration>* <EOF>
+<partDeclaration> ::=\gnewline{}
+  <partHeader> (<metadata> <topLevelDeclaration>)* <EOF>
 \end{grammar}
 
 \LMHash{}%


### PR DESCRIPTION
Cf. https://github.com/dart-lang/language/issues/2279. The grammar rule on `<partDeclaration>` in the language specification fails to include `<metadata>`. This PR adds it.