### PR TITLE
Add support for expressions `List<int>` and `myFunction<int>` in the grammar

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -38,6 +38,8 @@
 % Dec 2022
 % - Change the definition of the type function 'flatten' to resolve soundness
 %   issue, cf. SDK issue #49396.
+% - Add alternative `<typeArguments>` to grammar rule about `<selector>`.
+%   This enables expressions like `List<int>` and `myFunction<int>`.
 %
 % 2.15
 % - Allow generic instantiation of expressions with a generic function type
@@ -16117,6 +16119,7 @@ Postfix expressions invoke the postfix operators on objects.
 <selector> ::= `!'
   \alt <assignableSelector>
   \alt <argumentPart>
+  \alt <typeArguments>
 
 <argumentPart> ::=
   <typeArguments>? <arguments>


### PR DESCRIPTION
The ability to use a parameterized type as an expression and the ability to perform an explicit generic instantiation of a given generic function were added to Dart in version 2.15. The grammar change was not specified at the time. This PR does it.