### PR TITLE
Fix URL typo

### DIFF
--- a/working/0731 - horizontal inference/feature-specification.md
+++ b/working/0731 - horizontal inference/feature-specification.md
@@ -2,5 +2,4 @@
 
 **MOVED TO ACCEPTED**
 
-Further development happens in the [accepted folder](../../accepted/future-releases/horizontal-inference/feature_specification.md).
-
+Further development happens in the [accepted folder](../../accepted/future-releases/horizontal-inference/feature-specification.md).


### PR DESCRIPTION
This PR fixes a typo in a link from the old location for a feature spec (working) to the current one (accepted).