### PR TITLE
Adjust several locations where required types are discussed

### DIFF
--- a/accepted/future-releases/0546-patterns/feature-specification.md
+++ b/accepted/future-releases/0546-patterns/feature-specification.md
@@ -1913,7 +1913,8 @@ To type check a pattern `p` being matched against a value of type `M`:
 
     2.  A compile-time error occurs if `R` is not assignable to `bool`.
 
-    3.  Type check `c` with context type `A`. A compile-time error occurs if
+    3.  Type check `c` with context type `A?` when `op` is `==` or `!=`, and
+        with context type `A` otherwise. A compile-time error occurs if
         `c` is not a constant expression. Let `C` be the static type of `c`.
 
     4.  If `op` is `==` or `!=` then a compile-time error occurs if `C` is not

--- a/accepted/future-releases/0546-patterns/feature-specification.md
+++ b/accepted/future-releases/0546-patterns/feature-specification.md
@@ -1884,10 +1884,13 @@ var [int a, b] = <num>[1, 2];   // List<num>.
 
 To type check a pattern `p` being matched against a value of type `M`:
 
-*   **Logical-or**: Type check each branch using `M` as the
-    matched value type. The required type of the pattern is `Object?`.
-    *`M` will be used to perform checks on each operand, whose required types
-    may be more strict.*
+*   **Logical-or**: Type check the first subpattern using `M` as the
+    matched value type; type check the second subpattern using the matched value
+    which is obtained from the assumption that the first operand failed to
+    match *(this may cause promotion, e.g., when the left pattern is `==
+    null`)*. The required type of the pattern is `Object?`.
+    *The context types will be used to perform checks on each operand, whose
+    required types may be more strict.*
 
 *   **Logical-and**: Type check the first operand using `M` as the matched
     value type, and type check the second operand using the (possibly promoted)

--- a/accepted/future-releases/0546-patterns/feature-specification.md
+++ b/accepted/future-releases/0546-patterns/feature-specification.md
@@ -1889,11 +1889,10 @@ To type check a pattern `p` being matched against a value of type `M`:
     *`M` will be used to perform checks on each operand, whose required types
     may be more strict.*
 
-*   **Logical-and**: Type check each branch using `M` as the matched value
-    type of the left operand, and using the promoted type of the
-    scrutinee from the left operand as the matched value type of the right hand
-    operand *(that's `M` again, if there is no promotion)*. The required type of
-    the pattern is `Object?`.
+*   **Logical-and**: Type check the first operand using `M` as the matched
+    value type, and type check the second operand using the (possibly promoted)
+    matched value type obtained from the match-succeeded continuation of the
+    first operand. The required type of the pattern is `Object?`.
     *The chosen matched value type will be used to perform checks on each
     operand, whose required types may be more strict.*
 
@@ -1901,9 +1900,11 @@ To type check a pattern `p` being matched against a value of type `M`:
     of the following operators: `==`, `!=`, `<`, `<=`, `>=`, `>`, and `c` is an
     expression.
 
-    If `M` is `dynamic`: Type check `c` in context `_`; an error occurs
-    if `c` is not a constant expression; no further checks are
-    performed. Otherwise *(when `M` is not `dynamic`)*:
+    A compile-time error occurs if `M` is `void`.
+
+    If `M` is `dynamic` or `Never`: Type check `c` in context `_`; an error
+    occurs if `c` is not a constant expression; no further checks are
+    performed. Otherwise *(when `M` is not `dynamic` or `Never`)*:
 
     1.  A compile-time error occurs if `M` does not have an operator `op`,
         and there is no available and applicable extension operator `op`. 
@@ -1920,7 +1921,7 @@ To type check a pattern `p` being matched against a value of type `M`:
         compile-time error occurs if `C` is not assignable to `A`.
 
     *The language screens out `null` before calling the underlying `==`
-    method, which is why `T?` is the allowed type for equality checks. Since
+    method, which is why `A?` is the allowed type for equality checks. Since
     `Object` declares `==` to accept `Object` on the right, this compile-time
     error can only happen if a user-defined class has an override of `==` with a
     `covariant` parameter.*

--- a/accepted/future-releases/0546-patterns/feature-specification.md
+++ b/accepted/future-releases/0546-patterns/feature-specification.md
@@ -2102,7 +2102,8 @@ If `p` with required type `T` is in an irrefutable context:
     the value as a target or argument.
 
     If a coercion is inserted, this yields a new matched value type which is
-    the value of `M` used in the next step.
+    the value of `M` used in the next step. If no coercion is inserted, the
+    next step proceeds with the already given `M`.
 
     *Each pattern that requires a certain type can be thought of as an
     "assignment point" where an implicit coercion may happen when a value flows


### PR DESCRIPTION
This PR changes several locations in the patterns feature specification where the 'required type' of a pattern is discussed. It adds rules about the required type in some cases where it was left unspecified. In particular, it says that the constant expression in a relationalPattern is type checked with the context type `_` (I can't see that we have anything else). The required type of a relationalPattern is kept open (`Object?`). The actual checks associated with this kind of pattern are performed during the traversal of the pattern, and there is no single type `T` would would make the same checks occur just by being the matched value type.

The changes include a somewhat controversial part: The definition of "assignable". The new text changes the order of the two bullet points where assignability is discussed: First we check whether there is a need for a coercion, and insert it if needed, and obtain a new `M` (so `M` might have been `X Function<X>(X)` and is now `int Function(int)`). Next, we check that `M` is assignable to the required type of the pattern.

This approach is compatible with both definitions of 'assignable' (both the one in the nnbd feature specification and the language specification, and the one that includes coercions): We just don't rely on 'assignability' to take coercions into account, and then it doesn't matter whether or not they are part of 'assignability'. ;-)

Other changes:

I changed all references to primitive equality to use the phrase 'primitive equality'. There are several locations where 'operator `==`' is mentioned specifically, and some of them have been preserved, because it was actually specifically about this operator.

I added a few words to indicate that 'pattern type checking' can include provision of missing parts (so `[var j]` could be transformed into `<double>[var j]` at this time, based on `M`).

