### PR TITLE
Mention that enums are implicitly final

### DIFF
--- a/accepted/future-releases/class-modifiers/feature-specification.md
+++ b/accepted/future-releases/class-modifiers/feature-specification.md
@@ -657,6 +657,13 @@ we can specify the restrictions imposed by modifiers._
 
 ### Basic restrictions
 
+With respect to compile-time errors caused by missing required class
+modifiers, every enum declaration is considered to have the modifier
+`final`. *An enum declaration is always subject to restrictions which are at
+least as strong as the restrictions implied by that modifier. This ensures
+that we can specify those errors without mentioning an exception for enum
+declarations in every rule.*
+
 It's a compile-time error if:
 
 *   A declaration depends directly on a `sealed` declaration from another


### PR DESCRIPTION
Cf. https://github.com/dart-lang/language/issues/2998: This PR adds a paragraph where it is stated that every enum declaration is considered to be a `final` declaration with respect to the rules where certain class modifiers are required to exist.

The changelog says that the feature spec already says so, but I couldn't find it.