### PR TITLE
Standalone proposal for "closed" and "base" type modifiers.

### DIFF
--- a/working/closed-and-base/feature-specification.md
+++ b/working/closed-and-base/feature-specification.md
@@ -48,7 +48,7 @@ break much code.
 This proposal will likely build on top of the [sealed types][] proposal, in
 which case the full grammar is:
 
-[sealed types]: https://github.com/dart-lang/language/blob/master/working/type-modifiers/feature-specification.md
+[sealed types]: https://github.com/dart-lang/language/blob/master/working/sealed-types/feature-specification.md
 
 ```
 classDeclaration ::=

--- a/working/closed-and-base/feature-specification.md
+++ b/working/closed-and-base/feature-specification.md
@@ -17,6 +17,124 @@ larger breaking change. This proposal is non-breaking.
 
 [type modifiers]: https://github.com/dart-lang/language/blob/master/working/type-modifiers/feature-specification.md
 
+## Motivation
+
+Why might a class or mixin author want to *remove* capabilities? Doesn't that
+just make the type less useful? The type does end up more restricted, but in
+return, there are more invariants about the type that you can rely on being
+true. Those invariants may make the type easier to understand, maintain, evolve,
+or even just to use.
+
+### Preventing subclassing
+
+Most types contain methods that invoke other methods on `this`, for example:
+
+```dart
+class Account {
+  int _balance = 0;
+
+  bool canWithdraw(int amount) => amount <= _balance;
+
+  bool tryWithdraw(int amount) {
+    if (amount <= 0) throw ArgumentError("Amount must be positive.");
+
+    if (!canWithdraw(amount)) return false;
+    _balance -= amount;
+    return true;
+  }
+
+  // ...
+}
+```
+
+The intent is that `_balance` should never be negative. There may be other code
+in this class that breaks if that isn't true. However, there's nothing
+preventing a subclass from doing:
+
+```dart
+class BustedAccount extends Account {
+  // YOLO.
+  bool canWithdraw(int amount) => true;
+}
+```
+
+Extending a class gives you free rein to override whatever methods you want,
+while also inheriting concrete implementations of other methods that may
+assume you haven't.
+
+If we can prevent Account from being subclassed, we ensure that when
+`tryWithdraw()` calls `canWithdraw()`, it calls the actual `canWithdraw()`
+method we expect.
+
+Note that it's *not* necessary to prevent *implementing* `Account` for this use
+case. If you implement `Account`, you inherit *none* of its concrete
+implementation, so you don't end up with methods like `tryWithdraw()` whose
+behavior is broken.
+
+### Preventing implementing
+
+Consider:
+
+```dart
+class Account {
+  int _balance = 0;
+
+  bool tryTransfer(int amount, Account destination) {
+    if (amount > _balance) return false;
+
+    _balance -= amount;
+    destination._balance += amount;
+  }
+
+  // ...
+}
+```
+
+This code may fail with a `NoSuchMethodException` at runtime. Spot the bug?
+There's nothing preventing someone from passing in their own implementation of
+`Account` defined in another library that doesn't have a `_balance` field. In
+general, it's not safe to assume any object coming in to your library actually
+has the private members you expect, because it could be an outside
+implementation of the class's interface.
+
+Here's another example:
+
+```dart
+/// Assigns a unique ID to each instance.
+class Handle {
+  static int _nextID = 0;
+
+  final int id;
+
+  Handle() : id = _nextID++;
+}
+
+class Cache {
+  final Map<int, Handle> _handles = {};
+
+  void add(Handle handle) {
+    _handles[handle.id] = handle;
+  }
+
+  Handle? find(int id) => _handles[id];
+}
+```
+
+The `Cache` class assumes each `Handle` has a unique `id` field. The `Handle`
+class's constructor ensures that (ignoring integer overflow for the moment).
+But if an unrelated type could implement `Handle`'s interface, then there's
+no guarantee that every instance of `Handle` has actually gone through that
+constructor.
+
+If the constructor is doing validation or caching, you might want to assume that
+all instances of the type must run it. But if the class's interface can be
+implemented, then it's possible to route around the constructor and break the
+class's invariants.
+
+By preventing a class from having its interface implemented, you ensure that
+every instance of the class you will ever see has all of the private members you
+defined on it and has gone through the constructors you defined.
+
 ## Syntax
 
 A class declaration may be preceded with the built-in identifiers

--- a/working/closed-and-base/feature-specification.md
+++ b/working/closed-and-base/feature-specification.md
@@ -1,0 +1,84 @@
+# "Closed" and "base" types
+
+Author: Bob Nystrom
+
+Status: In-progress
+
+Version 1.0
+
+This proposal specifies `closed` and `base` modifiers on classes and mixins,
+which allow an author to prohibit the type being extended or implemented,
+respectively.
+
+This proposal is a subset of the [type modifiers][] strawman, which also
+contains most of the motivation. It is split out here because the type modifiers
+strawman also proposes prohibiting classes being used as mixins, which is a
+larger breaking change. This proposal is non-breaking.
+
+[type modifiers]: https://github.com/dart-lang/language/blob/master/working/type-modifiers/feature-specification.md
+
+## Syntax
+
+A class declaration may be preceded with the built-in identifiers
+`closed` and/or `base`:
+
+```
+classDeclaration ::=
+  'closed'? 'abstract'? 'base'? 'class' identifier typeParameters?
+  superclass? interfaces?
+  '{' (metadata classMemberDeclaration)* '}'
+  | 'closed'? 'abstract'? 'base'? 'class' mixinApplicationClass
+```
+
+A mixin declaration may be preceded with the built-in identifier `base`:
+
+```
+mixinDeclaration ::= 'base'? 'mixin' identifier typeParameters?
+  ('on' typeNotVoidList)? interfaces?
+  '{' (metadata classMemberDeclaration)* '}'
+```
+
+This proposal will likely build on top of the [sealed types][] proposal, in
+which case the full grammar is:
+
+```
+classDeclaration ::=
+  'closed'? ('sealed' | 'abstract')? 'base'? 'class' identifier typeParameters?
+  superclass? interfaces?
+  '{' (metadata classMemberDeclaration)* '}'
+  | 'closed'? ('sealed' | 'abstract')? 'base'? 'class' mixinApplicationClass
+
+mixinDeclaration ::= sealed? 'base'? 'mixin' identifier typeParameters?
+  ('on' typeNotVoidList)? interfaces?
+  '{' (metadata classMemberDeclaration)* '}'
+```
+
+[sealed types]: https://github.com/dart-lang/language/blob/master/working/type-modifiers/feature-specification.md
+
+**Breaking change:** Treating `closed` and `base` as built-in identifiers means
+that existing code that uses those the names of type will no longer compile.
+Since almost all types have capitalized names in Dart, this is unlikely to be
+break much code.
+
+### Static semantics
+
+It is a compile-time error to:
+
+*   Extend a class marked `closed` outside of the library where it is defined.
+
+*   Implement a type marked `base` outside of the library where it is defined.
+
+Any type that extends or mixes in a type marked `base` is implicitly treated as
+if it was also marked `base` (even when the subtype is within the same library).
+*This ensures that a subtype can't escape the `base` restriction of its
+supertype by offering its _own_ interface that could then be implemented
+without inheriting the concrete implementation from the supertype.*
+
+A typedef can't be used to subvert these restrictions. When extending,
+implementing, or mixing in a typedef, we look at the library where type the
+typedef resolves to is defined to determine if the behavior is allowed. *Note
+that the library where the _typedef_ is defined does not come into play.*
+
+### Runtime semantics
+
+There are no runtime semantics.

--- a/working/closed-and-base/feature-specification.md
+++ b/working/closed-and-base/feature-specification.md
@@ -210,11 +210,11 @@ It is a compile-time error to:
 
 *   Implement a type marked `base` outside of the library where it is defined.
 
-*   Extend or mix in a type marked `base` without also being marked `base`.
-    *This ensures that a subtype can't escape the `base` restriction of its
-    supertype by offering its _own_ interface that could then be implemented
-    without inheriting the concrete implementation from the supertype. Note that
-    this restriction applies even when both types are in the same library.*
+*   Extend or mix in a type marked `base` outside of the library where it is
+    defined without also being marked `base`. *This ensures that a subtype can't
+    escape the `base` restriction of its supertype by offering its _own_
+    interface that could then be implemented without inheriting the concrete
+    implementation from the supertype.*
 
 *   Mix in a class marked `closed` or `base`. *We want to eventually move away
     from classes as mixins. We don't want to break existing uses of classes as

--- a/working/closed-and-base/feature-specification.md
+++ b/working/closed-and-base/feature-specification.md
@@ -137,8 +137,7 @@ defined on it and has gone through the constructors you defined.
 
 ## Syntax
 
-A class declaration may be preceded with the built-in identifiers
-`closed` and/or `base`:
+A class declaration may be preceded with the identifiers `closed` and/or `base`:
 
 ```
 classDeclaration ::=
@@ -148,18 +147,13 @@ classDeclaration ::=
   | 'closed'? 'abstract'? 'base'? 'class' mixinApplicationClass
 ```
 
-A mixin declaration may be preceded with the built-in identifier `base`:
+A mixin declaration may be preceded with the identifier `base`:
 
 ```
 mixinDeclaration ::= 'base'? 'mixin' identifier typeParameters?
   ('on' typeNotVoidList)? interfaces?
   '{' (metadata classMemberDeclaration)* '}'
 ```
-
-**Breaking change:** Treating `closed` and `base` as built-in identifiers means
-that existing code that uses those the names of type will no longer compile.
-Since almost all types have capitalized names in Dart, this is unlikely to be
-break much code.
 
 ### With sealed types
 
@@ -175,7 +169,7 @@ classDeclaration ::=
   '{' (metadata classMemberDeclaration)* '}'
   | classModifiers 'class' mixinApplicationClass
 
-classModifiers ::= 'sealed' | 'closed'? 'abstract'? 'base'?
+classModifiers ::= 'sealed' | 'abstract'? 'closed'? 'base'?
 
 mixinDeclaration ::= ('sealed' | 'base')? 'mixin' identifier typeParameters?
   ('on' typeNotVoidList)? interfaces?
@@ -216,11 +210,16 @@ It is a compile-time error to:
 
 *   Implement a type marked `base` outside of the library where it is defined.
 
-Any type that extends or mixes in a type marked `base` is implicitly treated as
-if it was also marked `base` (even when the subtype is within the same library).
-*This ensures that a subtype can't escape the `base` restriction of its
-supertype by offering its _own_ interface that could then be implemented
-without inheriting the concrete implementation from the supertype.*
+*   Extend or mix in a type marked `base` without also being marked `base`.
+    *This ensures that a subtype can't escape the `base` restriction of its
+    supertype by offering its _own_ interface that could then be implemented
+    without inheriting the concrete implementation from the supertype. Note that
+    this restriction applies even when both types are in the same library.*
+
+*   Mix in a class marked `closed` or `base`. *We want to eventually move away
+    from classes as mixins. We don't want to break existing uses of classes as
+    mixins but since no existing code is using these modifiers, we can prevent
+    classes using those modifiers from also being used as mixins.*
 
 A typedef can't be used to subvert these restrictions. When extending,
 implementing, or mixing in a typedef, we look at the library where type the


### PR DESCRIPTION
This is a subset of the larger "type modifiers" proposal just covering the "closed" and "base" modifiers. I carved it out from type modifiers because the latter also proposes disallowing using classes as mixins, which is a much bigger change. It's separate from sealed types because "closed" and "base" aren't necessary for exhaustiveness.