### PR TITLE
[Patterns] Fixed typo in the specification

### DIFF
--- a/accepted/future-releases/0546-patterns/feature-specification.md
+++ b/accepted/future-releases/0546-patterns/feature-specification.md
@@ -752,10 +752,10 @@ display(Object obj) {
 
 It is a compile-time error if:
 
-*   `objectName` does not refer to a type.
+*   `typeName` does not refer to a type.
 
 *   A type argument list is present and does not match the arity of the type of
-    `objectName`.
+    `typeName`.
 
 *   A `patternField` is of the form `pattern`. Positional fields aren't allowed.
 


### PR DESCRIPTION
Object pattern grammar is
```
objectPattern ::= typeName typeArguments? '(' patternFields? ')'
```
So, there should be a `typeName`, not an `objectName`