### PR TITLE
[patterns] Clarify when a set of map patterns is exhaustive

### DIFF
--- a/accepted/future-releases/0546-patterns/feature-specification.md
+++ b/accepted/future-releases/0546-patterns/feature-specification.md
@@ -3013,6 +3013,12 @@ To match a pattern `p` against a value `v`:
             `{...}`, then any length is allowed, so we don't even ask the map
             for it.*
 
+            *The pattern `{...}` will match all maps (that pass the type test).
+            The only way to make a set of map patterns exhaustive is to include
+            `{...}`, because some misbehaving maps will not match any other map
+            pattern: for example, the map `v` could have a positive `length` but
+            `v[k] == null && !v.containsKey(k)` for every possible key `k`.*
+
         2.  Else let `l` be the length of the map determined by calling `length`
             on `v`.
 
@@ -3035,10 +3041,7 @@ To match a pattern `p` against a value `v`:
             1.  If `l > 0` then the match fails.
 
             *An empty map pattern can match only empty maps. Note that this
-            treats a misbehaving map whose `length` is negative as an empty map.
-            This is important so that a set of map patterns that is clearly
-            exhaustive over well-behaving maps will also cover a misbehaving
-            one.*
+            treats a misbehaving map whose `length` is negative as an empty map.*
 
         *These match failures become runtime exceptions if the map pattern is
         in an irrefutable context.*


### PR DESCRIPTION
For lists, one can use the empty list pattern `[]` to make an exhaustive set of list patterns.

But for maps, the only way to make an exhaustive set of map patterns is the trivial way, using the pattern `{...}` that's exhaustive (on maps) all by itself.

So move the remark about exhaustive sets of map patterns out of the context of the empty map pattern `{}`, and up to the discussion of `{...}`.  Also say that these are the only exhaustive sets of map patterns, and why.

Fix #2818.