### PR TITLE
modernize the specification script

### DIFF
--- a/specification/pubspec.yaml
+++ b/specification/pubspec.yaml
@@ -1,8 +1,7 @@
 name: scripts
 publish_to: none
 environment:
-  sdk: ">=2.10.0 <3.0.0"
-dependencies: 
+  sdk: ">=2.12.0 <3.0.0"
+dependencies:
   convert: ^3.0.1
   crypto: ^3.0.1
-  utf: ^0.9.0+5

--- a/specification/scripts/addlatexhash.dart
+++ b/specification/scripts/addlatexhash.dart
@@ -22,11 +22,11 @@
 // NB: This utility assumes UN*X style line endings, \n, in the LaTeX
 // source file received as input; it will not work with other styles.
 
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:crypto/crypto.dart';
 import 'package:convert/convert.dart';
-import 'package:utf/utf.dart';
 
 // ----------------------------------------------------------------------
 // Normalization of the text: removal or normalization of parts that
@@ -242,8 +242,7 @@ bool isntHashBlockTerminator(line) => !isSectioningCommand(line);
 extractHashLabel(line) {
   var startMatch = hashLabelStartRE.firstMatch(line);
   var endMatch = hashLabelEndRE.firstMatch(line);
-  assert(startMatch != null && endMatch != null);
-  return line.substring(startMatch.end, endMatch.start);
+  return line.substring(startMatch!.end, endMatch!.start);
 }
 
 // Event classes: Keep track of relevant information about the LaTeX
@@ -491,7 +490,7 @@ computeHashValue(lines, startIndex, nextIndex, listSink) {
   final gatheredLine = gatherLines(lines, startIndex, nextIndex);
   final simplifiedLine = simplifyLine(gatheredLine);
   listSink.write("  % $simplifiedLine\n");
-  var digest = sha1.convert(encodeUtf8(simplifiedLine));
+  var digest = sha1.convert(utf8.encode(simplifiedLine));
   return digest.bytes;
 }
 


### PR DESCRIPTION
This isn't runnable at all on Dart 3.0, updated it to Dart 2.12 so it is opted in to null safety and removed the `utf8` dep which was never migrated and is discontinued.