### PR TITLE
[Patterns] Small clarification added

### DIFF
--- a/accepted/future-releases/0546-patterns/feature-specification.md
+++ b/accepted/future-releases/0546-patterns/feature-specification.md
@@ -642,9 +642,9 @@ Field subpatterns can be in one of three forms:
     variable with the same name.
 
     As a convenience, the identifier can be omitted and inferred from `pattern`.
-    The subpattern must be a variable pattern which may be wrapped in a unary
-    pattern. The field name is then inferred from the name in the variable
-    pattern. These pairs of patterns are each equivalent:
+    In this case the subpattern must be a variable pattern which may be wrapped 
+    in a unary pattern. The field name is then inferred from the name in the 
+    variable pattern. These pairs of patterns are each equivalent:
 
     ```dart
     // Variable:


### PR DESCRIPTION
The subpattern must be a variable pattern not in all cases but in case of `: pattern` only. Without this change it can be read as if subpattern always must be a variable pattern