### PR TITLE
Patterns: adjust nomenclature of variable pattern types.

### DIFF
--- a/accepted/future-releases/0546-patterns/feature-specification.md
+++ b/accepted/future-releases/0546-patterns/feature-specification.md
@@ -1741,13 +1741,13 @@ To type check a pattern `p` being matched against a value of type `M`:
 
 *   **Variable**:
 
-    1.  In an assignment context, the required type of `p` is the declared
-        (unpromoted) type of the variable that `p` resolves to.
+    1.  In an assignment context, the required type of `p` is the (unpromoted)
+        static type of the variable that `p` resolves to.
 
     2.  Else if the variable has a type annotation, the required type of `p` is
-        that type, as is the declared type of the variable introduced by `p`.
+        that type, as is the static type of the variable introduced by `p`.
 
-    3.  Else the required type of `p` is `M`, as is the declared type of the
+    3.  Else the required type of `p` is `M`, as is the static type of the
         variable introduced by `p`. *This means that an untyped variable pattern
         can have its type indirectly inferred from the type of a superpattern:*
 


### PR DESCRIPTION
Change the "variables" part of section "Type checking and pattern required type" to consistently refer to the unpromoted type of the variable as its static type rather than its declared type.  Rationale: in the implementations, the term "declared type" is consistently used to refer to a type that's explicitly specified by the user for the variable pattern (and is `null` if the type is inferred).

This change is consistent with the following text from the "Pattern variable sets" section:

> Each variable in the set has a unique name, a static type (the declared or inferred type, but not its promoted type), and whether it is final or not.