### PR TITLE
Add feature specification for inline classes

### DIFF
--- a/accepted/future-releases/inline-classes/feature-specification.md
+++ b/accepted/future-releases/inline-classes/feature-specification.md
@@ -741,16 +741,18 @@ type.
 `R`, and `this` has type `V`.*
 
 Let _DV_ be an inline class declaration named `V` with representation
-type `R`. Assuming that all types have been fully alias expanded,
-we say that _DV_ is raw-dependent on an inline class declaration
-_DV2_ if `R` contains an identifier `id` (possibly qualified) that
-resolves to _DV2_, or `id` resolves to an inline class declaration
-_DV3_ and _DV3_ is raw-dependent on _DV2_.
+type `R`. Assuming that all types have been fully alias expanded, we
+say that _DV_ has a representation dependcy on an inline class
+declaration _DV2_ if `R` contains an identifier `id` (possibly
+qualified) that resolves to _DV2_, or `id` resolves to an inline class
+declaration _DV3_ and _DV3_ has a representation dependency on _DV2_.
 
-It is a compile-time error if an inline class declaration is
-raw-dependent on itself.
+It is a compile-time error if an inline class declaration has a
+representation dependency on itself.
 
-*In other words, cycles are not allowed.*
+*In other words, cycles are not allowed. This ensures that it is
+always possible to find a non-inline type which is the ultimate
+representation type of any given inline type.*
 
 An inline class declaration _DV_ named `Inline` may declare one or
 more constructors. A constructor which is declared in an inline class

--- a/accepted/future-releases/inline-classes/feature-specification.md
+++ b/accepted/future-releases/inline-classes/feature-specification.md
@@ -434,11 +434,11 @@ T<sub>s</sub></code> are implicit in the actual syntax.*
 We need to introduce a concept that is similar to existing concepts
 for regular classes.
 
-We say that an inline class `V` _has_ a member named `n` in the case
-where `V` declares a member named `n`, and in the case where `V` has
-no such declaration, but `V` has a superinterface `Vs` that has a
-member named `n`. In both cases,
-_the member declaration named `n` that `V` has_ is said declaration.
+We say that an inline class declaration _DV_ _has_ a member named `n`
+in the case where _DV_ declares a member named `n`, and in the case
+where _DV_ has no such declaration, but _DV_ has a direct
+superinterface `V` that has a member named `n`. In both cases,
+_the member declaration named `n` that DV has_ is said declaration.
 
 *This definition is unambiguous for an inline class that has no
 compile-time errors, because name clashes must be resolved by `V`.*
@@ -719,11 +719,11 @@ inline class. *For non-generic inline classes, the representation type
 is the same in either case.*
 
 Let `V` be an inline type of the form
-<code>Inline&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code>,
-and let `R` be the corresponding instantiated representation type.
-`V` is a proper subtype of `Object?`, and potentially non-nullable. If
-`R` is non-nullable then `V` is a proper subtype of `Object` as well,
-and non-nullable.
+<code>Inline&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code>, and let
+`R` be the corresponding instantiated representation type.  If `R` is
+non-nullable then `V` is a proper subtype of `Object`, and `V` is
+non-nullable.  Otherwise, `V` is a proper subtype of `Object?`, and
+`V` is potentially nullable.
 
 *That is, an expression of an inline type can be assigned to a top
 type (like all other expressions), and if the representation type is
@@ -749,7 +749,7 @@ type.
 
 Let _DV_ be an inline class declaration named `V` with representation
 type `R`. Assuming that all types have been fully alias expanded, we
-say that _DV_ has a representation dependcy on an inline class
+say that _DV_ has a representation dependency on an inline class
 declaration _DV2_ if `R` contains an identifier `id` (possibly
 qualified) that resolves to _DV2_, or `id` resolves to an inline class
 declaration _DV3_ and _DV3_ has a representation dependency on _DV2_.

--- a/accepted/future-releases/inline-classes/feature-specification.md
+++ b/accepted/future-releases/inline-classes/feature-specification.md
@@ -387,11 +387,12 @@ the inline class declaration with a fixed lookahead.*
 
 A few errors can be detected immediately from the syntax:
 
-A compile-time error occurs unless the inline class declares exactly
-one instance variable. Let `v` be the name of said instance
-variable. The declaration of `v` must have the modifier `final`
-and it must not have the modifier `late`; otherwise a compile-time
-error occurs.
+A compile-time error occurs if the inline class does not declare any
+instance variables, and if it declares two or more instance
+variables. Let `v` be the name of unique instance variable that it
+declares. The declaration of `v` must have the modifier `final`, and it
+can not have the modifier `late`; otherwise a compile-time error
+occurs.
 
 The _name of the representation_ in an inline class declaration is the
 name `id` of the unique final instance variable that it declares, and
@@ -739,11 +740,11 @@ Assume that _DV_ has two direct or indirect superinterface of the form
 respectively
 <code>W&lt;S<sub>1</sub>, .. S<sub>k</sub>&gt;</code>.
 A compile-time error
-occurs unless
+occurs if
 <code>T<sub>j</sub></code>
-is equal to
+is not equal to
 <code>S<sub>j</sub></code>
-for each _j_ in _1 .. k_. The notion of equality used here is the same
+for any _j_ in _1 .. k_. The notion of equality used here is the same
 as with the corresponding rule about superinterfaces of classes.
 
 Assume that an inline class declaration _DV_ named `Inline` has
@@ -751,7 +752,7 @@ representation type `R`, and that the inline type `V1` with
 declaration _DV1_ is a superinterface of _DV_ (*note that `V1` may
 have some actual type arguments*).  Assume that `S` is the
 instantiated representation type corresponding to `V1`. A compile-time
-error occurs unless `R` is a subtype of `S`.
+error occurs if `R` is not a subtype of `S`.
 
 *This ensures that it is sound to bind the value of `id` in _DV_ to `id1`
 in `V1` when invoking members of `V1`, where `id` is the representation

--- a/accepted/future-releases/inline-classes/feature-specification.md
+++ b/accepted/future-releases/inline-classes/feature-specification.md
@@ -590,6 +590,9 @@ the case where the values of the type variables do not satisfy their
 declared bounds, and those values will be obtained directly from the static
 type of the receiver in each member invocation on `V`.*
 
+A compile-time error occurs if a type parameter of an inline class
+occurs in a non-covariant position in the representation type.
+
 When `s` is zero,
 <code>V&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code>
 simply stands for `V`, a non-generic inline type.
@@ -641,6 +644,13 @@ and no actual argument part.
 
 *Setter invocations are treated as invocations of methods with a
 single argument.*
+
+If `e` is an expression whose static type `V` is the inline type
+<code>Inline&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code>
+and `V` has no member whose basename is the basename of `m`, a member
+access like `e.m(args)` may be an extension member access, following
+the normal rules about applicability and accessibility of extensions,
+in particular that `V` must match the on-type of the extension.
 
 *In the body of an inline class declaration _DV_ with name `Inline`
 and type parameters
@@ -704,15 +714,15 @@ is `R`, and the _instantiated representation type_ corresponding to
 
 We will omit 'declared' and 'instantiated' from the phrase when it is
 clear from the context whether we are talking about the inline class
-itself, or we're talking a particular instantiation of a generic
-inline. *For non-generic inline classes, the representation type is
-the same in either case.*
+itself, or we're talking about a particular instantiation of a generic
+inline class. *For non-generic inline classes, the representation type
+is the same in either case.*
 
 Let `V` be an inline type of the form
 <code>Inline&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code>,
 and let `R` be the corresponding instantiated representation type.
 `V` is a proper subtype of `Object?`. If `R` is non-nullable then `V`
-is a proper subtype of `Object` as well.
+is a proper subtype of `Object` as well, and non-nullable.
 
 *That is, an expression of an inline type can be assigned to a top type
 (like all other expressions), and if the representation type is
@@ -768,10 +778,13 @@ A compile-time error occurs if an inline class constructor includes a
 superinitializer. *That is, a term of the form `super(...)` or
 `super.id(...)` as the last element of the initializer list.*
 
+A compile-time error occurs if an inline class constructor declares a
+super parameter. *For instance, `Inline(super.x);`.*
+
 *In the body of a generative inline class constructor, the static type
-of `this` is the same as it is in any instance member of the inline,
-that is, `Inline<X1 .. Xk>`, where `X1 .. Xk` are the type parameters
-declared by `Inline`.*
+of `this` is the same as it is in any instance member of the inline
+class, that is, `Inline<X1 .. Xk>`, where `X1 .. Xk` are the type
+parameters declared by `Inline`.*
 
 An instance creation expression of the form
 <code>Inline&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;(...)</code>
@@ -787,6 +800,9 @@ variable, which is initialized according to the normal rules for
 constructors (in particular, it can occur by means of `this.id`, or in
 an initializer list, or by an initializing expression in the
 declaration itself, but it is an error if it does not occur at all).*
+
+An inline type `V` used as an expression (*a type literal*) is allowed
+and has static type `Type`.
 
 
 ### Composing Inline Classes
@@ -987,9 +1003,14 @@ use a cast to introduce or discard the inline type, as the static type
 of an instance, or as a type argument in the static type of a data
 structure or function involving the inline type.*
 
-A type test, `o is U` or `o is! U`, and a type cast, `o as U`, where `U` is
-or contains an inline type, is performed at run time as a type test and type
-cast on the run-time representation of the inline type as described above.
+A type test, `o is U` or `o is! U`, and a type cast, `o as U`, where
+`U` is or contains an inline type, is performed at run time as a type
+test and type cast on the run-time representation of the inline type
+as described above.
+
+An inline type `V` used as an expression (*a type literal*) evaluates
+to the value of the corresponding instantiated representation type
+used as an expression.
 
 
 ### Summary of Typing Relationships

--- a/accepted/future-releases/inline-classes/feature-specification.md
+++ b/accepted/future-releases/inline-classes/feature-specification.md
@@ -761,18 +761,24 @@ representation dependency on itself.
 always possible to find a non-inline type which is the ultimate
 representation type of any given inline type.*
 
+The *inline erasure* of an inline type `V` is obtained by recursively
+replacing every subterm of `V` which is an inline type by the
+corresponding representation type.
+
+*Note that this inline erasure exists, because it is a compile-time
+error to have a dependency cycle among inline types.*
+
 Let
 <code>X<sub>1</sub> extends B<sub>1</sub>, .. X<sub>s</sub> extends B<sub>s</sub></code>
 be a declaration of the type parameters of a generic entity (*it could
 be a generic class, inline or not, or mixin, or typedef, or function*).
-Let <code>BB<sub>j</sub></code> be the result of recursively
-replacing every inline type that occurs in <code>B<sub>j</sub></code>,
-for _j_ in _1 .. s_.
+Let <code>BB<sub>j</sub></code> be the inline erasure of
+<code>B<sub>j</sub></code>, for _j_ in _1 .. s_.
 It is a compile-time error if 
 <code>X<sub>1</sub> extends BB<sub>1</sub>, .. X<sub>s</sub> extends BB<sub>s</sub></code>
 has any compile-time errors.
 
-*For example, this erasure step could map
+*For example, the inline erasure could map
 <code>X extends C<Y>, Y extends X</code> to
 <code>X extends Y, Y extends X</code>,
 which is an error.*

--- a/accepted/future-releases/inline-classes/feature-specification.md
+++ b/accepted/future-releases/inline-classes/feature-specification.md
@@ -934,39 +934,6 @@ well as all members of `V1, .. Vk` that are not redeclared by a
 declaration in _DV_ can be invoked on a receiver of the type
 introduced by _DV_.
 
-In the body of _DV_, a superinvocation syntax can be used to invoke a
-member of a superinterface which is redeclared: The invocation starts
-with `super.` followed by the member access.
-
-*For example:*
-
-```dart
-inline class V2 {
-  final Object id;
-  V2(this.id);
-  void foo() { print('V2.foo()'); }
-  void bar() { print('V2.bar()'); }
-}
-
-inline class V3 {
-  final Object id;
-  V3(this.id);
-  void foo() { print('V3.foo()'); }
-  void baz() { print('V3.baz()'); }
-}
-
-inline class V1 implements V2, V3 {
-  final Object id;
-  V1(this.id);
-  void qux() {
-    super.bar(); // 'V2.bar()'.
-    super.baz(); // 'V3.baz()'.
-    // super.foo(); // Compile-time error, use this:
-    (this as V2).foo();
-  }
-}
-```
-
 
 ## Dynamic Semantics of Inline Classes
 

--- a/accepted/future-releases/inline-classes/feature-specification.md
+++ b/accepted/future-releases/inline-classes/feature-specification.md
@@ -740,27 +740,17 @@ type.
 *For example, in `inline class V { final R id; ...}`, `id` has type
 `R`, and `this` has type `V`.*
 
-Again, let `V` be an inline type of the form
-<code>Inline&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code>,
-and let `R` be the corresponding instantiated representation type.
-If `R` is not an inline type then we say that `V` is an inline type
-at level zero. If `R` is an inline type at level _k_ then we say that
-`V` is an inline type at level _k + 1_.
-A compile-time error occurs if the level of `V` is undefined.
+Let _DV_ be an inline class declaration named `V` with representation
+type `R`. Assuming that all types have been fully alias expanded,
+we say that _DV_ is raw-dependent on an inline class declaration
+_DV2_ if `R` contains an identifier `id` (possibly qualified) that
+resolves to _DV2_, or `id` resolves to an inline class declaration
+_DV3_ and _DV3_ is raw-dependent on _DV2_.
+
+It is a compile-time error if an inline class declaration is
+raw-dependent on itself.
 
 *In other words, cycles are not allowed.*
-
-For every inline class declaration _DV_ named `V`, it is a
-compile-time error if the inline type level of the raw type `V`
-is undefined.
-
-*In other words, we check for this kind of cycles on every non-generic
-inline class declaration using the type directly (even in the case
-where nobody uses that type), and we check for this kind of cycles on
-the instantiation-to-bound of every generic inline class declaration
-(again, even when nobody uses it). Finally, we check for this kind of
-cycles with every parameterized type `V<T1..Tk>` that actually
-occurs in the code which is being analyzed/compiled.*
 
 An inline class declaration _DV_ named `Inline` may declare one or
 more constructors. A constructor which is declared in an inline class

--- a/accepted/future-releases/inline-classes/feature-specification.md
+++ b/accepted/future-releases/inline-classes/feature-specification.md
@@ -721,13 +721,17 @@ is the same in either case.*
 Let `V` be an inline type of the form
 <code>Inline&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code>,
 and let `R` be the corresponding instantiated representation type.
-`V` is a proper subtype of `Object?`. If `R` is non-nullable then `V`
-is a proper subtype of `Object` as well, and non-nullable.
+`V` is a proper subtype of `Object?`, and potentially non-nullable. If
+`R` is non-nullable then `V` is a proper subtype of `Object` as well,
+and non-nullable.
 
-*That is, an expression of an inline type can be assigned to a top type
-(like all other expressions), and if the representation type is
-non-nullable then it can also be assigned to `Object`. Non-inline types
-(except bottom types) cannot be assigned to inline types without a cast.*
+*That is, an expression of an inline type can be assigned to a top
+type (like all other expressions), and if the representation type is
+non-nullable then it can also be assigned to `Object`. Non-inline
+types (except bottom types) cannot be assigned to inline types without
+a cast. Similarly, null cannot be assigned to an inline type without a
+cast, even in the case where the representation type is nullable (even
+better: don't use a cast, call a constructor instead).*
 
 In the body of a member of an inline class declaration _DV_ named
 `Inline` and declaring the type parameters

--- a/accepted/future-releases/inline-classes/feature-specification.md
+++ b/accepted/future-releases/inline-classes/feature-specification.md
@@ -606,6 +606,13 @@ _is the inline type_
 <code>V&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code>,
 and that its static type _is an inline type_.
 
+It is a compile-time error if `await e` occurs, and the static type of
+`e` is an inline type.
+
+*We may loosen this restriction in the future, especially if we
+introduce a way for an inline type to be a subtype of a type of the
+form `Future<T>` or `FutureOr<T>`.*
+
 A compile-time error occurs if an inline type declares a member whose
 name is declared by `Object` as well.
 

--- a/accepted/future-releases/inline-classes/feature-specification.md
+++ b/accepted/future-releases/inline-classes/feature-specification.md
@@ -731,7 +731,10 @@ non-nullable then it can also be assigned to `Object`. Non-inline
 types (except bottom types) cannot be assigned to inline types without
 a cast. Similarly, null cannot be assigned to an inline type without a
 cast, even in the case where the representation type is nullable (even
-better: don't use a cast, call a constructor instead).*
+better: don't use a cast, call a constructor instead). Another consequence of
+the fact that the inline type is potentially non-nullable is that it 
+is an error to have an instance variable whose type is an inline type,
+and then relying on implicit initialization to null.*
 
 In the body of a member of an inline class declaration _DV_ named
 `Inline` and declaring the type parameters

--- a/accepted/future-releases/inline-classes/feature-specification.md
+++ b/accepted/future-releases/inline-classes/feature-specification.md
@@ -1,0 +1,948 @@
+# Inline Classes
+
+Author: eernst@google.com
+
+Status: Accepted.
+
+
+## Change Log
+
+This document is built on several earlier proposals of a similar feature
+(with different terminology and syntax). The most recent version of the
+[views][1] proposal as well as the [extension struct][2] proposal provide
+information about the process, including in their change logs.
+
+[1]: https://github.com/dart-lang/language/blob/master/working/1462-extension-types/feature-specification-views.md
+[2]: https://github.com/dart-lang/language/blob/master/working/extension_structs/overview.md
+
+2022.11.11
+  - Initial version, which is a copy of the views proposal, renaming 'view'
+    to 'inline', and adjusting the text accordingly. Also remove support for
+    primary constructors.
+
+
+## Summary
+
+This document specifies a language feature that we call "inline classes".
+
+The feature introduces _inline classes_, which is a new kind of class
+declared by a new `inline class` declaration. An inline class provides a
+replacement of the members available on instances of an existing type:
+when the static type of the instance is an inline type _V_, the available
+instance members are exactly the ones provided by _V_ (noting that
+there may also be some accessible and applicable extension members).
+
+In contrast, when the static type of an instance is not an inline type,
+it is (by soundness) always the run-time type of the instance or a
+supertype thereof. This means that the available instance members are
+the members of the run-time type of the instance, or a subset thereof
+(and there may also be some extension members).
+
+Hence, using a supertype as the static type allows us to see only a
+subset of the members. Using an inline type allows us to _replace_ the
+set of members, with subsetting as a special case.
+
+This functionality is entirely static. Invocation of an inline member is
+resolved at compile-time, based on the static type of the receiver.
+
+An inline class may be considered to be a zero-cost abstraction in the
+sense that it works similarly to a wrapper object that holds the
+wrapped object in a final instance variable. The inline class thus
+provides an interface which is chosen independently of the interface
+of the wrapped object, and it provides implementations of the members
+of the interface of the inline class, and those implementations can use
+the members of the wrapped object as needed.
+
+However, even though an inline class behaves like a wrapping, the wrapper
+object will never exist at run time, and a reference whose type is the
+inline class will actually refer directly to the underlying wrapped
+object. Every member access (e.g., an invocation of a method or a
+getter) on an expression whose static type is an inline type will invoke
+a member of the inline class (with some exceptions, as explained below),
+but this occurs because those member accesses are resolved statically,
+which means that the wrapper object is not actually needed.
+
+Given that there is no wrapper object, we will refer to the "wrapped"
+object as the _representation object_ of the inline class, or just the
+_representation_.
+
+Inside the inline class declaration, the keyword `this` is a reference
+to the representation whose static type is the enclosing inline
+class. A member access to a member of the enclosing inline class may
+rely on `this` being induced implicitly (for example, `foo()` means
+`this.foo()` if the inline class contains a method declaration named
+`foo`).
+
+A reference to the representation typed by its run-time type or a
+supertype thereof (that is, typed by a "normal" type for the
+representation) is available as a declared name: The inline class must
+have exactly one instance variable whose type is the representation
+type, and it must be `final`.
+
+The representation type of the inline class (with `final int i` that's
+`int`) is similar to the on-type of an extension declaration.
+
+All in all, an inline class allows us to replace the interface of a given
+representation object and specify how to implement the new interface
+in terms of the interface of the representation object.
+
+This is something that we could obviously do with a regular class used
+as a wrapper, but when it is done with an inline class there is no
+wrapper object, and hence there is no run-time performance cost. In
+particular, in the case where we have an inline type `V` with
+representation type `R` we may be able to refer to a `List<R>` using
+the type `List<V>` (using `theRList as List<V>`), and this corresponds
+to "wrapping every element in the list", but it only takes time _O(1)_
+and no space, no matter how many elements the list contains.
+
+
+## Motivation
+
+A _inline class_ is a zero-cost abstraction mechanism that allows
+developers to replace the set of available operations on a given object
+(that is, the instance members of its type) by a different set of
+operations (the members declared by the given inline type).
+
+It is zero-cost in the sense that the value denoted by an expression
+whose type is an inline type is an object of a different type (known as
+the _representation type_ of the inline type), and there is no wrapper
+object, in spite of the fact that the inline class behaves similarly to
+a wrapping.
+
+The point is that the inline type allows for a convenient and safe treatment
+of a given object `o` (and objects reachable from `o`) for a specialized
+purpose. It is in particular aimed at the situation where that purpose
+requires a certain discipline in the use of `o`'s instance methods: We may
+call certain methods, but only in specific ways, and other methods should
+not be called at all. This kind of added discipline can be enforced by
+accessing `o` typed as an inline type, rather than typed as its run-time
+type `R` or some supertype of `R` (which is what we normally do). For
+example:
+
+```dart
+inline class IdNumber {
+  final int i;
+
+  IdNumber(this.i);
+
+  // Declare a few members.
+
+  // Assume that it makes sense to compare ID numbers
+  // because they are allocated with increasing values,
+  // so "smaller" means "older".
+  operator <(IdNumber other) => i < other.i;
+
+  // Assume that we can verify an ID number relative to
+  // `Some parameters`, filtering out some fake ID numbers.
+  bool verify(Some parameters) => ...;
+
+  ... // Some other members, whatever is needed.
+
+  // We do not declare, e.g., an operator +, because addition
+  // does not make sense for ID numbers.
+}
+
+void main() {
+  int myUnsafeId = 42424242;
+  myUnsafeId = myUnsafeId + 10; // No complaints.
+
+  var safeId = IdNumber(42424242);
+
+  safeId.verify(); // OK, could be true.
+  safeId + 10; // Compile-time error, no operator `+`.
+  10 + safeId; // Compile-time error, wrong argument type.
+  myUnsafeId = safeId; // Compile-time error, wrong type.
+  myUnsafeId = safeId as int; // OK, we can force it.
+  myUnsafeId = safeId.i; // OK, and safer than a cast.
+}
+```
+
+In short, we want an `int` representation, but we want to make sure
+that we don't accidentally add ID numbers or multiply them, and we
+don't want to silently pass an ID number (e.g., as an actual arguments
+or in an assignment) where an `int` is expected. The inline class
+`IdNumber` will do all these things.
+
+We can actually cast away the inline type and hence get access to the
+interface of the representation, but we assume that the developer
+wishes to maintain this extra discipline, and won't cast away the
+inline type unless there is a good reason to do so. Similarly, we can
+access the representation using the representation name as a getter.
+There is no reason to consider the latter to be a violation of any
+kind of encapsulation or protection barrier, it's just like any other
+getter invocation. If desired, the author of the inline class can
+choose to use a private representation name, to obtain a small amount
+of extra encapsulation.
+
+The extra discipline is enforced because the inline member
+implementations will only treat the representation object in ways that
+are written with the purpose of conforming to this particular
+discipline (and thereby defines what this discipline is). For example,
+if the discipline includes the rule that you should never call a
+method `foo` on the representation, then the author of the inline class
+will simply need to make sure that none of the inline member
+declarations ever calls `foo`.
+
+Another example would be that we're using interop with JavaScript, and
+we wish to work on a given `JSObject` representing a button, using a
+`Button` interface which is meaningful for buttons. In this case the
+implementation of the members of `Button` will call some low-level
+functions like `js_util.getProperty`, but a client who uses the inline
+class will have a full implementation of the `Button` interface, and
+will hence never need to call `js_util.getProperty`.
+
+(We _can_ just call `js_util.getProperty` anyway, because it accepts
+two arguments of type `Object`. But we assume that the developer will
+be happy about sticking to the rule that the low-level functions
+aren't invoked in application code, and they can do that by using inline
+classes like `Button`. It is then easy to `grep` your application code
+and verify that it never calls `js_util.getProperty`.)
+
+Another potential application would be to generate inline class
+declarations handling the navigation of dynamic object trees that are
+known to satisfy some sort of schema outside the Dart type system. For
+instance, they could be JSON values, modeled using `num`, `bool`,
+`String`, `List<dynamic>`, and `Map<String, dynamic>`, and those JSON
+values might again be structured according to some schema.
+
+Without inline types, the JSON value would most likely be handled with
+static type `dynamic`, and all operations on it would be unsafe. If the
+JSON value is assumed to satisfy a specific schema, then it would be
+possible to reason about this dynamic code and navigate the tree correctly
+according to the schema. However, the code where this kind of careful
+reasoning is required may be fragmented into many different locations, and
+there is no help detecting that some of those locations are treating the
+tree incorrectly according to the schema.
+
+If inline classes are available then we can declare a set of inline types
+with operations that are tailored to work correctly with the given
+schema and its subschemas. This is less error-prone and more
+maintainable than the approach where the tree is handled with static
+type `dynamic` everywhere.
+
+Here's an example that shows the core of that scenario. The schema that
+we're assuming allows for nested `List<dynamic>` with numbers at the
+leaves, and nothing else.
+
+```dart
+inline class TinyJson {
+  final Object it;
+  TinyJson(this.it);
+  Iterable<num> get leaves sync* {
+    if (it is num) {
+      yield it;
+    } else if (it is List<dynamic>) {
+      for (var element in it) {
+        yield* TinyJson(element).leaves;
+      }
+    } else {
+      throw "Unexpected object encountered in TinyJson value";
+    }
+  }
+}
+
+void main() {
+  var tiny = TinyJson(<dynamic>[<dynamic>[1, 2], 3, <dynamic>[]]);
+  print(tiny.leaves);
+  tiny.add("Hello!"); // Error.
+}
+```
+
+Note that `it` is subject to promotion in the above example. This is safe
+because there is no way to override this would-be final instance variable.
+
+An instance creation of an inline type, `Inline<T>(o)`, will evaluate
+to a reference to the value of the final instance variable of the
+inline class, with the static type `Inline<T>` (and there is no object
+at run time that represents the inline class itself).
+
+Returning to the example, the name `TinyJson` can be used as a type,
+and a reference with that type can refer to an instance of the
+underlying representation type `Object`. In the example, the inferred
+type of `tiny` is `TinyJson`.
+
+We can now impose an enhanced discipline on the use of `tiny`, because
+the inline type allows for invocations of the members of the inline class,
+which enables a specific treatment of the underlying instance of
+`Object`, consistent with the assumed schema.
+
+The getter `leaves` is an example of a disciplined use of the given object
+structure. The run-time type may be a `List<dynamic>`, but the schema which
+is assumed allows only for certain elements in this list (that is, nested
+lists or numbers), and in particular it should never be a `String`. The use
+of the `add` method on `tiny` would have been allowed if we had used the
+type `List<dynamic>` (or `dynamic`) for `tiny`, and that could break the
+schema.
+
+When the type of the receiver is the inline type `TinyJson`, it is a
+compile-time error to invoke any members that are not in the interface of
+the inline type (in this case that means: the members declared in the
+body of `TinyJson`). So it is an error to call `add` on `tiny`, and that
+protects us from this kind of schema violations.
+
+In general, the use of an inline class allows us to keep some unsafe
+operations in a specific location (namely inside the inline class, or
+inside one of a set of collaborating inline classes). We can then
+reason carefully about each operation once and for all. Clients use
+the inline class to access objects conforming to the given schema, and
+that gives them access to a set of known-safe operations, making all
+other operations in the interface of the representation type a
+compile-time error.
+
+One possible perspective is that an inline type corresponds to an abstract
+data type: There is an underlying representation, but we wish to restrict
+the access to that representation to a set of operations that are
+independent of the operations available on the representation. In other
+words, the inline type ensures that we only work with the representation in
+specific ways, even though the representation itself has an interface that
+allows us to do many other (wrong) things.
+
+It would be straightforward to enforce an added discipline like this by
+writing a wrapper class with the allowed operations as members, and
+working on a wrapper object rather than accessing the representation
+object and its methods directly:
+
+```dart
+// Emulate the inline class using a class.
+
+class TinyJson {
+  // The representation is assumed to be a nested list of numbers.
+  final Object it;
+
+  TinyJson(this.it);
+
+  Iterable<num> get leaves sync* {
+    var localIt = it; // To get promotion.
+    if (localIt is num) {
+      yield localIt;
+    } else if (localIt is List<dynamic>) {
+      for (var element in localIt) {
+        yield* TinyJson(element).leaves;
+      }
+    } else {
+      throw "Unexpected object encountered in TinyJson value";
+    }
+  }
+}
+
+void main() {
+  var tiny = TinyJson(<dynamic>[<dynamic>[1, 2], 3, <dynamic>[]]);
+  print(tiny.leaves);
+  tiny.add("Hello!"); // Error.
+}
+```
+
+This is similar to the inline type in that it enforces the use of
+specific operations only (here we have just one: `leaves`), and it
+makes it an error to use instance methods of the representation (e.g.,
+`add`).
+
+Creation of wrapper objects consumes space and time. In the case where
+we wish to work on an entire data structure, we'd need to wrap each
+object as we navigate the data structure. For instance, we need to
+create a wrapper `TinyJson(element)` in order to invoke `leaves`
+recursively.
+
+In contrast, the inline class is zero-cost, in the sense that it does
+_not_ use a wrapper object, it enforces the desired discipline
+statically. In the inline class, the invocation of `TinyJson(element)`
+in the body of `leaves` can be eliminated entirely by inlining.
+
+Inline classes are static in nature, like extension members: an inline
+class declaration may declare some type parameters. The type
+parameters will be bound to types which are determined by the static
+type of the receiver. Similarly, members of an inline type are resolved
+statically, i.e., if `tiny.leaves` is an invocation of an inline getter
+`leaves`, then the declaration named `leaves` whose body is executed
+is determined at compile-time. There is no support for late binding of
+an inline member, and hence there is no notion of overriding. In return
+for this lack of expressive power, we get improved performance.
+
+
+## Syntax
+
+A rule for `<inlineClassDeclaration>` is added to the grammar, along
+with some rules for elements used in inline class declarations:
+
+```ebnf
+<inlineClassDeclaration> ::=
+  'inline' 'class' <typeIdentifier> <typeParameters>? <interfaces>?
+  '{'
+    (<metadata> <inlineMemberDeclaration>)*
+  '}'
+
+<inlineMemberDeclaration> ::= <classMemberDefinition>
+```
+
+*The token `inline` is not made a built-in identifier: the reserved
+word `class` that occurs right after `inline` serves to disambiguate
+the inline class declaration with a fixed lookahead.*
+
+A few errors can be detected immediately from the syntax:
+
+A compile-time error occurs unless the inline class declares exactly
+one instance variable. Let `v` be the name of said instance
+variable. A compile-time error occurs unless the declaration of `v`
+has the modifier `final` or the modifier `late`.
+
+The _name of the representation_ in an inline class declaration is the
+name `id` of the unique final instance variable that it declares, and
+the _type of the representation_ is the declared type of `id`.
+
+A compile-time error occurs if an inline class declaration declares an
+abstract member.
+
+*There are no special rules for static members in inline classes. They
+can be declared and called or torn off as usual, e.g.,
+`Inline.myStaticMethod(42)`.*
+
+
+## Primitives
+
+This document needs to refer to explicit inline method invocations, so we
+will add a special primitive, `invokeInlineMethod`, to denote invocations of
+inline methods.
+
+`invokeInlineMethod` is used as a specification device and it cannot occur in
+Dart source code. (*As a reminder of this fact, it uses syntax which is not
+derivable in the Dart grammar.*)
+
+
+### Static Analysis of invokeInlineMethod
+
+We use
+<code>invokeInlineMethod(V, &lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;, o).m(args)</code>
+where `V` is a type name denoting an inline class to denote the
+invocation of the inline method `m` on `o` with arguments `args` and
+inline type arguments
+<code>T<sub>1</sub>, .. T<sub>s</sub></code>.
+Similar constructs exist for invocation of getters, setters, and
+operators.
+
+*For instance, `invokeInlineMethod(V, <int>, o).myGetter` and
+`invokeInlineMethod(V, <int>, o) + rightOperand`.*
+
+*We need special syntax because there is no syntax which will unambiguously
+denote an inline member invocation. We could consider using the syntax
+of explicit extension member invocations, e.g.,
+<code>V&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;(o).m(args)</code>,
+but this is ambiguous since
+<code>V&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;(o)</code>
+can be an inline class constructor invocation.  Similarly,
+<code>V&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;.m(o, args)</code>
+is similar to a named constructor invocation, but that is also
+confusing because it looks like actual source code, but it couldn't be
+used in an actual program.*
+
+The static analysis of `invokeInlineMethod` is that it takes exactly
+three positional arguments and must be the receiver in a member
+access. The first argument must be a type name, say, `Inline`, that
+denotes an inline class declaration. The next argument must be a type
+argument list. The first and second argumnt together yield an inline
+type _V_ (*the type argument list can be empty, which enables the
+non-generic case*). The third argument must be an expression whose
+static type is _V_ or the corresponding instantiated representation
+type (defined below). The member access must access a member of the
+declaration denoted by `Inline`, or a member of a superinterface of that
+inline class declaration.
+
+*Superinterfaces of inline classes are specified in the section
+'Composing inline classes.*
+
+If the member access is a method invocation (including an invocation of an
+operator that takes at least one argument), it is allowed to pass an actual
+argument list, and the static analysis of the actual arguments proceeds as
+with other function calls, using a signature where the formal type
+parameters of `V` are replaced by
+<code>T<sub>1</sub>, .. T<sub>s</sub></code>.
+The type of the entire member access is the return type of said member if
+it is a member invocation, and the function type of the method if it is a
+inline member tear-off, again substituting
+<code>T<sub>1</sub>, .. T<sub>s</sub></code>
+for the formal type parameters.
+
+
+### Dynamic Semantics of invokeInlineMethod
+
+Let `e0` be an expression of the form
+<code>invokeInlineMethod(Inline, &lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;, e).m(args)</code>.
+
+Evaluation of `e0` proceeds by evaluating `e` to an object `o` and
+evaluating `args` to an actual argument list `args1`, and then
+executing the body of `Inline.m` in an environment where `this` and the
+name of the representation are bound to `o`, the type variables of
+`Inline` are bound to the actual values of
+<code>T<sub>1</sub>, .. T<sub>s</sub></code>,
+and the formal parameters of `m` are bound to `args1` in the same way
+that they would be bound for a normal function call. If the body completes
+returning an object `o2`, then `e0` completes with the object `o2`; if the
+body throws then the evaluation of `e0` throws the same object and the
+same stack trace.
+
+*Getters, setters, and operators behave in the same way, with the
+obvious small adjustments.*
+
+
+## Static Analysis of Inline Classes
+
+Assume that
+<code>T<sub>1</sub>, .. T<sub>s</sub></code>
+are types, and `V` resolves to an inline class declaration of the
+following form:
+
+```dart
+inline class V<X1 extends B1, .. Xs extends Bs> ... {
+  final T id;
+  V(this.id);
+
+  ... // Other members.
+}
+```
+
+It is then allowed to use
+<code>V&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code>
+as a type.
+
+*For example, it can occur as the declared type of a variable or
+parameter, as the return type of a function or getter, as a type
+argument in a type, as the representation type of an inline class, as
+the on-type of an extension, as the type in the `onPart` of a
+try/catch statement, in a type test `o is V<...>`, in a type cast
+`o as V<...>`, or as the body of a type alias. It is also allowed to
+create a new instance where one or more inline types occur as type
+arguments (e.g., `List<V>.empty()`).*
+
+A compile-time error occurs if the type
+<code>V&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code>
+is not regular-bounded.
+
+*In other words, such types can not be super-bounded. The reason for this
+restriction is that it is unsound to execute code in the body of `V` in
+the case where the values of the type variables do not satisfy their
+declared bounds, and those values will be obtained directly from the static
+type of the receiver in each member invocation on `V`.*
+
+When `s` is zero,
+<code>V&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code>
+simply stands for `V`, a non-generic inline type.
+When `s` is greater than zero, a raw occurrence `V` is treated like a raw
+type: Instantiation to bound is used to obtain the omitted type arguments.
+*Note that this may yield a super-bounded type, which is then a
+compile-time error.*
+
+We say that the static type of said variable, parameter, etc.
+_is the inline type_
+<code>V&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code>,
+and that its static type _is an inline type_.
+
+A compile-time error occurs if an inline type is used as a
+superinterface of a class or a mixin, or if an inline type is used to
+derive a mixin.
+
+*In other words, an inline type cannot occur as a superinterface in an
+`extends`, `with`, `implements`, or `on` clause of a class or mixin.
+On the other hand, it can occur in other ways, e.g., as a type
+argument of a superinterface of a class etc.*
+
+If `e` is an expression whose static type `V` is the inline type
+<code>Inline&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code>
+and `m` is the name of a member declared by `V`, then a member access
+like `e.m(args)` is treated as
+<code>invokeInlineMethod(Inline, &lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;, e).m(args)</code>,
+and similarly for instance getters, setters, and operators.
+
+*In the body of an inline class declaration _DV_ with name `Inline`
+and type parameters
+<code>X<sub>1</sub>, .. X<sub>s</sub></code>, for an invocation like
+`m(args)`, if a declaration named `m` is found in the body of _DV_
+then that invocation is treated as
+<code>invokeInlineMethod(Inline, &lt;X<sub>1</sub>, .. X<sub>s</sub>&gt;, this).m(args)</code>.
+This is just the same treatment of `this` as in the body of a class.*
+
+*For example:*
+
+```dart
+extension E1 on int {
+  void foo() { print('E1.foo'); }
+}
+
+inline class V1 {
+  final int it;
+  V1(this.it);
+  void foo() { print('V1.foo'); }
+  void baz() { print('V1.baz'); }
+  void qux() { print('V1.qux'); }
+}
+
+void qux() { print('qux'); }
+
+inline class V2 {
+  final V1 it;
+  V2(this.it);
+  void foo() { print('V2.foo); }
+  void bar() {
+    foo(); // Prints 'V2.foo'.
+    it.foo(); // Prints 'V1.foo'.
+    it.baz(); // Prints 'V1.baz'.
+    1.foo(); // Prints 'E1.foo'.
+    1.baz(); // Compile-time error.
+    qux(); // Prints 'qux'.
+  }
+}
+```
+
+*That is, when the static type of an expression is an inline type `V`
+with representation type `R`, each method invocation on that
+expression will invoke an instance method declared by `V` or inherited
+from a superinterface (or it could be an extension method with on-type
+`V`).  Similarly for other member accesses.*
+
+Let _DV_ be an inline class declaration named `Inline` with type
+parameters
+<code>X<sub>1</sub> extends B<sub>1</sub>, .. X<sub>s</sub> extends B<sub>s</sub></code>.
+Assume that _DV_ declares a final instance variable with name `id` and
+type `R`.
+
+We say that the _declared representation type_ of `Inline`
+is `R`, and the _instantiated representation type_ corresponding to
+<code>Inline&lt;T<sub>1</sub>,.. T<sub>s</sub>&gt;</code> is
+<code>[T<sub>1</sub>/X<sub>1</sub>, .. T<sub>s</sub>/X<sub>s</sub>]R</code>.
+
+We will omit 'declared' and 'instantiated' from the phrase when it is
+clear from the context whether we are talking about the inline class
+itself, or we're talking a particular instantiation of a generic
+inline. *For non-generic inline classes, the representation type is
+the same in either case.*
+
+Let `V` be an inline type of the form
+<code>Inline&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code>,
+and let `R` be the corresponding instantiated representation type.
+`V` is a proper subtype of `Object?`. If `R` is non-nullable then `V`
+is a proper subtype of `Object` as well.
+
+*That is, an expression of an inline type can be assigned to a top type
+(like all other expressions), and if the representation type is
+non-nullable then it can also be assigned to `Object`. Non-inline types
+(except bottom types) cannot be assigned to inline types without a cast.*
+
+In the body of a member of an inline class declaration _DV_ named
+`Inline` and declaring the type parameters
+<code>X<sub>1</sub>, .. X<sub>s</sub></code>,
+the static type of `this` is
+<code>Inline&lt;X<sub>1</sub> .. X<sub>s</sub>&gt;</code>.
+The static type of the representation name is the representation
+type.
+
+*For example, in `inline class V { final R id; ...}`, `id` has type
+`R`, and `this` has type `V`.*
+
+Again, let `V` be an inline type of the form
+<code>Inline&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code>,
+and let `R` be the corresponding instantiated representation type.
+If `R` is not an inline type then we say that `V` is an inline type
+at level zero. If `R` is an inline type at level _k_ then we say that
+`V` is an inline type at level _k + 1_.
+A compile-time error occurs if the level of `V` is undefined.
+
+*In other words, cycles are not allowed.*
+
+An inline class declaration _DV_ named `Inline` may declare one or
+more constructors. A constructor which is declared in an inline class
+declaration is also known as an _inline class constructor_.
+
+*The purpose of having an inline class constructor is that it bundles
+an approach for building an instance of the representation type of an
+inline declaration _DV_ with _DV_ itself, which makes it easy to
+recognize that this is a way to obtain a value of that inline type. It
+can also be used to verify that an existing object (provided as an
+actual argument to the constructor) satisfies the requirements for
+having that inline type.*
+
+A compile-time error occurs if an inline class constructor includes a
+superinitializer. *That is, a term of the form `super(...)` or
+`super.id(...)` as the last element of the initializer list.*
+
+*In the body of a generative inline class constructor, the static type
+of `this` is the same as it is in any instance member of the inline,
+that is, `Inline<X1 .. Xk>`, where `X1 .. Xk` are the type parameters
+declared by `Inline`.*
+
+An instance creation expression of the form
+<code>Inline&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;(...)</code>
+or
+<code>Inline&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;.name(...)</code>
+is used to invoke these constructors, and the type of such an expression is
+<code>Inline&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code>.
+
+*In short, inline class constructors appear to be very similar to
+constructors in regular classes, and they correspond to the situation
+where the enclosing class has a single, non-late, final instance
+variable, which is initialized according to the normal rules for
+constructors (in particular, it must occur by means of `this.id` or in
+an initializer list).*
+
+
+### Composing Inline Classes
+
+This section describes the effect of including a clause derived from
+`<interfaces>` in an inline class declaration. We use the phrase
+_the implements clause_ to refer to this clause.
+
+*The rationale is that the set of members and member implementations
+of a given inline class may need to overlap with that of other inline
+classes. The implements clause allows for implementation reuse by
+putting some shared members in an inline class `V`, and including `V`
+in the implements clause of several inline class declarations
+<code>V<sub>1</sub> .. V<sub>k</sub></code>, thus "inheriting" the
+members of `V` into all of <code>V<sub>1</sub> .. V<sub>k</sub></code>
+without code duplication.*
+
+*The reason why this mechanism uses the keyword `implements` rather
+than `extends` to declare a relation that involves "inheritance" is
+that it has a similar semantics as that of extension members (in that
+they are statically resolved).*
+
+Assume that _DV_ is an inline class declaration named `Inline`, and
+`V1` occurs as one of the `<type>`s in the `<interfaces>` of _DV_. In
+this case we say that `V1` is a _superinterface_ of _DV_.
+
+A compile-time error occurs if `V1` is a type name or a parameterized
+type which occurs as a superinterface in an inline class declaration
+_DV_, but `V1` does not denote an inline type.
+
+A compile-time error occurs if any direct or indirect superinterface
+of _DV_ is the type `Inline` or a type of the form `Inline<...>`. *As
+usual, subtype cycles are not allowed.*
+
+Assume that _DV_ has two direct or indirect superinterface of the form
+<code>W&lt;T<sub>1</sub>, .. T<sub>k</sub>&gt;</code>
+respectively
+<code>W&lt;S<sub>1</sub>, .. S<sub>k</sub>&gt;</code>.
+A compile-time error
+occurs unless
+<code>T<sub>j</sub></code>
+is equal to
+<code>S<sub>j</sub></code>
+for each _j_ in _1 .. k_. The notion of equality used here is the same
+as with the corresponding rule about superinterfaces of classes.
+
+Assume that an inline class declaration _DV_ named `Inline` has
+representation type `R`, and that the inline type `V1` with
+declaration _DV1_ is a superinterface of _DV_ (*note that `V1` may
+have some actual type arguments*).  Assume that `S` is the
+instantiated representation type corresponding to `V1`. A compile-time
+error occurs unless `R` is a subtype of `S`.
+
+*This ensures that it is sound to bind the value of `id` in _DV_ to `id1`
+in `V1` when invoking members of `V1`, where `id` is the representation
+name of _DV_ and `id1` is the representation name of _DV1_.*
+
+Assume that _DV_ declares an inline class named `Inline` with type
+parameters
+<code>X<sub>1</sub> .. X<sub>s</sub></code>,
+and `V1` is a superinterface of _DV_. Then
+<code>Inline&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code> 
+is a subtype of
+<code>[T<sub>1</sub>/X<sub>1</sub> .. T<sub>s</sub>/X<sub>s</sub>]V1</code>
+for all <code>T<sub>1</sub>, .. T<sub>s</sub></code>.
+
+*In short, if `V1` is a superinterface of `V` then `V1` is also a
+supertype of `V`.*
+
+A compile-time error occurs if an inline class declaration _DV_ has
+two superinterfaces `V1` and `V2`, where both `V1` and `V2` have a
+member named _m_, and the two declarations of _m_ are distinct
+declarations, and _DV_ does not declare a member named _m_.
+
+*In other words, if two different declarations of _m_ are inherited
+from two superinterfaces then the subinterface must resolve the
+conflict. The so-called diamond inheritance pattern can create the
+case where two superinterfaces have an _m_, but they are both declared by
+the same declaration (so `V` is a subinterface of `V1` and `V2`, and both
+`V1` and `V2` are subinterfaces of `V3`, and only `V3` declares _m_,
+in which case there is no conflict in `V`).*
+
+*Assume that _DV_ is an inline class declaration named `Inline`, and
+the inline type `V1`, declared by _DV1_, is a superinterface of
+_DV_. Let `m` be the name of a member of `V1`. If _DV_ also declares a
+member named `m` then the latter may be considered similar to a
+declaration that "overrides" the former.  However, it should be noted
+that inline method invocation is resolved statically, and hence there
+is no override relationship among the two in the traditional
+object-oriented sense (that is, it will never occur that the
+statically known declaration is the member of `V1`, and the member
+invoked at run time is the one in _DV_). A receiver with static
+type `V1` will invoke the declaration in _DV1_, and a receiver with
+static type `Inline` (or `Inline<...>`) will invoke the one in _DV_.*
+
+Hence, we use a different word to describe the relationship between a
+member named _m_ of a superinterface, and a member named _m_ which is
+declared by the subinterface: We say that the latter _redeclares_ the
+former.
+
+*In particular, if two different declarations of _m_ is inherited
+from two superinterface then the subinterface can resolve the conflict
+by redeclaring _m_.*
+
+*Note that there is no notion of having a 'correct override relation'
+here. With inline classes, any member signature can redeclare any
+other member signature with the same name, including the case where a
+method is redeclared by a getter, or vice versa. The reason for this
+is that no call site will resolve to one of several declarations at
+run time. Each invocation will statically resolve to one particular
+declaration, and this makes it possible to ensure that the invocation
+is type correct.*
+
+Assume that _DV_ is an inline class declaration, and that the inline
+types `V1` and `V2` are superinterfaces of _DV_. Let `M1` be the
+members of `V1`, and `M2` the members of `V2`. A compile-time error
+occurs if there is a member name `m` such that `V1` as well as `V2`
+has a member named `m`, and they are distinct declarations, and _DV_
+does not declare a member named `m`.  *In other words, a name clash
+among distinct "inherited" members is an error, but it can be
+eliminated by redeclaring the clashing name.*
+
+The effect of having an inline class declaration _DV_ with
+superinterfaces `V1, .. Vk` is that the members declared by _DV_ as
+well as all members of `V1, .. Vk` that are not redeclared by a
+declaration in _DV_ can be invoked on a receiver of the type
+introduced by _DV_.
+
+In the body of _DV_, a superinvocation syntax similar to an explicit
+extension method invocation can be used to invoke a member of a
+superinterface which is redeclared: The invocation starts with `super.`
+followed by the name of the given superinterface, followed by the
+member access. The superinterface may be omitted in the case where
+there is no ambiguity.
+
+*For example:*
+
+```dart
+inline class V2 {
+  final Object id;
+  V2(this.id);
+  void foo() { print('V2.foo()'); }
+}
+
+inline class V3 {
+  final Object id;
+  V3(this.id);
+  void foo() { print('V3.foo()'); }
+}
+
+inline class V1 implements V2, V3 {
+  final Object id;
+  V1(this.id);
+  void bar() {
+    super.V3.foo(); // Prints "V3.foo()".
+  }
+}
+```
+
+
+## Dynamic Semantics of Inline Classes
+
+The dynamic semantics of inline member invocation follows from the code
+transformation specified in the section about the static analysis.
+
+*In short, with `e` of type
+<code>Inline&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code>,
+`e.m(args)` is treated as
+<code>invokeInlineMethod(Inline, &lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;, e).m(args)</code>.
+Similarly for getters, setters, and operators.*
+
+Consider an inline class declaration _DV_ named `Inline` with
+representation name `id` and representation type `R`.  Invocation of a
+non-redirecting generative inline class constructor proceeds as follows: A
+fresh, non-late, final variable `v` is created. An initializing formal
+`this.id` has the side-effect that it initializes `v` to the actual
+argument passed to this formal. An initializer list element of the
+form `id = e` or `this.id = e` is evaluated by evaluating `e` to an
+object `o` and binding `v` to `o`.  During the execution of the
+constructor body, `this` and `id` are bound to the value of `v`.  The
+value of the instance creation expression that gave rise to this
+constructor execution is the value of `this`.
+
+At run time, for a given instance `o` typed as an inline type `V`, there
+is _no_ reification of `V` associated with `o`.
+
+*This means that, at run time, an object never "knows" that it is being
+viewed as having an inline type. By soundness, the run-time type of `o`
+will be a subtype of the representation type of `V`.*
+
+The run-time representation of a type argument which is an inline type
+`V` is the corresponding instantiated representation type.
+
+*This means that an inline type and the underlying representation type
+are considered as being the same type at run time. So we can freely
+use a cast to introduce or discard the inline type, as the static type
+of an instance, or as a type argument in the static type of a data
+structure or function involving the inline type.*
+
+A type test, `o is U` or `o is! U`, and a type cast, `o as U`, where `U` is
+or contains an inline type, is performed at run time as a type test and type
+cast on the run-time representation of the inline type as described above.
+
+
+### Summary of Typing Relationships
+
+*Here is an overview of the subtype relationships of an inline type
+`V0` with representation type `R` and superinterfaces `V1 .. Vk`, as
+well as other typing relationships involving `V0`:*
+
+- *`V0` is a subtype of `Object?`.*
+- *`V0` is a supertype of `Never`.*
+- *If `R` is a top type then `V0` is a top type,
+  otherwise `V0` is a proper subtype of `Object?`.*
+- *If `R` is a non-nullable type then `V0` is a non-nullable type.*
+- `V0` is a subtype of each of `V1 .. Vk` (and a proper subtype
+  unless `V0` is a top type).*
+- *At run time, the type `V0` is identical to the type `R`. In
+  particular, `o is V0` and `o as V0` have the same dynamic
+  semantics as `o is R` respectively `o as R`, and
+  `t1 == t2` evaluates to true if `t1` is a `Type` that reifies
+  `V0` and `t2` reifies `R`, and the equality also holds if
+  `t1` and `t2` reify types where `V0` and `R` occur as subterms
+  (e.g., `List<V0>` is equal to `List<R>`).*
+
+
+## Discussion
+
+This section mentions a few topics that have given rise to
+discussions.
+
+
+### Support "private inheritance"?
+
+In the current proposal there is a subtype relationship between every
+inline class and each of its superinterfaces. So if we have
+`inline class V implements V1, V2 ...` then `V <: V1` and `V <: V2`.
+
+In some cases it might be preferable to omit the subtype relationship,
+even though there is a code reuse element (because `V1` is a
+superinterface of `V`, we just don't need or want `V <: V1`).
+
+A possible workaround would be to write forwarding methods manually:
+
+```dart
+inline class V1 {
+  final R it;
+  V1(this.it);
+  void foo() {...}
+}
+
+// `V` can reuse code from `V1` by using `implements`. Note that
+// `S <: R`, because otherwise it is a compile-time error.
+inline class V implements V1 {
+  final S it;
+  V(this.it);
+}
+
+// Alternatively, we can write forwarders, in order to avoid
+// having the subtype relationship `V <: V1`.
+inline class V {
+  final S it;
+  V(this.it);
+  void foo() => V1(it).foo();
+}
+```

--- a/accepted/future-releases/inline-classes/feature-specification.md
+++ b/accepted/future-releases/inline-classes/feature-specification.md
@@ -761,6 +761,22 @@ representation dependency on itself.
 always possible to find a non-inline type which is the ultimate
 representation type of any given inline type.*
 
+Let
+<code>X<sub>1</sub> extends B<sub>1</sub>, .. X<sub>s</sub> extends B<sub>s</sub></code>
+be a declaration of the type parameters of a generic entity (*it could
+be a generic class, inline or not, or mixin, or typedef, or function*).
+Let <code>BB<sub>j</sub></code> be the result of recursively
+replacing every inline type that occurs in <code>B<sub>j</sub></code>,
+for _j_ in _1 .. s_.
+It is a compile-time error if 
+<code>X<sub>1</sub> extends BB<sub>1</sub>, .. X<sub>s</sub> extends BB<sub>s</sub></code>
+has any compile-time errors.
+
+*For example, this erasure step could map
+<code>X extends C<Y>, Y extends X</code> to
+<code>X extends Y, Y extends X</code>,
+which is an error.*
+
 An inline class declaration _DV_ named `Inline` may declare one or
 more constructors. A constructor which is declared in an inline class
 declaration is also known as an _inline class constructor_.

--- a/working/1426-extension-types/feature-specification-views.md
+++ b/working/1426-extension-types/feature-specification-views.md
@@ -1,97 +1,90 @@
-# Views
+# Inline Classes
 
 Author: eernst@google.com
 
-Status: Draft
+Status: Accepted.
 
 
 ## Change Log
 
-2022.09.22
-  - Removed support for `export`, changed `view` to `view class`.
+This document is built on several earlier proposals of a similar feature (but with different terminology and syntax). The most recent version of the [views][1] proposal as well as the [extension struct][2] proposal provide information about the process in their own change logs.
 
-2022.09.20
-  - Updated the inheritance mechanism to fit in with a potential non-virtual
-    method mechanism for classes: Use `implements`, remove show/hide.
+[1]: https://github.com/dart-lang/language/blob/master/working/1462-extension-types/feature-specification-views.md
+[2]: https://github.com/dart-lang/language/blob/master/working/extension_structs/overview.md
 
-2022.08.30
-  - Used inspiration from the [extension struct][1] proposal and
-    various discussions to simplify and improve this proposal.
-
-2021.05.12
-  - Initial version.
-
-[1]: https://github.com/dart-lang/language/blob/master/working/extension_structs/overview.md
+2022.11.11
+  - Initial version, which is a copy of the views proposal, renaming 'view'
+    to 'inline' and adjusting the text accordingly.
 
 
 ## Summary
 
-This document specifies a language feature that we call "view classes".
+This document specifies a language feature that we call "inline classes".
 
-The feature introduces _view types_, which are a new kind of type
-declared by a new `view class` declaration. A view type provides a
+The feature introduces _inline types_, which are a new kind of type
+declared by a new `inline class` declaration. A inline type provides a
 replacement of the members available on instances of existing types:
-when the static type of the instance is a view type _V_, the available
+when the static type of the instance is a inline type _V_, the available
 instance members are exactly the ones provided by _V_ (noting that
 there may also be some accessible and applicable extension members).
 
-In contrast, when the static type of an instance is not a view type,
+In contrast, when the static type of an instance is not a inline type,
 it is (by soundness) always the run-time type of the instance, or a
 supertype thereof. This means that the available instance members are
 the members of the run-time type of the instance, or a subset thereof
 (again: there may also be some extension members).
 
 Hence, using a supertype as the static type allows us to see only a
-subset of the members. Using a view type allows us to _replace_ the
+subset of the members. Using a inline type allows us to _replace_ the
 set of members, with subsetting as a special case.
 
-This functionality is entirely static. Invocation of a view member is
+This functionality is entirely static. Invocation of a inline member is
 resolved at compile-time, based on the static type of the receiver.
 
-A view class may be considered to be a zero-cost abstraction in the
+A inline class may be considered to be a zero-cost abstraction in the
 sense that it works similarly to a wrapper object that holds the
-wrapped object in a final instance variable. The view class thus
+wrapped object in a final instance variable. The inline class thus
 provides an interface which is chosen independently of the interface
 of the wrapped object, and it provides implementations of the members
-of the interface of the view class, and those implementations can use
+of the interface of the inline class, and those implementations can use
 the members of the wrapped object as needed.
 
-However, even though a view class behaves like a wrapping, the wrapper
+However, even though a inline class behaves like a wrapping, the wrapper
 object will never exist at run time, and a reference whose type is the
-view class will actually refer directly to the underlying wrapped
+inline class will actually refer directly to the underlying wrapped
 object. Every member access (e.g., an invocation of a method or a
-getter) on an expression whose static type is a view type will invoke
-a member of the view class (with some exceptions, as explained below),
+getter) on an expression whose static type is a inline type will invoke
+a member of the inline class (with some exceptions, as explained below),
 but this occurs because those member accesses are resolved statically,
 which means that the wrapper object is not actually needed.
 
 Given that there is no wrapper object, we will refer to the "wrapped"
-object as the _representation object_ of the view class, or just the
+object as the _representation object_ of the inline class, or just the
 _representation_.
 
-Inside the view class declaration, the keyword `this` is a reference
-to the representation whose static type is the enclosing view class. A
-member access to a member of the enclosing view class may rely on
+Inside the inline class declaration, the keyword `this` is a reference
+to the representation whose static type is the enclosing inline class. A
+member access to a member of the enclosing inline class may rely on
 `this` being induced implicitly (for example, `foo()` means
-`this.foo()` if the view class contains a method declaration named
+`this.foo()` if the inline class contains a method declaration named
 `foo`). A reference to the representation typed by its run-time type
 or a supertype thereof (that is, typed by a "normal" type for the
 representation) is available as a declared name, which is introduced
 by a new syntax similar to a parameter list declaration (for example
-`(int i)`) which follows the name of the view class. (This syntax is
+`(int i)`) which follows the name of the inline class. (This syntax is
 intended to be a special case of an upcoming mechanism known as
-_primary constructors_.) The representation type of the view class
+_primary constructors_.) The representation type of the inline class
 (with `(int i)` that's `int`) is similar to the on-type of an
 extension declaration.
 
-All in all, a view class allows us to replace the interface of a given
+All in all, a inline class allows us to replace the interface of a given
 representation object and specify how to implement the new interface
 in terms of the interface of the representation object.
 
 This is something that we could obviously do with a wrapper, but when
-it is done with a view class there is no wrapper object, and hence
+it is done with a inline class there is no wrapper object, and hence
 there is no run-time performance cost. In particular, in the case
-where we have a view type `V` with representation type `R` we may be
+where we have a inline type `V` with representation type `R` we may be
 able to refer to a `List<R>` using the type `List<V>`
 (using `theRList as List<V>`), and this corresponds to "wrapping every
 element in the list", but it only takes time _O(1)_ and no space, no
@@ -100,29 +93,29 @@ matter how many elements the list contains.
 
 ## Motivation
 
-A _view class_ is a zero-cost abstraction mechanism that allows
+A _inline class_ is a zero-cost abstraction mechanism that allows
 developers to replace the set of available operations on a given object
 (that is, the instance members of its type) by a different set of
-operations (the members declared by the given view type).
+operations (the members declared by the given inline type).
 
 It is zero-cost in the sense that the value denoted by an expression
-whose type is a view type is an object of a different type (known as
-the _representation type_ of the view type), and there is no wrapper
-object, in spite of the fact that the view class behaves similarly to
+whose type is a inline type is an object of a different type (known as
+the _representation type_ of the inline type), and there is no wrapper
+object, in spite of the fact that the inline class behaves similarly to
 a wrapping.
 
-The point is that the view type allows for a convenient and safe treatment
+The point is that the inline type allows for a convenient and safe treatment
 of a given object `o` (and objects reachable from `o`) for a specialized
 purpose. It is in particular aimed at the situation where that purpose
 requires a certain discipline in the use of `o`'s instance methods: We may
 call certain methods, but only in specific ways, and other methods should
 not be called at all. This kind of added discipline can be enforced by
-accessing `o` typed as a view type, rather than typed as its run-time
+accessing `o` typed as a inline type, rather than typed as its run-time
 type `R` or some supertype of `R` (which is what we normally do). For
 example:
 
 ```dart
-view class IdNumber(int i) {
+inline class IdNumber(int i) {
   // Declare a few members.
 
   // Assume that it makes sense to compare ID numbers
@@ -158,52 +151,52 @@ void main() {
 In short, we want an `int` representation, but we want to make sure
 that we don't accidentally add ID numbers or multiply them, and we
 don't want to silently pass an ID number (e.g., as actual arguments or
-in assignments) where an `int` is expected. The view class `IdNumber`
+in assignments) where an `int` is expected. The inline class `IdNumber`
 will do all these things.
 
-We can actually cast away the view type and hence get access to the
+We can actually cast away the inline type and hence get access to the
 interface of the representation, but we assume that the developer
-wishes to maintain this extra discipline, and won't cast away the view
+wishes to maintain this extra discipline, and won't cast away the inline
 type onless there is a good reason to do so. Similarly, we can access
 the representation using the representation name as a getter.  There
 is no reason to consider the latter to be a violation of any kind of
 encapsulation or protection barrier, it's just like any other getter
-invocation. If desired, the author of the view class can choose to use
+invocation. If desired, the author of the inline class can choose to use
 a private representation name, to obtain a small amount of extra
 encapsulation.
 
-The extra discipline is enforced because the view member
+The extra discipline is enforced because the inline member
 implementations will only treat the representation object in ways that
 are written with the purpose of conforming to this particular
 discipline (and thereby defines what this discipline is). For example,
 if the discipline includes the rule that you should never call a
-method `foo` on the representation, then the author of the view class
-will simply need to make sure that none of the view member
+method `foo` on the representation, then the author of the inline class
+will simply need to make sure that none of the inline member
 declarations ever calls `foo`.
 
 Another example would be that we're using interop with JavaScript, and
 we wish to work on a given `JSObject` representing a button, using a
 `Button` interface which is meaningful for buttons. In this case the
 implementation of the members of `Button` will call some low-level
-functions like `js_util.getProperty`, but a client who uses the view
+functions like `js_util.getProperty`, but a client who uses the inline
 class will have a full implementation of the `Button` interface, and
 will hence never need to call `js_util.getProperty`.
 
 (We _can_ just call `js_util.getProperty` anyway, because it accepts
 two arguments of type `Object`. But we assume that the developer will
 be happy about sticking to the rule that the low-level functions
-aren't invoked in application code, and they can do that by using view
+aren't invoked in application code, and they can do that by using inline
 classes like `Button`. It is then easy to `grep` your application code
 and verify that it never calls `js_util.getProperty`.)
 
-Another potential application would be to generate view class
+Another potential application would be to generate inline class
 declarations handling the navigation of dynamic object trees that are
 known to satisfy some sort of schema outside the Dart type system. For
 instance, they could be JSON values, modeled using `num`, `bool`,
 `String`, `List<dynamic>`, and `Map<String, dynamic>`, and those JSON
 values might again be structured according to some schema.
 
-Without view types, the JSON value would most likely be handled with
+Without inline types, the JSON value would most likely be handled with
 static type `dynamic`, and all operations on it would be unsafe. If the
 JSON value is assumed to satisfy a specific schema, then it would be
 possible to reason about this dynamic code and navigate the tree correctly
@@ -212,7 +205,7 @@ reasoning is required may be fragmented into many different locations, and
 there is no help detecting that some of those locations are treating the
 tree incorrectly according to the schema.
 
-If view classes are available then we can declare a set of view types
+If inline classes are available then we can declare a set of inline types
 with operations that are tailored to work correctly with the given
 schema and its subschemas. This is less error-prone and more
 maintainable than the approach where the tree is handled with static
@@ -223,7 +216,7 @@ we're assuming allows for nested `List<dynamic>` with numbers at the
 leaves, and nothing else.
 
 ```dart
-view class TinyJson(Object it) {
+inline class TinyJson(Object it) {
   Iterable<num> get leaves sync* {
     if (it is num) {
       yield it;
@@ -247,10 +240,10 @@ void main() {
 Note that `it` is subject to promotion in the above example. This is safe
 because there is no way to override this would-be final instance variable.
 
-The syntax `(Object it)` in the declaration of the view class causes
-the view class to have a constructor and a final instance variable
+The syntax `(Object it)` in the declaration of the inline class causes
+the inline class to have a constructor and a final instance variable
 `it` of type `Object`, and it can be used to obtain a value of the
-view type from a given instance of the representation type. This
+inline type from a given instance of the representation type. This
 syntax is known as a _primary constructor_.
 
 It is possible to declare other constructors as well; details are
@@ -258,17 +251,17 @@ given in the proposal. A constructor body may be declared. It could be
 used, e.g., to verify that the given representation object satisfies
 some constraints.
 
-In any case, an instance creation of a view type, `View<T>(o)`, will
+In any case, an instance creation of a inline type, `Inline<T>(o)`, will
 evaluate to a reference to the value of the final instance variable of
-the view class, with the static type `View<T>` (and there is no object
-at run time that represents the view class itself).
+the inline class, with the static type `Inline<T>` (and there is no object
+at run time that represents the inline class itself).
 
 The name `TinyJson` can be used as a type, and a reference with that
 type can refer to an instance of the underlying representation type
 `Object`. In the example, the inferred type of `tiny` is `TinyJson`.
 
 We can now impose an enhanced discipline on the use of `tiny`, because
-the view type allows for invocations of the members of the view class,
+the inline type allows for invocations of the members of the inline class,
 which enables a specific treatment of the underlying instance of
 `Object`, consistent with the assumed schema.
 
@@ -280,24 +273,24 @@ of the `add` method on `tiny` would have been allowed if we had used the
 type `List<dynamic>` (or `dynamic`) for `tiny`, and that could break the
 schema.
 
-When the type of the receiver is the view type `TinyJson`, it is a
+When the type of the receiver is the inline type `TinyJson`, it is a
 compile-time error to invoke any members that are not in the interface of
-the view type (in this case that means: the members declared in the
+the inline type (in this case that means: the members declared in the
 body of `TinyJson`). So it is an error to call `add` on `tiny`, and that
 protects us from this kind of schema violations.
 
-In general, the use of a view type allows us to centralize some unsafe
+In general, the use of a inline type allows us to centralize some unsafe
 operations. We can then reason carefully about each operation once and
-for all. Clients use the view type to access objects conforming to the
+for all. Clients use the inline type to access objects conforming to the
 given schema, and that gives them access to a set of known-safe
 operations, making all other operations in the interface of the
 representation type a compile-time error.
 
-One possible perspective is that a view type corresponds to an abstract
+One possible perspective is that a inline type corresponds to an abstract
 data type: There is an underlying representation, but we wish to restrict
 the access to that representation to a set of operations that are
 independent of the operations available on the representation. In other
-words, the view type ensures that we only work with the representation in
+words, the inline type ensures that we only work with the representation in
 specific ways, even though the representation itself has an interface that
 allows us to do many other (wrong) things.
 
@@ -307,7 +300,7 @@ working on a wrapper object rather than accessing `o` and its methods
 directly:
 
 ```dart
-// Emulate the view class using a class.
+// Emulate the inline class using a class.
 
 class TinyJson {
   // `representation` is assumed to be a nested list of numbers.
@@ -336,7 +329,7 @@ void main() {
 }
 ```
 
-This is similar to the view type in that it enforces the use of specific
+This is similar to the inline type in that it enforces the use of specific
 operations (here we only have one: `leaves`) and in general makes it an
 error to use instance methods of the representation (e.g., `add`).
 
@@ -345,143 +338,143 @@ wish to work on an entire data structure we'd need to wrap each object as
 we navigate the data structure. For instance, we need to create a wrapper
 `TinyJson(element)` in order to invoke `leaves` recursively.
 
-In contrast, the view class is zero-cost, in the sense that it does
+In contrast, the inline class is zero-cost, in the sense that it does
 _not_ use a wrapper object, it enforces the desired discipline
-statically. In the view class, the invocation of `TinyJson(element)`
+statically. In the inline class, the invocation of `TinyJson(element)`
 in the body of `leaves` can be eliminated entirely by inlining.
 
-View classes are static in nature, like extension members: A view
+Inline classes are static in nature, like extension members: A inline
 class declaration may declare some type parameters. The type
 parameters will be bound to types which are determined by the static
-type of the receiver. Similarly, members of a view type are resolved
-statically, i.e., if `tiny.leaves` is an invocation of a view getter
+type of the receiver. Similarly, members of a inline type are resolved
+statically, i.e., if `tiny.leaves` is an invocation of a inline getter
 `leaves`, then the declaration named `leaves` whose body is executed
 is determined at compile-time. There is no support for late binding of
-a view member, and hence there is no notion of overriding. In return
+a inline member, and hence there is no notion of overriding. In return
 for this lack of expressive power, we get improved performance.
 
 
 ## Syntax
 
-A rule for `<viewDeclaration>` is added to the grammar, along with some
-rules for elements used in view declarations:
+A rule for `<inlineDeclaration>` is added to the grammar, along with some
+rules for elements used in inline declarations:
 
 ```ebnf
-<viewDeclaration> ::=
-  'view' 'class' <typeIdentifier> <typeParameters>?
-      <viewPrimaryConstructor>?
+<inlineDeclaration> ::=
+  'inline' 'class' <typeIdentifier> <typeParameters>?
+      <inlinePrimaryConstructor>?
       <interfaces>?
   '{'
-    (<metadata> <viewMemberDeclaration>)*
+    (<metadata> <inlineMemberDeclaration>)*
   '}'
 
-<viewPrimaryConstructor> ::=
+<inlinePrimaryConstructor> ::=
   '(' <type> <identifier> ')'
 
-<viewMemberDeclaration> ::=
+<inlineMemberDeclaration> ::=
   <classMemberDefinition>
 ```
 
-The token `view` is made a built-in identifier.
+The token `inline` is made a built-in identifier.
 
 A few errors can be detected immediately from the syntax:
 
-If a view declaration named `View` includes a
-`<viewPrimaryConstructor>` then it is a compile-time error if the
-declaration includes a constructor declaration named `View`. (*But it
+If a inline declaration named `Inline` includes a
+`<inlinePrimaryConstructor>` then it is a compile-time error if the
+declaration includes a constructor declaration named `Inline`. (*But it
 can still contain other constructors.*)
 
-If a view declaration named `View` does not include a
-`<viewPrimaryConstructor>` then an error occurs unless the view declares
+If a inline declaration named `Inline` does not include a
+`<inlinePrimaryConstructor>` then an error occurs unless the inline declares
 exactly one instance variable `v`. An error occurs unless the declaration of `v`
 is final. An error occurs if the declaration of `v` is late.
 
-The _name of the representation_ in a view declaration that includes a
-`<viewPrimaryConstructor>` is the identifier `id` specified in there, and
+The _name of the representation_ in a inline declaration that includes a
+`<inlinePrimaryConstructor>` is the identifier `id` specified in there, and
 the _type of the representation_ is the declared type of `id`.
 
-In a view declaration named `View` that does not include a
-`<viewPrimaryConstructor>`, the _name of the representation_ is the name
+In a inline declaration named `Inline` that does not include a
+`<inlinePrimaryConstructor>`, the _name of the representation_ is the name
 `id` of the unique final instance variable that it declares, and the
 _type of the representation_ is the declared type of `id`.
 
-A compile-time error occurs if a view declaration declares an abstract
-member. A compile-time error occurs if a view declaration has a
-`<viewPrimaryConstructor>` and declares an instance variable. Finally,
-a compile-time error occurs if a view does not have a
-`<viewPrimaryConstructor>`, and it does not declare an instance
+A compile-time error occurs if a inline declaration declares an abstract
+member. A compile-time error occurs if a inline declaration has a
+`<inlinePrimaryConstructor>` and declares an instance variable. Finally,
+a compile-time error occurs if a inline does not have a
+`<inlinePrimaryConstructor>`, and it does not declare an instance
 variable, or it declares more than one instance variable.
 
-*That is, every view declares exactly one instance variable, and it is
+*That is, every inline declares exactly one instance variable, and it is
 final. A primary constructor (as defined in this document) is just an
 abbreviated syntax whose desugaring includes a declaration of exactly
 one final instance variable.*
 
 ```dart
 // Using a primary constructor.
-view class V1(R it) {}
+inline class V1(R it) {}
 
 // Same thing, using a normal constructor.
-view class V2 {
+inline class V2 {
   final R it;
   V2(this.it);
 }
 ```
 
-*There are no special rules for static members in views. They can be
+*There are no special rules for static members in inlines. They can be
 declared and called or torn off as usual, e.g.,
-`View.myStaticMethod(42)`.*
+`Inline.myStaticMethod(42)`.*
 
 
 ## Primitives
 
-This document needs to refer to explicit view method invocations, so we
-will add a special primitive, `invokeViewMethod`, to denote invocations of
-view methods.
+This document needs to refer to explicit inline method invocations, so we
+will add a special primitive, `invokeInlineMethod`, to denote invocations of
+inline methods.
 
-`invokeViewMethod` is used as a specification device and it cannot occur in
+`invokeInlineMethod` is used as a specification device and it cannot occur in
 Dart source code. (*As a reminder of this fact, it uses syntax which is not
 derivable in the Dart grammar.*)
 
 
-### Static Analysis of invokeViewMethod
+### Static Analysis of invokeInlineMethod
 
 We use
-<code>invokeViewMethod(V, &lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;, o).m(args)</code>
-where `V` is a type name denoting a view to denote the invocation of
-the view method `m` on `o` with arguments `args` and view type
+<code>invokeInlineMethod(V, &lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;, o).m(args)</code>
+where `V` is a type name denoting a inline to denote the invocation of
+the inline method `m` on `o` with arguments `args` and inline type
 arguments
 <code>T<sub>1</sub>, .. T<sub>s</sub></code>.
 Similar constructs exist for invocation of getters, setters, and
 operators.
 
-*For instance, `invokeViewMethod(V, <int>, o).myGetter` and
-`invokeViewMethod(V, <int>, o) + rightOperand`.*
+*For instance, `invokeInlineMethod(V, <int>, o).myGetter` and
+`invokeInlineMethod(V, <int>, o) + rightOperand`.*
 
 *We need special syntax because there is no syntax which will unambiguously
-denote a view member invocation. We could consider the syntax of explicit
+denote a inline member invocation. We could consider the syntax of explicit
 extension member invocations, e.g.,
 <code>V&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;(o).m(args)</code>,
 but this is ambiguous since
 <code>V&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;(o)</code>
-can be a view constructor invocation.  Similarly,
+can be a inline constructor invocation.  Similarly,
 <code>V&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;.m(o, args)</code>
 is similar to a named constructor invocation, but that is also
 confusing because it looks like actual source code, but it couldn't be
 used in an actual program.*
 
-The static analysis of `invokeViewMethod` is that it takes exactly
+The static analysis of `invokeInlineMethod` is that it takes exactly
 three positional arguments and must be the receiver in a member
-access. The first argument must be a type name `View` that denotes a
-view declaration, the next argument must be a type argument list, together
-yielding a view type _V_ (*the type argument list may be empty, to
+access. The first argument must be a type name `Inline` that denotes a
+inline declaration, the next argument must be a type argument list, together
+yielding a inline type _V_ (*the type argument list may be empty, to
 handle the non-generic case*). The third argument must be an expression
 whose static type is _V_ or the corresponding instantiated
 representation type (defined below). The member access must access a
-member of the declaration denoted by `View`, or a member of a
-superview of that view declaration.
+member of the declaration denoted by `Inline`, or a member of a
+superinline of that inline declaration.
 
-*Superviews are specified in the section 'Composing view types'.*
+*Superinlines are specified in the section 'Composing inline types'.*
 
 If the member access is a method invocation (including an invocation of an
 operator that takes at least one argument), it is allowed to pass an actual
@@ -491,21 +484,21 @@ parameters of `V` are replaced by
 <code>T<sub>1</sub>, .. T<sub>s</sub></code>.
 The type of the entire member access is the return type of said member if
 it is a member invocation, and the function type of the method if it is a
-view member tear-off, again substituting
+inline member tear-off, again substituting
 <code>T<sub>1</sub>, .. T<sub>s</sub></code>
 for the formal type parameters.
 
 
-### Dynamic Semantics of invokeViewMethod
+### Dynamic Semantics of invokeInlineMethod
 
 Let `e0` be an expression of the form
-<code>invokeViewMethod(View, &lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;, e).m(args)</code>.
+<code>invokeInlineMethod(Inline, &lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;, e).m(args)</code>.
 
 Evaluation of `e0` proceeds by evaluating `e` to an object `o` and
 evaluating `args` to an actual argument list `args1`, and then
-executing the body of `View.m` in an environment where `this` and the
+executing the body of `Inline.m` in an environment where `this` and the
 name of the representation are bound to `o`, the type variables of
-`View` are bound to the actual values of
+`Inline` are bound to the actual values of
 <code>T<sub>1</sub>, .. T<sub>s</sub></code>,
 and the formal parameters of `m` are bound to `args1` in the same way
 that they would be bound for a normal function call. If the body completes
@@ -517,15 +510,15 @@ same stack trace.
 obvious small adjustments.*
 
 
-## Static Analysis of Views
+## Static Analysis of Inlines
 
 Assume that
 <code>T<sub>1</sub>, .. T<sub>s</sub></code>
-are types and `V` resolves to a view declaration of the
+are types and `V` resolves to a inline declaration of the
 following form:
 
 ```dart
-view class V<X1 extends B1, .. Xs extends Bs>(T id) ... {
+inline class V<X1 extends B1, .. Xs extends Bs>(T id) ... {
   ... // Members
 }
 ```
@@ -536,11 +529,11 @@ as a type.
 
 *For example, it can occur as the declared type of a variable or
 parameter, as the return type of a function or getter, as a type
-argument in a type, as the representation type of a view, as the
+argument in a type, as the representation type of a inline, as the
 on-type of an extension, as the type in the `onPart` of a try/catch
 statement, in a type test `o is V<...>`, in a type cast `o as V<...>`,
 or as the body of a type alias. It is also allowed to create a new
-instance where one or more view types occur as type arguments.*
+instance where one or more inline types occur as type arguments.*
 
 A compile-time error occurs if the type
 <code>V&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code>
@@ -554,36 +547,36 @@ type of the receiver in each member invocation on `V`.*
 
 When `s` is zero,
 <code>V&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code>
-simply stands for `V`, a non-generic view.
+simply stands for `V`, a non-generic inline.
 When `s` is greater than zero, a raw occurrence `V` is treated like a raw
 type: Instantiation to bound is used to obtain the omitted type arguments.
 *Note that this may yield a super-bounded type, which is then a
 compile-time error.*
 
 We say that the static type of said variable, parameter, etc. _is the
-view type_
+inline type_
 <code>V&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code>,
-and that its static type _is a view type_.
+and that its static type _is a inline type_.
 
-A compile-time error occurs if a view type is used as a superinterface of a
-class or a mixin, or if a view type is used to derive a mixin.
+A compile-time error occurs if a inline type is used as a superinterface of a
+class or a mixin, or if a inline type is used to derive a mixin.
 
-*In other words, a view type cannot occur as a superinterface in an `extends`,
+*In other words, a inline type cannot occur as a superinterface in an `extends`,
 `with`, `implements`, or `on` clause of a class or mixin. On the other hand,
 it can occur in other ways, e.g., as a type argument of a superinterface.*
 
-If `e` is an expression whose static type `V` is the view type
-<code>View&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code>
+If `e` is an expression whose static type `V` is the inline type
+<code>Inline&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code>
 and `m` is the name of a member declared by `V`, then a member access
 like `e.m(args)` is treated as
-<code>invokeViewMethod(View, &lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;, e).m(args)</code>,
+<code>invokeInlineMethod(Inline, &lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;, e).m(args)</code>,
 and similarly for instance getters, setters, and operators.
 
-*In the body of a view declaration _DV_ with name `View` and type parameters
+*In the body of a inline declaration _DV_ with name `Inline` and type parameters
 <code>X<sub>1</sub>, .. X<sub>s</sub></code>, for an invocation like
 `m(args)`, if a declaration named `m` is found in the body of _DV_
 then that invocation is treated as
-<code>invokeViewMethod(View, &lt;X<sub>1</sub>, .. X<sub>s</sub>&gt;, this).m(args)</code>.
+<code>invokeInlineMethod(Inline, &lt;X<sub>1</sub>, .. X<sub>s</sub>&gt;, this).m(args)</code>.
 This is just the same treatment of `this` as in the body of a class.*
 
 *For example:*
@@ -593,7 +586,7 @@ extension E1 on int {
   void foo() { print('E1.foo'); }
 }
 
-view class V1(int it) {
+inline class V1(int it) {
   void foo() { print('V1.foo'); }
   void baz() { print('V1.baz'); }
   void qux() { print('V1.qux'); }
@@ -601,7 +594,7 @@ view class V1(int it) {
 
 void qux() { print('qux'); }
 
-view class V2(V1 it) {
+inline class V2(V1 it) {
   void foo() { print('V2.foo); }
   void bar() {
     foo(); // Prints 'V2.foo'.
@@ -614,114 +607,114 @@ view class V2(V1 it) {
 }
 ```
 
-*That is, when the static type of an expression is a view type `V`
+*That is, when the static type of an expression is a inline type `V`
 with representation type `R`, each method invocation on that
 expression will invoke an instance method declared by `V` or inherited
-from a superview (or it could be an extension method with on-type `V`).
+from a superinline (or it could be an extension method with on-type `V`).
 Similarly for other member accesses.*
 
-Let _DV_ be a view declaration named `View` with type parameters
+Let _DV_ be a inline declaration named `Inline` with type parameters
 <code>X<sub>1</sub> extends B<sub>1</sub>, .. X<sub>s</sub> extends B<sub>s</sub></code>
 and primary constructor `(R id)`.
 Alternatively, assume that _DV_ does not declare a primary
 constructor, but _DV_ declares a unique, final instance variable named
 `id` with declared type `R`.
 
-In both cases we say that the _declared representation type_ of `View`
+In both cases we say that the _declared representation type_ of `Inline`
 is `R`, and the _instantiated representation type_ corresponding to
-<code>View&lt;T<sub>1</sub>,.. T<sub>s</sub>&gt;</code> is
+<code>Inline&lt;T<sub>1</sub>,.. T<sub>s</sub>&gt;</code> is
 <code>[T<sub>1</sub>/X<sub>1</sub>, .. T<sub>s</sub>/X<sub>s</sub>]R</code>.
 
 We will omit 'declared' and 'instantiated' from the phrase when it is
-clear from the context whether we are talking about the view itself or
-a particular instantiation of a generic view. *For non-generic views,
+clear from the context whether we are talking about the inline itself or
+a particular instantiation of a generic inline. *For non-generic inlines,
 the representation type is the same in either case.*
 
-Let `V` be a view type of the form
-<code>View&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code>,
+Let `V` be a inline type of the form
+<code>Inline&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code>,
 and let `R` be the corresponding instantiated representation type.
 `V` is a proper subtype of `Object?`. If `R` is non-nullable then `V`
 is a proper subtype of `Object` as well.
 
-*That is, an expression of a view type can be assigned to a top type
+*That is, an expression of a inline type can be assigned to a top type
 (like all other expressions), and if the representation type is
-non-nullable then it can also be assigned to `Object`. Non-view types
-(except bottom types) cannot be assigned to view types without a cast.*
+non-nullable then it can also be assigned to `Object`. Non-inline types
+(except bottom types) cannot be assigned to inline types without a cast.*
 
-In the body of a member of a view declaration _DV_ named `View`
+In the body of a member of a inline declaration _DV_ named `Inline`
 and declaring the type parameters
 <code>X<sub>1</sub>, .. X<sub>s</sub></code>,
 the static type of `this` is
-<code>View&lt;X<sub>1</sub> .. X<sub>s</sub>&gt;</code>.
+<code>Inline&lt;X<sub>1</sub> .. X<sub>s</sub>&gt;</code>.
 The static type of the name of the representation name is the
 representation type.
 
-*For example, in `view class V(R id) {...}`, `id` has type `R`, and
+*For example, in `inline class V(R id) {...}`, `id` has type `R`, and
 `this` has type `V`.*
 
-Again, let `V` be a view type of the form
-<code>View&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code>,
+Again, let `V` be a inline type of the form
+<code>Inline&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code>,
 and let `R` be the corresponding instantiated representation type.
-If `R` is not a view type then we say that `V` is a view type
-at level zero. If `R` is a view type at level _k_ then we say that
-`V` is a view type at level _k + 1_.
+If `R` is not a inline type then we say that `V` is a inline type
+at level zero. If `R` is a inline type at level _k_ then we say that
+`V` is a inline type at level _k + 1_.
 A compile-time error occurs if the level of `V` is undefined.
 
 *In other words, cycles are not allowed.*
 
-A view declaration _DV_ named `View` may declare one or more
-constructors. A constructor which is declared in a view declaration is
-also known as a _view constructor_.
+A inline declaration _DV_ named `Inline` may declare one or more
+constructors. A constructor which is declared in a inline declaration is
+also known as a _inline constructor_.
 
-*The purpose of having a view constructor is that it bundles an
-approach for building an instance of the representation type of a view
+*The purpose of having a inline constructor is that it bundles an
+approach for building an instance of the representation type of a inline
 declaration _DV_ with _DV_ itself, which makes it easy to recognize
-that this is a way to obtain a value of that view type. It can also be
+that this is a way to obtain a value of that inline type. It can also be
 used to verify that an existing object (provided as an actual argument
-to the constructor) satisfies the requirements for having that view
+to the constructor) satisfies the requirements for having that inline
 type.*
 
 A primary constructor `(R id)` in _DV_ is a concise notation that
-gives rise to a constructor named `View` (that is, it is not "named")
+gives rise to a constructor named `Inline` (that is, it is not "named")
 that accepts one parameter of the form `this.id` and has no body.
 Moreover, the primary constructor induces an instance variable
 declaration of the form `final R id;`.
 
-A compile-time error occurs if a view constructor includes a
+A compile-time error occurs if a inline constructor includes a
 superinitializer. *That is, a term of the form `super(...)` or
 `super.id(...)` as the last element of the initializer list.*
 
-*In the body of a generative view constructor, the static type of
-`this` is the same as it is in any instance member of the view, that
-is, `View<X1 .. Xk>`, where `X1 .. Xk` are the type parameters
-declared by `View`.*
+*In the body of a generative inline constructor, the static type of
+`this` is the same as it is in any instance member of the inline, that
+is, `Inline<X1 .. Xk>`, where `X1 .. Xk` are the type parameters
+declared by `Inline`.*
 
 An instance creation expression of the form
-<code>View&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;(...)</code>
+<code>Inline&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;(...)</code>
 or
-<code>View&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;.name(...)</code>
+<code>Inline&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;.name(...)</code>
 is used to invoke these constructors, and the type of such an expression is
-<code>View&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code>.
+<code>Inline&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code>.
 
-*In short, view constructors appear to be very similar to constructors
+*In short, inline constructors appear to be very similar to constructors
 in classes, and they correspond to the situation where the enclosing
 class has a single non-late final instance variable which is initialized
 according to the normal rules for constructors (in particular, it must
 occur by means of `this.id` or in an initializer list).*
 
 
-### Composing view types
+### Composing inline types
 
 This section describes the effect of including a clause derived from
-`<interfaces>` in a view declaration. We use the phrase
-_the view implements clause_ to refer to this clause, or just
+`<interfaces>` in a inline declaration. We use the phrase
+_the inline implements clause_ to refer to this clause, or just
 _the implements clause_ when no ambiguity can arise.
 
 *The rationale is that the set of members and member implementations
-of a given view may need to overlap with that of other views. The
+of a given inline may need to overlap with that of other inlines. The
 implements clause allows for implementation reuse by putting shared
-members in a "super-view" `V1` and putting `V1` in the implements
-clause of several view declarations <code>V<sub>1</sub>
+members in a "super-inline" `V1` and putting `V1` in the implements
+clause of several inline declarations <code>V<sub>1</sub>
 .. V<sub>k</sub></code>, thus "inheriting" the members of `V1` into
 all of <code>V<sub>1</sub> .. V<sub>k</sub></code> without code
 duplication.*
@@ -729,23 +722,23 @@ duplication.*
 *The reason why this mechanism uses the keyword `implements` rather
 than `extends` to declare a relation that involves inheritance is that
 it has the same semantics as that of class extension members (a
-mechanism which is currently being considered), and view members are
+mechanism which is currently being considered), and inline members are
 similar to class extension members in that they are statically
 resolved.*
 
-Assume that _DV_ is a view declaration named `View`, and `V1` occurs as
+Assume that _DV_ is a inline declaration named `Inline`, and `V1` occurs as
 one of the `<type>`s in the `<interfaces>` of _DV_. In this case we
-say that `V1` is a superview of _DV_.
+say that `V1` is a superinline of _DV_.
 
 A compile-time error occurs if `V1` is a type name or a parameterized type
-which occurs as a superview in a view declaration _DV_, but `V1` does not
-denote a view type.
+which occurs as a superinline in a inline declaration _DV_, but `V1` does not
+denote a inline type.
 
-A compile-time error occurs if any direct or indirect superview of _DV_
-is the type `View` or a type of the form `View<...>`. *As usual,
+A compile-time error occurs if any direct or indirect superinline of _DV_
+is the type `Inline` or a type of the form `Inline<...>`. *As usual,
 subtype cycles are not allowed.*
 
-Assume that _DV_ has two direct or indirect superviews of the form
+Assume that _DV_ has two direct or indirect superinlines of the form
 <code>W&lt;T<sub>1</sub>, .. T<sub>k</sub>&gt;</code>
 respectively
 <code>W&lt;S<sub>1</sub>, .. S<sub>k</sub>&gt;</code>.
@@ -757,9 +750,9 @@ is equal to
 for each _j_ in _1 .. k_. The notion of equality used here is the same
 as with the corresponding rule about superinterfaces of classes.
 
-Assume that a view declaration _DV_ named `View` has representation
-type `R`, and that the view type `V1` with declaration _DV1_ is a
-superview of _DV_ (*note that `V1` may have some actual type
+Assume that a inline declaration _DV_ named `Inline` has representation
+type `R`, and that the inline type `V1` with declaration _DV1_ is a
+superinline of _DV_ (*note that `V1` may have some actual type
 arguments*).  Assume that `S` is the instantiated representation type
 corresponding to `V1`. A compile-time error occurs unless `R` is a
 subtype of `S`.
@@ -768,54 +761,54 @@ subtype of `S`.
 in `V1` when invoking members of `V1`, where `id` is the representation
 name of _DV_ and `id1` is the representation name of _DV1_.*
 
-Assume that _DV_ declares a view named `View` with type parameters
-<code>X<sub>1</sub> .. X<sub>s</sub></code> and `V1` is a superview of
+Assume that _DV_ declares a inline named `Inline` with type parameters
+<code>X<sub>1</sub> .. X<sub>s</sub></code> and `V1` is a superinline of
 _DV_. Then
-<code>View&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code> is a subtype of
+<code>Inline&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code> is a subtype of
 <code>[T<sub>1</sub>/X<sub>1</sub> .. T<sub>s</sub>/X<sub>s</sub>]V1</code>
 for all <code>T<sub>1</sub>, .. T<sub>s</sub></code>
 where these types are regular-bounded.
 
 *If they aren't regular-bounded then the type is a compile-time error
-in itself. In short, if `V1` is a superview of `V` then `V1` is also
+in itself. In short, if `V1` is a superinline of `V` then `V1` is also
 a supertype of `V`.*
 
-A compile-time error occurs if a view _DV_ has two superviews `V1` and
+A compile-time error occurs if a inline _DV_ has two superinlines `V1` and
 `V2`, where both `V1` and `V2` has a member named _m_ with distinct
 declarations, and _DV_ does not declare a member named _m_.
 
 *In other words, if two different declarations of _m_ are inherited
-from two superviews then the subview must resolve the conflict. The
+from two superinlines then the subinline must resolve the conflict. The
 so-called diamond inheritance pattern can create the case where two
-superviews have an _m_, but they are both declared by the same
-declaration (so `V` is a subview of `V1` and `V2`, and both `V1` and
-`V2` are subviews of `V3`, and `V3` declares _m_, in which case there
+superinlines have an _m_, but they are both declared by the same
+declaration (so `V` is a subinline of `V1` and `V2`, and both `V1` and
+`V2` are subinlines of `V3`, and `V3` declares _m_, in which case there
 is no conflict in `V`).*
 
-*Assume that _DV_ is a view declaration named `View` and that the view
-type `V1`, declared by _DV1_, is a superview of _DV_. Let `m` be the
+*Assume that _DV_ is a inline declaration named `Inline` and that the inline
+type `V1`, declared by _DV1_, is a superinline of _DV_. Let `m` be the
 name of a member of `V1`. If _DV_ also declares a member named `m`
 then the latter may be considered similar to a declaration that
-"overrides" the former.  However, it should be noted that view method
+"overrides" the former.  However, it should be noted that inline method
 invocation is resolved statically, and hence there is no override
 relationship among the two in the traditional object-oriented sense
 (that is, it will never occur that the statically known declaration is
 the member of `V1`, and the member invoked at run time is the one in
 _DV_). Still, a receiver with static type `V1` will invoke the
-declaration in _DV1_, and a receiver with static type `View` (or
-`View<...>`) will invoke the one in _DV_.*
+declaration in _DV1_, and a receiver with static type `Inline` (or
+`Inline<...>`) will invoke the one in _DV_.*
 
 Hence, we use a different word to describe the relationship between a
-member named _m_ of a superview, and a member named _m_ which is
-declared by the subview: We say that the latter _redeclares_ the
+member named _m_ of a superinline, and a member named _m_ which is
+declared by the subinline: We say that the latter _redeclares_ the
 former.
 
 *In particular, if two different declarations of _m_ is inherited
-from two superviews then the subview can resolve the conflict by
+from two superinlines then the subinline can resolve the conflict by
 redeclaring _m_.*
 
 *Note that there is no notion of having a 'correct override relation'
-here. With views, any member signature can redeclare any other member
+here. With inlines, any member signature can redeclare any other member
 signature with the same name, including the case where a method is
 overridden by a getter or vice versa. The reason for this is that no
 call site will resolve to one of several declarations at run time,
@@ -823,8 +816,8 @@ each invocation will statically resolve to one particular declaration,
 and this makes it possible to ensure that the invocation is type
 correct.*
 
-Assume that _DV_ is a view declaration and that the view types `V1`
-and `V2` are superviews of _DV_. Let `M1` be the members of `V1`, and
+Assume that _DV_ is a inline declaration and that the inline types `V1`
+and `V2` are superinlines of _DV_. Let `M1` be the members of `V1`, and
 `M2` the members of `V2`. A compile-time error occurs if there is a
 member name `m` such that `V1` as well as `V2` has a member named `m`,
 and they are distinct declarations, and _DV_ does not declare a member
@@ -832,30 +825,30 @@ named `m`.  *In other words, a name clash among distinct "inherited"
 members is an error, but it can be eliminated by redeclaring the
 clashing name.*
 
-The effect of having a view declaration _DV_ with superviews
+The effect of having a inline declaration _DV_ with superinlines
 `V1, .. Vk` is that the members declared by _DV_ as well as all
 members of `V1, .. Vk` that are not redeclared by a declaration in
 _DV_ can be invoked on a receiver of the type introduced by _DV_.
 
 In the body of _DV_, a superinvocation syntax similar to an explicit
 extension method invocation can be used to invoke a member of a
-superview which is redeclared: The invocation starts with `super.`
-followed by the name of the given superview, followed by the member
-access. The superview may be omitted in the case where there is no
+superinline which is redeclared: The invocation starts with `super.`
+followed by the name of the given superinline, followed by the member
+access. The superinline may be omitted in the case where there is no
 ambiguity.
 
 *For example:*
 
 ```dart
-view class V2(Object id) {
+inline class V2(Object id) {
   void foo() { print('V2.foo()'); }
 }
 
-view class V3(Object id) {
+inline class V3(Object id) {
   void foo() { print('V3.foo()'); }
 }
 
-view class V1(Object id) implements V2, V3 {
+inline class V1(Object id) implements V2, V3 {
   void bar() {
     super.V3.foo(); // Prints "V3.foo()".
   }
@@ -863,20 +856,20 @@ view class V1(Object id) implements V2, V3 {
 ```
 
 
-## Dynamic Semantics of Views
+## Dynamic Semantics of Inlines
 
-The dynamic semantics of view member invocation follows from the code
+The dynamic semantics of inline member invocation follows from the code
 transformation specified in the section about the static analysis.
 
 *In short, with `e` of type
-<code>View&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code>,
+<code>Inline&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code>,
 `e.m(args)` is treated as
-<code>invokeViewMethod(View, &lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;, e).m(args)</code>.
+<code>invokeInlineMethod(Inline, &lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;, e).m(args)</code>.
 Similarly for getters, setters, and operators.*
 
-Consider a view declaration _DV_ named `View` with representation name
+Consider a inline declaration _DV_ named `Inline` with representation name
 `id` and representation type `R`.  Invocation of a non-redirecting
-generative view constructor proceeds as follows: A fresh, non-late,
+generative inline constructor proceeds as follows: A fresh, non-late,
 final variable `v` is created. An initializing formal `this.id`
 has the side-effect that it initializes `v` to the actual argument
 passed to this formal. An initializer list element of the form
@@ -886,31 +879,31 @@ body, `this` and `id` are bound to the value of `v`.  The value of the
 instance creation expression that gave rise to this constructor
 execution is the value of `this`.
 
-At run time, for a given instance `o` typed as a view type `V`, there
+At run time, for a given instance `o` typed as a inline type `V`, there
 is _no_ reification of `V` associated with `o`.
 
 *This means that, at run time, an object never "knows" that it is being
-viewed as having a view type. By soundness, the run-time type of `o`
+inlineed as having a inline type. By soundness, the run-time type of `o`
 will be a subtype of the representation type of `V`.*
 
-The run-time representation of a type argument which is a view type
+The run-time representation of a type argument which is a inline type
 `V` is the corresponding instantiated representation type.
 
-*This means that a view type and the underlying representation type
+*This means that a inline type and the underlying representation type
 are considered as being the same type at run time. So we can freely
-use a cast to introduce or discard the view type, as the static type
+use a cast to introduce or discard the inline type, as the static type
 of an instance, or as a type argument in the static type of a data
-structure or function involving the view type.*
+structure or function involving the inline type.*
 
 A type test, `o is U` or `o is! U`, and a type cast, `o as U`, where `U` is
-or contains a view type, is performed at run time as a type test and type
-cast on the run-time representation of the view type as described above.
+or contains a inline type, is performed at run time as a type test and type
+cast on the run-time representation of the inline type as described above.
 
 
 ### Summary of Typing Relationships
 
-*Here is an overview of the subtype relationships of a view type
-`V0` with representation type `R` and superviews `V1 .. Vk`, as well
+*Here is an overinline of the subtype relationships of a inline type
+`V0` with representation type `R` and superinlines `V1 .. Vk`, as well
 as other typing relationships involving `V0`:*
 
 - *`V0` is a subtype of `Object?`.*
@@ -938,27 +931,27 @@ discussions.
 ### Support "private inheritance"?
 
 In the current proposal there is a subtype relationship between every
-view and each of its superviews. So if we have
-`view V(...) extends V1, V2 ...` then `V <: V1` and `V <: V2`.
+inline and each of its superinlines. So if we have
+`inline V(...) extends V1, V2 ...` then `V <: V1` and `V <: V2`.
 
 In some cases it might be preferable to omit the subtype relationship,
-even though there is a code reuse element (because `V1` is a superview
+even though there is a code reuse element (because `V1` is a superinline
 of `V`, we just don't need or want `V <: V1`).
 
 A possible workaround would be to write forwarding methods manually:
 
 ```dart
-view class V1(R it) {
+inline class V1(R it) {
   void foo() {...}
 }
 
 // `V` can reuse code from `V1` by using `implements`. Note that
 // `S <: R`, because otherwise it is a compile-time error.
-view class V(S it) implements V1 {}
+inline class V(S it) implements V1 {}
 
 // Alternatively, we can write a forwarder, in order to avoid
 // having the subtype relationship `V <: V1`.
-view class V(S it) {
+inline class V(S it) {
   void foo() => V1(it).foo();
 }
 ```

--- a/working/1426-extension-types/feature-specification-views.md
+++ b/working/1426-extension-types/feature-specification-views.md
@@ -1,90 +1,97 @@
-# Inline Classes
+# Views
 
 Author: eernst@google.com
 
-Status: Accepted.
+Status: Draft
 
 
 ## Change Log
 
-This document is built on several earlier proposals of a similar feature (but with different terminology and syntax). The most recent version of the [views][1] proposal as well as the [extension struct][2] proposal provide information about the process in their own change logs.
+2022.09.22
+  - Removed support for `export`, changed `view` to `view class`.
 
-[1]: https://github.com/dart-lang/language/blob/master/working/1462-extension-types/feature-specification-views.md
-[2]: https://github.com/dart-lang/language/blob/master/working/extension_structs/overview.md
+2022.09.20
+  - Updated the inheritance mechanism to fit in with a potential non-virtual
+    method mechanism for classes: Use `implements`, remove show/hide.
 
-2022.11.11
-  - Initial version, which is a copy of the views proposal, renaming 'view'
-    to 'inline' and adjusting the text accordingly.
+2022.08.30
+  - Used inspiration from the [extension struct][1] proposal and
+    various discussions to simplify and improve this proposal.
+
+2021.05.12
+  - Initial version.
+
+[1]: https://github.com/dart-lang/language/blob/master/working/extension_structs/overview.md
 
 
 ## Summary
 
-This document specifies a language feature that we call "inline classes".
+This document specifies a language feature that we call "view classes".
 
-The feature introduces _inline types_, which are a new kind of type
-declared by a new `inline class` declaration. A inline type provides a
+The feature introduces _view types_, which are a new kind of type
+declared by a new `view class` declaration. A view type provides a
 replacement of the members available on instances of existing types:
-when the static type of the instance is a inline type _V_, the available
+when the static type of the instance is a view type _V_, the available
 instance members are exactly the ones provided by _V_ (noting that
 there may also be some accessible and applicable extension members).
 
-In contrast, when the static type of an instance is not a inline type,
+In contrast, when the static type of an instance is not a view type,
 it is (by soundness) always the run-time type of the instance, or a
 supertype thereof. This means that the available instance members are
 the members of the run-time type of the instance, or a subset thereof
 (again: there may also be some extension members).
 
 Hence, using a supertype as the static type allows us to see only a
-subset of the members. Using a inline type allows us to _replace_ the
+subset of the members. Using a view type allows us to _replace_ the
 set of members, with subsetting as a special case.
 
-This functionality is entirely static. Invocation of a inline member is
+This functionality is entirely static. Invocation of a view member is
 resolved at compile-time, based on the static type of the receiver.
 
-A inline class may be considered to be a zero-cost abstraction in the
+A view class may be considered to be a zero-cost abstraction in the
 sense that it works similarly to a wrapper object that holds the
-wrapped object in a final instance variable. The inline class thus
+wrapped object in a final instance variable. The view class thus
 provides an interface which is chosen independently of the interface
 of the wrapped object, and it provides implementations of the members
-of the interface of the inline class, and those implementations can use
+of the interface of the view class, and those implementations can use
 the members of the wrapped object as needed.
 
-However, even though a inline class behaves like a wrapping, the wrapper
+However, even though a view class behaves like a wrapping, the wrapper
 object will never exist at run time, and a reference whose type is the
-inline class will actually refer directly to the underlying wrapped
+view class will actually refer directly to the underlying wrapped
 object. Every member access (e.g., an invocation of a method or a
-getter) on an expression whose static type is a inline type will invoke
-a member of the inline class (with some exceptions, as explained below),
+getter) on an expression whose static type is a view type will invoke
+a member of the view class (with some exceptions, as explained below),
 but this occurs because those member accesses are resolved statically,
 which means that the wrapper object is not actually needed.
 
 Given that there is no wrapper object, we will refer to the "wrapped"
-object as the _representation object_ of the inline class, or just the
+object as the _representation object_ of the view class, or just the
 _representation_.
 
-Inside the inline class declaration, the keyword `this` is a reference
-to the representation whose static type is the enclosing inline class. A
-member access to a member of the enclosing inline class may rely on
+Inside the view class declaration, the keyword `this` is a reference
+to the representation whose static type is the enclosing view class. A
+member access to a member of the enclosing view class may rely on
 `this` being induced implicitly (for example, `foo()` means
-`this.foo()` if the inline class contains a method declaration named
+`this.foo()` if the view class contains a method declaration named
 `foo`). A reference to the representation typed by its run-time type
 or a supertype thereof (that is, typed by a "normal" type for the
 representation) is available as a declared name, which is introduced
 by a new syntax similar to a parameter list declaration (for example
-`(int i)`) which follows the name of the inline class. (This syntax is
+`(int i)`) which follows the name of the view class. (This syntax is
 intended to be a special case of an upcoming mechanism known as
-_primary constructors_.) The representation type of the inline class
+_primary constructors_.) The representation type of the view class
 (with `(int i)` that's `int`) is similar to the on-type of an
 extension declaration.
 
-All in all, a inline class allows us to replace the interface of a given
+All in all, a view class allows us to replace the interface of a given
 representation object and specify how to implement the new interface
 in terms of the interface of the representation object.
 
 This is something that we could obviously do with a wrapper, but when
-it is done with a inline class there is no wrapper object, and hence
+it is done with a view class there is no wrapper object, and hence
 there is no run-time performance cost. In particular, in the case
-where we have a inline type `V` with representation type `R` we may be
+where we have a view type `V` with representation type `R` we may be
 able to refer to a `List<R>` using the type `List<V>`
 (using `theRList as List<V>`), and this corresponds to "wrapping every
 element in the list", but it only takes time _O(1)_ and no space, no
@@ -93,29 +100,29 @@ matter how many elements the list contains.
 
 ## Motivation
 
-A _inline class_ is a zero-cost abstraction mechanism that allows
+A _view class_ is a zero-cost abstraction mechanism that allows
 developers to replace the set of available operations on a given object
 (that is, the instance members of its type) by a different set of
-operations (the members declared by the given inline type).
+operations (the members declared by the given view type).
 
 It is zero-cost in the sense that the value denoted by an expression
-whose type is a inline type is an object of a different type (known as
-the _representation type_ of the inline type), and there is no wrapper
-object, in spite of the fact that the inline class behaves similarly to
+whose type is a view type is an object of a different type (known as
+the _representation type_ of the view type), and there is no wrapper
+object, in spite of the fact that the view class behaves similarly to
 a wrapping.
 
-The point is that the inline type allows for a convenient and safe treatment
+The point is that the view type allows for a convenient and safe treatment
 of a given object `o` (and objects reachable from `o`) for a specialized
 purpose. It is in particular aimed at the situation where that purpose
 requires a certain discipline in the use of `o`'s instance methods: We may
 call certain methods, but only in specific ways, and other methods should
 not be called at all. This kind of added discipline can be enforced by
-accessing `o` typed as a inline type, rather than typed as its run-time
+accessing `o` typed as a view type, rather than typed as its run-time
 type `R` or some supertype of `R` (which is what we normally do). For
 example:
 
 ```dart
-inline class IdNumber(int i) {
+view class IdNumber(int i) {
   // Declare a few members.
 
   // Assume that it makes sense to compare ID numbers
@@ -151,52 +158,52 @@ void main() {
 In short, we want an `int` representation, but we want to make sure
 that we don't accidentally add ID numbers or multiply them, and we
 don't want to silently pass an ID number (e.g., as actual arguments or
-in assignments) where an `int` is expected. The inline class `IdNumber`
+in assignments) where an `int` is expected. The view class `IdNumber`
 will do all these things.
 
-We can actually cast away the inline type and hence get access to the
+We can actually cast away the view type and hence get access to the
 interface of the representation, but we assume that the developer
-wishes to maintain this extra discipline, and won't cast away the inline
+wishes to maintain this extra discipline, and won't cast away the view
 type onless there is a good reason to do so. Similarly, we can access
 the representation using the representation name as a getter.  There
 is no reason to consider the latter to be a violation of any kind of
 encapsulation or protection barrier, it's just like any other getter
-invocation. If desired, the author of the inline class can choose to use
+invocation. If desired, the author of the view class can choose to use
 a private representation name, to obtain a small amount of extra
 encapsulation.
 
-The extra discipline is enforced because the inline member
+The extra discipline is enforced because the view member
 implementations will only treat the representation object in ways that
 are written with the purpose of conforming to this particular
 discipline (and thereby defines what this discipline is). For example,
 if the discipline includes the rule that you should never call a
-method `foo` on the representation, then the author of the inline class
-will simply need to make sure that none of the inline member
+method `foo` on the representation, then the author of the view class
+will simply need to make sure that none of the view member
 declarations ever calls `foo`.
 
 Another example would be that we're using interop with JavaScript, and
 we wish to work on a given `JSObject` representing a button, using a
 `Button` interface which is meaningful for buttons. In this case the
 implementation of the members of `Button` will call some low-level
-functions like `js_util.getProperty`, but a client who uses the inline
+functions like `js_util.getProperty`, but a client who uses the view
 class will have a full implementation of the `Button` interface, and
 will hence never need to call `js_util.getProperty`.
 
 (We _can_ just call `js_util.getProperty` anyway, because it accepts
 two arguments of type `Object`. But we assume that the developer will
 be happy about sticking to the rule that the low-level functions
-aren't invoked in application code, and they can do that by using inline
+aren't invoked in application code, and they can do that by using view
 classes like `Button`. It is then easy to `grep` your application code
 and verify that it never calls `js_util.getProperty`.)
 
-Another potential application would be to generate inline class
+Another potential application would be to generate view class
 declarations handling the navigation of dynamic object trees that are
 known to satisfy some sort of schema outside the Dart type system. For
 instance, they could be JSON values, modeled using `num`, `bool`,
 `String`, `List<dynamic>`, and `Map<String, dynamic>`, and those JSON
 values might again be structured according to some schema.
 
-Without inline types, the JSON value would most likely be handled with
+Without view types, the JSON value would most likely be handled with
 static type `dynamic`, and all operations on it would be unsafe. If the
 JSON value is assumed to satisfy a specific schema, then it would be
 possible to reason about this dynamic code and navigate the tree correctly
@@ -205,7 +212,7 @@ reasoning is required may be fragmented into many different locations, and
 there is no help detecting that some of those locations are treating the
 tree incorrectly according to the schema.
 
-If inline classes are available then we can declare a set of inline types
+If view classes are available then we can declare a set of view types
 with operations that are tailored to work correctly with the given
 schema and its subschemas. This is less error-prone and more
 maintainable than the approach where the tree is handled with static
@@ -216,7 +223,7 @@ we're assuming allows for nested `List<dynamic>` with numbers at the
 leaves, and nothing else.
 
 ```dart
-inline class TinyJson(Object it) {
+view class TinyJson(Object it) {
   Iterable<num> get leaves sync* {
     if (it is num) {
       yield it;
@@ -240,10 +247,10 @@ void main() {
 Note that `it` is subject to promotion in the above example. This is safe
 because there is no way to override this would-be final instance variable.
 
-The syntax `(Object it)` in the declaration of the inline class causes
-the inline class to have a constructor and a final instance variable
+The syntax `(Object it)` in the declaration of the view class causes
+the view class to have a constructor and a final instance variable
 `it` of type `Object`, and it can be used to obtain a value of the
-inline type from a given instance of the representation type. This
+view type from a given instance of the representation type. This
 syntax is known as a _primary constructor_.
 
 It is possible to declare other constructors as well; details are
@@ -251,17 +258,17 @@ given in the proposal. A constructor body may be declared. It could be
 used, e.g., to verify that the given representation object satisfies
 some constraints.
 
-In any case, an instance creation of a inline type, `Inline<T>(o)`, will
+In any case, an instance creation of a view type, `View<T>(o)`, will
 evaluate to a reference to the value of the final instance variable of
-the inline class, with the static type `Inline<T>` (and there is no object
-at run time that represents the inline class itself).
+the view class, with the static type `View<T>` (and there is no object
+at run time that represents the view class itself).
 
 The name `TinyJson` can be used as a type, and a reference with that
 type can refer to an instance of the underlying representation type
 `Object`. In the example, the inferred type of `tiny` is `TinyJson`.
 
 We can now impose an enhanced discipline on the use of `tiny`, because
-the inline type allows for invocations of the members of the inline class,
+the view type allows for invocations of the members of the view class,
 which enables a specific treatment of the underlying instance of
 `Object`, consistent with the assumed schema.
 
@@ -273,24 +280,24 @@ of the `add` method on `tiny` would have been allowed if we had used the
 type `List<dynamic>` (or `dynamic`) for `tiny`, and that could break the
 schema.
 
-When the type of the receiver is the inline type `TinyJson`, it is a
+When the type of the receiver is the view type `TinyJson`, it is a
 compile-time error to invoke any members that are not in the interface of
-the inline type (in this case that means: the members declared in the
+the view type (in this case that means: the members declared in the
 body of `TinyJson`). So it is an error to call `add` on `tiny`, and that
 protects us from this kind of schema violations.
 
-In general, the use of a inline type allows us to centralize some unsafe
+In general, the use of a view type allows us to centralize some unsafe
 operations. We can then reason carefully about each operation once and
-for all. Clients use the inline type to access objects conforming to the
+for all. Clients use the view type to access objects conforming to the
 given schema, and that gives them access to a set of known-safe
 operations, making all other operations in the interface of the
 representation type a compile-time error.
 
-One possible perspective is that a inline type corresponds to an abstract
+One possible perspective is that a view type corresponds to an abstract
 data type: There is an underlying representation, but we wish to restrict
 the access to that representation to a set of operations that are
 independent of the operations available on the representation. In other
-words, the inline type ensures that we only work with the representation in
+words, the view type ensures that we only work with the representation in
 specific ways, even though the representation itself has an interface that
 allows us to do many other (wrong) things.
 
@@ -300,7 +307,7 @@ working on a wrapper object rather than accessing `o` and its methods
 directly:
 
 ```dart
-// Emulate the inline class using a class.
+// Emulate the view class using a class.
 
 class TinyJson {
   // `representation` is assumed to be a nested list of numbers.
@@ -329,7 +336,7 @@ void main() {
 }
 ```
 
-This is similar to the inline type in that it enforces the use of specific
+This is similar to the view type in that it enforces the use of specific
 operations (here we only have one: `leaves`) and in general makes it an
 error to use instance methods of the representation (e.g., `add`).
 
@@ -338,143 +345,143 @@ wish to work on an entire data structure we'd need to wrap each object as
 we navigate the data structure. For instance, we need to create a wrapper
 `TinyJson(element)` in order to invoke `leaves` recursively.
 
-In contrast, the inline class is zero-cost, in the sense that it does
+In contrast, the view class is zero-cost, in the sense that it does
 _not_ use a wrapper object, it enforces the desired discipline
-statically. In the inline class, the invocation of `TinyJson(element)`
+statically. In the view class, the invocation of `TinyJson(element)`
 in the body of `leaves` can be eliminated entirely by inlining.
 
-Inline classes are static in nature, like extension members: A inline
+View classes are static in nature, like extension members: A view
 class declaration may declare some type parameters. The type
 parameters will be bound to types which are determined by the static
-type of the receiver. Similarly, members of a inline type are resolved
-statically, i.e., if `tiny.leaves` is an invocation of a inline getter
+type of the receiver. Similarly, members of a view type are resolved
+statically, i.e., if `tiny.leaves` is an invocation of a view getter
 `leaves`, then the declaration named `leaves` whose body is executed
 is determined at compile-time. There is no support for late binding of
-a inline member, and hence there is no notion of overriding. In return
+a view member, and hence there is no notion of overriding. In return
 for this lack of expressive power, we get improved performance.
 
 
 ## Syntax
 
-A rule for `<inlineDeclaration>` is added to the grammar, along with some
-rules for elements used in inline declarations:
+A rule for `<viewDeclaration>` is added to the grammar, along with some
+rules for elements used in view declarations:
 
 ```ebnf
-<inlineDeclaration> ::=
-  'inline' 'class' <typeIdentifier> <typeParameters>?
-      <inlinePrimaryConstructor>?
+<viewDeclaration> ::=
+  'view' 'class' <typeIdentifier> <typeParameters>?
+      <viewPrimaryConstructor>?
       <interfaces>?
   '{'
-    (<metadata> <inlineMemberDeclaration>)*
+    (<metadata> <viewMemberDeclaration>)*
   '}'
 
-<inlinePrimaryConstructor> ::=
+<viewPrimaryConstructor> ::=
   '(' <type> <identifier> ')'
 
-<inlineMemberDeclaration> ::=
+<viewMemberDeclaration> ::=
   <classMemberDefinition>
 ```
 
-The token `inline` is made a built-in identifier.
+The token `view` is made a built-in identifier.
 
 A few errors can be detected immediately from the syntax:
 
-If a inline declaration named `Inline` includes a
-`<inlinePrimaryConstructor>` then it is a compile-time error if the
-declaration includes a constructor declaration named `Inline`. (*But it
+If a view declaration named `View` includes a
+`<viewPrimaryConstructor>` then it is a compile-time error if the
+declaration includes a constructor declaration named `View`. (*But it
 can still contain other constructors.*)
 
-If a inline declaration named `Inline` does not include a
-`<inlinePrimaryConstructor>` then an error occurs unless the inline declares
+If a view declaration named `View` does not include a
+`<viewPrimaryConstructor>` then an error occurs unless the view declares
 exactly one instance variable `v`. An error occurs unless the declaration of `v`
 is final. An error occurs if the declaration of `v` is late.
 
-The _name of the representation_ in a inline declaration that includes a
-`<inlinePrimaryConstructor>` is the identifier `id` specified in there, and
+The _name of the representation_ in a view declaration that includes a
+`<viewPrimaryConstructor>` is the identifier `id` specified in there, and
 the _type of the representation_ is the declared type of `id`.
 
-In a inline declaration named `Inline` that does not include a
-`<inlinePrimaryConstructor>`, the _name of the representation_ is the name
+In a view declaration named `View` that does not include a
+`<viewPrimaryConstructor>`, the _name of the representation_ is the name
 `id` of the unique final instance variable that it declares, and the
 _type of the representation_ is the declared type of `id`.
 
-A compile-time error occurs if a inline declaration declares an abstract
-member. A compile-time error occurs if a inline declaration has a
-`<inlinePrimaryConstructor>` and declares an instance variable. Finally,
-a compile-time error occurs if a inline does not have a
-`<inlinePrimaryConstructor>`, and it does not declare an instance
+A compile-time error occurs if a view declaration declares an abstract
+member. A compile-time error occurs if a view declaration has a
+`<viewPrimaryConstructor>` and declares an instance variable. Finally,
+a compile-time error occurs if a view does not have a
+`<viewPrimaryConstructor>`, and it does not declare an instance
 variable, or it declares more than one instance variable.
 
-*That is, every inline declares exactly one instance variable, and it is
+*That is, every view declares exactly one instance variable, and it is
 final. A primary constructor (as defined in this document) is just an
 abbreviated syntax whose desugaring includes a declaration of exactly
 one final instance variable.*
 
 ```dart
 // Using a primary constructor.
-inline class V1(R it) {}
+view class V1(R it) {}
 
 // Same thing, using a normal constructor.
-inline class V2 {
+view class V2 {
   final R it;
   V2(this.it);
 }
 ```
 
-*There are no special rules for static members in inlines. They can be
+*There are no special rules for static members in views. They can be
 declared and called or torn off as usual, e.g.,
-`Inline.myStaticMethod(42)`.*
+`View.myStaticMethod(42)`.*
 
 
 ## Primitives
 
-This document needs to refer to explicit inline method invocations, so we
-will add a special primitive, `invokeInlineMethod`, to denote invocations of
-inline methods.
+This document needs to refer to explicit view method invocations, so we
+will add a special primitive, `invokeViewMethod`, to denote invocations of
+view methods.
 
-`invokeInlineMethod` is used as a specification device and it cannot occur in
+`invokeViewMethod` is used as a specification device and it cannot occur in
 Dart source code. (*As a reminder of this fact, it uses syntax which is not
 derivable in the Dart grammar.*)
 
 
-### Static Analysis of invokeInlineMethod
+### Static Analysis of invokeViewMethod
 
 We use
-<code>invokeInlineMethod(V, &lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;, o).m(args)</code>
-where `V` is a type name denoting a inline to denote the invocation of
-the inline method `m` on `o` with arguments `args` and inline type
+<code>invokeViewMethod(V, &lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;, o).m(args)</code>
+where `V` is a type name denoting a view to denote the invocation of
+the view method `m` on `o` with arguments `args` and view type
 arguments
 <code>T<sub>1</sub>, .. T<sub>s</sub></code>.
 Similar constructs exist for invocation of getters, setters, and
 operators.
 
-*For instance, `invokeInlineMethod(V, <int>, o).myGetter` and
-`invokeInlineMethod(V, <int>, o) + rightOperand`.*
+*For instance, `invokeViewMethod(V, <int>, o).myGetter` and
+`invokeViewMethod(V, <int>, o) + rightOperand`.*
 
 *We need special syntax because there is no syntax which will unambiguously
-denote a inline member invocation. We could consider the syntax of explicit
+denote a view member invocation. We could consider the syntax of explicit
 extension member invocations, e.g.,
 <code>V&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;(o).m(args)</code>,
 but this is ambiguous since
 <code>V&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;(o)</code>
-can be a inline constructor invocation.  Similarly,
+can be a view constructor invocation.  Similarly,
 <code>V&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;.m(o, args)</code>
 is similar to a named constructor invocation, but that is also
 confusing because it looks like actual source code, but it couldn't be
 used in an actual program.*
 
-The static analysis of `invokeInlineMethod` is that it takes exactly
+The static analysis of `invokeViewMethod` is that it takes exactly
 three positional arguments and must be the receiver in a member
-access. The first argument must be a type name `Inline` that denotes a
-inline declaration, the next argument must be a type argument list, together
-yielding a inline type _V_ (*the type argument list may be empty, to
+access. The first argument must be a type name `View` that denotes a
+view declaration, the next argument must be a type argument list, together
+yielding a view type _V_ (*the type argument list may be empty, to
 handle the non-generic case*). The third argument must be an expression
 whose static type is _V_ or the corresponding instantiated
 representation type (defined below). The member access must access a
-member of the declaration denoted by `Inline`, or a member of a
-superinline of that inline declaration.
+member of the declaration denoted by `View`, or a member of a
+superview of that view declaration.
 
-*Superinlines are specified in the section 'Composing inline types'.*
+*Superviews are specified in the section 'Composing view types'.*
 
 If the member access is a method invocation (including an invocation of an
 operator that takes at least one argument), it is allowed to pass an actual
@@ -484,21 +491,21 @@ parameters of `V` are replaced by
 <code>T<sub>1</sub>, .. T<sub>s</sub></code>.
 The type of the entire member access is the return type of said member if
 it is a member invocation, and the function type of the method if it is a
-inline member tear-off, again substituting
+view member tear-off, again substituting
 <code>T<sub>1</sub>, .. T<sub>s</sub></code>
 for the formal type parameters.
 
 
-### Dynamic Semantics of invokeInlineMethod
+### Dynamic Semantics of invokeViewMethod
 
 Let `e0` be an expression of the form
-<code>invokeInlineMethod(Inline, &lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;, e).m(args)</code>.
+<code>invokeViewMethod(View, &lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;, e).m(args)</code>.
 
 Evaluation of `e0` proceeds by evaluating `e` to an object `o` and
 evaluating `args` to an actual argument list `args1`, and then
-executing the body of `Inline.m` in an environment where `this` and the
+executing the body of `View.m` in an environment where `this` and the
 name of the representation are bound to `o`, the type variables of
-`Inline` are bound to the actual values of
+`View` are bound to the actual values of
 <code>T<sub>1</sub>, .. T<sub>s</sub></code>,
 and the formal parameters of `m` are bound to `args1` in the same way
 that they would be bound for a normal function call. If the body completes
@@ -510,15 +517,15 @@ same stack trace.
 obvious small adjustments.*
 
 
-## Static Analysis of Inlines
+## Static Analysis of Views
 
 Assume that
 <code>T<sub>1</sub>, .. T<sub>s</sub></code>
-are types and `V` resolves to a inline declaration of the
+are types and `V` resolves to a view declaration of the
 following form:
 
 ```dart
-inline class V<X1 extends B1, .. Xs extends Bs>(T id) ... {
+view class V<X1 extends B1, .. Xs extends Bs>(T id) ... {
   ... // Members
 }
 ```
@@ -529,11 +536,11 @@ as a type.
 
 *For example, it can occur as the declared type of a variable or
 parameter, as the return type of a function or getter, as a type
-argument in a type, as the representation type of a inline, as the
+argument in a type, as the representation type of a view, as the
 on-type of an extension, as the type in the `onPart` of a try/catch
 statement, in a type test `o is V<...>`, in a type cast `o as V<...>`,
 or as the body of a type alias. It is also allowed to create a new
-instance where one or more inline types occur as type arguments.*
+instance where one or more view types occur as type arguments.*
 
 A compile-time error occurs if the type
 <code>V&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code>
@@ -547,36 +554,36 @@ type of the receiver in each member invocation on `V`.*
 
 When `s` is zero,
 <code>V&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code>
-simply stands for `V`, a non-generic inline.
+simply stands for `V`, a non-generic view.
 When `s` is greater than zero, a raw occurrence `V` is treated like a raw
 type: Instantiation to bound is used to obtain the omitted type arguments.
 *Note that this may yield a super-bounded type, which is then a
 compile-time error.*
 
 We say that the static type of said variable, parameter, etc. _is the
-inline type_
+view type_
 <code>V&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code>,
-and that its static type _is a inline type_.
+and that its static type _is a view type_.
 
-A compile-time error occurs if a inline type is used as a superinterface of a
-class or a mixin, or if a inline type is used to derive a mixin.
+A compile-time error occurs if a view type is used as a superinterface of a
+class or a mixin, or if a view type is used to derive a mixin.
 
-*In other words, a inline type cannot occur as a superinterface in an `extends`,
+*In other words, a view type cannot occur as a superinterface in an `extends`,
 `with`, `implements`, or `on` clause of a class or mixin. On the other hand,
 it can occur in other ways, e.g., as a type argument of a superinterface.*
 
-If `e` is an expression whose static type `V` is the inline type
-<code>Inline&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code>
+If `e` is an expression whose static type `V` is the view type
+<code>View&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code>
 and `m` is the name of a member declared by `V`, then a member access
 like `e.m(args)` is treated as
-<code>invokeInlineMethod(Inline, &lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;, e).m(args)</code>,
+<code>invokeViewMethod(View, &lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;, e).m(args)</code>,
 and similarly for instance getters, setters, and operators.
 
-*In the body of a inline declaration _DV_ with name `Inline` and type parameters
+*In the body of a view declaration _DV_ with name `View` and type parameters
 <code>X<sub>1</sub>, .. X<sub>s</sub></code>, for an invocation like
 `m(args)`, if a declaration named `m` is found in the body of _DV_
 then that invocation is treated as
-<code>invokeInlineMethod(Inline, &lt;X<sub>1</sub>, .. X<sub>s</sub>&gt;, this).m(args)</code>.
+<code>invokeViewMethod(View, &lt;X<sub>1</sub>, .. X<sub>s</sub>&gt;, this).m(args)</code>.
 This is just the same treatment of `this` as in the body of a class.*
 
 *For example:*
@@ -586,7 +593,7 @@ extension E1 on int {
   void foo() { print('E1.foo'); }
 }
 
-inline class V1(int it) {
+view class V1(int it) {
   void foo() { print('V1.foo'); }
   void baz() { print('V1.baz'); }
   void qux() { print('V1.qux'); }
@@ -594,7 +601,7 @@ inline class V1(int it) {
 
 void qux() { print('qux'); }
 
-inline class V2(V1 it) {
+view class V2(V1 it) {
   void foo() { print('V2.foo); }
   void bar() {
     foo(); // Prints 'V2.foo'.
@@ -607,114 +614,114 @@ inline class V2(V1 it) {
 }
 ```
 
-*That is, when the static type of an expression is a inline type `V`
+*That is, when the static type of an expression is a view type `V`
 with representation type `R`, each method invocation on that
 expression will invoke an instance method declared by `V` or inherited
-from a superinline (or it could be an extension method with on-type `V`).
+from a superview (or it could be an extension method with on-type `V`).
 Similarly for other member accesses.*
 
-Let _DV_ be a inline declaration named `Inline` with type parameters
+Let _DV_ be a view declaration named `View` with type parameters
 <code>X<sub>1</sub> extends B<sub>1</sub>, .. X<sub>s</sub> extends B<sub>s</sub></code>
 and primary constructor `(R id)`.
 Alternatively, assume that _DV_ does not declare a primary
 constructor, but _DV_ declares a unique, final instance variable named
 `id` with declared type `R`.
 
-In both cases we say that the _declared representation type_ of `Inline`
+In both cases we say that the _declared representation type_ of `View`
 is `R`, and the _instantiated representation type_ corresponding to
-<code>Inline&lt;T<sub>1</sub>,.. T<sub>s</sub>&gt;</code> is
+<code>View&lt;T<sub>1</sub>,.. T<sub>s</sub>&gt;</code> is
 <code>[T<sub>1</sub>/X<sub>1</sub>, .. T<sub>s</sub>/X<sub>s</sub>]R</code>.
 
 We will omit 'declared' and 'instantiated' from the phrase when it is
-clear from the context whether we are talking about the inline itself or
-a particular instantiation of a generic inline. *For non-generic inlines,
+clear from the context whether we are talking about the view itself or
+a particular instantiation of a generic view. *For non-generic views,
 the representation type is the same in either case.*
 
-Let `V` be a inline type of the form
-<code>Inline&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code>,
+Let `V` be a view type of the form
+<code>View&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code>,
 and let `R` be the corresponding instantiated representation type.
 `V` is a proper subtype of `Object?`. If `R` is non-nullable then `V`
 is a proper subtype of `Object` as well.
 
-*That is, an expression of a inline type can be assigned to a top type
+*That is, an expression of a view type can be assigned to a top type
 (like all other expressions), and if the representation type is
-non-nullable then it can also be assigned to `Object`. Non-inline types
-(except bottom types) cannot be assigned to inline types without a cast.*
+non-nullable then it can also be assigned to `Object`. Non-view types
+(except bottom types) cannot be assigned to view types without a cast.*
 
-In the body of a member of a inline declaration _DV_ named `Inline`
+In the body of a member of a view declaration _DV_ named `View`
 and declaring the type parameters
 <code>X<sub>1</sub>, .. X<sub>s</sub></code>,
 the static type of `this` is
-<code>Inline&lt;X<sub>1</sub> .. X<sub>s</sub>&gt;</code>.
+<code>View&lt;X<sub>1</sub> .. X<sub>s</sub>&gt;</code>.
 The static type of the name of the representation name is the
 representation type.
 
-*For example, in `inline class V(R id) {...}`, `id` has type `R`, and
+*For example, in `view class V(R id) {...}`, `id` has type `R`, and
 `this` has type `V`.*
 
-Again, let `V` be a inline type of the form
-<code>Inline&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code>,
+Again, let `V` be a view type of the form
+<code>View&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code>,
 and let `R` be the corresponding instantiated representation type.
-If `R` is not a inline type then we say that `V` is a inline type
-at level zero. If `R` is a inline type at level _k_ then we say that
-`V` is a inline type at level _k + 1_.
+If `R` is not a view type then we say that `V` is a view type
+at level zero. If `R` is a view type at level _k_ then we say that
+`V` is a view type at level _k + 1_.
 A compile-time error occurs if the level of `V` is undefined.
 
 *In other words, cycles are not allowed.*
 
-A inline declaration _DV_ named `Inline` may declare one or more
-constructors. A constructor which is declared in a inline declaration is
-also known as a _inline constructor_.
+A view declaration _DV_ named `View` may declare one or more
+constructors. A constructor which is declared in a view declaration is
+also known as a _view constructor_.
 
-*The purpose of having a inline constructor is that it bundles an
-approach for building an instance of the representation type of a inline
+*The purpose of having a view constructor is that it bundles an
+approach for building an instance of the representation type of a view
 declaration _DV_ with _DV_ itself, which makes it easy to recognize
-that this is a way to obtain a value of that inline type. It can also be
+that this is a way to obtain a value of that view type. It can also be
 used to verify that an existing object (provided as an actual argument
-to the constructor) satisfies the requirements for having that inline
+to the constructor) satisfies the requirements for having that view
 type.*
 
 A primary constructor `(R id)` in _DV_ is a concise notation that
-gives rise to a constructor named `Inline` (that is, it is not "named")
+gives rise to a constructor named `View` (that is, it is not "named")
 that accepts one parameter of the form `this.id` and has no body.
 Moreover, the primary constructor induces an instance variable
 declaration of the form `final R id;`.
 
-A compile-time error occurs if a inline constructor includes a
+A compile-time error occurs if a view constructor includes a
 superinitializer. *That is, a term of the form `super(...)` or
 `super.id(...)` as the last element of the initializer list.*
 
-*In the body of a generative inline constructor, the static type of
-`this` is the same as it is in any instance member of the inline, that
-is, `Inline<X1 .. Xk>`, where `X1 .. Xk` are the type parameters
-declared by `Inline`.*
+*In the body of a generative view constructor, the static type of
+`this` is the same as it is in any instance member of the view, that
+is, `View<X1 .. Xk>`, where `X1 .. Xk` are the type parameters
+declared by `View`.*
 
 An instance creation expression of the form
-<code>Inline&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;(...)</code>
+<code>View&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;(...)</code>
 or
-<code>Inline&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;.name(...)</code>
+<code>View&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;.name(...)</code>
 is used to invoke these constructors, and the type of such an expression is
-<code>Inline&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code>.
+<code>View&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code>.
 
-*In short, inline constructors appear to be very similar to constructors
+*In short, view constructors appear to be very similar to constructors
 in classes, and they correspond to the situation where the enclosing
 class has a single non-late final instance variable which is initialized
 according to the normal rules for constructors (in particular, it must
 occur by means of `this.id` or in an initializer list).*
 
 
-### Composing inline types
+### Composing view types
 
 This section describes the effect of including a clause derived from
-`<interfaces>` in a inline declaration. We use the phrase
-_the inline implements clause_ to refer to this clause, or just
+`<interfaces>` in a view declaration. We use the phrase
+_the view implements clause_ to refer to this clause, or just
 _the implements clause_ when no ambiguity can arise.
 
 *The rationale is that the set of members and member implementations
-of a given inline may need to overlap with that of other inlines. The
+of a given view may need to overlap with that of other views. The
 implements clause allows for implementation reuse by putting shared
-members in a "super-inline" `V1` and putting `V1` in the implements
-clause of several inline declarations <code>V<sub>1</sub>
+members in a "super-view" `V1` and putting `V1` in the implements
+clause of several view declarations <code>V<sub>1</sub>
 .. V<sub>k</sub></code>, thus "inheriting" the members of `V1` into
 all of <code>V<sub>1</sub> .. V<sub>k</sub></code> without code
 duplication.*
@@ -722,23 +729,23 @@ duplication.*
 *The reason why this mechanism uses the keyword `implements` rather
 than `extends` to declare a relation that involves inheritance is that
 it has the same semantics as that of class extension members (a
-mechanism which is currently being considered), and inline members are
+mechanism which is currently being considered), and view members are
 similar to class extension members in that they are statically
 resolved.*
 
-Assume that _DV_ is a inline declaration named `Inline`, and `V1` occurs as
+Assume that _DV_ is a view declaration named `View`, and `V1` occurs as
 one of the `<type>`s in the `<interfaces>` of _DV_. In this case we
-say that `V1` is a superinline of _DV_.
+say that `V1` is a superview of _DV_.
 
 A compile-time error occurs if `V1` is a type name or a parameterized type
-which occurs as a superinline in a inline declaration _DV_, but `V1` does not
-denote a inline type.
+which occurs as a superview in a view declaration _DV_, but `V1` does not
+denote a view type.
 
-A compile-time error occurs if any direct or indirect superinline of _DV_
-is the type `Inline` or a type of the form `Inline<...>`. *As usual,
+A compile-time error occurs if any direct or indirect superview of _DV_
+is the type `View` or a type of the form `View<...>`. *As usual,
 subtype cycles are not allowed.*
 
-Assume that _DV_ has two direct or indirect superinlines of the form
+Assume that _DV_ has two direct or indirect superviews of the form
 <code>W&lt;T<sub>1</sub>, .. T<sub>k</sub>&gt;</code>
 respectively
 <code>W&lt;S<sub>1</sub>, .. S<sub>k</sub>&gt;</code>.
@@ -750,9 +757,9 @@ is equal to
 for each _j_ in _1 .. k_. The notion of equality used here is the same
 as with the corresponding rule about superinterfaces of classes.
 
-Assume that a inline declaration _DV_ named `Inline` has representation
-type `R`, and that the inline type `V1` with declaration _DV1_ is a
-superinline of _DV_ (*note that `V1` may have some actual type
+Assume that a view declaration _DV_ named `View` has representation
+type `R`, and that the view type `V1` with declaration _DV1_ is a
+superview of _DV_ (*note that `V1` may have some actual type
 arguments*).  Assume that `S` is the instantiated representation type
 corresponding to `V1`. A compile-time error occurs unless `R` is a
 subtype of `S`.
@@ -761,54 +768,54 @@ subtype of `S`.
 in `V1` when invoking members of `V1`, where `id` is the representation
 name of _DV_ and `id1` is the representation name of _DV1_.*
 
-Assume that _DV_ declares a inline named `Inline` with type parameters
-<code>X<sub>1</sub> .. X<sub>s</sub></code> and `V1` is a superinline of
+Assume that _DV_ declares a view named `View` with type parameters
+<code>X<sub>1</sub> .. X<sub>s</sub></code> and `V1` is a superview of
 _DV_. Then
-<code>Inline&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code> is a subtype of
+<code>View&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code> is a subtype of
 <code>[T<sub>1</sub>/X<sub>1</sub> .. T<sub>s</sub>/X<sub>s</sub>]V1</code>
 for all <code>T<sub>1</sub>, .. T<sub>s</sub></code>
 where these types are regular-bounded.
 
 *If they aren't regular-bounded then the type is a compile-time error
-in itself. In short, if `V1` is a superinline of `V` then `V1` is also
+in itself. In short, if `V1` is a superview of `V` then `V1` is also
 a supertype of `V`.*
 
-A compile-time error occurs if a inline _DV_ has two superinlines `V1` and
+A compile-time error occurs if a view _DV_ has two superviews `V1` and
 `V2`, where both `V1` and `V2` has a member named _m_ with distinct
 declarations, and _DV_ does not declare a member named _m_.
 
 *In other words, if two different declarations of _m_ are inherited
-from two superinlines then the subinline must resolve the conflict. The
+from two superviews then the subview must resolve the conflict. The
 so-called diamond inheritance pattern can create the case where two
-superinlines have an _m_, but they are both declared by the same
-declaration (so `V` is a subinline of `V1` and `V2`, and both `V1` and
-`V2` are subinlines of `V3`, and `V3` declares _m_, in which case there
+superviews have an _m_, but they are both declared by the same
+declaration (so `V` is a subview of `V1` and `V2`, and both `V1` and
+`V2` are subviews of `V3`, and `V3` declares _m_, in which case there
 is no conflict in `V`).*
 
-*Assume that _DV_ is a inline declaration named `Inline` and that the inline
-type `V1`, declared by _DV1_, is a superinline of _DV_. Let `m` be the
+*Assume that _DV_ is a view declaration named `View` and that the view
+type `V1`, declared by _DV1_, is a superview of _DV_. Let `m` be the
 name of a member of `V1`. If _DV_ also declares a member named `m`
 then the latter may be considered similar to a declaration that
-"overrides" the former.  However, it should be noted that inline method
+"overrides" the former.  However, it should be noted that view method
 invocation is resolved statically, and hence there is no override
 relationship among the two in the traditional object-oriented sense
 (that is, it will never occur that the statically known declaration is
 the member of `V1`, and the member invoked at run time is the one in
 _DV_). Still, a receiver with static type `V1` will invoke the
-declaration in _DV1_, and a receiver with static type `Inline` (or
-`Inline<...>`) will invoke the one in _DV_.*
+declaration in _DV1_, and a receiver with static type `View` (or
+`View<...>`) will invoke the one in _DV_.*
 
 Hence, we use a different word to describe the relationship between a
-member named _m_ of a superinline, and a member named _m_ which is
-declared by the subinline: We say that the latter _redeclares_ the
+member named _m_ of a superview, and a member named _m_ which is
+declared by the subview: We say that the latter _redeclares_ the
 former.
 
 *In particular, if two different declarations of _m_ is inherited
-from two superinlines then the subinline can resolve the conflict by
+from two superviews then the subview can resolve the conflict by
 redeclaring _m_.*
 
 *Note that there is no notion of having a 'correct override relation'
-here. With inlines, any member signature can redeclare any other member
+here. With views, any member signature can redeclare any other member
 signature with the same name, including the case where a method is
 overridden by a getter or vice versa. The reason for this is that no
 call site will resolve to one of several declarations at run time,
@@ -816,8 +823,8 @@ each invocation will statically resolve to one particular declaration,
 and this makes it possible to ensure that the invocation is type
 correct.*
 
-Assume that _DV_ is a inline declaration and that the inline types `V1`
-and `V2` are superinlines of _DV_. Let `M1` be the members of `V1`, and
+Assume that _DV_ is a view declaration and that the view types `V1`
+and `V2` are superviews of _DV_. Let `M1` be the members of `V1`, and
 `M2` the members of `V2`. A compile-time error occurs if there is a
 member name `m` such that `V1` as well as `V2` has a member named `m`,
 and they are distinct declarations, and _DV_ does not declare a member
@@ -825,30 +832,30 @@ named `m`.  *In other words, a name clash among distinct "inherited"
 members is an error, but it can be eliminated by redeclaring the
 clashing name.*
 
-The effect of having a inline declaration _DV_ with superinlines
+The effect of having a view declaration _DV_ with superviews
 `V1, .. Vk` is that the members declared by _DV_ as well as all
 members of `V1, .. Vk` that are not redeclared by a declaration in
 _DV_ can be invoked on a receiver of the type introduced by _DV_.
 
 In the body of _DV_, a superinvocation syntax similar to an explicit
 extension method invocation can be used to invoke a member of a
-superinline which is redeclared: The invocation starts with `super.`
-followed by the name of the given superinline, followed by the member
-access. The superinline may be omitted in the case where there is no
+superview which is redeclared: The invocation starts with `super.`
+followed by the name of the given superview, followed by the member
+access. The superview may be omitted in the case where there is no
 ambiguity.
 
 *For example:*
 
 ```dart
-inline class V2(Object id) {
+view class V2(Object id) {
   void foo() { print('V2.foo()'); }
 }
 
-inline class V3(Object id) {
+view class V3(Object id) {
   void foo() { print('V3.foo()'); }
 }
 
-inline class V1(Object id) implements V2, V3 {
+view class V1(Object id) implements V2, V3 {
   void bar() {
     super.V3.foo(); // Prints "V3.foo()".
   }
@@ -856,20 +863,20 @@ inline class V1(Object id) implements V2, V3 {
 ```
 
 
-## Dynamic Semantics of Inlines
+## Dynamic Semantics of Views
 
-The dynamic semantics of inline member invocation follows from the code
+The dynamic semantics of view member invocation follows from the code
 transformation specified in the section about the static analysis.
 
 *In short, with `e` of type
-<code>Inline&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code>,
+<code>View&lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;</code>,
 `e.m(args)` is treated as
-<code>invokeInlineMethod(Inline, &lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;, e).m(args)</code>.
+<code>invokeViewMethod(View, &lt;T<sub>1</sub>, .. T<sub>s</sub>&gt;, e).m(args)</code>.
 Similarly for getters, setters, and operators.*
 
-Consider a inline declaration _DV_ named `Inline` with representation name
+Consider a view declaration _DV_ named `View` with representation name
 `id` and representation type `R`.  Invocation of a non-redirecting
-generative inline constructor proceeds as follows: A fresh, non-late,
+generative view constructor proceeds as follows: A fresh, non-late,
 final variable `v` is created. An initializing formal `this.id`
 has the side-effect that it initializes `v` to the actual argument
 passed to this formal. An initializer list element of the form
@@ -879,31 +886,31 @@ body, `this` and `id` are bound to the value of `v`.  The value of the
 instance creation expression that gave rise to this constructor
 execution is the value of `this`.
 
-At run time, for a given instance `o` typed as a inline type `V`, there
+At run time, for a given instance `o` typed as a view type `V`, there
 is _no_ reification of `V` associated with `o`.
 
 *This means that, at run time, an object never "knows" that it is being
-inlineed as having a inline type. By soundness, the run-time type of `o`
+viewed as having a view type. By soundness, the run-time type of `o`
 will be a subtype of the representation type of `V`.*
 
-The run-time representation of a type argument which is a inline type
+The run-time representation of a type argument which is a view type
 `V` is the corresponding instantiated representation type.
 
-*This means that a inline type and the underlying representation type
+*This means that a view type and the underlying representation type
 are considered as being the same type at run time. So we can freely
-use a cast to introduce or discard the inline type, as the static type
+use a cast to introduce or discard the view type, as the static type
 of an instance, or as a type argument in the static type of a data
-structure or function involving the inline type.*
+structure or function involving the view type.*
 
 A type test, `o is U` or `o is! U`, and a type cast, `o as U`, where `U` is
-or contains a inline type, is performed at run time as a type test and type
-cast on the run-time representation of the inline type as described above.
+or contains a view type, is performed at run time as a type test and type
+cast on the run-time representation of the view type as described above.
 
 
 ### Summary of Typing Relationships
 
-*Here is an overinline of the subtype relationships of a inline type
-`V0` with representation type `R` and superinlines `V1 .. Vk`, as well
+*Here is an overview of the subtype relationships of a view type
+`V0` with representation type `R` and superviews `V1 .. Vk`, as well
 as other typing relationships involving `V0`:*
 
 - *`V0` is a subtype of `Object?`.*
@@ -931,27 +938,27 @@ discussions.
 ### Support "private inheritance"?
 
 In the current proposal there is a subtype relationship between every
-inline and each of its superinlines. So if we have
-`inline V(...) extends V1, V2 ...` then `V <: V1` and `V <: V2`.
+view and each of its superviews. So if we have
+`view V(...) extends V1, V2 ...` then `V <: V1` and `V <: V2`.
 
 In some cases it might be preferable to omit the subtype relationship,
-even though there is a code reuse element (because `V1` is a superinline
+even though there is a code reuse element (because `V1` is a superview
 of `V`, we just don't need or want `V <: V1`).
 
 A possible workaround would be to write forwarding methods manually:
 
 ```dart
-inline class V1(R it) {
+view class V1(R it) {
   void foo() {...}
 }
 
 // `V` can reuse code from `V1` by using `implements`. Note that
 // `S <: R`, because otherwise it is a compile-time error.
-inline class V(S it) implements V1 {}
+view class V(S it) implements V1 {}
 
 // Alternatively, we can write a forwarder, in order to avoid
 // having the subtype relationship `V <: V1`.
-inline class V(S it) {
+view class V(S it) {
   void foo() => V1(it).foo();
 }
 ```


### PR DESCRIPTION
This PR adds a feature specification of 'inline classes', which was obtained by taking the current version of the feature specification of 'views' and rename the construct from 'view class' to 'inline class'. It also removes the support for primary constructors (such that we get more time to get that feature just right and introduce it in general, not just for inline classes).

Finally, this PR adjusts the text accordingly. In particular, it changes the word 'superview' to 'superinterface', and it specifies that it is a compile-time error for an inline class to have a type `T` in the `implements` clause unless `T` is an inline class.

The rules about name clashes among "inherited" names are unchanged: It is a compile-time error if an inline class `V` has superinterfaces `V1` and `V2`, and both of them has a member named `m`, and it is not the same declaration (e.g., in a diamond superinterface structure). The error is eliminated by adding a declaration named `m` to `V`.
