### PR TITLE
[Patterns] Fixed typo in the variable declaration scope example

### DIFF
--- a/accepted/future-releases/0546-patterns/feature-specification.md
+++ b/accepted/future-releases/0546-patterns/feature-specification.md
@@ -2184,8 +2184,8 @@ appears:
       print(c);
       //    ^ Error: Refers to C declared below:
 
-      var [c] = c;
-      //        ^ Error: Not initialized yet.
+      var [c] = [c];
+      //         ^ Error: Not initialized yet.
 
       print(c);
       //    ^ OK.


### PR DESCRIPTION
Before the change there was another error `The value of type 'int' is not assignable to the required type 'List<int>'`