### PR TITLE
Add links from UP/DOWN (as defined on types) to UP/DOWN (as defined on type schemas).

### DIFF
--- a/resources/type-system/upper-lower-bounds.md
+++ b/resources/type-system/upper-lower-bounds.md
@@ -61,6 +61,10 @@ which are specified in the
 
 ## Upper bounds
 
+*Note that this algorithm is defined for types, not type schemas.  For the upper
+bound of two type schemas, see the [inference
+specification](https://github.com/dart-lang/language/blob/master/resources/type-system/inference.md#upper-bound).*
+
 We define the upper bound of two types T1 and T2 to be **UP**(`T1`,`T2`) as follows.
 
 
@@ -215,6 +219,10 @@ We define the upper bound of two types T1 and T2 to be **UP**(`T1`,`T2`) as foll
 [inference.md]: https://github.com/dart-lang/language/blob/master/resources/type-system/inference.md
 
 ## Lower bounds
+
+*Note that this algorithm is defined for types, not type schemas.  For the upper
+bound of two type schemas, see the [inference
+specification](https://github.com/dart-lang/language/blob/master/resources/type-system/inference.md#upper-bound).*
 
 We define the lower bound of two types T1 and T2 to be **DOWN**(T1,T2) as
 follows.


### PR DESCRIPTION
This would have avoided the confusion that caused me to file https://github.com/dart-lang/language/issues/2648.