### PR TITLE
Address a bunch of records issues.

### DIFF
--- a/working/0546-patterns/records-feature-specification.md
+++ b/working/0546-patterns/records-feature-specification.md
@@ -429,17 +429,23 @@ calling `toString()` or relying on it for end-user visible output.
 
 #### Equality
 
-The `==` method on record `r` with right operand `o` is defined as:
+Records have value equality, which means two records are equal if they have the
+same shape and the corresponding fields are equal. Since named field order is
+*not* part of a record's shape, that implies that the order of named fields
+does not affect equality:
 
-1.  If `o` is not a record with the same shape as `r` then return `false`.
+```dart
+var a = (x: 1, 2);
+var b = (2, x: 1);
+print(a == b); // true.
+```
 
-1.  For each pair of corresponding positional fields `rf` and `of` in position
-    order:
+More precisely, the `==` method on record `r` with right operand `o` is defined
+as:
 
-    1.  If `rf == of` is `false` then return `false`.
+1.  If `o` is not a record with the same shape as `r` then `false`.
 
-1.  For each pair of corresponding named fields `rf` and `of`, in unspecified
-    order:
+1.  For each pair of corresponding fields `rf` and `of` in unspecified order:
 
     1.  If `rf == of` is `false` then `false`.
 
@@ -447,15 +453,9 @@ The `==` method on record `r` with right operand `o` is defined as:
 
 *The order that fields are iterated is potentially user-visible since
 user-defined `==` methods can have side effects. Most well-behaved `==`
-implementations are pure. The order that named fields are visited is
-deliberately left unspecified so that implementations are free to canonicalize
-their order.*
-
-```dart
-var a = (x: 1, 2);
-var b = (2, x: 1);
-print(a == b); // true.
-```
+implementations are pure. The order that fields are visited is deliberately left
+unspecified so that implementations are free to reorder the field comparisons
+for performance.*
 
 The implementation of `hashCode` follows this. The hash code returned should
 depend on the field values such that two records that compare equal must have

--- a/working/0546-patterns/records-feature-specification.md
+++ b/working/0546-patterns/records-feature-specification.md
@@ -374,11 +374,27 @@ calling `toString()` or relying on it for end-user visible output.
 
 #### Equality
 
-Records behave similar to other primitive types in Dart with regards to
-equality. They implement `==` such that two records are equal iff they have the
-same shape and all corresponding pairs of fields are equal. Fields are compared
-for equality by calling `==` on the corresponding field values in the same
-order that `==` was called on the records.
+The `==` method on record `r` with right operand `o` is defined as:
+
+1.  If `o` is not a record with the same shape as `r` then return `false`.
+
+1.  For each pair of corresponding positional fields `rf` and `of` in position
+    order:
+
+    1.  If `rf == of` is `false` then return `false`.
+
+1.  For each pair of corresponding named fields `rf` and `of`, in unspecified
+    order:
+
+    1.  If `rf == of` is `false` then `false`.
+
+1.  Else, `true`.
+
+*The order that fields are iterated is potentially user-visible since
+user-defined `==` methods can have side effects. Most well-behaved `==`
+implementations are pure. The order that named fields are visited is
+deliberately left unspecified so that implementations are free to canonicalize
+their order.*
 
 ```dart
 var a = (x: 1, 2);
@@ -386,8 +402,9 @@ var b = (2, x: 1);
 print(a == b); // true.
 ```
 
-The implementation of `hashCode` follows this. Two records that are equal must
-have the same hash code.
+The implementation of `hashCode` follows this. The hash code returned should
+depend on the field values such that two records that compare equal must have
+the same hash code.
 
 #### Identity
 
@@ -467,6 +484,8 @@ covariant in their field types.
 - Specify the behavior of `toString()` (#2389).
 
 - Disambiguate record types in `on` clauses (#2406).
+
+- Clarify the iteration order of fields in `==`.
 
 ### 1.5
 


### PR DESCRIPTION
- Support constant records. Fix #2337.
- Support empty and one-positional-field records. Fix #2386.
- Re-add support for positional field getters Fix #2388.
- Specify the behavior of `toString()`. Fix #2389.
- Disambiguate record types in `on` clauses. Fix #2406.

cc @eernstg @stereotype441 @jakemac53 @natebosch @kallentu @mit-mit 