### PR TITLE
Remove "mixin" from some positions in the @reopen text.

### DIFF
--- a/accepted/future-releases/class-modifiers/feature-specification.md
+++ b/accepted/future-releases/class-modifiers/feature-specification.md
@@ -905,8 +905,8 @@ warning is reported if a class is not annotated `@reopen` and it:
 
 *   extends a class marked `interface` or `final`
     and is not itself marked `interface` or `final`, or
-*   extends a `sealed` class which itself transitively extends a class marked `interface` or `final`.
-    transitively extends or mixes in an `interface` or `final` declaration.
+*   extends a `sealed` class which itself transitively extends a class marked
+    `interface` or `final`.
 
 [meta]: https://pub.dev/packages/meta
 [linter]: https://dart.dev/guides/language/analysis-options#enabling-linter-rules

--- a/accepted/future-releases/class-modifiers/feature-specification.md
+++ b/accepted/future-releases/class-modifiers/feature-specification.md
@@ -905,7 +905,7 @@ warning is reported if a class is not annotated `@reopen` and it:
 
 *   extends a class marked `interface` or `final`
     and is not itself marked `interface` or `final`, or
-*   extends or mixes in a `sealed` declaration which itself
+*   extends a `sealed` class which itself transitively extends a class marked `interface` or `final`.
     transitively extends or mixes in an `interface` or `final` declaration.
 
 [meta]: https://pub.dev/packages/meta

--- a/accepted/future-releases/class-modifiers/feature-specification.md
+++ b/accepted/future-releases/class-modifiers/feature-specification.md
@@ -901,11 +901,11 @@ Instead, it's a suggested part of the overall user experience of the feature.
 
 A metadata annotation `@reopen` is added to package [meta][] and a lint
 "implicit_reopen" is added to the [linter][]. When the lint is enabled, a lint
-warning is reported if a class or mixin is not annotated `@reopen` and it:
+warning is reported if a class is not annotated `@reopen` and it:
 
-*   Extends or mixes in a class, mixin, or mixin class marked `interface` or
-    `final` and is not itself marked `interface` or `final`,
-    or extends or mixes in a `sealed` declaration which itself
+*   extends or mixes in a class or mixin class marked `interface` or `final`
+    and is not itself marked `interface` or `final`, or
+*   extends or mixes in a `sealed` declaration which itself
     transitively extends or mixes in an `interface` or `final` declaration.
 
 [meta]: https://pub.dev/packages/meta

--- a/accepted/future-releases/class-modifiers/feature-specification.md
+++ b/accepted/future-releases/class-modifiers/feature-specification.md
@@ -903,7 +903,7 @@ A metadata annotation `@reopen` is added to package [meta][] and a lint
 "implicit_reopen" is added to the [linter][]. When the lint is enabled, a lint
 warning is reported if a class is not annotated `@reopen` and it:
 
-*   extends or mixes in a class or mixin class marked `interface` or `final`
+*   extends a class marked `interface` or `final`
     and is not itself marked `interface` or `final`, or
 *   extends or mixes in a `sealed` declaration which itself
     transitively extends or mixes in an `interface` or `final` declaration.


### PR DESCRIPTION
Regarding reopened mixins and reopening mixins, I think @eernstg [worded it well](https://github.com/dart-lang/linter/pull/4235#discussion_r1152164227):

> It is not possible to reopen a mixin or a mixin class: It has the modifier `base` or no modifier, and no subtype of a `base` declaration can exist without a modifier which is at least as strong as `base`.

Based on this, I made these changes:

* removed "or mixin" from the things which can be annotated with `@reopen`
* removed "or mixin" from the things which can be extended or mixed in and be modified with `interface` or `final`
* spread a sentence which has 7 "or"s in it 🤣 across two bullet points.

CC @pq @kallentu @munificent 