### PR TITLE
Change `<extensionDeclaration>` to use `<typeIdentifier>`

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -6064,7 +6064,7 @@ and whether the invocation satisfies several other requirements.
 
 \begin{grammar}
 <extensionDeclaration> ::=
-  \gnewline{} \EXTENSION{} <identifier>? <typeParameters>? \ON{} <type>
+  \gnewline{} \EXTENSION{} <typeIdentifier>? <typeParameters>? \ON{} <type>
   \gnewline{} `\{' (<metadata> <classMemberDeclaration>)* `\}'
 \end{grammar}
 

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -20688,11 +20688,6 @@ that is,
 it denotes an \synt{IDENTIFIER} which is not a \synt{BUILT\_IN\_IDENTIFIER}
 (\ref{identifierReference}).%
 }
-%% TODO(eernst): The following non-terminals are currently unused (they will
-%% be used when we transfer more grammar rules from Dart.g): <typeNotVoid>
-%% and <typeNotVoidNotFunctionList>. They are used in the syntax for
-%% \EXTENDS, \WITH, \IMPLEMENTS{} syntax and for mixin applications
-%% in Dart.g, and it seems likely that we will use them here as well.
 
 \commentary{%
 Non-terminals with names of the form \synt{\ldots{}NotFunction}
@@ -20708,13 +20703,13 @@ but it is the least upper bound of all function types.%
   \alt <typeNotFunction>
 
 <typeNotVoid> ::= <functionType> `?'?
-  \alt <typeNotVoidNotFunction>
+  \alt <typeNotVoidNotFunction> `?'?
 
 <typeNotFunction> ::= \VOID{}
-  \alt <typeNotVoidNotFunction>
+  \alt <typeNotVoidNotFunction> `?'?
 
-<typeNotVoidNotFunction> ::= <typeName> <typeArguments>? `?'?
-  \alt \FUNCTION{} `?'?
+<typeNotVoidNotFunction> ::= <typeName> <typeArguments>?
+  \alt \FUNCTION{}
 
 <typeName> ::= <typeIdentifier> (`.' <typeIdentifier>)?
 

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -58,6 +58,9 @@
 % Mar 2023
 % - Clarify how line breaks are handled in a multi-line string literal. Rename
 %   the lexical token NEWLINE to LINE\_BREAK (clarifying that it is not `\n`).
+% - Clean up grammar rules (avoid `T?` as a superclass/etc., which is an
+%   error anyway; change extension names to `typeIdentifier`, avoiding
+%   built-in identifiers).
 %
 % Feb 2023
 % - Change the specification of constant expressions of the form `e1 == e2`

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -6167,8 +6167,6 @@ but it can be used to denote the extension itself
 e.g., in order to access static members of the extension,
 or in order to resolve an invocation explicitly%
 }).
-A compile-time error occurs if the declared name of an extension
-is a built-in identifier.
 
 \LMHash{}%
 An extension declaration introduces two scopes:


### PR DESCRIPTION
The language specification currently uses an `<identifier>` as the name of an `<extensionDeclaration>`. Implementations require this name to be a `<typeIdentifier>`, just like class and mixin declarations.

I see no value in forcing implementations to accept a built-in identifier as the name of an extension. This PR changes the language specification accordingly, which ensures that it is in sync with the implementations. This is arguably more consistent, and yields more readable code.

Added another small cleanup, cf. https://dart-review.googlesource.com/c/sdk/+/288981: Moves `?` from `typeNotVoidNotFunction` rule to usages, such that we do not (syntactically) allow constructs like `extends C?`, which are errors anyway.

Cf. https://github.com/dart-lang/sdk/issues/51751.