### PR TITLE
[patterns] A handful of mostly small changes to patterns and records:

### DIFF
--- a/accepted/future-releases/records/records-feature-specification.md
+++ b/accepted/future-releases/records/records-feature-specification.md
@@ -4,7 +4,7 @@ Author: Bob Nystrom
 
 Status: Accepted
 
-Version 1.8 (see [CHANGELOG](#CHANGELOG) at end)
+Version 1.9 (see [CHANGELOG](#CHANGELOG) at end)
 
 ## Motivation
 
@@ -498,6 +498,18 @@ The implementation of `hashCode` follows this. The hash code returned should
 depend on the field values such that two records that compare equal must have
 the same hash code.
 
+### Primitive equality
+
+A record object has a primitive `==` operator if all of its field have primitive
+`==` operators.
+
+*Note that this is a dynamic property of a record object, not a static property
+of its type. Since primitive equality only comes into play in constants, the
+compiler can see the actual field values for a relevant record at compile time
+because it has the actual constant record value with all of its constant fields.
+This means records can be used in constant sets and maps keys, but only when the
+records' fields could be as well.*
+
 ### Identity
 
 We expect records to often be used for multiple return values. In that case, and
@@ -565,9 +577,13 @@ covariant in their field types.
 
 ## CHANGELOG
 
+### 1.9
+
+- Specify that a record has a primitive `==` when its fields all do.
+
 ### 1.8
 
-- Move to accepted
+- Move to `accepted/`.
 
 ### 1.7
 

--- a/working/0546-patterns/patterns-feature-specification.md
+++ b/working/0546-patterns/patterns-feature-specification.md
@@ -1834,7 +1834,7 @@ or expression are exhaustive or not. Given that:
     mistakes at compile time.*
 
 *   It is a compile-time error if the static type of the matched value in a
-    switch statement is an *enxhaustive type* and the cases are not exhaustive.
+    switch statement is an *exhaustive type* and the cases are not exhaustive.
     An exhaustive type is:
 
     *   `bool`
@@ -1842,6 +1842,7 @@ or expression are exhaustive or not. Given that:
     *   A type whose declaration is marked sealed
     *   `T?` where `T` is exhaustive
     *   `FutureOr<T>` for some type `T` that is exhaustive
+    *   A record type whose fields are all exhaustive types
 
     **TODO: Finalize the syntax for marking a class as a sealed family.**
 

--- a/working/0546-patterns/patterns-feature-specification.md
+++ b/working/0546-patterns/patterns-feature-specification.md
@@ -2190,9 +2190,6 @@ To match a pattern `p` against a value `v`:
 
     4.  The match succeeds if all entry subpatterns match.
 
-    *Note that, unlike with lists, a matched map may have additional entries
-    that are not checked by the pattern.*
-
 *   **Record**:
 
     1.  If the runtime type of `v` is not a record type with the same type as

--- a/working/0546-patterns/patterns-feature-specification.md
+++ b/working/0546-patterns/patterns-feature-specification.md
@@ -2209,7 +2209,7 @@ To match a pattern `p` against a value `v`:
     1.  If the runtime type of `v` is not a subtype of the static type of `p`
         then the match fails.
 
-    3.  Otherwise, for each field `f` in `p`, in source order:
+    2.  Otherwise, for each field `f` in `p`, in source order:
 
         1.  Call the getter with the same name as `f` on `v` to a result `r`.
             The getter may be an in-scope extension member.


### PR DESCRIPTION
- Clarify that patterns can call extension members. Fix #2457.
- Non-boolean results throw in relational patterns. Fix #2461.
- Maps and extractors are evaluated in source order. Fix #2466.
- Specify non-exhaustive switch errors and warnings. Fix #2474.
- Allow `final` before type annotated variables. Fix #2486.
- Rename some grammars to align with Analyzer AST names. Fix #2491.