### PR TITLE
[patterns] Fix "||" vs "&&" in rationale for no repeated named fields

### DIFF
--- a/accepted/future-releases/0546-patterns/feature-specification.md
+++ b/accepted/future-releases/0546-patterns/feature-specification.md
@@ -701,7 +701,7 @@ var (:x, x: y) = (x: 1);
 ```
 
 *Destructuring the same field multiple times is never necessary because you can
-always just destructure it once with an `||` subpattern. If a user does it, it's
+always just destructure it once with an `&&` subpattern. If a user does it, it's
 mostly like a copy/paste mistake and it's more helpful to draw their attention
 to the error than silently accept it.*
 

--- a/accepted/future-releases/0546-patterns/feature-specification.md
+++ b/accepted/future-releases/0546-patterns/feature-specification.md
@@ -1684,7 +1684,7 @@ To orchestrate this, type inference on patterns proceeds in three phases:
 
     ```dart
     T id<T>(T t) => t;
-    (T Function<T>(T), dynamic) record = (t, 'str');
+    (T Function<T>(T), dynamic) record = (id, 'str');
     var (int Function(int) f, String s) = record;
     ```
 


### PR DESCRIPTION
If this syntax were allowed, one would expect it to bind the variables from both patterns.  The way to do that is with "&&".

Also fix a minor typo, in a separate commit.
