### PR TITLE
Correct `typeIdentifier` to include `dynamic`

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -16567,6 +16567,7 @@ than it is to any single one of those grammar rules where it is used.%
 
 <typeIdentifier> ::= <IDENTIFIER>
   \alt <OTHER\_IDENTIFIER>
+  \alt \DYNAMIC{}
 
 <qualifiedName> ::= <typeIdentifier> `.' <identifier>
   \alt <typeIdentifier> `.' <typeIdentifier> `.' <identifier>


### PR DESCRIPTION
The language specification currently has a grammar rule where `<typeIdentifier>` does not include `dynamic`, which is a mistake. This PR adds it. Thanks to @kaby76 for noticing this issue!

`Function` was mentioned in the same context, but `typeIdentifier` should actually not include `Function`. The word `Function` is treated specially in the rules about `<type>`, because it is used in ways that would otherwise give rise to ambiguities.

Resolves https://github.com/dart-lang/language/issues/2276.