### PR TITLE
Specify private override errors

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -5230,7 +5230,11 @@ is $\overrides{I, L}$.
 \commentary{%
 Note that an interface can inherit members that are inaccessible
 (because they are private to a different library),
-but it can only override members that are accessible.%
+but it can only override members that are accessible.
+This is the reason why it is called ``with respect to $K$''
+when the topic is inheritance,
+but no library is mentioned when the topic is overriding:
+only one library is relevant, namely the one that declares $C$.%
 }
 
 \LMHash{}%
@@ -5240,12 +5244,15 @@ $m$ if $I$ inherits $m$ with respect to any library,
 or $I$ overrides $m$.
 
 \LMHash{}%
-\BlindDefineSymbol{I, K, n, m}%
-Let $I$ be an interface, $K$ a library, and
-$n$ a name such that a member $m$ with the name $n$
+\BlindDefineSymbol{I, C, K, n, m}%
+Let $I$ be the interface of the class $C$ declared by the library $L$,
+$K$ a library
+(\commentary{which may or may not be the same as $L$}),
+and $n$ a name such that a member $m$ with the name $n$
 is inherited by $I$ with respect to $K$.
 \commentary{%
-Note that there may be more than one such member.%
+Note that there may be more than one such member,
+and also that $C$ does not override $m$.%
 }
 The
 \IndexCustom{member signature}{interface!member signature}
@@ -5256,6 +5263,21 @@ In the case where the computation of the combined member signature fails,
 we say that $I$ has a
 \IndexCustom{member signature conflict}{interface!member signature conflict}
 with respect to $n$ and $K$.
+
+\commentary{%
+When $n$ is a public name, $K$ can be $L$
+or any other library where $C$ is in scope.
+In other words, $K$ does not matter.
+But when $n$ is a private name then
+$K$ must be the library that declares $m$,
+such that $m$ is accessible to $K$.
+This covers the case where the interface $I$
+(as well as the underlying class $C$) has
+a member signature conflict on
+a member which is private to another library.
+This can be a compile-time error
+(\ref{classes}).%
+}
 
 
 \subsubsection{Correct Member Overrides}


### PR DESCRIPTION
Cf. https://github.com/dart-lang/language/issues/2263#issuecomment-1145106457, this PR eliminates the notion of a 'combined interface' from the language specification and clarifies the specification of how to check override errors. The main point in doing that is that it specifies how incorrect overrides are detected and reported in the case where a class or a similar declaration in a library _L_ gives rise to an error involving private members that aren't accessible to _L_.

The discussion about this change gave rise to the following [summary of the rules](https://github.com/dart-lang/language/issues/2263#issuecomment-1145106457).

I've added some remarks inline to indicate that we do in fact have these properties.

> More concretely, this means that we end up with the following as the
> proposed semantics for the errors and warnings around a given method
> `m` with respect to a class declaration `C` in library `L`:

> Case: `m` is declared in `C` (`C` is abstract, or concrete, `m` must be accessible in `L` by definition)
> - We don’t require that `m` have a combined signature in the super-interfaces
> - We do require that `m` is a proper override of all signatures for `m` from all direct super-interfaces

We already specify this requirement for methods, abstract as well as concrete in [line 2724](https://github.com/dart-lang/language/blob/812f939ec0130da119ad2cbe5f9a4121e31b0831/specification/dartLangSpec.tex#L2722).

This PR moves that rule from the section 'Instance Methods' to the section 'Classes', because it is relevant to getters and setters as well (the rule was worded correctly, but it was basically misplaced).

> - The declared signature of `m` from `C` becomes the signature of `m` in the interface of `C`

This is already specified in [line 4917](https://github.com/dart-lang/language/blob/812f939ec0130da119ad2cbe5f9a4121e31b0831/specification/dartLangSpec.tex#L4917).

> Case: `m` is not declared in `C` (`m` may be accessible in `L` or not)
> - We require that a combined member signature for `m` WRT to the direct super-interfaces of `C` exist, including private members (i.e. even if `m` is not accessible in `L`, we still require that a combined member signature exist for `m`).

This was not stated unambiguously. This PR changes `\ref{interfaceInheritanceAndOverriding}` such that it is explicitly defined to be a 'member signature conflict' if an interface brings together two member signatures such that no combined member signature can be computed, and the section about classes says that it is a compile-time error if the interface of the class has any of these member signature conflicts.

This covers mixins as well, because of the phrase 'It is a compile-time error for the mixin declaration if the $M_S$ class declaration would cause a compile-time error' in the section about mixin declarations.

> - The combined member signature of `m` becomes the signature of `m` in the interface of `C`.

This is defined as the combined member signature of a name with respect to a library, and it is defined as mentioned here in `\ref{interfaceInheritanceAndOverriding}`.

> - If `C` is abstract, we are done: we do not require that `C` implement its interface
> - If `C` is concrete and `m` is public, we separately require that the concrete implementation of `m` implement its signature in the interface as defined above.

This is already covered by the section ['Fully Implementing an Interface'](https://github.com/dart-lang/language/blob/812f939ec0130da119ad2cbe5f9a4121e31b0831/specification/dartLangSpec.tex#L2575).

> - If `C` is concrete and `m` is private to a different library, we introduce a noSuchMethod thrower (forced by privacy) with the combined member signature for `m` as defined above.

This is already covered [here](https://github.com/dart-lang/language/blob/812f939ec0130da119ad2cbe5f9a4121e31b0831/specification/dartLangSpec.tex#L3004).

>
> These restrictions enforce the following properties:
>
> Every class (abstract or concrete) has a single well-defined signature for every member (accessible or not) in its interface.
> Every concrete class has a single well-defined concrete implementation of every member (accessible or not) in its interface, and that implementation correctly implements the signature from the previous bullet.

