### PR TITLE
[patterns] Fix spec for context type schema of variable and identifiers.

### DIFF
--- a/accepted/future-releases/0546-patterns/feature-specification.md
+++ b/accepted/future-releases/0546-patterns/feature-specification.md
@@ -1769,25 +1769,25 @@ The context type schema for a pattern `p` is:
 
 *   **Variable**:
 
-    1.  In an assignment context, the context type schema is the static type of
-        the variable that `p` resolves to.
-
-    1.  Else if `p` has no type annotation, the context type schema is `_`.
-        *This lets us potentially infer the variable's type from the matched
-        value.*
-
-    2.  Else the context type schema is the annotated type. *When a typed
-        variable pattern is used in a destructuring variable declaration, we
-        do push the type over to the value for inference, as in:*
+    1.  If `p` has a type annotation, the context type schema is the annotated
+        type. *When a typed variable pattern is used in a destructuring variable
+        declaration, we push the type over to the value for inference, as in:*
 
         ```dart
         var (items: List<int> x) = (items: []);
         //                                 ^- Infers List<int>.
         ```
 
-*   **Identifier**: Context type schemas are only used in irrefutable contexts,
-    so an identifier pattern is always a variable and is handled like a
-    variable pattern, as above.
+    2.  Else the context type schema is `_`. *This lets us potentially infer the
+        variable's type from the matched value.*
+
+*   **Identifier**:
+
+    1.  In an assignment context, the context type schema is the static type of
+        the variable that `p` resolves to.
+
+    2.  Else the context type schema is `_`. *This lets us potentially infer the
+        variable's type from the matched value.*
 
 *   **Cast**: The context type schema is `_`.
 


### PR DESCRIPTION
This got slightly broken when I moved identifiers out to a separate pattern grammar. This PR puts it back to right.

Fix #2795.

I took the opportunity to slightly clean things up too. Thanks for noticing, @sgrekhov!