### PR TITLE
Add a github actions workflow for dart analysis and tests

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -17,15 +17,20 @@ jobs:
       - uses: dart-lang/setup-dart@v1
         with:
             sdk: dev
-      - run: dart pub get
+      - name: dart pub get (specification)
+        run: dart pub get
         working-directory: specification
-      - run: dart pub get
+      - name: dart pub get (working/macros/example)
+        run: dart pub get
         working-directory: working/macros/example
-      - run: dart pub get
+      - name: dart pub get (accepted/2.3/spread-collections/benchmarks)
+        run: dart pub get
         working-directory: accepted/2.3/spread-collections/benchmarks
-      - run: dart pub get
+      - name: dart pub get (accepted/future-releases/0546-patterns/exhaustiveness_prototype)
+        run: dart pub get
         working-directory: accepted/future-releases/0546-patterns/exhaustiveness_prototype
-      - run: dart analyze --fatal-infos .
+      - name: dart analyze --fatal-infos .
+        run: dart analyze --fatal-infos .
   test:
     runs-on: ubuntu-latest
     steps:
@@ -33,7 +38,9 @@ jobs:
       - uses: dart-lang/setup-dart@v1
         with:
             sdk: dev
-      - run: dart pub get
+      - name: dart pub get (accepted/future-releases/0546-patterns/exhaustiveness_prototype)
+        run: dart pub get
         working-directory: accepted/future-releases/0546-patterns/exhaustiveness_prototype
-      - run: dart test
+      - name: dart test (accepted/future-releases/0546-patterns/exhaustiveness_prototype)
+        run: dart test
         working-directory: accepted/future-releases/0546-patterns/exhaustiveness_prototype

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,0 +1,39 @@
+name: Dart CI
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+env:
+  PUB_ENVIRONMENT: bot.github
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dart-lang/setup-dart@v1
+        with:
+            sdk: dev
+      - run: dart pub get
+        working-directory: specification
+      - run: dart pub get
+        working-directory: working/macros/example
+      - run: dart pub get
+        working-directory: accepted/2.3/spread-collections/benchmarks
+      - run: dart pub get
+        working-directory: accepted/future-releases/0546-patterns/exhaustiveness_prototype
+      - run: dart analyze --fatal-infos .
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dart-lang/setup-dart@v1
+        with:
+            sdk: dev
+      - run: dart pub get
+        working-directory: accepted/future-releases/0546-patterns/exhaustiveness_prototype
+      - run: dart test
+        working-directory: accepted/future-releases/0546-patterns/exhaustiveness_prototype

--- a/accepted/2.3/spread-collections/benchmarks/bin/lrhn_benchmark.dart
+++ b/accepted/2.3/spread-collections/benchmarks/bin/lrhn_benchmark.dart
@@ -1,21 +1,25 @@
-import"dart:collection";
+import "dart:collection";
+
 void copy1(Map<String, int> from, Map<String, int> to) {
   for (var entry in from.entries) {
     to[entry.key] = entry.value;
   }
 }
+
 void copy2(Map<String, int> from, Map<String, int> to) {
   for (var key in from.keys) {
-    to[key] = from[key];
+    to[key] = from[key]!;
   }
 }
+
 void copy3(Map<String, int> from, Map<String, int> to) {
-  var tmp = to;
+  Map<String, int>? tmp = to;
   from.forEach((key, value) {
-    tmp[key] = value;
+    tmp![key] = value;
   });
   tmp = null;
 }
+
 void copy4(Map<String, int> from, Map<String, int> to) {
   to.addAll(from);
 }
@@ -29,15 +33,17 @@ main() {
   }
 }
 
-int id(int x)=>x;
+int id(int x) => x;
 var maps = List.generate(100, (n) {
-  var map = Map<String, int>.fromIterable(Iterable.generate(n * 10), key: (n) =>"#$n");
+  var map = Map<String, int>.fromIterable(Iterable.generate(n * 10),
+      key: (n) => "#$n");
   if (n % 4 == 1) map = SplayTreeMap<String, int>.from(map);
   if (n % 4 == 2) map = HashMap<String, int>.from(map);
   return map;
 });
 
-void bench(String name, void Function(Map<String, int>, Map<String, int>) action) {
+void bench(
+    String name, void Function(Map<String, int>, Map<String, int>) action) {
   var e = 0;
   var c = 0;
   var sw = Stopwatch()..start();
@@ -49,5 +55,5 @@ void bench(String name, void Function(Map<String, int>, Map<String, int>) action
     }
     e = sw.elapsedMilliseconds;
   } while (e < 2000);
-  print("$name: ${c/e} entries/ms");
+  print("$name: ${c / e} entries/ms");
 }

--- a/accepted/2.3/spread-collections/benchmarks/bin/profile.dart
+++ b/accepted/2.3/spread-collections/benchmarks/bin/profile.dart
@@ -13,8 +13,8 @@ final lists = <List<String>>[];
 final maps = <Map<String, int>>[];
 final mapsWithSplay = <Map<String, int>>[];
 
-String _configuration;
-int _length;
+late String _configuration;
+late int _length;
 bool _csvOutput = false;
 bool _warmingUp = true;
 
@@ -136,7 +136,7 @@ void benchmarkMaps(String collection, List<Map<String, int>> maps) {
 
 double benchmarkIterable(
     String method, void Function(Iterable<String>, List<String>) action,
-    [double overhead]) {
+    [double? overhead]) {
   var time = bench(() {
     for (var i = 0; i < lists.length; i++) {
       var from = lists[i];
@@ -155,7 +155,7 @@ double benchmarkIterable(
 
 double benchmarkList(
     String method, void Function(List<String>, List<String>) action,
-    [double overhead]) {
+    [double? overhead]) {
   var time = bench(() {
     for (var i = 0; i < lists.length; i++) {
       var from = lists[i];
@@ -177,7 +177,7 @@ double benchmarkMap(
     String method,
     List<Map<String, int>> maps,
     void Function(Map<String, int>, Map<String, int>) action,
-    [double overhead]) {
+    [double? overhead]) {
   var time = bench(() {
     for (var i = 0; i < maps.length; i++) {
       var from = maps[i];
@@ -250,7 +250,7 @@ void show(String collection, String method, double overhead, double baseline) {
 
 double bestTime(String collection, String method) {
   var runs = _runs["$collection $method"];
-  var min = runs.first;
+  var min = runs!.first;
   for (var i = 1; i < runs.length; i++) {
     if (runs[i] < min) min = runs[i];
   }
@@ -259,7 +259,7 @@ double bestTime(String collection, String method) {
 }
 
 double standardDeviation(String collection, String method) {
-  var runs = _runs["$collection $method"];
+  var runs = _runs["$collection $method"]!;
 
   var mean = runs.fold<double>(0.0, (a, b) => a + b) / runs.length;
 
@@ -281,9 +281,9 @@ void iterableIterator(Iterable<String> from, List<String> to) {
 }
 
 void iterableForEach(Iterable<String> from, List<String> to) {
-  var temp = to;
+  List<String>? temp = to;
   from.forEach((s) {
-    temp.add(s);
+    temp!.add(s);
   });
   temp = null;
 }
@@ -317,9 +317,9 @@ void listSubscript(List<String> from, List<String> to) {
 }
 
 void listForEach(List<String> from, List<String> to) {
-  var temp = to;
+  List<String>? temp = to;
   from.forEach((s) {
-    temp.add(s);
+    temp!.add(s);
   });
   temp = null;
 }
@@ -334,14 +334,14 @@ void mapEntries(Map<String, int> from, Map<String, int> to) {
 
 void mapKeys(Map<String, int> from, Map<String, int> to) {
   for (var key in from.keys) {
-    to[key] = from[key];
+    to[key] = from[key]!;
   }
 }
 
 void mapForEach(Map<String, int> from, Map<String, int> to) {
-  var temp = to;
+  Map<String, int>? temp = to;
   from.forEach((key, value) {
-    temp[key] = value;
+    temp![key] = value;
   });
   temp = null;
 }

--- a/accepted/2.3/spread-collections/benchmarks/bin/profile.dart
+++ b/accepted/2.3/spread-collections/benchmarks/bin/profile.dart
@@ -249,8 +249,8 @@ void show(String collection, String method, double overhead, double baseline) {
 }
 
 double bestTime(String collection, String method) {
-  var runs = _runs["$collection $method"];
-  var min = runs!.first;
+  var runs = _runs["$collection $method"]!;
+  var min = runs.first;
   for (var i = 1; i < runs.length; i++) {
     if (runs[i] < min) min = runs[i];
   }

--- a/accepted/2.3/spread-collections/benchmarks/bin/profile_list_spread.dart
+++ b/accepted/2.3/spread-collections/benchmarks/bin/profile_list_spread.dart
@@ -35,7 +35,7 @@ void main() {
 
 double runBench(
     String name, int length, void Function(List<String>, List<String>) action,
-    [double baseline]) {
+    [double? baseline]) {
   var from = <String>[];
   for (var i = 0; i < length; i++) {
     from.add(String.fromCharCode(i % 26 + 65));
@@ -63,8 +63,8 @@ double runBench(
 }
 
 /// Runs [bench] a number of times and returns the best (highest) result.
-double benchBest(
-    List<List<String>> froms, void Function(List<String>, List<String>) action) {
+double benchBest(List<List<String>> froms,
+    void Function(List<String>, List<String>) action) {
   var best = 0.0;
   for (var i = 0; i < 4; i++) {
     var result = bench(froms, action);
@@ -127,9 +127,9 @@ void addAll(List<String> from, List<String> to) {
 }
 
 void forEach(List<String> from, List<String> to) {
-  var temp = to;
+  List<String>? temp = to;
   from.forEach((s) {
-    temp.add(s);
+    temp!.add(s);
   });
   temp = null;
 }

--- a/accepted/2.3/spread-collections/benchmarks/bin/profile_map.dart
+++ b/accepted/2.3/spread-collections/benchmarks/bin/profile_map.dart
@@ -40,10 +40,12 @@ void benchmarks() {
     warmup = i < rounds;
 
     var baseline = bench("addEntries", maps, addEntries);
-    var entriesMap =
-        bench("iterate entries into map", maps, iterateEntriesIntoNewMap, baseline);
-    var keysMap = bench("iterate keys into map", maps, iterateKeysIntoNewMap, baseline);
-    var forEachMap = bench("forEach into map", maps, forEachIntoNewMap, baseline);
+    var entriesMap = bench(
+        "iterate entries into map", maps, iterateEntriesIntoNewMap, baseline);
+    var keysMap =
+        bench("iterate keys into map", maps, iterateKeysIntoNewMap, baseline);
+    var forEachMap =
+        bench("forEach into map", maps, forEachIntoNewMap, baseline);
 
     log();
 
@@ -87,7 +89,8 @@ List<Map<String, int>> makeMaps(List<int> sizes,
 }
 
 double bench(String label, List<Map<String, int>> maps,
-    void Function(Map<String, int>) action, [double baseline]) {
+    void Function(Map<String, int>) action,
+    [double? baseline]) {
   var watch = Stopwatch()..start();
   for (var i = 0; i < trials; i++) {
     for (var i = 0; i < maps.length; i++) {
@@ -101,12 +104,12 @@ double bench(String label, List<Map<String, int>> maps,
   return microPerTrial;
 }
 
-void log([String label, double microseconds, double baseline]) {
+void log([String? label, double? microseconds, double? baseline]) {
   if (warmup) return;
 
   if (microseconds != null) {
     var perMs = (1000 / microseconds).toStringAsFixed(2);
-    var output = "${label.padLeft(30)} ${perMs.padLeft(10)} spreads/ms";
+    var output = "${label!.padLeft(30)} ${perMs.padLeft(10)} spreads/ms";
     if (baseline != null) {
       var relative = baseline / microseconds;
       output += " ${relative.toStringAsFixed(2).padLeft(5)}x";
@@ -144,7 +147,7 @@ void iterateEntriesIntoNewMap(Map<String, int> from) {
 void iterateKeys(Map<String, int> from) {
   var sum = 0;
   for (var key in from.keys) {
-    sum += from[key];
+    sum += from[key]!;
   }
 
   preventOptimization(sum);
@@ -154,7 +157,7 @@ void iterateKeysIntoNewMap(Map<String, int> from) {
   var to = <String, int>{"a": 1, "b": 2};
 
   for (var key in from.keys) {
-    to[key] = from[key];
+    to[key] = from[key]!;
   }
 
   to["b"] = 3;
@@ -175,9 +178,9 @@ void forEach(Map<String, int> from) {
 void forEachIntoNewMap(Map<String, int> from) {
   var to = <String, int>{"a": 1, "b": 2};
 
-  var temp = to;
+  Map<String, int>? temp = to;
   from.forEach((key, value) {
-    temp[key] = value;
+    temp![key] = value;
   });
   temp = null;
 

--- a/accepted/2.3/spread-collections/benchmarks/pubspec.yaml
+++ b/accepted/2.3/spread-collections/benchmarks/pubspec.yaml
@@ -1,4 +1,4 @@
 name: benchmarks
 publish_to: none
 environment:
-  sdk: ">=2.3.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
This may be controversial, but I wanted to send it out anyways to see what kind of reaction it gets :).

This also migrates an old benchmark to null safety so it can be ran with Dart 3. I will separate out that change if we don't land this PR. I already submitted other fixes upstream, I just missed that one :).

## Why is it worth enforcing clean analysis?

This is helpful because otherwise all the diagnostics become pointless/unusable, as you are drowned in a sea of them (there were well over 100 until yesterday, and I previously cleaned up a similar amount). It also just looks unprofessional IMO if our repo has a bunch of diagnostics when you clone it.

This repo is constantly collecting new diagnostics today, so the problem just gets worse and worse. I suspect most of the language team are not heavy users of IDEs which report diagnostics for the entire workspace, and so it just isn't as present for most of us (if you only see the ones for open files it is less annoying)? But I see them all :), and I suspect most external users cloning the repo would also see them.

Another argument here is this will ensure that any example code we have is _actually valid_, at least once such validation is possible. And it won't trigger diagnostics when copied into users repos (for the most part, they could enable extra lints though).

### How can I create examples for code that doesn't work yet? 

It is definitely intended and supported that we will have invalid Dart code in this repo, but we should simply exclude that code from analysis using the `analysis_options.yaml` file. This is a one liner change when adding a new proposal that has example code, and thus not a heavy burden.

## What about formatting?

I am not requiring formatted code right now because the formatter [doesn't support excluding files](https://github.com/dart-lang/dart_style/issues/864). Otherwise I would. I do have a wrapper around the formatter which does support that if we were willing to take a dependency on it, but I presume that would be a bridge too far.

## Won't this be a maintenance burden?

Yes, some amount of ongoing work will be needed here, but it will prevent us from accumulating larger amounts of technical debt. I would rather deal with small bits of maintenance over time (adding excludes where necessary mostly).

We could also decide to use different lint sets if we don't think the existing lints are providing value. Or no lints. I don't really care, I just don't want lints enabled that are being ignored :). 