### PR TITLE
Tweak `Records` class description

### DIFF
--- a/working/0546-patterns/records-feature-specification.md
+++ b/working/0546-patterns/records-feature-specification.md
@@ -92,10 +92,12 @@ These primitive types are added to `dart:core`:
 
 ### The `Record` class
 
-A built-in class `Record` with no members except those inherited from `Object`.
+A built-in class `Record` with no instance members except those inherited 
+from `Object`, and which exposes no constructors.
 All record types are a subtype of this class. This type cannot be constructed,
-extended, mixed in, or implemented by user-defined classes. *This is similar to
-how the `Function` class is the superclass for all function types.*
+extended, mixed in, or implemented by user-defined classes.
+*This is similar to how the `Function` class is the superclass 
+for all function types.*
 
 ## Syntax
 


### PR DESCRIPTION
Opens up the opportunity to have static members, and is precise that there are no exposed constructors ("members inherited from `Object`" could be read as ambiguous about a default constructor).