### PR TITLE
Adjust definition of flatten

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -11268,16 +11268,12 @@ We define the auxiliary function
 which is used below and in other sections, as follows:
 
 \begin{itemize}
-\item{} If $T$ is a type variable $X$ with bound $B$,
-  or $T$ is an intersection type
-  (\ref{intersectionTypes})
-  \code{$X$\,\,\&\,\,$B$},
-  then \DefEquals{\flatten{T}}{\flatten{B}}.
-
 \item{} If $T$ is \code{$S$?}\ for some $S$
   then \DefEquals{\flatten{T}}{\code{\flatten{S}?}}.
 
-\item{} If $T$ is \code{FutureOr<$S$>} then \DefEquals{\flatten{T}}{S}.
+\item{} If $T$ is \code{FutureOr<$S$>} bounded
+  (\ref{bindingActualsToFormals})
+  then \DefEquals{\flatten{T}}{S}.
 
 \item{} If $T$ implements \code{Future<$S$>}
   (\ref{interfaceSuperinterfaces})
@@ -11288,7 +11284,13 @@ which is used below and in other sections, as follows:
 
 \commentary{%
 This definition guarantees that for any type $T$,
-\code{$T <:$ FutureOr<$\flatten{T}$>}.%
+\code{$T <:$ FutureOr<$\flatten{T}$>}.
+Note that when $X$ is a type variable with bound $B$,
+it is possible that \flatten{X} is different from $X$:
+$B$ could, for some $S$, be \code{FutureOr<$S$>},
+or a type variable $Y$ with bound \code{FutureOr<$S$>},
+or a class $C$ that implements \code{Future<$S$>},
+or a type variable $X$ with bound $C$.%
 }
 
 \LMHash{}%


### PR DESCRIPTION
Adjust definition of flatten to ensure that `flatten(X) == X` when `X` is a type variable which is unrelated to future types. It deletes the case which is explicitly dealing with type variables, and relies on the existing cases where the given type is related to `FutureOr` or `Future`, but adds one thing: The `FutureOr` case is applicable to types that are _bounded_ by `FutureOr<S>` for some `S`, not just the ones that _are_ `FutureOr<S>`, and this includes `X extends FutureOr<S>`.