### PR TITLE
Revise the views feature specification substantially

### DIFF
--- a/working/1426-extension-types/feature-specification-views.md
+++ b/working/1426-extension-types/feature-specification-views.md
@@ -14,7 +14,7 @@ Status: Draft
 2021.05.12
   - Initial version.
 
-[1](https://github.com/dart-lang/language/blob/master/working/extension_structs/overview.md)
+[1]: https://github.com/dart-lang/language/blob/master/working/extension_structs/overview.md
 
 
 ## Summary

--- a/working/1426-extension-types/feature-specification-views.md
+++ b/working/1426-extension-types/feature-specification-views.md
@@ -8,8 +8,8 @@ Status: Draft
 ## Change Log
 
 2022.08.30
-  - Used inspiration from the [extension struct][1] proposal to simplify and
-    improve this proposal.
+  - Used inspiration from the [extension struct][1] proposal and
+    various discussions to simplify and improve this proposal.
 
 2021.05.12
   - Initial version.

--- a/working/1426-extension-types/feature-specification-views.md
+++ b/working/1426-extension-types/feature-specification-views.md
@@ -986,9 +986,9 @@ arguments*).  Assume that `S` is the instantiated representation type
 corresponding to `V0`. A compile-time error occurs unless `T` is a
 subtype of `S`.
 
-*This ensures that it is sound to bind the value of `n` in _DV_ to `n0`
-in `V0` when invoking members of `V0`, where `n` is the representation
-name of _DV_ and `n0` is the representation name of _DV2_.*
+*This ensures that it is sound to bind the value of `id` in _DV_ to `id0`
+in `V0` when invoking members of `V0`, where `id` is the representation
+name of _DV_ and `id0` is the representation name of _DV2_.*
 
 Assume that _DV_ declares a view named `View` with type parameters
 <code>X<sub>1</sub> .. X<sub>k</sub></code> and `V0` is a superview of
@@ -1008,16 +1008,24 @@ members that `V0` has in the same way as we compute the included
 instance members of the representation type based on a member export
 declaration.
 
-Assume that _DV_ is a view declaration and that the view type `V0` is
-a superview of `V`. Let `m` be the name of an associated member of
-`V0`. A compile-time error occurs if _DV_ also declares a member named
-`m`.
+*Assume that _DV_ is a view declaration named `View` and that the view
+type `V0`, declared by _DV0_, is a superview of _DV_. Let `m` be the
+name of an associated member of `V0`. If _DV_ also declares a member
+named `m` then the latter may be considered similar to a declaration
+that "overrides" the former.  However, it should be noted that view
+method invocation is resolved statically, and hence there is no
+override relationship among the two (that is, it will never occur that
+the statically known declaration is the member of `V0`, and the member
+invoked at run time is the one in _DV_). Still, a receiver with static
+type `V0` will invoke the declaration in _DV0_, and a receiver with
+static type `View` will invoke the one in _DV_.*
 
 Assume that _DV_ is a view declaration and that the view types `V0a` and
 `V0b` are superviews of _DV_. Let `Ma` be the associated members of `V0a`,
 and `Mb` the associated members of `V0b`. A compile-time error occurs
-unless the member names of `Ma` and the member names of `Mb` are disjoint
-sets.
+if there is a member name `m` such that `V0a` as well as `V0b` has a
+member named `m`, and _DV_ does not declare a member named `m`.
+*In other words, a name clash among "inherited" members is an error.*
 
 *It is allowed for _DV_ to select a getter from `V0a` and the
 corresponding setter from `V0b`, even though Dart generally treats a
@@ -1116,7 +1124,7 @@ extensions belonging to _DV_ which are declared in libraries
 _L<sub>1</sub> .. L<sub>n</sub>_ (*not necessarily distinct*)
 that are imported directly or indirectly by _L_.
 
-For the given member name (*in the example: `foo`*), let
+For the given member name (*in the example above: `foo`*), let
 _VX<sub>1</sub> .. VX<sub>m</sub>_ be the subset of
 _VX<sub>1</sub> .. VX<sub>n</sub>_ that declare a member with that
 name (*we can assume that we have chosen a numbering that makes this
@@ -1139,20 +1147,9 @@ view as well as any of its superviews, and "inheritance" proceeds as
 usual as if the added members were written in those views directly,
 rather than being added by view extensions.*
 
-View members that are added to a view by view extensions are subject
-to the same name clash checks as views that are declared in the view.
-
-*In particular, a view extension cannot add a member named `m` to a
-view `V` that inherits a member named `m` from a superview, `V` must
-already have a `hide m` clause (or something similar), ensuring that
-the name `m` is "available". As a rule of thumb, view extensions can
-be used to add members with fresh names, they can't interfere with the
-treatment of member names that are already in use in the target view.*
-
-*In short, a view extension cannot redefine an existing view
-member, declared in the view or inherited by the view, but it may
-conflict with a member declared by another view extension. View
-namespaces are used to enable specific view extensions.*
+An error occurs if two enabled view extensions both add a member named
+`m` to the same view, or if an enabled view extension adds a member
+named `m` to a view that already declares a member named `m`.
 
 *These rules ensure that it is possible to extend the set of members
 available for a given view in different ways, depending on the import

--- a/working/1426-extension-types/feature-specification-views.md
+++ b/working/1426-extension-types/feature-specification-views.md
@@ -7,8 +7,14 @@ Status: Draft
 
 ## Change Log
 
+2022.08.30
+  - Used inspiration from the [extension struct] proposal to simplify and
+    improve this proposal.
+
 2021.05.12
   - Initial version.
+
+[extension struct](https://github.com/dart-lang/language/blob/master/working/extension_structs/overview.md)
 
 
 ## Summary
@@ -18,26 +24,63 @@ This document specifies a language feature that we call "views".
 The feature introduces _view types_, which are a new kind of type
 declared by a new `view` declaration. A view type provides a
 replacement or modification of the members available on instances of
-existing types: when the static type of the instance is a view type _V_,
-the available members are exactly the ones provided by _V_
-(plus the accessible and applicable extension methods, if any).
+existing types: when the static type of the instance is a view type
+_V_, the available instance members are exactly the ones provided by
+_V_ (noting that there may of course also be some accessible and
+applicable extension members).
 
 In contrast, when the static type of an instance is not a view type,
-it is always the run-time type of the instance or a supertype. This means
-that the available members are the members of the run-time type of the
-instance or a subset thereof (again: plus extension methods, if
-any). Hence, using a supertype as the static type allows us to see only a
-subset of the members, but using a view type allows us to _replace_
-the set of members, with subsetting as a special case.
+it is (by soundness) always the run-time type of the instance, or a
+supertype thereof. This means that the available instance members are
+the members of the run-time type of the instance, or a subset thereof
+(again: there may also be some extension methods).
 
-The functionality is entirely static. Invocation of a view member is
-resolved at compile-time, based on the static type of the receiver.  Inside
-the view declaration, the scoping and the type and meaning of `this` is the
-same as for extension methods (a feature which was added to Dart in version
-2.6). This is important because it implies that the language Dart has a
-single and consistent semantics for all statically resolved member
-invocations, rather than having one set of rules for extension methods, and
-a different set of rules for view members.
+Hence, using a supertype as the static type allows us to see only a
+subset of the members. Using a view type allows us to _replace_ the
+set of members, with subsetting as a special case.
+
+This functionality is entirely static. Invocation of a view member is
+resolved at compile-time, based on the static type of the receiver.
+
+A view may be considered to be a zero-cost abstraction in the sense
+that it works similarly to a wrapper object that holds the wrapped
+object in a final instance variable. The view thus provides an
+interface which is chosen independently of the interface of the
+wrapped object, and it provides implementations of the members of the
+interface of the view, and those implementations can use the members
+of the wrapped object as needed.
+
+However, even though a view behaves like a wrapping, the wrapper
+object will never exist at run time, and a reference whose type is the
+view will actually refer directly to the underlying wrapped
+object. Every member access (e.g., an invocation of a method or a
+getter) on an expression whose static type is a view will invoke a
+member of the view (with a few exceptions, as explained below), but
+this occurs because those member accesses are resolved statically,
+which means that the wrapper object is not actually needed.
+
+In this document, given that there is no wrapper object, we will refer
+to the "wrapped" object as the _representation object_ of the view, or
+just the _representation_.
+
+Inside the view declaration, the keyword `this` is a reference to the
+representation whose static type is the enclosing view. A member
+access to a member of the enclosing view may rely on `this` being
+induced implicitly (for example, `foo()` means `this.foo()` if the
+view contains a method declaration named `foo`). A reference to the
+representation typed by its run-time type or a supertype thereof (that
+is, typed by a "normal" type for the representation) is available as a
+declared name, which is introduced by a new syntax similar to a
+parameter list declaration (for example `(int i)`) which follows the
+name of the view. (This syntax is intended to be a special case of an
+upcoming mechanism known as _primary constructors_.)
+
+All in all, a view allows us to replace the interface of a given
+representation object and specify how to implement the new interface
+in terms of the interface of the representation object itself. This is
+something that we could obviously do with a wrapper, but when it is
+done with a view there is no wrapper object, and hence there is no
+run-time performance cost.
 
 
 ## Motivation
@@ -49,7 +92,7 @@ operations (the members declared by the given view type).
 
 It is zero-cost in the sense that the value denoted by an expression whose
 type is a view type is an object of a different type (known as the
-on-type of the view type), there is no wrapper object.
+_representation type_ of the view type), and there is no wrapper object.
 
 The point is that the view type allows for a convenient and safe treatment
 of a given object `o` (and objects reachable from `o`) for a specialized
@@ -60,10 +103,38 @@ not be called at all. This kind of added discipline can be enforced by
 accessing `o` typed as a view type, rather than typed as its run-time
 type `R` or some supertype of `R` (which is what we normally do).
 
-A potential application would be generated view declarations handling the
-navigation of dynamic object trees. For instance, they could be JSON
-values, modeled using `num`, `bool`, `String`, `List<dynamic>`, and
-`Map<String, dynamic>`.
+(We can actually cast away the view type and hence get access to the
+interface of the representation, but we assume that the developer
+_wishes_ to maintain this extra discipline, and won't cast away the
+view type onless there is a good reason to do so.)
+
+The extra discipline is enforced because the view member
+implementations will only treat the representation object in ways that
+are written with the purpose of conforming to this particular
+discipline (and thereby defines what this discipline is). For example,
+if the discipline includes the rule that you should never call a
+method `foo` on the representation, then the author of the view will
+simply need to make sure that none of the view member declarations
+ever calls `foo`.
+
+Another example would be that we're using interop with JavaScript, and
+we wish to work on a given `JSObject` representing a button, using a
+`Button` interface which is meaningful for buttons. In this case the
+implementation of the members of `Button` will call some low-level
+functions like `js_util.getProperty`, but a client who uses the view
+will have a full implementation of the `Button` interface, and will
+hence never need to call `js_util.getProperty`.
+
+(Again, we can just call `js_util.getProperty` anyway, because it
+accepts two arguments of type `Object`, but we assume that the
+developer will be happy about sticking to the rule that the low-level
+functions aren't invoked in application code, and they can do that by
+using views like `Button`.)
+
+Another potential application would be generated view declarations
+handling the navigation of dynamic object trees. For instance, they
+could be JSON values, modeled using `num`, `bool`, `String`,
+`List<dynamic>`, and `Map<String, dynamic>`.
 
 Without view types, the JSON value would most likely be handled with
 static type `dynamic`, and all operations on it would be unsafe. If the
@@ -74,24 +145,24 @@ reasoning is required may be fragmented into many different locations, and
 there is no help detecting that some of those locations are treating the
 tree incorrectly according to the schema.
 
-If views are supported, we can declare a set of view types with
-operations that are tailored to work correctly with the given schema and
-its subschemas. This is less error-prone and more maintainable than the
-approach where the tree is handled with static type `dynamic` everywhere.
+If views are available then we can declare a set of view types with
+operations that are tailored to work correctly with the given schema
+and its subschemas. This is less error-prone and more maintainable
+than the approach where the tree is handled with static type `dynamic`
+everywhere.
 
 Here's an example that shows the core of that scenario. The schema that
 we're assuming allows for nested `List<dynamic>` with numbers at the
 leaves, and nothing else.
 
 ```dart
-view TinyJson on Object {
+view TinyJson(Object it) {
   Iterable<num> get leaves sync* {
-    var self = this;
-    if (self is num) {
-      yield self;
-    } else if (self is List<dynamic>) {
-      for (var element in self) {
-        yield* element.leaves;
+    if (it is num) {
+      yield it;
+    } else if (it is List<dynamic>) {
+      for (var element in it) {
+        yield* TinyJson(element).leaves;
       }
     } else {
       throw "Unexpected object encountered in TinyJson value";
@@ -100,40 +171,49 @@ view TinyJson on Object {
 }
 
 void main() {
-  TinyJson tiny = <dynamic>[<dynamic>[1, 2], 3, <dynamic>[]];
+  var tiny = TinyJson(<dynamic>[<dynamic>[1, 2], 3, <dynamic>[]]);
   print(tiny.leaves);
   tiny.add("Hello!"); // Error.
 }
 ```
 
-The name `TinyJson` can be used as a type, and a reference with that type
-can refer to an instance of the underlying on-type `Object`. We use this
-feature to declare a variable `tiny` in the main function whose type is
-`TinyJson`. The point is that we can now impose an enhanced discipline on
-the use of `tiny`, because the view type allows for invocations of the
-members of the view, which enables a specific treatment of the underlying
-instance of `Object`, consistent with the intended schema.
+The syntax `(Object it)` in the declaration of the view causes the
+view to have a constructor, and it can be used to obtain a value of
+the view type from a given instance of the representation type.
+
+The constructor is a factory that actually just returns its argument,
+but typed as the view type. A constructor body may be declared if we
+wish to verify that the given object satisfies some constraints.
+
+The name `TinyJson` can be used as a type, and a reference with that
+type can refer to an instance of the underlying representation type
+`Object`. In the example, the inferred type of `tiny` is `TinyJson`.
+
+We can now impose an enhanced discipline on the use of `tiny`, because
+the view type allows for invocations of the members of the view, which
+enables a specific treatment of the underlying instance of `Object`,
+consistent with the assumed schema.
 
 The getter `leaves` is an example of a disciplined use of the given object
 structure. The run-time type may be a `List<dynamic>`, but the schema which
 is assumed allows only for certain elements in this list (that is, nested
 lists or numbers), and in particular it should never be a `String`. The use
 of the `add` method on `tiny` would have been allowed if we had used the
-type `List<dynamic>` (or `dynamic`) for `tiny`, and that would break the
+type `List<dynamic>` (or `dynamic`) for `tiny`, and that could break the
 schema.
 
 When the type of the receiver is the view type `TinyJson`, it is a
 compile-time error to invoke any members that are not in the interface of
 the view type (in this case that means: the members declared in the
 body of `TinyJson`). So it is an error to call `add` on `tiny`, and that
-protects us from violations of the scheme.
+protects us from this kind of schema violations.
 
 In general, the use of a view type allows us to centralize some unsafe
-operations. We can then reason carefully about each operation once and for
-all. Clients use the view type to access objects conforming to the given
-schema, and that gives them access to a set of known-safe operations,
-making all other operations in the interface of the on-type a compile-time
-error.
+operations. We can then reason carefully about each operation once and
+for all. Clients use the view type to access objects conforming to the
+given schema, and that gives them access to a set of known-safe
+operations, making all other operations in the interface of the
+representation type a compile-time error.
 
 One possible perspective is that a view type corresponds to an abstract
 data type: There is an underlying representation, but we wish to restrict
@@ -153,16 +233,15 @@ directly:
 
 class TinyJson {
   // `representation` is assumed to be a nested list of numbers.
-  final Object representation;
+  final Object it;
 
-  TinyJson(this.representation);
+  TinyJson(this.it);
 
   Iterable<num> get leaves sync* {
-    var self = representation;
-    if (self is num) {
-      yield self;
-    } else if (self is List<dynamic>) {
-      for (var element in self) {
+    if (it is num) {
+      yield it;
+    } else if (it is List<dynamic>) {
+      for (var element in it) {
         yield* TinyJson(element).leaves;
       }
     } else {
@@ -172,7 +251,7 @@ class TinyJson {
 }
 
 void main() {
-  TinyJson tiny = TinyJson(<dynamic>[<dynamic>[1, 2], 3, <dynamic>[]]);
+  var tiny = TinyJson(<dynamic>[<dynamic>[1, 2], 3, <dynamic>[]]);
   print(tiny.leaves);
   tiny.add("Hello!"); // Error.
 }
@@ -188,7 +267,9 @@ we navigate the data structure. For instance, we need to create a wrapper
 `TinyJson(element)` in order to invoke `leaves` recursively.
 
 In contrast, the view is zero-cost, in the sense that it does _not_ use a
-wrapper object, it enforces the desired discipline statically.
+wrapper object, it enforces the desired discipline statically. In the
+view, the invocation of `TinyJson(element)` in the body of `leaves`
+can be eliminated entirely by inlining.
 
 Views are static in nature, like extension methods: A view declaration may
 declare some type parameters. The type parameters will be bound to types
@@ -200,29 +281,33 @@ for late binding of a view member, and hence there is no notion of
 overriding. In return for this lack of expressive power, we get improved
 performance.
 
-Here is another example. It illustrates the fact that a plain view with
-on-type `T` introduces a view type `V` which is a supertype of `T`. (There
-are two other kinds, `open` and `closed` views, with different subtyping
-relationships.) This makes it possible to assign an expression of type `T`
-to a variable of type `V`. This corresponds to "entering" the view type
-(accepting the specific discipline associated with `V`). Conversely, a cast
-from `V` to `T` is a downcast, and hence it must be written explicitly.
-This cast corresponds to "exiting" the view type (allowing for violations
-of the discipline associated with `V`), and the fact that the cast must be
-written explicitly helps developers maintaining the discipline as intended,
-rather than dropping out of the view type by accident, silently.
+Here is another example. It illustrates the fact that a view with
+representation type `T` may introduce a view type `V` which is a
+supertype of `T`, in the case where the view has the modifier
+`implicit`.
+
+This makes it possible to assign an expression of type `T` to a
+variable of type `V` (in order words, we do not need to call the
+constructor). This corresponds to "entering" the view type (accepting
+the specific discipline associated with `V`). Conversely, a cast from
+`V` to `T` is a downcast, and hence it must be written explicitly.
+This cast corresponds to "exiting" the view type (allowing for
+violations of the discipline associated with `V`), and the fact that
+the cast must be written explicitly helps developers maintaining the
+discipline as intended, rather than dropping out of the view type by
+accident, silently.
 
 ```dart
-view ListSize<X> on List<X> {
-  int get size => length;
-  X front() => this[0];
+implicit view ListSize<X>(List<X> it) {
+  int get size => it.length;
+  X front() => it[0];
 }
 
 void main() {
   ListSize<String> xs = <String>['Hello']; // OK, upcast.
   print(xs); // OK, `toString()` available on `Object`.
   print("Size: ${xs.size}. Front: ${xs.front()}"); // OK.
-  xs[0]; // Error, `operator []` not a member of `ListSize`.
+  xs[0]; // Error, `operator []` is not a member of `ListSize`.
 
   List<ListSize<String>> ys = [xs]; // OK.
   List<List<String>> ys2 = ys; // Error, downcast.
@@ -241,21 +326,21 @@ rules for elements used in view declarations:
 
 ```ebnf
 <viewDeclaration> ::=
-  ('open' | 'closed')? 'view' <typeIdentifier> <typeParameters>?
+  'implicit'? 'view' <typeIdentifier> <typeParameters>?
+      <viewPrimaryConstructor>?
       <viewExtendsPart>?
-      'on' <type>
-      <viewShowHidePart>
-      <interfaces>?
-      ('box' 'as' <typeName>)?
   '{'
-    (<metadata> <viewMemberDefinition>)*
+    (<metadata> <viewMemberDeclaration>)*
   '}'
+
+<viewPrimaryConstructor> ::=
+  '(' <type> <identifier> ')'
 
 <viewExtendsPart> ::=
   'extends' <viewExtendsList>
 
 <viewExtendsList> ::=
-  <viewExtendsElement> (',' <viewExtendsList>)?
+  <viewExtendsElement> (',' <viewExtendsElement>)*
 
 <viewExtendsElement> ::= <type> <viewShowHidePart>
 
@@ -275,7 +360,19 @@ rules for elements used in view declarations:
   'operator' <operator> |
   ('get'|'set') <identifier>
 
-<viewMemberDefinition> ::= <classMemberDefinition>
+<viewMemberDeclaration> ::= 
+  <classMemberDefinition> |
+  <memberExportDeclaration>
+
+<memberExportDeclaration> ::=
+  'export' <identifier> <viewShowHidePart>
+
+<viewExtensionDeclaration> ::=
+  'view' 'extension' (<typeIdentifier> '.')? <typeIdentifier> <typeParameters>?
+      <viewPrimaryConstructor>?
+  '{'
+    (<metadata> <viewMemberDeclaration>)*
+  '}'
 ```
 
 The token `view` is made a built-in identifier.
@@ -285,6 +382,22 @@ The token `view` is made a built-in identifier.
 `<identifier>` is still needed because it includes some strings that cannot
 be the name of a type but can be the basename of a member, e.g., the
 built-in identifiers.*
+
+If a view declaration named `V` includes a `<viewPrimaryConstructor>`
+then it is a compile-time error if the declaration includes a
+constructor declaration named `V`. (*But it can still contain other
+constructors.*)
+
+If a view declaration named `V` does not include a
+`<viewPrimaryConstructor>` then an error occurs unless it declares a
+factory constructor named `V`, that declares one required, positional
+formal parameter, and does not declare any other parameters.
+
+The _name of the representation_ in a view declaration that includes a
+`<viewPrimaryConstructor>` is the identifier specified in there. In a
+view declaration named `V` that does not include a
+`<viewPrimaryConstructor>`, the name of the representation is the name
+of the unique formal parameter of the factory constructor named `V`.
 
 
 ## Primitives
@@ -319,28 +432,18 @@ but this is ambiguous since
 <code>V<T<sub>1</sub>, .. T<sub>k</sub>>(o)</code>
 can be a view constructor invocation.  Similarly,
 <code>V<T<sub>1</sub>, .. T<sub>k</sub>>.m(o, args)</code>
-is similar to a static method invocation and it may match the semantics
-quite well, but that is also confusing because it looks like actual source
-code, but it couldn't be used in an actual program.*
+is similar to a named constructor invocation, but that is also
+confusing because it looks like actual source code, but it couldn't be
+used in an actual program.*
 
-*Let us compare view methods to extension methods, noting that they are
-similar in many ways. With an extension declaration `E`,
-<code>E<T<sub>1</sub>, .. T<sub>k</sub>>(o).m(args)</code>
-denotes an explicit invocation of the extension member
-named `m` declared by the extension `E`, with `o` bound to `this`, the type
-parameters bound to <code>T<sub>1</sub>, .. T<sub>k</sub></code>,
-and value parameters bound to the values of `args`.  If `V` is a view with
-the same on-type, type parameters, and same declaration of a member `m`,
-<code>invokeViewMethod(V, <T<sub>1</sub>, .. T<sub>k</sub>>, o).m(args)</code>
-denotes an invocation of the view method `m` with the same bindings.*
-
-The static analysis of `invokeViewMethod` is that it takes exactly three
-positional arguments and must be the receiver in a member access. The first
-argument must be a type name that denotes a view declaration, the next
-argument must be a type argument list, together yielding a view type
-_V_. The third argument must be an expression whose static type is _V_ or
-the corresponding instantiated on-type (defined below). The member access
-must be a member of `V` or an associated member of a superview of `V`.
+The static analysis of `invokeViewMethod` is that it takes exactly
+three positional arguments and must be the receiver in a member
+access. The first argument must be a type name that denotes a view
+declaration, the next argument must be a type argument list, together
+yielding a view type _V_. The third argument must be an expression
+whose static type is _V_ or the corresponding instantiated
+representation type (defined below). The member access must be a
+member of `V` or an associated member of a superview of `V`.
 
 *Superviews and associated members are specified in the section 'Composing
 view types'.*
@@ -361,11 +464,13 @@ for the formal type parameters.
 ### Dynamic Semantics of invokeViewMethod
 
 Let `e0` be an expression of the form
-<code>invokeViewMethod(View, <S<sub>1</sub>, .. S<sub>k</sub>>, e).m(args)</code>
+<code>invokeViewMethod(View, <S<sub>1</sub>, .. S<sub>k</sub>>, e).m(args)</code>.
+
 Evaluation of `e0` proceeds by evaluating `e` to an object `o` and
-evaluating `args` to an actual argument list `args1`, and then executing
-the body of `View.m` in an environment where `this` is bound to `o`,
-the type variables of `View` are bound to the actual values of
+evaluating `args` to an actual argument list `args1`, and then
+executing the body of `View.m` in an environment where `this` and the
+name of the representation are bound to `o`, the type variables of
+`View` are bound to the actual values of
 <code>S<sub>1</sub>, .. S<sub>k</sub></code>,
 and the formal parameters of `m` are bound to `args1` in the same way
 that they would be bound for a normal function call. If the body completes
@@ -379,19 +484,20 @@ same stack trace.
 Assume that _V_ is a view declaration of the following form:
 
 ```dart
-view V<X1 extends B1, .. Xk extends Bk> on T {
+view V<X1 extends B1, .. Xk extends Bk>(T id) ... {
   ... // Members
 }
 ```
 
 It is then allowed to use `V<S1, .. Sk>` as a type.
 
-*For example, it can occur as the declared type of a variable or parameter,
-as the return type of a function or getter, as a type argument in a type,
-as the on-type of an extension or view, as the type in the `onPart` of a
-try/catch statement, or in a type test `o is V` or a type cast `o as V`, or
-as the body of a type alias. It is also allowed to create a new instance
-where one or more view types occur as type arguments.*
+*For example, it can occur as the declared type of a variable or
+parameter, as the return type of a function or getter, as a type
+argument in a type, as the representation type of an extension or
+view, as the type in the `onPart` of a try/catch statement, or in a
+type test `o is V` or a type cast `o as V`, or as the body of a type
+alias. It is also allowed to create a new instance where one or more
+view types occur as type arguments.*
 
 A compile-time error occurs if the type `V<S1, .. Sk>` is not
 regular-bounded.
@@ -414,10 +520,6 @@ view type_ `V<S1, .. Sk>`, and that its static type _is a view type_.
 A compile-time error occurs if a view type is used as a superinterface of a
 class or mixin, or if a view type is used to derive a mixin.
 
-*So `class C extends V1 with V2 implements V3 {}` has three errors if `V1`,
-`V2`, and `V3` are view types, and `mixin M on V1 implements V2 {}`
-has two errors.*
-
 If `e` is an expression whose static type `V` is the view type
 <code>View<S<sub>1</sub>, .. S<sub>k</sub>></code>
 and the basename of `m` is the basename of a member declared by `V`,
@@ -425,27 +527,20 @@ then a member access like `e.m(args)` is treated as
 <code>invokeViewMethod(View, <S<sub>1</sub>, .. S<sub>k</sub>>, e).m(args)</code>,
 and similarly for instance getters and operators.
 
-Lexical lookup for identifier references and unqualified function
-invocations in the body of a view declaration work the same as the same
-lookup in an extension declaration with the same type parameters and
-on-type and members:
 In the body of a view declaration `V` with name `View` and type parameters
 <code>X<sub>1</sub>, .. X<sub>k</sub></code>, for an invocation like
 `m(args)`, if a declaration named `m` is found in the body of `V`
 then that invocation is treated as
 <code>invokeViewMethod(View, <X<sub>1</sub>, .. X<sub>k</sub>>, this).m(args)</code>.
-If there is no declaration in scope whose basename is the basename of `m`,
-`m(args)` is treated as `this.m(args)`. *See a later section for the lookup
-rule when an `extends` clause is present.*
 
 *For example:*
 
 ```dart
-extension E1 on int {
+extension E1(int it) {
   void foo() { print('E1.foo'); }
 }
 
-view V1 on int {
+view V1(int it) {
   void foo() { print('V1.foo'); }
   void baz() { print('V1.baz'); }
   void qux() { print('V1.qux'); }
@@ -453,91 +548,84 @@ view V1 on int {
 
 void qux() { print('qux'); }
 
-view V2 on V1 {
+view V2(V1 it) {
   void foo() { print('V2.foo); }
   void bar() {
     foo(); // Prints 'V2.foo'.
-    this.foo(); // Prints 'V1.foo'.
+    it.foo(); // Prints 'V1.foo'.
+    it.baz(); // Prints 'V1.baz'.
     1.foo(); // Prints 'E1.foo'.
     1.baz(); // Compile-time error.
-    baz(); // Prints 'V1.baz'.
     qux(); // Prints 'qux'.
   }
 }
 ```
 
-*That is, when the type of an expression is a view type `V` with on-type
-`T`, all method invocations on that expression will invoke an instance
-method declared by `V`, and similarly for other member accesses (or it is
-an extension method invocation on some extension `E1` with on-type `T1`
-such that `T` matches `T1`). In particular, we cannot invoke an instance
-member of the on-type when the receiver type is a view type (unless the
-view type enables them explicitly, cf. the show/hide part specified in a
-later section).*
+*That is, when the static type of an expression is a view type `V`
+with representation type `T`, all method invocations on that
+expression will invoke an instance method declared by `V`, and
+similarly for other member accesses (or it is an extension method
+invocation on some extension `E1` with representation type `T1` such
+that `V` matches `T1`). In particular, we cannot invoke an instance
+member of the representation type when the receiver type is a view
+type (unless the view type enables them explicitly, cf. the show/hide
+part specified in a later section).*
 
 Let `D` be a view declaration named `View` with type parameters
 <code>X<sub>1</sub> extends B<sub>1</sub>, .. X<sub>k</sub> extends B<sub>k</sub></code>
-and on-type clause `on T`. Then we say that the _declared on-type_ of `View`
-is `T`, and the _instantiated on-type_ corresponding to
-<code>View<S<sub>1</sub>, .. S<sub>k</sub>></code>
-is
+and primary constructor `(T id)`. Then we say that the _declared
+representation type_ of `View` is `T`, and the _instantiated
+representation type_ corresponding to <code>View<S<sub>1</sub>,
+.. S<sub>k</sub>></code> is
 <code>[S<sub>1</sub>/X<sub>1</sub>, .. S<sub>k</sub>/X<sub>k</sub>]T</code>.
-We will omit 'declared' and 'instantiated' from the phrase when it is clear
-from the context whether we are talking about the view itself or a
-particular instantiation of a generic view. For non-generic views, the
-on-type is the same in either case.
 
-We say that `D` is _open_ respectively _closed_ if its declaration
-starts with the keyword `open` respectively `closed`, and similarly we
-say that a view type <code>View<S<sub>1</sub>, .. S<sub>k</sub>></code>
-where `View` denotes `D` is _open_ respectively _closed_.
-If `D` starts with the keyword `view` we say that `D` is _plain_
-and that corresponding view types are _plain_.
+We will omit 'declared' and 'instantiated' from the phrase when it is
+clear from the context whether we are talking about the view itself or
+a particular instantiation of a generic view. For non-generic views,
+the representation type is the same in either case.
+
+We say that `D` is _implicit_ respectively _plain_ if its declaration
+does respectively does not start with the keyword `implicit`.
+Similarly, we say that a view type
+<code>View<S<sub>1</sub>, .. S<sub>k</sub>></code>
+where `View` denotes `D` is _implicit_ respectively _plain_.
 
 Let `V` be a view type of the form
 <code>View<S<sub>1</sub>, .. S<sub>k</sub>></code>,
-and let `T` be the corresponding instantiated on-type.
+and let `T` be the corresponding instantiated representation type.
 When `T` is a top type, `V` is also a top type.
 Otherwise the following applies:
 
-- If `V` is a plain view type then `V` is a proper subtype of `Object?`,
-and a proper supertype of `T`. *That is, an expression of the on-type can
-freely be assigned to a variable of the view type, but in the opposite
-direction there must be an explicit cast.*
-- If `V` is a closed view type then `V` is a proper subtype of `Object?`.
-*So the on-type and the view type are unrelated, and there is no
-assignability in either direction. In this case a view constructor may be
-used to obtain a value of the view type (see below).*
-- If `V` is an open view type then `V` is an alias for `T`. *So the on-type
-and the view type are freely assignable to each other.*
+- If `V` is a plain view type then `V` is a proper subtype of
+`Object?`.  *So the representation type and the view type are
+unrelated, and there is no assignability in either direction. In this
+case a view constructor may be used to obtain a value of the view type
+(see below).*
+- If `V` is an implicit view type then `V` is a proper subtype of
+`Object?`, and a proper supertype of `T`. *That is, an expression of
+the representation type can freely be assigned to a variable of the
+view type, but in the opposite direction there must be an explicit
+cast.*
 
-When `V` is a view type which is not closed, a type test `o is V`
-or `o is! V` and a type check `o as V` can be performed. Such checks
-performed on a local variable can promote the variable to the view type
-using the normal rules for type promotion.
-
-In the body of a member of a view `V`, the static type of `this` is the
-on-type of `V`.
-
-*Compared to the extension methods feature, there is no difference wrt the
-type of `this` in the body of a view type _V_. Similarly, members of _V_
-invoked in the body of _V_ are subject to the same treatment as members of
-an extension, which means that view members of the enclosing view can be
-invoked implicitly, and view members are given higher priority than
-instance methods on `this`, when `this` is implicit. Note that 
-associated members of superviews can be invoked implicitly as well, as
-specified in section 'Composing view types'.*
+In the body of a member of a view `V`, the static type of `this` is
+`V` and the static type of the name of the representation is the
+representation type.
 
 A view declaration may declare one or more non-redirecting
 factory constructors. A factory constructor which is declared in a
 view declaration is also known as a _view constructor_.
 
 *The purpose of having a view constructor is that it bundles an
-approach for building an instance of the on-type of a view type `V`
-with `V` itself, which makes it easy to recognize that this is a way to
-obtain a value of type `V`. It can also be used to verify that an existing
-object (provided as an actual argument to the constructor) satisfies the
-requirements for having the type `V`.*
+approach for building an instance of the representation type of a view
+type `V` with `V` itself, which makes it easy to recognize that this
+is a way to obtain a value of type `V`. It can also be used to verify
+that an existing object (provided as an actual argument to the
+constructor) satisfies the requirements for having the type `V`.*
+
+A primary constructor is a concise notation that gives rise to a
+factory constructor named `V` (that is, it is not "named") that does
+nothing other than returning its unique argument, applying a cast to
+the view type if the view is not implicit.
 
 An instance creation expression of the form
 <code>V<T<sub>1</sub>, .. T<sub>k</sub>>(...)</code>
@@ -546,48 +634,134 @@ or
 is used to invoke these constructors, and the type of such an expression is
 <code>V<T<sub>1</sub>, .. T<sub>k</sub>></code>.
 
-During static analysis of the body of a view constructor of a view which is
-not closed, the return type is considered to be the view type declared by
-the enclosing declaration.
-
-*This means that the constructor can return an expression whose static type
-is the on-type, as well as an expression whose static type is the view
-type.*
-
-During static analysis of the body of a view constructor of a view which is
-closed, the return type is considered to be the on-type of the enclosing
+During static analysis of the body of a view constructor, the return
+type is considered to be the view type declared by the enclosing
 declaration.
 
-*So these constuctors can only return an expression of the on-type, not an
-expression of the view type, but an explicit cast to the on-type can be
-used if needed.*
+*This means that the constructor can return an expression whose static type
+is the view type, and in an implicit view it can also return an
+expression whose static type is the representation type.*
 
-It is a compile-time error if it is possible to reach the end of a view
-constructor without returning anything. *Even in the case where the on-type
-is nullable and the intended representation is the null object, an explicit
-`return null;` is required.*
+It is a compile-time error if it is possible to reach the end of a
+view constructor without returning anything. *Even in the case where
+the representation type is nullable and the intended representation is
+the null object, an explicit `return null;` is required.*
 
 Let `V` be a view declaration. It is an error to declare a member in
 `V` which is also a member of `Object`.
 
-*This is because the members of `Object` are by default shown, as
-specified below in the section about the show/hide part. It is possible to
-use `hide` to omit some or all of these members, in which case it is
-possible to declare members in `V` with those names.*
+*This is because the members of `Object` are by default exported, as
+specified below in the section about the export declaration. It is
+possible to use `hide` to omit some or all of these members, in which
+case it is possible to declare members in `V` with those names.*
 
 
-### Allow instance member access using `show` and `hide`
+### Allow instance member access using `export`
 
-This section specifies the effect of including a non-empty
-`<viewShowHidePart>` in a view declaration.
+This section specifies the effect of including a
+`<memberExportDeclaration>` in a view declaration.
 
-*The show/hide part provides access to a subset of the members of the
-interface of the on-type. For instance, if the intended purpose of the
-view type is to maintain a certain set of invariants about the state
-of the on-type instance, it is no problem to let clients invoke any methods
-that do not change the state. We could write forwarding members in the
-view body to enable those methods, but using show/hide can have the
-same effect, and it is much more concise and convenient.*
+*A member export declaration is used to provide access to the members
+of the interface of the representation type (or a subset thereof). For
+instance, if the intended purpose of the view type is to maintain a
+certain set of invariants about the state of the underlying
+representation type instance, it is no problem to let clients invoke
+any methods that do not change the state. We could write forwarding
+members in the view body to enable those methods, but using an export
+declaration can have the same effect, and it is much more concise and
+convenient.*
+
+*A member export delaration can also be used to provide access to
+members of other objects reachable from the representation object,
+by exporting any getter of the view. An example is shown below.*
+
+A term derived from `<viewShowHideElement>` may occur in several
+locations in a member export declaration. We define the set of member
+names specified by this construct as follows: Let _SH_ be a term derived
+from `<viewShowHideElement>`. Let _M<sub>SH</sub>_ be the set of
+member names specified by _SH_. Then:
+
+- If _SH_ is of the form `<identifier>` and it does not denote a type
+  then _M<sub>SH</sub>_ is the set containing the single member name
+  which is that identifier.
+- Otherwise, if _SH_ is of the form `<type>` and denotes a type `T` then
+  _M<sub>SH</sub>_ is the set of member names in the interface of `T`
+  except the member names in the interface of `Object`
+  (*but including both `g` and `g=` in the case where said
+  interface contains both a setter and a getter with basename `g`*).
+- If _SH_ is of the form `operator <operator>` then _M<sub>SH</sub>_ 
+  is the singleton set containing that operator.
+- If _SH_ is of the form `get <identifier>` then _M<sub>SH</sub>_ is the
+  singleton set containing that identifier.
+- If _SH_ is of the form `set <identifier>` then _M<sub>SH</sub>_ is the
+  singleton set containing that identifier concatenated with `=`.
+
+*If _SH_ is an identifier that denotes a type, and it is intended to
+denote a member name, it will denote the type. In order to avoid this
+conflict it may be necessary to import said type with a prefix, such
+that the identifier will denote a member name. However, this kind of
+conflict is very unlikely to occur in practice, because member names
+usually start with a lowercase letter, and type names usually start
+with an uppercase letter, and the few expections (like `int` and
+`dynamic`) are unlikely to be used as names of members.*
+
+We use the notation <code>members(_SH_)</code> to denote the set of
+member names specified by _SH_.
+
+Consider a view declaration _D_ named `V` whose representation object
+has the name `n` and the declared type `T`. Assume that _D_ contains a member
+export declaration _DX_ of the form `export n S H;` where `S` is
+derived from `<viewShowClause>?` and `H` is derived from
+`<viewHideClause>?`.
+
+The set of _member names exported_ by _DX_ is computed as follows. 
+
+If `S` and `H` are empty then the set of member names exported by _DX_
+is the set of member names in the interface of `T`.
+
+If `S` is empty and `H` is
+<code>hide H<sub>1</sub>, .. H<sub>k</sub></code>
+then let _M<sub>0</sub>_
+be the set of member names in the interface of `T`.
+For _j_ in _0 .. k-1_, let _M<sub>j+1</sub>_ be
+_M<sub>j</sub> \ members(H<sub>j+1</sub>)_.
+The set of member names exported by _DX_ is then _M<sub>k</sub>_.
+
+If `H` is empty and `S` is
+<code>show S<sub>1</sub>, .. S<sub>k</sub></code>
+then let _M<sub>0</sub>_ be the set of member names in the interface
+of `Object`.
+For _j_ in _0 .. k-1_, let _M<sub>j+1</sub>_ be
+_M<sub>j</sub> &cup; members(S<sub>j+1</sub>)_.
+The set of member names exported by _DX_ is then _M<sub>k</sub>_.
+
+If both `H` and `S` are non-empty then let
+_M<sub>0</sub>_ be the set of member names exported by 
+`export n S`.
+For _j_ in _0 .. k-1_, let _M<sub>j+1</sub>_ be
+_M<sub>j</sub> \ members(H<sub>j+1</sub>)_.
+The set of member names exported by _DX_ is then _M<sub>k</sub>_.
+
+*Note that each member name in the interface of `Object` is included
+except if they are explicitly and individually hidden.*
+
+Assume that _DX_ exports a member name _m_.
+A compile-time error occurs unless the representation type of _D_
+has a member named _m_.
+
+A compile-time error occurs if _D_ contains a declaration named _m_,
+or _D_ extends a view _W_, and _W_ has a declaration named _m_.
+
+A compile-time error occurs if `H` is of the form `hide H1, .. Hk` and
+`Hj` denotes a type `S`, and `S` is not a
+superinterface of `T`, and not a denotation of a generic class `G`
+such that there exist types `U1 .. Un` such that `G<U1, .. Un>` is a
+superinterface of `T`. Similarly for `S` of the form `show S1, .. Sk`.
+
+*That is, an exported name cannot clash with a declared or inherited
+name, such conflicts must be resolved using show/hide. Also, we can
+only show or hide a type if it is a superinterface of the
+representation type, or the raw version of such a type.*
 
 We use the phrase _view show/hide part_, or just _show/hide part_ when
 no doubt can arise, to denote a phrase derived from
@@ -596,186 +770,51 @@ as a _view show clause_, and a `<viewHideClause>` is known as
 a _view hide clause_, similarly abbreviated to _show clause_ and
 _hide clause_.
 
-The show/hide part specifies which instance members of the on-type are
-available for invocation on a receiver whose type is the given view type.
+Consider a member access (*e.g., a method call or tear-off, or a
+getter/setter/operator invocation*) with receiver type `W` which is a
+parameterized type of the form `V<T1, .. Tk>` where `V` is the name of
+_D_. Assume that the member access invokes or tears off a member
+named `m`, where `m` is exported by an export clause of the form
+`export n S H` in _D_, where `n` is the representation name of _D_. In
+this case, the member access is treated as if the receiver had had the
+representation type `T`.
 
-If the show/hide part is empty, no instance members except the ones
-declared for `Object` can be invoked on a receiver whose static type is
-the given view type.
-
-*That is, an empty show/hide part works like `show Object`.*
-
-If the show/hide part is a show clause listing some identifiers and types,
-invocation of an instance member is allowed if its basename is one of the
-given identifiers, or it is the name of a member of the interface of one of
-the types. Instance members declared for `Object` can also be invoked.
-
-*That is, a lone show clause enables the specified members plus the ones
-declared for `Object` (if not already included).*
-
-If the show/hide part is a hide clause listing some identifiers and types,
-invocation of an instance member is allowed if it is in the interface of
-the on-type and _not_ among the given identifiers, nor in the interface of
-the specified types.
-
-*That is, a lone hide clause `hide t1, .. tk` works like
-`show T hide t1, .. tk` where `T` is the on-type.*
-
-If the show/hide part is a show clause followed by a hide clause, then the
-available instance members is computed by first computing the set of
-included instance members specified by the show clause as described above,
-and then removing instance members from that set according to the hide
-clause, as described above.
-
-A `<viewShowHideElement>` can be of the form `get <id>` or `set <id>`
-or `operator <operator>` where `<operator>` must be an operator which can
-be declared as an instance member of a class. These forms are used to
-specify a getter (without the setter), a setter (without the getter), or an
-operator.
-
-*If the interface contains a getter `x` and a setter `x=` then `show x`
-will enable both, but `show get x` or `show set x` can be used to enable
-only one of them, and similarly for `hide`.*
-
-In a show or hide clause, it is possible that a `<viewShowHideElement>` is
-an identifier that is the basename of a member of the interface of the
-on-type, and it is also the name of a type in scope. In this case, the name
-shall refer to the member.
-
-*A conflict is unlikely because type names in general are capitalized, and
-member names start with a lower-case letter. Some type names start with a
-lower-case letter, too (e.g., `int` and `dynamic`), but those names do not
-occur frequently as member names. Should a conflict arise anyway, a
-work-around is to use a type alias declaration to obtain a fresh name for
-the shadowed type name.*
-
-A compile-time error occurs if a hide or show clause contains an identifier
-which is not the basename of an instance member of the on-type, and also
-not the name of a type in scope. A compile-time error occurs if a hide or
-show clause contains a type which is not among the types that are
-implemented by the on-type of the view.
-
-A compile-time error occurs if a member included by the show/hide part has
-a name which is also the name of a member declaration in the view type.
-
-*For instance, if a view `V` with a hide clause contains a declaration of a
-method named `toString`, the hide clause must include `toString` (or a
-class type, because they all include `toString`). Otherwise, the member
-declaration named `toString` would be an error.*
-
-Let `V` be a view type with a show/hide part such that a member `m` is
-included in the interface of `V`. The member signature of `m` is the member
-signature of `m` in the on-type of `V`.
-
-A type in a hide or show clause may be raw (*that is, an identifier or
-qualified identifier denoting a generic type, but no actual type
-arguments*). In this case the omitted type arguments are determined by the
-corresponding superinterface of the on-type.
-
-*Here is an example using a show/hide part:*
+*For example:*
 
 ```dart
-view MyInt on int show num, isEven hide floor {
-  int get twice => 2 * this;
+view V(int it) {
+  export n show num, isEven hide hashCode;
+  int get twice => it * 2;
+  void hashCode(String silly) {} // OK.
 }
 
 void main() {
-  MyInt m = 42;
-  m.twice; // OK, is in the view type.
-  m.isEven; // OK, a shown instance member.
-  m.ceil(); // OK, a shown instance member.
-  m.toString(); // OK, an `Object` member.
-  m.floor(); // Error, now shown.
+  var v = V(42);
+  v.isEven; // OK, `v` is treated as having type `int`.
+  v.isOdd; // Compile-time error, not exported.
+  v.twice; // OK, declared by `V`.
+  v.toString(); // OK, `Object` is exported by default.
+  v.hashCode('Silly indeed!'); // OK.
 }
 ```
 
+If _D_ does not include any member export declarations exporting the
+representation name `n`, it is treated as if it had declared
+`export n show Object;`.
 
-### Implementing superinterfaces
+*In short, if a view on a type `T` is like a veil hiding `T` and
+showing something else, then the exported members of the
+representation are like a hole in the veil: We get to see the
+underlying representation type, with exactly the same semantics as an
+invocation where the receiver type is the representation type,
+including OO dispatch and the treatment of default values of optional
+parameters.*
 
-This section specifies the effect of having an `<interfaces>` part in a
-view declaration.
+It is a compile time error if _D_ contains a member export declaration
+of the form `export m S H` where `m` is not the representation name.
 
-Let `V` be a view declaration where `<interfaces>?` is of the form
-`implements T1, .. Tm`. We say that `V` has `T1` .. `Tm` as its direct
-superinterfaces.
-
-A compile-time error occurs if a direct superinterface does not denote a
-class, or if it denotes a class which cannot be a superinterface of a
-class.
-
-*For instance, `implements int` is an error.*
-
-For each member `m` named `n` in each direct superinterface of `V`, an
-error occurs unless `V` declares a member `m1` named `n` which is a correct
-override of `m`, or the show/hide part of `V` enables an instance member of
-the on-type which is a correct override of `m`.
-
-No subtype relationship exists between `V` and `T1, .. Tm`.
-
-*This means that when a view type implements a set of interfaces, it
-is enforced that all the specified members are available, and that they
-have a signature which is compatible with the ones in `T1, .. Tm`. But
-there is no assignability from an expression of type `V` to a variable
-whose declared type is `Tj` for some `j` in 1..m. For that, it is necessary
-to use `box`, as described below.*
-
-If the `<interfaces>?` part of `V` is empty, the errors specified in this
-section can not occur. *In particular, even `toString` and other members of
-`Object` can be declared with signatures that are not correct overrides of
-the correspsonding member signature in `Object`. Note, however, that a
-different error occurs for a declaration named, say, `toString`, unless
-there is a clause like `hide toString` in the show/hide part (because of
-the name clash).*
-
-
-### Boxing
-
-This section describes the `box` getter of a view type, which is implicitly
-induced when the clause `'box' 'as' <typeName>` is included.
-
-*It may be helpful to equip each view with a companion class whose
-instances have a single field holding an instance of the on-type. So it's a
-wrapper with the same interface as the view type, except that the view type
-may have an implicitly induced getter named `box` and the companion class
-may have an implicitly induced getter named `unbox`.*
-
-Let `V` be a view whose declaration includes the clause `box as typeName`.
-
-In the case where `typeName` denotes an existing class, it is a
-compile-time error unless it has members with signatures as described
-below. In the case where `typeName` denotes any other declaration, a
-compile-time error occurs.
-
-In the case where `typeName` does not resolve to a declaration, a
-compile-time error occurs unless `typeName` is a `<typeIdentifier>`.
-If no error occurred, a new class named `typeName` is implicitly induced
-into the same scope as the view declaration as follows:
-
-The class `typeName` has the same type parameters and members as `V`. It is
-a subclass of `Object`, with the same direct superinterfaces as `V`, with a
-final private field whose type is the on-type of `V`, and with an unnamed
-single argument constructor setting that field to the argument. A getter
-`Name get box` is implicitly induced in `V`, and it returns an object that
-wraps `this`.
-
-`Name` also implicitly induces a getter `V get unbox` which returns the
-value of the final field mentioned above, typed as the associated view
-type.
-
-In the case where it would be a compile-time error to declare such a member
-named `box` or `unbox`, said member is not induced.
-
-*The latter rule helps avoiding conflicts in situations where `box` or
-`unbox` is a non-hidden instance member, and it allows developers to write
-their own implementations if needed.*
-
-*The rationale for having this mechanism is that the wrapper object is a
-full-fledged object: It is a subtype of all the direct superinterfaces of
-`V`, so it can be used in code where `V` is not in scope. Moreover, it
-supports late binding of the view methods, and even dynamic invocations. It
-is costly (it takes space and time to allocate and initialize the wrapper
-object), but it is more robust than the view type, which will only work in
-a manner which is resolved statically.*
+*We may wish to generalize the export mechanism to allow such cases
+later on. See the discussion section for further details.*
 
 
 ### Composing view types
@@ -794,32 +833,29 @@ thus "inheriting" the members of `V0` into all of
 <code>V<sub>1</sub> .. V<sub>k</sub></code>
 without code duplication.*
 
-*Note that there is no subtype relationship between `V0` and
-<code>V<sub>j</sub></code>
-in this scenario, only code reuse. This also implies that there is no need
-to require anything that resembles a correct override relationship.*
-
-Assume that `V` is a view declaration, and `V0` occurs as the `<type>`
-in a `<viewExtendsElement>` in the extends clause of `V`. In this
-case we say that `V0` is a superview of `V`.
+Assume that _D_ is a view declaration named `V`, and `V0` occurs as
+the `<type>` in a `<viewExtendsElement>` in the extends clause of
+`V`. In this case we say that `V0` is a superview of `V`.
 
 A compile-time error occurs if `V0` is a type name or a parameterized type
 which occurs as a superview in a view declaration `V`, but `V0` does not
-denote a view type nor an extension.
+denote a view type.
 
-Assume that a view declaration `V` has on-type `T`, and that the view type
-`V0` is a superview of `V` (*note that `V0` may have some actual type
-arguments*).  Assume that `S` is the instantiated on-type corresponding to
-`V0`. A compile-time error occurs unless `T` is a subtype of `S`.
+Assume that a view declaration `V` has representation type `T`, and
+that the view type `V0` is a superview of `V` (*note that `V0` may
+have some actual type arguments*).  Assume that `S` is the
+instantiated representation type corresponding to `V0`. A compile-time
+error occurs unless `T` is a subtype of `S`.
 
 *This ensures that it is sound to bind the value of `this` in `V` to `this`
 in `V0` when invoking members of `V0`.*
 
+If `V0` is a superview of `V` then `V` is a subtype of `V0`.
+
 Consider a `<viewExtendsElement>` of the form `V0 <viewShowHidePart>`.  The
 _associated members_ of said extends element are computed from the instance
 members of `V0` in the same way as we compute the included instance members
-of the on-type using the `<viewShowHidePart>` that follows the on-type in
-the declaration.
+of the representation type based on a member export declaration.
 
 Assume that `V` is a view declaration and that the view type `V0` is a
 superview of `V`. Let `m` be the name of an associated member of `V0`. A
@@ -849,38 +885,129 @@ The effect of having a view type `V` with superviews `V1, .. Vk` is that
 the union of the members declared by `V` and associated members of `V1,
 .. Vk` can be invoked on a receiver of type `V`.
 
-In the body of `V`, the specification of lexical lookup is changed to
-include an additional case: If a lexical lookup is performed for a name
-`n`, and no declarations whose basename is the basename of `n` is found in
-the enclosing scopes, and a member declaration named `n` exists in the sets
-of associated members of superviews, then that member declaration is
-the result of the lookup; if the lookup is for a setter and a getter is
-found or vice versa, then a compile-time error occurs. Otherwise, if the
-set of associated members does not contain a member whose basename is the
-basename of `n`, the lexical lookup yields nothing (*which implies that
-`this.` will be prepended to the expression, following the existing
-rules*).
-
 In the body of `V`, a superinvocation syntax similar to an explicit
 extension method invocation can be used to invoke a member of a superview
 which is hidden: The invocation starts with `super.` followed by the name
 of the given superview, followed by the member access. The superview may be
 omitted in the case where there is no ambiguity.
 
-*For instance, `super.V3.foo()` can be used to call the `foo` of `V3` on
-`this` in the case where the extends clause has `extends ... V3 hide
-foo, ...`. If no other superview has a member with basename `foo` it is
+*For instance, `super.V3.foo()` can be used to call the `foo` of `V3`
+in the case where the extends clause has `extends ... V3 hide foo, ...`.
+If no other superview has a member with basename `foo`, it is
 also possible to call it using `super.foo()`.*
 
-*This means that the declarations that occur in the enclosing syntax, i.e.,
-in an enclosing lexical scope, get the highest priority, as always in
-Dart. Those declarations may be top-level declarations, or they may be
-members of the enclosing view declaration (in which case an invocation
-involves `this` when it is an instance member). The second highest priority
-is given to instance members of superviews. The next priority is given to
-instance members of the on-type.  Finally we can have an implicit
-invocation of a member of an extension `E1` in some cases where the type of
-`this` matches the on-type of `E1`.*
+
+## View Extensions
+
+A _view extension_ is a declaration that adds members to an existing
+view which is in scope.
+
+*The quick intuitive perspective on this mechanism is that it is
+similar to extension methods, but they are 'sticky' in the sense that
+they are associated with a given view type and they do not require the
+declaration of the view extension to be imported directly.*
+
+A view extension declaration is derived from
+`<viewExtensionDeclaration>`. A compile-time error occurs if a view
+extension declaration contains a member export declaration.
+
+Assume that _DX_ is a view extension declaration named `prefix.V`.
+A compile-time error occurs unless there is a unique view declaration
+named `V` which is imported into the current library with the import
+prefix `prefix`.
+
+Assume that _DX_ is a view extension declaration named `V`.
+A compile-time error occurs unless there is a unique view declaration
+named `V` which is imported into the current library without an import
+prefix.
+
+Whether or not `V` is imported with a prefix, let _DV_ be that unique
+view declaration.
+
+We say that _DX_ provides an _extension of the view_ declared by _DV_,
+and we say that _DX_ _belongs to_ _DV_.
+
+A compile-time error occurs unless _DX_ and _DV_ have exactly the same
+type parameters with exactly the same bounds up to consistent
+renaming. A compile-time error occurs unless the representation type of
+_DX_ is equal to the representation type of _DV_.
+
+Consider a member access _a_ (*e.g., `v.foo()`*), in a library _L_,
+where the receiver type is `V<T1, .. Tk>` where `V` denotes _DV_.
+
+Let _VX<sub>1</sub> .. VX<sub>n</sub>_ be the set of view extensions
+specifying extensions of _DV_ which are declared in libraries
+_L<sub>1</sub> .. L<sub>n</sub>_ (*not necessarily distinct*).
+
+We say that a library _L1_ is _dominated by_ a library _L0_ iff _L1_
+is in the transitive closure of imports from _L0_. *In other words,
+each library dominates every library to which it has an import path.*
+
+Similarly, a view extension declaration _DX1_ in a library _L1_ is
+dominated by a view extension declaration _DX0_ in a library _L0_ iff
+_L1_ is dominated by _L0_.
+
+For the given member name (*in the example: `foo`*), let
+_VX<sub>1</sub> .. VX<sub>m</sub>_ be the subset of view extension
+declarations belonging to _DV_ that declare a member with that name
+(*we're just lucky to have chosen a numbering that makes this
+possible*) and let _VX<sub>1</sub> .. VX<sub>p</sub>_ be the subset of
+_VX<sub>1</sub> .. VX<sub>m</sub>_ which are not dominated by any
+other member of _VX<sub>1</sub> .. VX<sub>m</sub>_.
+
+A compile-time error occurs if _p_ is zero or larger than 1.
+Otherwise, the member access _a_ is resolved to denote the declaration
+with that name in _VX<sub>1</sub>_.
+
+*This means that it is possible to extend the set of members available
+for a given view `V` in different ways, depending on the import
+graph. For example:*
+
+```dart
+// Library 'base.dart'.
+view V(int it) {
+  bool isThree => it == 3;
+}
+
+// Library 'extension1.dart'.
+view extension V(int it) {
+  void foo() {
+    print('Whether I am three: $isThree!');
+  }
+  void bar() {}
+}
+
+// Library 'extension2.dart'.
+view Extension V(int it) {
+  int get foo => 3;
+  set baz(String s) {}
+}
+
+// Library 'main1.dart'.
+import 'base.dart';
+import 'extension1.dart';
+import 'extension2.dart';
+
+void main() {
+  var v = V(3);
+  v.isThree; // OK, available from view.
+  v.bar(); // OK, from extension 1.
+  v.baz = 'Hello'; // OK, from extension 2.
+  v.foo; // Compile-time error, conflict.
+}
+
+// Library 'main2.dart'.
+import 'base.dart';
+import 'extension1.dart';
+
+void main() {
+  var v = V(3);
+  v.isThree; // OK, from view.
+  v.foo(); // OK, from extension 1.
+  v.bar(); // OK, from extension 1.
+  v.baz; // Compile-time error, no such member.
+}
+```
 
 
 ## Dynamic Semantics of Views
@@ -893,48 +1020,40 @@ transformation specified in the section about the static analysis.
 `e.m(args)` is treated as
 <code>invokeViewMethod(View, <S<sub>1</sub>, .. S<sub>k</sub>>, e).m(args)</code>.*
 
-The dynamic semantics of an invocation of an instance method of the on-type
-which is enabled in a view type by the show/hide part is as if a forwarder
-were implicitly induced in the view, with the same signature as that of the
-on-type. *For example:*
-
-```dart
-view MyNum on num show floor {}
-
-void main() {
-  MyNum myNum = 1;
-  myNum.floor(); // Call instance method as if myNum had had type `int`.
-}
-```
+The dynamic semantics of an invocation or tear-off of an instance
+member of the representation type which is enabled in a view type by a
+member export declaration is the same as invoking/tearing-off the same
+member on the representation object typed as the representation type.
 
 At run time, for a given instance `o` typed as a view type `V`, there
 is _no_ reification of `V` associated with `o`.
 
 *This means that, at run time, an object never "knows" that it is being
 viewed as having a view type. By soundness, the run-time type of `o`
-will be a subtype of the on-type of `V`.*
+will be a subtype of the representation type of `V`.*
 
 The run-time representation of a type argument which is a view type
 `V` (respectively
 <code>V<T<sub>1</sub>, .. T<sub>k</sub>></code>)
-is the corresponding instantiated on-type.
+is the corresponding instantiated representation type.
 
-*This means that a view type and the underlying on-type are considered as
-being the same type at run time. So we can freely use a cast to introduce
-or discard the view type, as the static type of an instance, or as a type
-argument in the static type of a data structure or function involving the
-view type.*
+*This means that a view type and the underlying representation type
+are considered as being the same type at run time. So we can freely
+use a cast to introduce or discard the view type, as the static type
+of an instance, or as a type argument in the static type of a data
+structure or function involving the view type.*
 
-*This treatment may appear to be unsound. However, it is in fact sound: Let
-`E` be a view type with on-type `T`. This implies that `void Function(E)`
-is represented as `void Function(T)` at run-time. In other words, it is
-possible to have a variable of type `void Function(E)` that refers to a
-function object of type `void Function(T)`. This seems to be a soundness
-violation because `T <: E` and not vice versa, statically. However, we
-consider such types to be the same type at run time, which is in any case
-the finest distinction that we can maintain because there is no
-representation of `E` at run time. There is no soundness issue, because the
-added discipline of a view type is voluntary.*
+*This treatment may appear to be unsound. However, it is in fact
+sound: Let `V` be a view type with representation type `T`. This
+implies that `void Function(V)` is represented as `void Function(T)`
+at run-time. In other words, it is possible to have a variable of type
+`void Function(V)` that refers to a function object of type `void
+Function(T)`. This seems to be a soundness violation because `T <: V`
+and not vice versa, statically. However, we consider such types to be
+the same type at run time, which is in any case the finest distinction
+that we can maintain because there is no representation of `V` at run
+time. There is no soundness issue, because the added discipline of a
+view type is voluntary.*
 
 A type test, `o is U` or `o is! U`, and a type cast, `o as U`, where `U` is
 or contains a view type, is performed at run time as a type test and type
@@ -943,23 +1062,54 @@ cast on the run-time representation of the view type as described above.
 
 ## Discussion
 
+This section mentions a few topics that have given rise to
+discussions.
+
+
 ### Non-object types
 
-If we introduce any non-object entities in Dart (that is, entities that
-cannot be assigned to a variable of type `Object?`, e.g., external C /
-JavaScript / ... entities, or non-boxed tuples, etc), then we may wish to
-allow for view types whose on-type is a non-object type.
+If we introduce any non-object entities in Dart (that is, entities
+that cannot be assigned to a variable of type `Object?`, e.g.,
+external C / JavaScript / ... entities, or non-boxed tuples, etc),
+then we may wish to allow for view types whose representation type is
+a non-object type.
 
 In this case we may be able to consider a view type `V` on a
-non-object type `T` to be a supertype of `T`, but unrelated to all subtypes
-of `Object?`.
+non-object type `T` to be a supertype of `T`, but unrelated to all
+subtypes of `Object?`.
 
-### Protection
 
-The ability to "enter" a view type implicitly may be considered to be
-too permissive.
+### Exporting other things than the representation
 
-If we wish to uphold the property that every instance typed as a given view
-type `V` has been "vetted" by a particular piece of user-written code then
-we may use a protected view. This concept is described in a separate
-document.
+As stated, this proposal only allows member export statements where
+the representation object exports some members from its statically
+known interface.
+
+However, this mechanism could very well be generalized to allow export
+declarations where any property or path of properties is
+exported. Here is an example.
+
+Let _D_ be a view declaration named `V`. Assume that _D_ includes a
+member export declaration _DX2_ exporting a getter `g`. In this case
+the set of exported member names of _DX2_ is computed in the same way
+as the set of exported member names of the representation object,
+based on the interface of the return type of `g`. For example:
+
+```dart
+view V2(int it) {
+  export it hide int, runtimeType, noSuchMethod;
+  export predecessor hide num, toString, hashCode, operator ==;
+  int get predecessor => it - 1;
+}
+
+void main() {
+  var v = V2(42);
+  v == 42; // OK, returns true.
+  v.predecessor; // OK, returns 41.
+  v.isEven; // OK, returns false, same as `m.predecessor.isEven`.
+  v.isNegative; // Error, not exported, not declared.
+  v.toString(); // OK, returns '42'.
+}
+```
+
+Obviously, a generalized member export feature would need to handle 

--- a/working/1426-extension-types/feature-specification-views.md
+++ b/working/1426-extension-types/feature-specification-views.md
@@ -8,13 +8,13 @@ Status: Draft
 ## Change Log
 
 2022.08.30
-  - Used inspiration from the [extension struct][] proposal to simplify and
+  - Used inspiration from the [extension struct][1] proposal to simplify and
     improve this proposal.
 
 2021.05.12
   - Initial version.
 
-[extension struct](https://github.com/dart-lang/language/blob/master/working/extension_structs/overview.md)
+[1](https://github.com/dart-lang/language/blob/master/working/extension_structs/overview.md)
 
 
 ## Summary

--- a/working/1426-extension-types/feature-specification-views.md
+++ b/working/1426-extension-types/feature-specification-views.md
@@ -1205,6 +1205,34 @@ void main() {
 ```
 
 
+### View namespace usage
+
+*This section is a non-normative discussion about some ways that view
+namespaces could be managed.*
+
+*If view extensions are used to handle an API migration then a useful
+approach could be to have a view namespace indicating the topic (e.g.,
+`html`) and a namespace indicating the version (e.g., `legacy` and
+`v3_0_0`). Developers would then enable the particular version of a
+set of views by means of `view namespace show <topic>, <version>`, for
+example: `view namespace show html, v3_0_0;`.*
+
+*Namespaces used as "topics" in this sense could be managed by the
+community. For instance, a convention could be applied where large
+companies or organizations could use specific suffixes (for example,
+view namespaces managed by the Dart team could have the form
+`..._core`, e.g., `html_core`; a company ACME could use `..._acme`,
+and so on).*
+
+*It would then typically be the case that `..._acme` view namespaces
+would contain view extensions on views provided by ACME, and ACME
+would take responsibility for avoiding (or eliminating) name clashes
+among members added by view extensions, for any given version. So
+you're never supposed to enable multiple versions of the same topic in
+the same library, and when exactly one version of a given topic is
+enabled then it can be expected that there are no name clashes.*
+
+
 ## Dynamic Semantics of Views
 
 The dynamic semantics of view member invocation follows from the code

--- a/working/1426-extension-types/feature-specification-views.md
+++ b/working/1426-extension-types/feature-specification-views.md
@@ -8,7 +8,7 @@ Status: Draft
 ## Change Log
 
 2022.08.30
-  - Used inspiration from the [extension struct] proposal to simplify and
+  - Used inspiration from the [extension struct][] proposal to simplify and
     improve this proposal.
 
 2021.05.12


### PR DESCRIPTION
This PR uses recent ideas (from the extension struct proposal and several other sources) to create a substantially revised version of the views proposal.

In particular:

- Views no longer have an `implements` clause.
- Views no longer support boxing. 
- Views allow for the use of a 'primary constructor' (a parenthesized list occurring right after the name and type parameters). Hence, the "wrapped" object is denoted by the name declared in this constructor, and `this` has the enclosing view as its type.
- Views use an `export` declaration in the body rather than a `show`/`hide` clause in the header to provide access to members of the underlying representation type.
- Views come in only two variants: Plain ones where the representation type and the view type are unrelated, and `implicit` ones where the representation type is a subtype of the view type.
- Views are enhanced with a new mechanism known as 'view extensions'. A view extension declaration allows for adding members to a view, in a manner which is much like that of a regular extension methods, but the added members are "sticky" (which means that they are available on any expression whose type is the view type, even in the case where the import path to the view extension declaration has more than one edge).
