### PR TITLE
Fix typo in URI

### DIFF
--- a/accepted/future-releases/inline-classes/feature-specification.md
+++ b/accepted/future-releases/inline-classes/feature-specification.md
@@ -12,7 +12,7 @@ This document is built on several earlier proposals of a similar feature
 [views][1] proposal as well as the [extension struct][2] proposal provide
 information about the process, including in their change logs.
 
-[1]: https://github.com/dart-lang/language/blob/master/working/1462-extension-types/feature-specification-views.md
+[1]: https://github.com/dart-lang/language/blob/master/working/1426-extension-types/feature-specification-views.md
 [2]: https://github.com/dart-lang/language/blob/master/working/extension_structs/overview.md
 
 2022.12.20


### PR DESCRIPTION
Turns out that there was a stray Control-T at some point, swapping two characters and thus messing up a URI. This PR fixes it.