### PR TITLE
[Records] Fix typo. It's an error to have named field hashCode, etc..

### DIFF
--- a/accepted/future-releases/records/records-feature-specification.md
+++ b/accepted/future-releases/records/records-feature-specification.md
@@ -210,7 +210,7 @@ It is a compile-time error if a record type has any of:
     this is symmetric with record expressions and leaves the potential for
     later support for parentheses for grouping in type expressions.*
 
-*   A positional field named `hashCode`, `runtimeType`, `noSuchMethod`, or
+*   A named field named `hashCode`, `runtimeType`, `noSuchMethod`, or
     `toString`.
 
 *   A field name that collides with the synthesized getter name of a positional


### PR DESCRIPTION
Changelog reads:

> Allow positional fields in record types named hashCode, runtimeType, noSuchMethod, or toString.

So, I think, that it is a compile-time error to have a _named_ field with the name equal any of `Object` members