### PR TITLE
Specify that downwards inference of object pattern required types uses instantiate to bounds.

### DIFF
--- a/accepted/future-releases/0546-patterns/feature-specification.md
+++ b/accepted/future-releases/0546-patterns/feature-specification.md
@@ -2106,7 +2106,10 @@ To type check a pattern `p` being matched against a value of type `M`:
 
     1.  Resolve the object name to a type `X`. It is a compile-time error if the
         name does not refer to a type. Apply downwards inference with context
-        type `M` to infer type arguments for `X`, if needed.
+        type `M` to infer type arguments for `X`, if needed.  If any type
+        arguments are left unconstrained, do instantiate to bounds (using the
+        partial solution from downwards inference) to fill in their values.
+
 
     2.  For each field subpattern of `p`, with name `n` and subpattern `f`:
 

--- a/accepted/future-releases/0546-patterns/feature-specification.md
+++ b/accepted/future-releases/0546-patterns/feature-specification.md
@@ -4,7 +4,7 @@ Author: Bob Nystrom
 
 Status: Accepted
 
-Version 2.26 (see [CHANGELOG](#CHANGELOG) at end)
+Version 2.27 (see [CHANGELOG](#CHANGELOG) at end)
 
 Note: This proposal is broken into a couple of separate documents. See also
 [records][] and [exhaustiveness][].
@@ -3537,6 +3537,12 @@ Here is one way it could be broken down into separate pieces:
     *   Parenthesized patterns
 
 ## Changelog
+
+### 2.27
+
+-   Clarify that when downwards is used to infer type arguments for an object
+    pattern, any type arguments that are left unconstrained are filled in using
+    instantiate to bounds.
 
 ### 2.26
 


### PR DESCRIPTION
Fixes #2770.

Note that this behaviour has already been fully implemented--see https://github.com/dart-lang/sdk/commit/c358118e9f09e24add2c4f93339bbe5faafce9fd.