### PR TITLE
Change noSuchMethod example to be correct with null safety

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -2965,7 +2965,7 @@ Note that it must be a method that accepts one positional argument,
 in order to correctly override \code{noSuchMethod} in \code{Object}.
 For instance, it can have signature
 \code{noSuchMethod(Invocation i)} or
-\code{noSuchMethod(Object i, [String s])},
+\code{noSuchMethod(Object i, [String s = ''])},
 but not
 \code{noSuchMethod(Invocation i, String s)}.
 This implies that the situation where \code{noSuchMethod} is invoked


### PR DESCRIPTION
Cf. https://github.com/dart-lang/language/pull/2052. This PR changes an example in the language specification section on `noSuchMethod` such that it is correct with null safety (it is correct without null safety as well, so we can do it now, and it will simply be there when we land the null safety updates).