### PR TITLE
Introduce `ERASEINTERSECTION`

### DIFF
--- a/accepted/2.12/nnbd/feature-specification.md
+++ b/accepted/2.12/nnbd/feature-specification.md
@@ -1150,6 +1150,12 @@ variables with the same bound.
 - **MOREBOTTOM**(`S`, `X&T`) = false
 - **MOREBOTTOM**(`X extends T`, `Y extends S`) = **MOREBOTTOM**(`T`, `S`)
 
+The **ERASEINTERSECTION** function maps `X&T` to `X` and every other type to
+itself.
+
+- **ERASEINTERSECTION**(`X&T`) = `X`
+- **ERASEINTERSECTION**(`T`) = `T`
+
 ### The main function
 
 The section 'Scripts' in the language specification is replaced by the

--- a/resources/type-system/upper-lower-bounds.md
+++ b/resources/type-system/upper-lower-bounds.md
@@ -52,6 +52,7 @@ which are specified in the
 **NULL**, which is true for types equivalent to `Null`;
 **MORETOP**, which is a total order on top and `Object` types; and
 **MOREBOTTOM**, which is an (almost) total order on bottom and `Null` types.
+**ERASEINTERSECTION**, which maps `X & T` to `X` and every other type to itself.
 
 ## Upper bounds
 
@@ -78,12 +79,12 @@ We define the upper bound of two types T1 and T2 to be **UP**(`T1`,`T2`) as foll
 - **UP**(`T1`, `T2`) where **NULL**(`T1`) =
   - `T2` if  `T2` is nullable
   - `T2*` if `Null <: T2` or `T1 <: Object` (that is, `T1` or `T2` is legacy)
-  - `T2?` otherwise
+  - `T3?` otherwise, where `T3` is **ERASEINTERSECTION**(`T2`).
 
 - **UP**(`T1`, `T2`) where **NULL**(`T2`) =
   - `T1` if  `T1` is nullable
   - `T1*` if `Null <: T1` or `T2 <: Object` (that is, `T1` or `T2` is legacy)
-  - `T1?` otherwise
+  - `T3?` otherwise, where `T3` is **ERASEINTERSECTION**(`T1`).
 
 - **UP**(`T1`, `T2`) where **OBJECT**(`T1`) and **OBJECT**(`T2`) =
   - `T1` if **MORETOP**(`T1`, `T2`)
@@ -92,12 +93,12 @@ We define the upper bound of two types T1 and T2 to be **UP**(`T1`,`T2`) as foll
 - **UP**(`T1`, `T2`) where **OBJECT**(`T1`) =
   - `T1` if `T2` is non-nullable
   - `T1*` if `Null <: T2` (that is, `T2` is legacy)
-  - `T1?` otherwise
+  - `T3?` otherwise, where `T3` is **ERASEINTERSECTION**(`T1`).
 
 - **UP**(`T1`, `T2`) where **OBJECT**(`T2`) =
   - `T2` if `T1` is non-nullable
   - `T2*` if `Null <: T1` (that is, `T1` is legacy)
-  - `T2?` otherwise
+  - `T3?` otherwise, where `T3` is **ERASEINTERSECTION**(`T2`).
 
 - **UP**(`T1*`, `T2*`) = `S*` where `S` is **UP**(`T1`, `T2`)
 - **UP**(`T1*`, `T2?`) = `S?` where `S` is **UP**(`T1`, `T2`)


### PR DESCRIPTION
Cf. https://github.com/dart-lang/sdk/issues/49691.

The current definition of the **UP** function (computing the standard upper bound of two types) allows for the creation of a type of the form `(X & T)?`, even though such types should never exist.

This PR changes the definition of **UP** such that it will not return any such type. **DOWN** has been inspected as well, and it will not create any such type. The changed definition of **UP** uses a new type function, **ERASEINTERSECTION**, which is defined together with a handful of other helper functions in the null safety feature specification.
