### PR TITLE
Breaking change to await, update to flatten.

### DIFF
--- a/specification/dart.sty
+++ b/specification/dart.sty
@@ -281,7 +281,7 @@
 % name of optional parameters, number of optional parameters.
 \newcommand{\FunctionTypeNamedArguments}[4]{%
   \List{#1}{1}{#2},\ \{\PairList{#1}{#3}{{#2}+1}{{#2}+{#4}}\}}
-  
+
 \newcommand{\FunctionTypeNamedArgumentsStd}{%
   \FunctionTypeNamedArguments{T}{n}{x}{k}}
 
@@ -386,6 +386,12 @@
 \newcommand{\LiteralSequence}[1]{\ensuremath{[\![{#1}]\!]}}
 \newcommand{\EvaluateElementName}{\metavar{evaluateElement}}
 \newcommand{\EvaluateElement}[1]{\ensuremath{\EvaluateElementName({#1})}}
+
+\newcommand{\DefEquals}[2]{\ensuremath{{#1}\stackrel{\vartriangle}{=}{#2}}}
+\newcommand{\DefEqualsNewline}[2]{
+  \ensuremath{{#1}\stackrel{\vartriangle}{=}}\\
+  \ensuremath{{#2}}%
+}
 
 % ----------------------------------------------------------------------
 % Support for hash valued Location Markers

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -11271,15 +11271,18 @@ which is used below and in other sections, as follows:
   or $T$ is an intersection type
   (\ref{intersectionTypes})
   \code{$X$\,\,\&\,\,$B$},
-  then $\flatten{T} = \flatten{B}$.
+  then \DefEquals{\flatten{$T$}}{\code{\flatten{$B$}}}.
 
-\item Otherwise if $T$ is \code{FutureOr<$S$>} for some $S$
-    then $\flatten{T} = S$.
+\item If $T$ is \code{$S$?}\ for some $S$
+  then \DefEquals{\flatten{$T$}}{\code{\flatten{$S$}?}}.
 
-\item Otherwise if $T$ implements \code{Future<$S$>} for some $S$
-    (\ref{interfaceSuperinterfaces}) then $\flatten{T} = S$.
+\item If $T$ is \code{FutureOr<$S$>} then \DefEquals{\flatten{$T$}}{S}.
 
-\item In any other circumstance, $\flatten{T} = T$.
+\item If $T$ implements \code{Future<$S$>}
+  (\ref{interfaceSuperinterfaces})
+  then \DefEquals{\flatten{$T$}}{S}.
+
+\item Otherwise, \DefEquals{\flatten{$T$}}{T}.
 \end{itemize}
 
 \commentary{%

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -15988,7 +15988,9 @@ Let $R$ be the run-time type of $o$.
 If $R$ implements \code{Future<$S$>} for some $S$
 (\ref{interfaceSuperinterfaces}) then
 it is a dynamic type error if $S$ is not a subtype of $T$.
-If $S$ is a subtype of $T$, let $f$ be $o$.
+Otherwise
+(\commentary{if no run-time error occurred}),
+let $f$ be $o$.
 
 Otherwise (when $R$ does not implement \code{Future}),
 let $f$ be a future object, implementing \code{Future<$T$>},

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -13748,7 +13748,7 @@ to an object---that would not even be possible for an extension.%
 }
 
 \commentary{%
-An member access on a type literal
+A member access on a type literal
 (e.g., \code{C.id()}, \code{C.id}, or \code{C?.id()}),
 always treats the declaration denoted by the literal as
 a namespace for accessing static members or constructors.

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -11267,22 +11267,22 @@ We define the auxiliary function
 which is used below and in other sections, as follows:
 
 \begin{itemize}
-\item If $T$ is a type variable $X$ with bound $B$,
+\item{} If $T$ is a type variable $X$ with bound $B$,
   or $T$ is an intersection type
   (\ref{intersectionTypes})
   \code{$X$\,\,\&\,\,$B$},
-  then \DefEquals{\flatten{$T$}}{\code{\flatten{$B$}}}.
+  then \DefEquals{\flatten{T}}{\flatten{B}}.
 
-\item If $T$ is \code{$S$?}\ for some $S$
-  then \DefEquals{\flatten{$T$}}{\code{\flatten{$S$}?}}.
+\item{} If $T$ is \code{$S$?}\ for some $S$
+  then \DefEquals{\flatten{T}}{\code{\flatten{S}?}}.
 
-\item If $T$ is \code{FutureOr<$S$>} then \DefEquals{\flatten{$T$}}{S}.
+\item{} If $T$ is \code{FutureOr<$S$>} then \DefEquals{\flatten{T}}{S}.
 
-\item If $T$ implements \code{Future<$S$>}
+\item{} If $T$ implements \code{Future<$S$>}
   (\ref{interfaceSuperinterfaces})
-  then \DefEquals{\flatten{$T$}}{S}.
+  then \DefEquals{\flatten{T}}{S}.
 
-\item Otherwise, \DefEquals{\flatten{$T$}}{T}.
+\item{} Otherwise, \DefEquals{\flatten{T}}{T}.
 \end{itemize}
 
 \commentary{%

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -15996,7 +15996,7 @@ let $f$ be $o$.
 
 Otherwise
 (\commentary{when $R$ does not implement \code{Future}}),
-let $f$ be a future object, implementing \code{Future<$T$>},
+let $f$ be an object whose run-time type implements \code{Future<$T$>},
 which is completed with the value $o$.
 
 \LMHash{}%

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -11267,32 +11267,23 @@ We define the auxiliary function
 which is used below and in other sections, as follows:
 
 \begin{itemize}
-\item If $T$ is \code{FutureOr<$S$>} for some $S$ then $\flatten{T} = S$.
+\item If $T$ is a type variable $X$ with bound $B$,
+  or $T$ is a promoted type variable $X & B$,
+  then $\flatten{T} = \flatten{B}$.
 
-\item Otherwise if
-  \code{$T <:$ Future}
-  then let $S$ be a type such that
-  \code{$T <:$ Future<$S$>}
-  and for all $R$, if
-  \code{$T <:$ Future<$R$>}
-  then $S <: R$.
+\item Otherwise if $T$ is \code{FutureOr<$S$>} for some $S$
+    then $\flatten{T} = S$.
 
-  \rationale{%
-    This ensures that
-    \code{Future<$S$>}
-    is the most specific generic instantiation of \code{Future} that is
-    a supertype of $T$.
-    %% TODO[class-interfaces]: When we have finished the specification of class
-    %% interface computations we may have the following property, but it is not
-    %% true at this point. Adjust the following by then!
-    Note that $S$ is well-defined because of
-    the requirements on superinterfaces.%
-  }
-
-  Then $\flatten{T} = S$.
+\item Otherwise if $T$ implements \code{Future<$S$>} for some $S$
+    (\ref{interfaceSuperinterfaces}) then $\flatten{T} = S$.
 
 \item In any other circumstance, $\flatten{T} = T$.
 \end{itemize}
+
+\commentary{%
+This definition guarantees that for any type $T$,
+\code{$T <:$ FutureOr<$\flatten{T}$>}.%
+}
 
 \LMHash{}%
 \Case{Positional, arrow}
@@ -13755,7 +13746,7 @@ to an object---that would not even be possible for an extension.%
 }
 
 \commentary{%
-An member access on a type literal 
+An member access on a type literal
 (e.g., \code{C.id()}, \code{C.id}, or \code{C?.id()}),
 always treats the declaration denoted by the literal as
 a namespace for accessing static members or constructors.
@@ -15993,11 +15984,15 @@ of $T$ nor of \code{Future<$T$>})}.
 % NOTICE: Removed the requirement that an error thrown by $e$ is caught in a
 % future. There is no reason $var x = e; await x;$ and $await e$ should behave
 % differently, and no implementation actually implemented it.
-If the run-time type of $o$ is a subtype of \code{Future<$T$>},
-then let $f$ be $o$;
-otherwise let $f$ be the result of creating
-a new object using the constructor \code{Future<$T$>.value()}
-with $o$ as its argument.
+Let $R$ be the run-time type of $o$.
+If $R$ implements \code{Future<$S$>} for some $S$
+(\ref{interfaceSuperinterfaces}) then
+it is a dynamic type error if $S$ is not a subtype of $T$.
+If $S$ is a subtype of $T$, let $f$ be $o$.
+
+Otherwise (when $R$ does not implement \code{Future}),
+let $f$ be a future object, implementing \code{Future<$T$>},
+which is completed with the value $o$.
 
 \LMHash{}%
 Next, the stream associated with the innermost enclosing asynchronous for loop

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -11268,7 +11268,9 @@ which is used below and in other sections, as follows:
 
 \begin{itemize}
 \item If $T$ is a type variable $X$ with bound $B$,
-  or $T$ is a promoted type variable $X & B$,
+  or $T$ is an intersection type
+  (\ref{intersectionTypes})
+  \code{$X$\,\,\&\,\,$B$},
   then $\flatten{T} = \flatten{B}$.
 
 \item Otherwise if $T$ is \code{FutureOr<$S$>} for some $S$

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -15994,7 +15994,8 @@ Otherwise
 (\commentary{if no run-time error occurred}),
 let $f$ be $o$.
 
-Otherwise (when $R$ does not implement \code{Future}),
+Otherwise
+(\commentary{when $R$ does not implement \code{Future}}),
 let $f$ be a future object, implementing \code{Future<$T$>},
 which is completed with the value $o$.
 


### PR DESCRIPTION
Changes **flatten** to be specified for a static type which is a type variable.

Changes `await` to throw when provided a `Future` value
of a type that could provide an unsound value if awaited.

This differes from the current specification, which instead treats the future as
a value, so `await someFuture` can evaluate to `someFuture`.

It also differs from the current implementation,
which awaits `someFuture` to its value,
whether the result is sound or not.

The result *can* be sound. Compare:
```dart
Object o = await (Future<Object?>.value(3) as FutureOr<Object));
```
which ends up not breaking soundness, with
```dart
Object o = await (Future<Object?>.value(null) as FutureOr<Object));
```
which currently does break soundness.

This change will make both into runtime errors.

(The alternative, and current specification,
to make both expression evaluate to the future itself,
is considered just as error prone and harder to debug,
since a type error is likely happen further downstream
when the `Object` is unexpectedly still a `Future`.)