### PR TITLE
Dependency injection example for macros

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -5,6 +5,7 @@ analyzer:
     # TODO: remove these when the analyzer supports macros
     - working/macros/example/lib/auto_dispose.dart
     - working/macros/example/lib/data_class.dart
+    - working/macros/example/lib/injectable.dart
     - working/macros/example/lib/observable.dart
     - working/macros/example/lib/json_serializable.dart
     - working/macros/example/bin/user_main.dart

--- a/working/macros/example/benchmark/simple.dart
+++ b/working/macros/example/benchmark/simple.dart
@@ -29,6 +29,7 @@ import 'package:_fe_analyzer_shared/src/macros/executor/multi_executor.dart'
     as multiExecutor;
 
 import 'src/data_class.dart' as data_class;
+import 'src/injectable.dart' as injectable;
 
 final _watch = Stopwatch()..start();
 void _log(String message) {
@@ -167,6 +168,7 @@ Macro: $macro
     _log('Running benchmark');
     await switch (macro) {
       'DataClass' => data_class.runBenchmarks(executor, macroUri),
+      'Injectable' => injectable.runBenchmarks(executor, macroUri),
       _ => throw UnsupportedError('Unrecognized macro $macro'),
     };
     await executor.close();

--- a/working/macros/example/benchmark/simple.dart
+++ b/working/macros/example/benchmark/simple.dart
@@ -17,16 +17,9 @@ library language.working.macros.benchmark.simple;
 import 'dart:io';
 
 import 'package:args/args.dart';
-import 'package:dart_style/dart_style.dart';
-
-// There is no public API exposed yet, the in progress api lives here.
-import 'package:_fe_analyzer_shared/src/macros/api.dart';
 
 // Private impls used actually execute the macro
 import 'package:_fe_analyzer_shared/src/macros/bootstrap.dart';
-import 'package:_fe_analyzer_shared/src/macros/executor.dart';
-import 'package:_fe_analyzer_shared/src/macros/executor/introspection_impls.dart';
-import 'package:_fe_analyzer_shared/src/macros/executor/remote_instance.dart';
 import 'package:_fe_analyzer_shared/src/macros/executor/serialization.dart';
 import 'package:_fe_analyzer_shared/src/macros/executor/isolated_executor.dart'
     as isolatedExecutor;
@@ -34,6 +27,8 @@ import 'package:_fe_analyzer_shared/src/macros/executor/process_executor.dart'
     as processExecutor;
 import 'package:_fe_analyzer_shared/src/macros/executor/multi_executor.dart'
     as multiExecutor;
+
+import 'src/data_class.dart' as data_class;
 
 final _watch = Stopwatch()..start();
 void _log(String message) {
@@ -54,6 +49,7 @@ final argParser = ArgParser()
       defaultsTo: 'stdio',
       help: 'The communication channel to use when running as a separate'
           ' process.')
+  ..addOption('macro', allowed: ['DataClass', 'Injectable'], mandatory: true)
   ..addFlag('help', negatable: false, hide: true);
 
 // Run this script to print out the generated augmentation library for an example class.
@@ -90,6 +86,8 @@ void main(List<String> args) async {
       ? 'jit'
       : 'aot';
 
+  var macro = parsedArgs['macro'] as String;
+
   var communicationChannel = parsedArgs['communication-channel'] == 'stdio'
       ? processExecutor.CommunicationChannel.stdio
       : processExecutor.CommunicationChannel.socket;
@@ -99,30 +97,47 @@ Running with the following options:
 Serialization strategy: $parsedSerializationStrategy
 Macro execution strategy: $macroExecutionStrategy
 Host app mode: $hostMode
+Macro: $macro
 ''');
 
   // You must run from the `macros` directory, paths are relative to that.
-  var dataClassFile = File('lib/data_class.dart');
-  if (!dataClassFile.existsSync()) {
+  var macroFile = switch (macro) {
+    'DataClass' => File('lib/data_class.dart'),
+    'Injectable' => File('lib/injectable.dart'),
+    _ => throw UnsupportedError('Unrecognized macro $macro'),
+  };
+  if (!macroFile.existsSync()) {
     print('This script must be ran from the `macros` directory.');
     exit(1);
   }
-  var tmpDir = Directory.systemTemp.createTempSync('data_class_macro_example');
+  var tmpDir = Directory.systemTemp.createTempSync('macro_benchmark');
   try {
-    var macroUri = Uri.parse('package:macro_proposal/data_class.dart');
-    var macroName = 'DataClass';
+    var macroUri = switch (macro) {
+      'DataClass' => Uri.parse('package:macro_proposal/data_class.dart'),
+      'Injectable' => Uri.parse('package:macro_proposal/injectable.dart'),
+      _ => throw UnsupportedError('Unrecognized macro $macro'),
+    };
+    var macroConstructors = switch (macro) {
+      'DataClass' => {
+          'DataClass': ['']
+        },
+      'Injectable' => {
+          'Injectable': [''],
+          'Provides': [''],
+          'Component': [''],
+        },
+      _ => throw UnsupportedError('Unrecognized macro $macro'),
+    };
 
     var bootstrapContent = bootstrapMacroIsolate({
-      macroUri.toString(): {
-        macroName: [''],
-      }
+      macroUri.toString(): macroConstructors,
     }, clientSerializationMode);
 
     var bootstrapFile = File(tmpDir.uri.resolve('main.dart').toFilePath())
       ..writeAsStringSync(bootstrapContent);
     var kernelOutputFile =
         File(tmpDir.uri.resolve('main.dart.dill').toFilePath());
-    _log('Compiling DataClass macro');
+    _log('Compiling $macro macro');
     var buildSnapshotResult = await Process.run('dart', [
       'compile',
       macroExecutionStrategy == 'aot' ? 'exe' : 'jit-snapshot',
@@ -149,325 +164,13 @@ Host app mode: $hostMode
     var executor = multiExecutor.MultiMacroExecutor()
       ..registerExecutorFactory(() => executorImpl, {macroUri});
 
-    _log('Instantiating macro');
-    var instanceId = await executor.instantiateMacro(
-        macroUri, macroName, '', Arguments([], {}));
-
-    _log('Running DataClass macro 100 times...');
-    var results = <MacroExecutionResult>[];
-    var macroExecutionStart = _watch.elapsed;
-    late Duration firstRunEnd;
-    late Duration first11RunsEnd;
-    for (var i = 1; i <= 111; i++) {
-      var _shouldLog = i == 1 || i == 11 || i == 111;
-      if (_shouldLog) _log('Running DataClass macro for the ${i}th time');
-      if (instanceId.shouldExecute(DeclarationKind.classType, Phase.types)) {
-        if (_shouldLog) _log('Running types phase');
-        var result = await executor.executeTypesPhase(
-            instanceId, myClass, SimpleIdentifierResolver());
-        if (i == 1) results.add(result);
-      }
-      if (instanceId.shouldExecute(
-          DeclarationKind.classType, Phase.declarations)) {
-        if (_shouldLog) _log('Running declarations phase');
-        var result = await executor.executeDeclarationsPhase(
-            instanceId,
-            myClass,
-            SimpleIdentifierResolver(),
-            SimpleTypeDeclarationResolver(),
-            SimpleTypeResolver(),
-            SimpleTypeIntrospector());
-        if (i == 1) results.add(result);
-      }
-      if (instanceId.shouldExecute(
-          DeclarationKind.classType, Phase.definitions)) {
-        if (_shouldLog) _log('Running definitions phase');
-        var result = await executor.executeDefinitionsPhase(
-            instanceId,
-            myClass,
-            SimpleIdentifierResolver(),
-            SimpleTypeDeclarationResolver(),
-            SimpleTypeResolver(),
-            SimpleTypeIntrospector(),
-            FakeTypeInferrer());
-        if (i == 1) results.add(result);
-      }
-      if (_shouldLog) _log('Done running DataClass macro for the ${i}th time.');
-
-      if (i == 1) {
-        firstRunEnd = _watch.elapsed;
-      } else if (i == 11) {
-        first11RunsEnd = _watch.elapsed;
-      }
-    }
-    var first111RunsEnd = _watch.elapsed;
-
-    _log('Building augmentation library');
-    var library = executor.buildAugmentationLibrary(
-        results,
-        (identifier) => identifier == myClass.identifier
-            ? myClass
-            : throw UnsupportedError('Can only resolve myClass'), (identifier) {
-      if (['bool', 'Object', 'String', 'int'].contains(identifier.name)) {
-        return ResolvedIdentifier(
-            kind: IdentifierKind.topLevelMember,
-            name: identifier.name,
-            staticScope: null,
-            uri: null);
-      } else {
-        return ResolvedIdentifier(
-            kind: identifier.name == 'MyClass'
-                ? IdentifierKind.topLevelMember
-                : IdentifierKind.instanceMember,
-            name: identifier.name,
-            staticScope: null,
-            uri: Uri.parse('package:app/main.dart'));
-      }
-    },
-        (annotation) =>
-            throw UnsupportedError('Omitted types are not supported!'));
-    executor.close();
-    _log('Formatting augmentation library');
-    var formatted = DartFormatter()
-        .format(library
-            // comment out the `augment` keywords temporarily
-            .replaceAll('augment', '/*augment*/'))
-        .replaceAll('/*augment*/', 'augment');
-
-    _log('Macro augmentation library:\n\n$formatted');
-    _log('Time for the first run: ${macroExecutionStart - firstRunEnd}');
-    _log('Average time for the next 10 runs: '
-        '${(first11RunsEnd - firstRunEnd).dividedBy(10)}');
-    _log('Average time for the next 100 runs: '
-        '${(first111RunsEnd - first11RunsEnd).dividedBy(100)}');
+    _log('Running benchmark');
+    await switch (macro) {
+      'DataClass' => data_class.runBenchmarks(executor, macroUri),
+      _ => throw UnsupportedError('Unrecognized macro $macro'),
+    };
+    await executor.close();
   } finally {
     tmpDir.deleteSync(recursive: true);
   }
-}
-
-final boolIdentifier =
-    IdentifierImpl(id: RemoteInstance.uniqueId, name: 'bool');
-final intIdentifier = IdentifierImpl(id: RemoteInstance.uniqueId, name: 'int');
-final objectIdentifier =
-    IdentifierImpl(id: RemoteInstance.uniqueId, name: 'Object');
-final stringIdentifier =
-    IdentifierImpl(id: RemoteInstance.uniqueId, name: 'String');
-
-final boolType = NamedTypeAnnotationImpl(
-    id: RemoteInstance.uniqueId,
-    identifier: boolIdentifier,
-    isNullable: false,
-    typeArguments: const []);
-final intType = NamedTypeAnnotationImpl(
-    id: RemoteInstance.uniqueId,
-    identifier: intIdentifier,
-    isNullable: false,
-    typeArguments: const []);
-final stringType = NamedTypeAnnotationImpl(
-    id: RemoteInstance.uniqueId,
-    identifier: stringIdentifier,
-    isNullable: false,
-    typeArguments: const []);
-
-final objectClass = IntrospectableClassDeclarationImpl(
-    id: RemoteInstance.uniqueId,
-    identifier: objectIdentifier,
-    interfaces: [],
-    hasAbstract: false,
-    hasBase: false,
-    hasExternal: false,
-    hasFinal: false,
-    hasInterface: false,
-    hasMixin: false,
-    hasSealed: false,
-    mixins: [],
-    superclass: null,
-    typeParameters: []);
-
-final myClassIdentifier =
-    IdentifierImpl(id: RemoteInstance.uniqueId, name: 'MyClass');
-final myClass = IntrospectableClassDeclarationImpl(
-    id: RemoteInstance.uniqueId,
-    identifier: myClassIdentifier,
-    interfaces: [],
-    hasAbstract: false,
-    hasBase: false,
-    hasExternal: false,
-    hasFinal: false,
-    hasInterface: false,
-    hasMixin: false,
-    hasSealed: false,
-    mixins: [],
-    superclass: NamedTypeAnnotationImpl(
-      id: RemoteInstance.uniqueId,
-      isNullable: false,
-      identifier: objectIdentifier,
-      typeArguments: [],
-    ),
-    typeParameters: []);
-
-final myClassFields = [
-  FieldDeclarationImpl(
-      definingType: myClassIdentifier,
-      id: RemoteInstance.uniqueId,
-      identifier: IdentifierImpl(id: RemoteInstance.uniqueId, name: 'myString'),
-      isExternal: false,
-      isFinal: true,
-      isLate: false,
-      isStatic: false,
-      type: stringType),
-  FieldDeclarationImpl(
-      definingType: myClassIdentifier,
-      id: RemoteInstance.uniqueId,
-      identifier: IdentifierImpl(id: RemoteInstance.uniqueId, name: 'myBool'),
-      isExternal: false,
-      isFinal: true,
-      isLate: false,
-      isStatic: false,
-      type: boolType),
-];
-
-final myClassMethods = [
-  MethodDeclarationImpl(
-    definingType: myClassIdentifier,
-    id: RemoteInstance.uniqueId,
-    identifier: IdentifierImpl(id: RemoteInstance.uniqueId, name: '=='),
-    isAbstract: false,
-    isExternal: false,
-    isGetter: false,
-    isOperator: true,
-    isSetter: false,
-    isStatic: false,
-    namedParameters: [],
-    positionalParameters: [
-      ParameterDeclarationImpl(
-        id: RemoteInstance.uniqueId,
-        identifier: IdentifierImpl(id: RemoteInstance.uniqueId, name: 'other'),
-        isNamed: false,
-        isRequired: true,
-        type: NamedTypeAnnotationImpl(
-            id: RemoteInstance.uniqueId,
-            identifier: objectIdentifier,
-            isNullable: false,
-            typeArguments: const []),
-      )
-    ],
-    returnType: boolType,
-    typeParameters: [],
-  ),
-  MethodDeclarationImpl(
-    definingType: myClassIdentifier,
-    id: RemoteInstance.uniqueId,
-    identifier: IdentifierImpl(id: RemoteInstance.uniqueId, name: 'hashCode'),
-    isAbstract: false,
-    isExternal: false,
-    isOperator: false,
-    isGetter: true,
-    isSetter: false,
-    isStatic: false,
-    namedParameters: [],
-    positionalParameters: [],
-    returnType: intType,
-    typeParameters: [],
-  ),
-  MethodDeclarationImpl(
-    definingType: myClassIdentifier,
-    id: RemoteInstance.uniqueId,
-    identifier: IdentifierImpl(id: RemoteInstance.uniqueId, name: 'toString'),
-    isAbstract: false,
-    isExternal: false,
-    isGetter: false,
-    isOperator: false,
-    isSetter: false,
-    isStatic: false,
-    namedParameters: [],
-    positionalParameters: [],
-    returnType: stringType,
-    typeParameters: [],
-  ),
-];
-
-abstract class Fake {
-  @override
-  void noSuchMethod(Invocation invocation) =>
-      throw UnimplementedError(invocation.memberName.toString());
-}
-
-/// Returns data as if everything was [myClass].
-class SimpleTypeIntrospector implements TypeIntrospector {
-  @override
-  Future<List<ConstructorDeclaration>> constructorsOf(
-          IntrospectableType type) async =>
-      [];
-
-  @override
-  Future<List<FieldDeclaration>> fieldsOf(IntrospectableType type) async =>
-      type == myClass ? myClassFields : [];
-
-  @override
-  Future<List<MethodDeclaration>> methodsOf(IntrospectableType type) async =>
-      type == myClass ? myClassMethods : [];
-
-  @override
-  Future<List<EnumValueDeclaration>> valuesOf(
-          IntrospectableEnumDeclaration type) async =>
-      [];
-}
-
-/// This is a very basic identifier resolver, it does no actual resolution.
-class SimpleIdentifierResolver implements IdentifierResolver {
-  /// Just returns a new [Identifier] whose name is [name].
-  @override
-  Future<Identifier> resolveIdentifier(Uri library, String name) async =>
-      IdentifierImpl(id: RemoteInstance.uniqueId, name: name);
-}
-
-class SimpleTypeDeclarationResolver implements TypeDeclarationResolver {
-  @override
-  Future<TypeDeclaration> declarationOf(covariant Identifier identifier) async {
-    if (identifier == myClass.identifier) {
-      return myClass;
-    } else if (identifier == objectClass.identifier) {
-      return objectClass;
-    } else {
-      throw UnsupportedError('Could not resolve identifier ${identifier.name}');
-    }
-  }
-}
-
-class FakeTypeInferrer extends Fake implements TypeInferrer {}
-
-/// Only supports named types with no type arguments.
-class SimpleTypeResolver implements TypeResolver {
-  @override
-  Future<StaticType> resolve(TypeAnnotationCode type) async {
-    if (type is! NamedTypeAnnotationCode) {
-      throw UnsupportedError('Only named type annotations are supported');
-    }
-    if (type.typeArguments.isNotEmpty) {
-      throw UnsupportedError('Type arguments are not supported');
-    }
-    return SimpleNamedStaticType(type.name.name, isNullable: type.isNullable);
-  }
-}
-
-/// Only supports exact matching, and only goes off of the name and nullability.
-class SimpleNamedStaticType implements NamedStaticType {
-  final bool isNullable;
-  final String name;
-
-  SimpleNamedStaticType(this.name, {this.isNullable = false});
-
-  @override
-  Future<bool> isExactly(covariant SimpleNamedStaticType other) async =>
-      isNullable == other.isNullable && name == other.name;
-
-  @override
-  Future<bool> isSubtypeOf(covariant StaticType other) =>
-      throw UnimplementedError();
-}
-
-extension _ on Duration {
-  Duration dividedBy(int amount) =>
-      Duration(microseconds: (this.inMicroseconds / amount).round());
 }

--- a/working/macros/example/benchmark/src/data_class.dart
+++ b/working/macros/example/benchmark/src/data_class.dart
@@ -1,0 +1,242 @@
+import 'package:_fe_analyzer_shared/src/macros/api.dart';
+import 'package:_fe_analyzer_shared/src/macros/executor/introspection_impls.dart';
+import 'package:_fe_analyzer_shared/src/macros/executor/remote_instance.dart';
+import 'package:_fe_analyzer_shared/src/macros/executor.dart';
+import 'package:benchmark_harness/benchmark_harness.dart';
+
+import 'shared.dart';
+
+Future<void> runBenchmarks(MacroExecutor executor, Uri macroUri) async {
+  final typeDeclarations = {
+    myClass.identifier: myClass,
+    objectClass.identifier: objectClass
+  };
+  final typeIntrospector = SimpleTypeIntrospector(
+      {myClass: myClassFields}, {myClass: myClassMethods}, {});
+  final typeDeclarationResolver =
+      SimpleTypeDeclarationResolver(typeDeclarations);
+  final instantiateBenchmark =
+      DataClassInstantiateBenchmark(executor, macroUri);
+  await instantiateBenchmark.report();
+  final instanceId = instantiateBenchmark.instanceIdentifier;
+  final typesBenchmark =
+      DataClassTypesPhaseBenchmark(executor, macroUri, instanceId);
+  await typesBenchmark.report();
+  BuildAugmentationLibraryBenchmark.reportAndPrint(
+      executor, typesBenchmark.results, typeDeclarations);
+  final declarationsBenchmark = DataClassDeclarationsPhaseBenchmark(executor,
+      macroUri, instanceId, typeIntrospector, typeDeclarationResolver);
+  await declarationsBenchmark.report();
+  BuildAugmentationLibraryBenchmark.reportAndPrint(
+      executor, declarationsBenchmark.results, typeDeclarations);
+  final definitionsBenchmark = DataClassDefinitionPhaseBenchmark(executor,
+      macroUri, instanceId, typeIntrospector, typeDeclarationResolver);
+  await definitionsBenchmark.report();
+  BuildAugmentationLibraryBenchmark.reportAndPrint(
+      executor, definitionsBenchmark.results, typeDeclarations);
+}
+
+class DataClassInstantiateBenchmark extends AsyncBenchmarkBase {
+  final MacroExecutor executor;
+  final Uri macroUri;
+  late MacroInstanceIdentifier instanceIdentifier;
+
+  DataClassInstantiateBenchmark(this.executor, this.macroUri)
+      : super('DataClassInstantiate');
+
+  Future<void> run() async {
+    instanceIdentifier = await executor.instantiateMacro(
+        macroUri, 'DataClass', '', Arguments([], {}));
+  }
+}
+
+class DataClassTypesPhaseBenchmark extends AsyncBenchmarkBase {
+  final MacroExecutor executor;
+  final Uri macroUri;
+  final MacroInstanceIdentifier instanceIdentifier;
+  late List<MacroExecutionResult> results;
+
+  DataClassTypesPhaseBenchmark(
+      this.executor, this.macroUri, this.instanceIdentifier)
+      : super('DataClassTypesPhase');
+
+  Future<void> run() async {
+    results = <MacroExecutionResult>[];
+    if (instanceIdentifier.shouldExecute(
+        DeclarationKind.classType, Phase.types)) {
+      var result = await executor.executeTypesPhase(
+          instanceIdentifier, myClass, SimpleIdentifierResolver());
+      results.add(result);
+    }
+  }
+}
+
+class DataClassDeclarationsPhaseBenchmark extends AsyncBenchmarkBase {
+  final MacroExecutor executor;
+  final Uri macroUri;
+  final MacroInstanceIdentifier instanceIdentifier;
+  final TypeIntrospector typeIntrospector;
+  final TypeDeclarationResolver typeDeclarationResolver;
+
+  late List<MacroExecutionResult> results;
+
+  DataClassDeclarationsPhaseBenchmark(
+      this.executor,
+      this.macroUri,
+      this.instanceIdentifier,
+      this.typeIntrospector,
+      this.typeDeclarationResolver)
+      : super('DataClassDeclarationsPhase');
+
+  Future<void> run() async {
+    results = <MacroExecutionResult>[];
+    if (instanceIdentifier.shouldExecute(
+        DeclarationKind.classType, Phase.declarations)) {
+      var result = await executor.executeDeclarationsPhase(
+          instanceIdentifier,
+          myClass,
+          SimpleIdentifierResolver(),
+          typeDeclarationResolver,
+          SimpleTypeResolver(),
+          typeIntrospector);
+      results.add(result);
+    }
+  }
+}
+
+class DataClassDefinitionPhaseBenchmark extends AsyncBenchmarkBase {
+  final MacroExecutor executor;
+  final Uri macroUri;
+  final MacroInstanceIdentifier instanceIdentifier;
+  final TypeIntrospector typeIntrospector;
+  final TypeDeclarationResolver typeDeclarationResolver;
+
+  late List<MacroExecutionResult> results;
+
+  DataClassDefinitionPhaseBenchmark(
+      this.executor,
+      this.macroUri,
+      this.instanceIdentifier,
+      this.typeIntrospector,
+      this.typeDeclarationResolver)
+      : super('DataClassDefinitionPhase');
+
+  Future<void> run() async {
+    results = <MacroExecutionResult>[];
+    if (instanceIdentifier.shouldExecute(
+        DeclarationKind.classType, Phase.definitions)) {
+      var result = await executor.executeDefinitionsPhase(
+          instanceIdentifier,
+          myClass,
+          SimpleIdentifierResolver(),
+          typeDeclarationResolver,
+          SimpleTypeResolver(),
+          typeIntrospector,
+          FakeTypeInferrer());
+      results.add(result);
+    }
+  }
+}
+
+final myClassIdentifier =
+    IdentifierImpl(id: RemoteInstance.uniqueId, name: 'MyClass');
+final myClass = IntrospectableClassDeclarationImpl(
+    id: RemoteInstance.uniqueId,
+    identifier: myClassIdentifier,
+    interfaces: [],
+    hasAbstract: false,
+    hasBase: false,
+    hasExternal: false,
+    hasFinal: false,
+    hasInterface: false,
+    hasMixin: false,
+    hasSealed: false,
+    mixins: [],
+    superclass: NamedTypeAnnotationImpl(
+      id: RemoteInstance.uniqueId,
+      isNullable: false,
+      identifier: objectIdentifier,
+      typeArguments: [],
+    ),
+    typeParameters: []);
+
+final myClassFields = [
+  FieldDeclarationImpl(
+      definingType: myClassIdentifier,
+      id: RemoteInstance.uniqueId,
+      identifier: IdentifierImpl(id: RemoteInstance.uniqueId, name: 'myString'),
+      isExternal: false,
+      isFinal: true,
+      isLate: false,
+      isStatic: false,
+      type: stringType),
+  FieldDeclarationImpl(
+      definingType: myClassIdentifier,
+      id: RemoteInstance.uniqueId,
+      identifier: IdentifierImpl(id: RemoteInstance.uniqueId, name: 'myBool'),
+      isExternal: false,
+      isFinal: true,
+      isLate: false,
+      isStatic: false,
+      type: boolType),
+];
+
+final myClassMethods = [
+  MethodDeclarationImpl(
+    definingType: myClassIdentifier,
+    id: RemoteInstance.uniqueId,
+    identifier: IdentifierImpl(id: RemoteInstance.uniqueId, name: '=='),
+    isAbstract: false,
+    isExternal: false,
+    isGetter: false,
+    isOperator: true,
+    isSetter: false,
+    isStatic: false,
+    namedParameters: [],
+    positionalParameters: [
+      ParameterDeclarationImpl(
+        id: RemoteInstance.uniqueId,
+        identifier: IdentifierImpl(id: RemoteInstance.uniqueId, name: 'other'),
+        isNamed: false,
+        isRequired: true,
+        type: NamedTypeAnnotationImpl(
+            id: RemoteInstance.uniqueId,
+            identifier: objectIdentifier,
+            isNullable: false,
+            typeArguments: const []),
+      )
+    ],
+    returnType: boolType,
+    typeParameters: [],
+  ),
+  MethodDeclarationImpl(
+    definingType: myClassIdentifier,
+    id: RemoteInstance.uniqueId,
+    identifier: IdentifierImpl(id: RemoteInstance.uniqueId, name: 'hashCode'),
+    isAbstract: false,
+    isExternal: false,
+    isOperator: false,
+    isGetter: true,
+    isSetter: false,
+    isStatic: false,
+    namedParameters: [],
+    positionalParameters: [],
+    returnType: intType,
+    typeParameters: [],
+  ),
+  MethodDeclarationImpl(
+    definingType: myClassIdentifier,
+    id: RemoteInstance.uniqueId,
+    identifier: IdentifierImpl(id: RemoteInstance.uniqueId, name: 'toString'),
+    isAbstract: false,
+    isExternal: false,
+    isGetter: false,
+    isOperator: false,
+    isSetter: false,
+    isStatic: false,
+    namedParameters: [],
+    positionalParameters: [],
+    returnType: stringType,
+    typeParameters: [],
+  ),
+];

--- a/working/macros/example/benchmark/src/data_class.dart
+++ b/working/macros/example/benchmark/src/data_class.dart
@@ -26,6 +26,16 @@ Future<void> runBenchmarks(MacroExecutor executor, Uri macroUri) async {
       'String': stringIdentifier,
     }
   });
+  final identifierDeclarations = {
+    ...typeDeclarations,
+    for (final constructors in typeIntrospector.constructors.values)
+      for (final constructor in constructors)
+        constructor.identifier: constructor,
+    for (final methods in typeIntrospector.methods.values)
+      for (final method in methods) method.identifier: method,
+    for (final fields in typeIntrospector.fields.values)
+      for (final field in fields) field.identifier: field,
+  };
   final instantiateBenchmark =
       DataClassInstantiateBenchmark(executor, macroUri);
   await instantiateBenchmark.report();
@@ -34,7 +44,7 @@ Future<void> runBenchmarks(MacroExecutor executor, Uri macroUri) async {
       executor, macroUri, identifierResolver, instanceId);
   await typesBenchmark.report();
   BuildAugmentationLibraryBenchmark.reportAndPrint(
-      executor, typesBenchmark.results, typeDeclarations);
+      executor, typesBenchmark.results, identifierDeclarations);
   final declarationsBenchmark = DataClassDeclarationsPhaseBenchmark(
       executor,
       macroUri,
@@ -44,7 +54,7 @@ Future<void> runBenchmarks(MacroExecutor executor, Uri macroUri) async {
       typeDeclarationResolver);
   await declarationsBenchmark.report();
   BuildAugmentationLibraryBenchmark.reportAndPrint(
-      executor, declarationsBenchmark.results, typeDeclarations);
+      executor, declarationsBenchmark.results, identifierDeclarations);
   final definitionsBenchmark = DataClassDefinitionPhaseBenchmark(
       executor,
       macroUri,
@@ -54,7 +64,7 @@ Future<void> runBenchmarks(MacroExecutor executor, Uri macroUri) async {
       typeDeclarationResolver);
   await definitionsBenchmark.report();
   BuildAugmentationLibraryBenchmark.reportAndPrint(
-      executor, definitionsBenchmark.results, typeDeclarations);
+      executor, definitionsBenchmark.results, identifierDeclarations);
 }
 
 class DataClassInstantiateBenchmark extends AsyncBenchmarkBase {

--- a/working/macros/example/benchmark/src/injectable.dart
+++ b/working/macros/example/benchmark/src/injectable.dart
@@ -1,0 +1,620 @@
+import 'package:_fe_analyzer_shared/src/macros/api.dart';
+import 'package:_fe_analyzer_shared/src/macros/executor/introspection_impls.dart';
+import 'package:_fe_analyzer_shared/src/macros/executor/remote_instance.dart';
+import 'package:_fe_analyzer_shared/src/macros/executor.dart';
+import 'package:benchmark_harness/benchmark_harness.dart';
+
+import 'shared.dart';
+
+Future<void> runBenchmarks(MacroExecutor executor, Uri macroUri) async {
+  final typeDeclarations = {
+    objectClass.identifier: objectClass,
+    heaterClass.identifier: heaterClass,
+    electricHeaterClass.identifier: electricHeaterClass,
+    pumpClass.identifier: pumpClass,
+    thermosiphonClass.identifier: thermosiphonClass,
+    coffeeMakerClass.identifier: coffeeMakerClass,
+    dripCoffeeModuleClass.identifier: dripCoffeeModuleClass,
+    dripCoffeeComponentClass.identifier: dripCoffeeComponentClass,
+    providerType.identifier: providerType,
+  };
+  final typeIntrospector = SimpleTypeIntrospector(
+    constructors: {
+      coffeeMakerClass: coffeeMakerConstructors,
+      dripCoffeeComponentClass: dripCoffeeComponentConstructors,
+      electricHeaterClass: electricHeaterConstructors,
+      thermosiphonClass: thermosiphonConstructors,
+    },
+    enumValues: {},
+    fields: {
+      coffeeMakerClass: coffeeMakerFields,
+      thermosiphonClass: thermosiphonFields,
+    },
+    methods: {
+      dripCoffeeModuleClass: dripCoffeeModuleMethods,
+      dripCoffeeComponentClass: dripCoffeeComponentMethods,
+    },
+  );
+  final typeDeclarationResolver =
+      SimpleTypeDeclarationResolver(typeDeclarations);
+  final identifierResolver = SimpleIdentifierResolver({
+    Uri.parse('package:macro_proposal/injectable.dart'): {
+      'Provider': providerIdentifier
+    }
+  });
+  final instantiateBenchmark =
+      InjectableInstantiateBenchmark(executor, macroUri);
+  await instantiateBenchmark.report();
+  final instanceId = instantiateBenchmark.instanceIdentifier;
+  final typesBenchmark = InjectableTypesPhaseBenchmark(
+      executor, macroUri, identifierResolver, instanceId);
+  await typesBenchmark.report();
+  BuildAugmentationLibraryBenchmark.reportAndPrint(
+      executor, typesBenchmark.results, typeDeclarations);
+  final declarationsBenchmark = InjectableDeclarationsPhaseBenchmark(
+      executor,
+      macroUri,
+      identifierResolver,
+      instanceId,
+      typeIntrospector,
+      typeDeclarationResolver);
+  await declarationsBenchmark.report();
+  BuildAugmentationLibraryBenchmark.reportAndPrint(
+      executor, declarationsBenchmark.results, typeDeclarations);
+  final definitionsBenchmark = InjectableDefinitionPhaseBenchmark(
+      executor,
+      macroUri,
+      identifierResolver,
+      instanceId,
+      typeIntrospector,
+      typeDeclarationResolver);
+  await definitionsBenchmark.report();
+  BuildAugmentationLibraryBenchmark.reportAndPrint(
+      executor, definitionsBenchmark.results, typeDeclarations);
+}
+
+class InjectableInstantiateBenchmark extends AsyncBenchmarkBase {
+  final MacroExecutor executor;
+  final Uri macroUri;
+  late MacroInstanceIdentifier instanceIdentifier;
+
+  InjectableInstantiateBenchmark(this.executor, this.macroUri)
+      : super('InjectableInstantiate');
+
+  Future<void> run() async {
+    instanceIdentifier = await executor.instantiateMacro(
+        macroUri, 'Injectable', '', Arguments([], {}));
+  }
+}
+
+class InjectableTypesPhaseBenchmark extends AsyncBenchmarkBase {
+  final MacroExecutor executor;
+  final Uri macroUri;
+  final IdentifierResolver identifierResolver;
+  final MacroInstanceIdentifier instanceIdentifier;
+  late List<MacroExecutionResult> results;
+
+  InjectableTypesPhaseBenchmark(this.executor, this.macroUri,
+      this.identifierResolver, this.instanceIdentifier)
+      : super('InjectableTypesPhase');
+
+  Future<void> run() async {
+    results = <MacroExecutionResult>[];
+    if (instanceIdentifier.shouldExecute(
+        DeclarationKind.classType, Phase.types)) {
+      for (var clazz in injectableClasses) {
+        results.add(await executor.executeTypesPhase(
+            instanceIdentifier, clazz, identifierResolver));
+      }
+    }
+  }
+}
+
+class InjectableDeclarationsPhaseBenchmark extends AsyncBenchmarkBase {
+  final MacroExecutor executor;
+  final Uri macroUri;
+  final IdentifierResolver identifierResolver;
+  final MacroInstanceIdentifier instanceIdentifier;
+  final TypeIntrospector typeIntrospector;
+  final TypeDeclarationResolver typeDeclarationResolver;
+
+  late List<MacroExecutionResult> results;
+
+  InjectableDeclarationsPhaseBenchmark(
+      this.executor,
+      this.macroUri,
+      this.identifierResolver,
+      this.instanceIdentifier,
+      this.typeIntrospector,
+      this.typeDeclarationResolver)
+      : super('InjectableDeclarationsPhase');
+
+  Future<void> run() async {
+    results = <MacroExecutionResult>[];
+    if (instanceIdentifier.shouldExecute(
+        DeclarationKind.classType, Phase.declarations)) {
+      for (var clazz in injectableClasses) {
+        results.add(await executor.executeDeclarationsPhase(
+            instanceIdentifier,
+            clazz,
+            identifierResolver,
+            typeDeclarationResolver,
+            SimpleTypeResolver(),
+            typeIntrospector));
+      }
+    }
+  }
+}
+
+class InjectableDefinitionPhaseBenchmark extends AsyncBenchmarkBase {
+  final MacroExecutor executor;
+  final Uri macroUri;
+  final IdentifierResolver identifierResolver;
+  final MacroInstanceIdentifier instanceIdentifier;
+  final TypeIntrospector typeIntrospector;
+  final TypeDeclarationResolver typeDeclarationResolver;
+
+  late List<MacroExecutionResult> results;
+
+  InjectableDefinitionPhaseBenchmark(
+      this.executor,
+      this.macroUri,
+      this.identifierResolver,
+      this.instanceIdentifier,
+      this.typeIntrospector,
+      this.typeDeclarationResolver)
+      : super('InjectableDefinitionPhase');
+
+  Future<void> run() async {
+    results = <MacroExecutionResult>[];
+    if (instanceIdentifier.shouldExecute(
+        DeclarationKind.classType, Phase.definitions)) {
+      for (var clazz in injectableClasses) {
+        results.add(await executor.executeDefinitionsPhase(
+            instanceIdentifier,
+            clazz,
+            identifierResolver,
+            typeDeclarationResolver,
+            SimpleTypeResolver(),
+            typeIntrospector,
+            FakeTypeInferrer()));
+      }
+    }
+  }
+}
+
+// All the classes that are maked @injectable
+final injectableClasses = [
+  electricHeaterClass,
+  thermosiphonClass,
+  coffeeMakerClass
+];
+
+// typedef Provider<T> = T Function();
+final providerIdentifier =
+    IdentifierImpl(id: RemoteInstance.uniqueId, name: 'Provider');
+final providerTypeIdentifier =
+    IdentifierImpl(id: RemoteInstance.uniqueId, name: 'T');
+final providerType = TypeAliasDeclarationImpl(
+    id: RemoteInstance.uniqueId,
+    identifier: providerIdentifier,
+    typeParameters: [
+      TypeParameterDeclarationImpl(
+          id: RemoteInstance.uniqueId,
+          identifier: providerTypeIdentifier,
+          bound: null)
+    ],
+    aliasedType: FunctionTypeAnnotationImpl(
+        id: RemoteInstance.uniqueId,
+        isNullable: false,
+        namedParameters: [],
+        positionalParameters: [],
+        returnType: NamedTypeAnnotationImpl(
+            id: RemoteInstance.uniqueId,
+            isNullable: false,
+            identifier: providerTypeIdentifier,
+            typeArguments: []),
+        typeParameters: []));
+
+// interface class Heater {}
+final heaterIdentifier =
+    IdentifierImpl(id: RemoteInstance.uniqueId, name: 'Heater');
+final heaterClass = IntrospectableClassDeclarationImpl(
+    id: RemoteInstance.uniqueId,
+    identifier: heaterIdentifier,
+    typeParameters: [],
+    interfaces: [],
+    hasAbstract: false,
+    hasBase: false,
+    hasExternal: false,
+    hasFinal: false,
+    hasInterface: true,
+    hasMixin: false,
+    hasSealed: false,
+    mixins: [],
+    superclass: null);
+
+// @Injectable()
+// class ElectricHeater implements Heater {
+//   // TODO: This is required for now.
+//   ElectricHeater();
+// }
+final electricHeaterIdentifier =
+    IdentifierImpl(id: RemoteInstance.uniqueId, name: 'ElectricHeater');
+final electricHeaterClass = IntrospectableClassDeclarationImpl(
+    id: RemoteInstance.uniqueId,
+    identifier: electricHeaterIdentifier,
+    typeParameters: [],
+    interfaces: [
+      NamedTypeAnnotationImpl(
+          id: RemoteInstance.uniqueId,
+          isNullable: false,
+          identifier: heaterIdentifier,
+          typeArguments: []),
+    ],
+    hasAbstract: false,
+    hasBase: false,
+    hasExternal: false,
+    hasFinal: false,
+    hasInterface: false,
+    hasMixin: false,
+    hasSealed: false,
+    mixins: [],
+    superclass: null);
+final electricHeaterConstructors = [
+  ConstructorDeclarationImpl(
+      id: RemoteInstance.uniqueId,
+      identifier: IdentifierImpl(id: RemoteInstance.uniqueId, name: ''),
+      isAbstract: false,
+      isExternal: false,
+      isGetter: false,
+      isOperator: false,
+      isSetter: false,
+      namedParameters: [],
+      positionalParameters: [],
+      returnType: NamedTypeAnnotationImpl(
+          id: RemoteInstance.uniqueId,
+          isNullable: false,
+          identifier: electricHeaterIdentifier,
+          typeArguments: []),
+      typeParameters: [],
+      definingType: electricHeaterIdentifier,
+      isFactory: false)
+];
+
+// interface class Pump {}
+final pumpIdentifier =
+    IdentifierImpl(id: RemoteInstance.uniqueId, name: 'Pump');
+final pumpClass = IntrospectableClassDeclarationImpl(
+    id: RemoteInstance.uniqueId,
+    identifier: pumpIdentifier,
+    typeParameters: [],
+    interfaces: [],
+    hasAbstract: false,
+    hasBase: false,
+    hasExternal: false,
+    hasFinal: false,
+    hasInterface: true,
+    hasMixin: false,
+    hasSealed: false,
+    mixins: [],
+    superclass: null);
+
+// @Injectable()
+// class Thermosiphon implements Pump {
+//   final Heater heater;
+//
+//   Thermosiphon(this.heater);
+// }
+final thermosiphonIdentifier =
+    IdentifierImpl(id: RemoteInstance.uniqueId, name: 'Thermosiphon');
+final thermosiphonClass = IntrospectableClassDeclarationImpl(
+    id: RemoteInstance.uniqueId,
+    identifier: thermosiphonIdentifier,
+    typeParameters: [],
+    interfaces: [
+      NamedTypeAnnotationImpl(
+          id: RemoteInstance.uniqueId,
+          isNullable: false,
+          identifier: pumpIdentifier,
+          typeArguments: []),
+    ],
+    hasAbstract: false,
+    hasBase: false,
+    hasExternal: false,
+    hasFinal: false,
+    hasInterface: false,
+    hasMixin: false,
+    hasSealed: false,
+    mixins: [],
+    superclass: null);
+final thermosiphonFields = [
+  FieldDeclarationImpl(
+      id: RemoteInstance.uniqueId,
+      identifier: IdentifierImpl(id: RemoteInstance.uniqueId, name: 'heater'),
+      isExternal: false,
+      isFinal: true,
+      isLate: false,
+      type: NamedTypeAnnotationImpl(
+          id: RemoteInstance.uniqueId,
+          isNullable: false,
+          identifier: heaterIdentifier,
+          typeArguments: []),
+      definingType: thermosiphonIdentifier,
+      isStatic: false),
+];
+final thermosiphonConstructors = [
+  ConstructorDeclarationImpl(
+      id: RemoteInstance.uniqueId,
+      identifier: IdentifierImpl(id: RemoteInstance.uniqueId, name: ''),
+      isAbstract: false,
+      isExternal: false,
+      isGetter: false,
+      isOperator: false,
+      isSetter: false,
+      namedParameters: [],
+      positionalParameters: [
+        for (var field in thermosiphonFields)
+          ParameterDeclarationImpl(
+            id: RemoteInstance.uniqueId,
+            identifier: field.identifier,
+            isNamed: false,
+            isRequired: true,
+            type: field.type,
+          ),
+      ],
+      returnType: NamedTypeAnnotationImpl(
+          id: RemoteInstance.uniqueId,
+          isNullable: false,
+          identifier: thermosiphonIdentifier,
+          typeArguments: []),
+      typeParameters: [],
+      definingType: thermosiphonIdentifier,
+      isFactory: false)
+];
+
+// @Injectable()
+// class CoffeeMaker {
+//   final Heater heater;
+//   final Pump pump;
+
+//   CoffeeMaker(this.heater, this.pump);
+// }
+final coffeeMakerIdentifier =
+    IdentifierImpl(id: RemoteInstance.uniqueId, name: 'CoffeeMaker');
+final coffeeMakerClass = IntrospectableClassDeclarationImpl(
+    id: RemoteInstance.uniqueId,
+    identifier: coffeeMakerIdentifier,
+    typeParameters: [],
+    interfaces: [],
+    hasAbstract: false,
+    hasBase: false,
+    hasExternal: false,
+    hasFinal: false,
+    hasInterface: false,
+    hasMixin: false,
+    hasSealed: false,
+    mixins: [],
+    superclass: null);
+final coffeeMakerFields = [
+  FieldDeclarationImpl(
+      id: RemoteInstance.uniqueId,
+      identifier: IdentifierImpl(id: RemoteInstance.uniqueId, name: 'heater'),
+      isExternal: false,
+      isFinal: true,
+      isLate: false,
+      type: NamedTypeAnnotationImpl(
+          id: RemoteInstance.uniqueId,
+          isNullable: false,
+          identifier: heaterIdentifier,
+          typeArguments: []),
+      definingType: coffeeMakerIdentifier,
+      isStatic: false),
+  FieldDeclarationImpl(
+      id: RemoteInstance.uniqueId,
+      identifier: IdentifierImpl(id: RemoteInstance.uniqueId, name: 'pump'),
+      isExternal: false,
+      isFinal: true,
+      isLate: false,
+      type: NamedTypeAnnotationImpl(
+          id: RemoteInstance.uniqueId,
+          isNullable: false,
+          identifier: pumpIdentifier,
+          typeArguments: []),
+      definingType: coffeeMakerIdentifier,
+      isStatic: false),
+];
+final coffeeMakerConstructors = [
+  ConstructorDeclarationImpl(
+      id: RemoteInstance.uniqueId,
+      identifier: IdentifierImpl(id: RemoteInstance.uniqueId, name: ''),
+      isAbstract: false,
+      isExternal: false,
+      isGetter: false,
+      isOperator: false,
+      isSetter: false,
+      namedParameters: [],
+      positionalParameters: [
+        for (var field in coffeeMakerFields)
+          ParameterDeclarationImpl(
+            id: RemoteInstance.uniqueId,
+            identifier: field.identifier,
+            isNamed: false,
+            isRequired: true,
+            type: field.type,
+          ),
+      ],
+      returnType: NamedTypeAnnotationImpl(
+          id: RemoteInstance.uniqueId,
+          isNullable: false,
+          identifier: coffeeMakerIdentifier,
+          typeArguments: []),
+      typeParameters: [],
+      definingType: coffeeMakerIdentifier,
+      isFactory: false),
+];
+
+// class DripCoffeeModule {
+//   @Provides()
+//   Heater provideHeater(ElectricHeater impl) => impl;
+//   @Provides()
+//   Pump providePump(Thermosiphon impl) => impl;
+// }
+final dripCoffeeModuleIdentifier =
+    IdentifierImpl(id: RemoteInstance.uniqueId, name: 'DripCoffeeModule');
+final dripCoffeeModuleClass = IntrospectableClassDeclarationImpl(
+    id: RemoteInstance.uniqueId,
+    identifier: dripCoffeeModuleIdentifier,
+    typeParameters: [],
+    interfaces: [],
+    hasAbstract: false,
+    hasBase: false,
+    hasExternal: false,
+    hasFinal: false,
+    hasInterface: false,
+    hasMixin: false,
+    hasSealed: false,
+    mixins: [],
+    superclass: null);
+final dripCoffeeModuleMethods = [
+  MethodDeclarationImpl(
+      id: RemoteInstance.uniqueId,
+      identifier:
+          IdentifierImpl(id: RemoteInstance.uniqueId, name: 'provideHeater'),
+      isAbstract: false,
+      isExternal: false,
+      isGetter: false,
+      isOperator: false,
+      isSetter: false,
+      namedParameters: [],
+      positionalParameters: [
+        ParameterDeclarationImpl(
+            id: RemoteInstance.uniqueId,
+            identifier:
+                IdentifierImpl(id: RemoteInstance.uniqueId, name: 'impl'),
+            isNamed: false,
+            isRequired: true,
+            type: NamedTypeAnnotationImpl(
+                id: RemoteInstance.uniqueId,
+                isNullable: false,
+                identifier: electricHeaterIdentifier,
+                typeArguments: [])),
+      ],
+      returnType: NamedTypeAnnotationImpl(
+          id: RemoteInstance.uniqueId,
+          isNullable: false,
+          identifier: heaterIdentifier,
+          typeArguments: []),
+      typeParameters: [],
+      definingType: dripCoffeeModuleIdentifier,
+      isStatic: false),
+  MethodDeclarationImpl(
+      id: RemoteInstance.uniqueId,
+      identifier:
+          IdentifierImpl(id: RemoteInstance.uniqueId, name: 'providePump'),
+      isAbstract: false,
+      isExternal: false,
+      isGetter: false,
+      isOperator: false,
+      isSetter: false,
+      namedParameters: [],
+      positionalParameters: [
+        ParameterDeclarationImpl(
+            id: RemoteInstance.uniqueId,
+            identifier:
+                IdentifierImpl(id: RemoteInstance.uniqueId, name: 'impl'),
+            isNamed: false,
+            isRequired: true,
+            type: NamedTypeAnnotationImpl(
+                id: RemoteInstance.uniqueId,
+                isNullable: false,
+                identifier: thermosiphonIdentifier,
+                typeArguments: [])),
+      ],
+      returnType: NamedTypeAnnotationImpl(
+          id: RemoteInstance.uniqueId,
+          isNullable: false,
+          identifier: pumpIdentifier,
+          typeArguments: []),
+      typeParameters: [],
+      definingType: dripCoffeeModuleIdentifier,
+      isStatic: false),
+];
+
+// @Component(modules: [])
+// class DripCoffeeComponent {
+//   external CoffeeMaker coffeeMaker();
+
+//   // TODO: Generate this from the modules given above once macro args are
+//   // supported.
+//   external factory DripCoffeeComponent(DripCoffeeModule dripCoffeeModule);
+// }
+final dripCoffeeComponentIdentifier =
+    IdentifierImpl(id: RemoteInstance.uniqueId, name: 'DripCoffeeComponent');
+final dripCoffeeComponentClass = IntrospectableClassDeclarationImpl(
+    id: RemoteInstance.uniqueId,
+    identifier: dripCoffeeComponentIdentifier,
+    typeParameters: [],
+    interfaces: [],
+    hasAbstract: false,
+    hasBase: false,
+    hasExternal: false,
+    hasFinal: false,
+    hasInterface: false,
+    hasMixin: false,
+    hasSealed: false,
+    mixins: [],
+    superclass: null);
+final dripCoffeeComponentMethods = [
+  MethodDeclarationImpl(
+      id: RemoteInstance.uniqueId,
+      identifier:
+          IdentifierImpl(id: RemoteInstance.uniqueId, name: 'coffeeMaker'),
+      isAbstract: false,
+      isExternal: true,
+      isGetter: false,
+      isOperator: false,
+      isSetter: false,
+      namedParameters: [],
+      positionalParameters: [],
+      returnType: NamedTypeAnnotationImpl(
+          id: RemoteInstance.uniqueId,
+          isNullable: false,
+          identifier: coffeeMakerIdentifier,
+          typeArguments: []),
+      typeParameters: [],
+      definingType: dripCoffeeComponentIdentifier,
+      isStatic: false),
+];
+final dripCoffeeComponentConstructors = [
+  ConstructorDeclarationImpl(
+      id: RemoteInstance.uniqueId,
+      identifier: IdentifierImpl(id: RemoteInstance.uniqueId, name: ''),
+      isAbstract: false,
+      isExternal: true,
+      isGetter: false,
+      isOperator: false,
+      isSetter: false,
+      namedParameters: [],
+      positionalParameters: [
+        ParameterDeclarationImpl(
+            id: RemoteInstance.uniqueId,
+            identifier: IdentifierImpl(
+                id: RemoteInstance.uniqueId, name: 'dripCoffeeModule'),
+            isNamed: false,
+            isRequired: true,
+            type: NamedTypeAnnotationImpl(
+                id: RemoteInstance.uniqueId,
+                isNullable: false,
+                identifier: dripCoffeeModuleIdentifier,
+                typeArguments: [])),
+      ],
+      returnType: NamedTypeAnnotationImpl(
+          id: RemoteInstance.uniqueId,
+          isNullable: false,
+          identifier: dripCoffeeComponentIdentifier,
+          typeArguments: []),
+      typeParameters: [],
+      definingType: dripCoffeeComponentIdentifier,
+      isFactory: true),
+];

--- a/working/macros/example/benchmark/src/shared.dart
+++ b/working/macros/example/benchmark/src/shared.dart
@@ -41,7 +41,7 @@ class BuildAugmentationLibraryBenchmark extends BenchmarkBase {
             uri: null);
       } else {
         return ResolvedIdentifier(
-            kind: identifier.name == 'MyClass'
+            kind: typeDeclarations.containsKey(identifier)
                 ? IdentifierKind.topLevelMember
                 : IdentifierKind.instanceMember,
             name: identifier.name,
@@ -78,17 +78,23 @@ abstract class Fake {
 
 /// Returns data as if everything was [myClass].
 class SimpleTypeIntrospector implements TypeIntrospector {
-  final Map<IntrospectableType, List<FieldDeclaration>> fields;
-  final Map<IntrospectableType, List<MethodDeclaration>> methods;
+  final Map<IntrospectableType, List<ConstructorDeclaration>> constructors;
   final Map<IntrospectableEnumDeclaration, List<EnumValueDeclaration>>
       enumValues;
+  final Map<IntrospectableType, List<FieldDeclaration>> fields;
+  final Map<IntrospectableType, List<MethodDeclaration>> methods;
 
-  SimpleTypeIntrospector(this.fields, this.methods, this.enumValues);
+  SimpleTypeIntrospector({
+    required this.constructors,
+    required this.enumValues,
+    required this.fields,
+    required this.methods,
+  });
 
   @override
   Future<List<ConstructorDeclaration>> constructorsOf(
           IntrospectableType type) async =>
-      [];
+      constructors[type] ?? [];
 
   @override
   Future<List<FieldDeclaration>> fieldsOf(IntrospectableType type) async =>
@@ -106,10 +112,14 @@ class SimpleTypeIntrospector implements TypeIntrospector {
 
 /// This is a very basic identifier resolver, it does no actual resolution.
 class SimpleIdentifierResolver implements IdentifierResolver {
+  final Map<Uri, Map<String, Identifier>> knownIdentifiers;
+
+  SimpleIdentifierResolver(this.knownIdentifiers);
+
   /// Just returns a new [Identifier] whose name is [name].
   @override
   Future<Identifier> resolveIdentifier(Uri library, String name) async =>
-      IdentifierImpl(id: RemoteInstance.uniqueId, name: name);
+      knownIdentifiers[library]![name]!;
 }
 
 class SimpleTypeDeclarationResolver implements TypeDeclarationResolver {

--- a/working/macros/example/benchmark/src/shared.dart
+++ b/working/macros/example/benchmark/src/shared.dart
@@ -1,0 +1,202 @@
+// There is no public API exposed yet, the in progress api lives here.
+import 'package:_fe_analyzer_shared/src/macros/api.dart';
+import 'package:_fe_analyzer_shared/src/macros/executor/introspection_impls.dart';
+import 'package:_fe_analyzer_shared/src/macros/executor/remote_instance.dart';
+import 'package:_fe_analyzer_shared/src/macros/executor.dart';
+import 'package:benchmark_harness/benchmark_harness.dart';
+import 'package:dart_style/dart_style.dart';
+
+class BuildAugmentationLibraryBenchmark extends BenchmarkBase {
+  final MacroExecutor executor;
+  final List<MacroExecutionResult> results;
+  final Map<Identifier, TypeDeclaration> typeDeclarations;
+  late String library;
+
+  BuildAugmentationLibraryBenchmark(
+      this.executor, this.results, this.typeDeclarations)
+      : super('AugmentationLibrary');
+
+  static void reportAndPrint(
+      MacroExecutor executor,
+      List<MacroExecutionResult> results,
+      Map<Identifier, TypeDeclaration> typeDeclarations) {
+    final benchmark =
+        BuildAugmentationLibraryBenchmark(executor, results, typeDeclarations);
+    benchmark.report();
+    final formatBenchmark = FormatLibraryBenchmark(benchmark.library)..report();
+    print('${formatBenchmark.formattedResult}');
+  }
+
+  void run() {
+    library = executor.buildAugmentationLibrary(
+        results,
+        (identifier) =>
+            typeDeclarations[identifier] ??
+            (throw UnsupportedError('Can only resolve myClass')), (identifier) {
+      if (['bool', 'Object', 'String', 'int'].contains(identifier.name)) {
+        return ResolvedIdentifier(
+            kind: IdentifierKind.topLevelMember,
+            name: identifier.name,
+            staticScope: null,
+            uri: null);
+      } else {
+        return ResolvedIdentifier(
+            kind: identifier.name == 'MyClass'
+                ? IdentifierKind.topLevelMember
+                : IdentifierKind.instanceMember,
+            name: identifier.name,
+            staticScope: null,
+            uri: Uri.parse('package:app/main.dart'));
+      }
+    },
+        (annotation) =>
+            throw UnsupportedError('Omitted types are not supported!'));
+  }
+}
+
+class FormatLibraryBenchmark extends BenchmarkBase {
+  final formatter = DartFormatter();
+  final String library;
+  late String formattedResult;
+
+  FormatLibraryBenchmark(this.library) : super('FormatLibrary');
+
+  void run() {
+    formattedResult = formatter
+        .format(library
+            // comment out the `augment` keywords temporarily
+            .replaceAll('augment', '/*augment*/'))
+        .replaceAll('/*augment*/', 'augment');
+  }
+}
+
+abstract class Fake {
+  @override
+  void noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError(invocation.memberName.toString());
+}
+
+/// Returns data as if everything was [myClass].
+class SimpleTypeIntrospector implements TypeIntrospector {
+  final Map<IntrospectableType, List<FieldDeclaration>> fields;
+  final Map<IntrospectableType, List<MethodDeclaration>> methods;
+  final Map<IntrospectableEnumDeclaration, List<EnumValueDeclaration>>
+      enumValues;
+
+  SimpleTypeIntrospector(this.fields, this.methods, this.enumValues);
+
+  @override
+  Future<List<ConstructorDeclaration>> constructorsOf(
+          IntrospectableType type) async =>
+      [];
+
+  @override
+  Future<List<FieldDeclaration>> fieldsOf(IntrospectableType type) async =>
+      fields[type] ?? [];
+
+  @override
+  Future<List<MethodDeclaration>> methodsOf(IntrospectableType type) async =>
+      methods[type] ?? [];
+
+  @override
+  Future<List<EnumValueDeclaration>> valuesOf(
+          IntrospectableEnumDeclaration type) async =>
+      enumValues[type] ?? [];
+}
+
+/// This is a very basic identifier resolver, it does no actual resolution.
+class SimpleIdentifierResolver implements IdentifierResolver {
+  /// Just returns a new [Identifier] whose name is [name].
+  @override
+  Future<Identifier> resolveIdentifier(Uri library, String name) async =>
+      IdentifierImpl(id: RemoteInstance.uniqueId, name: name);
+}
+
+class SimpleTypeDeclarationResolver implements TypeDeclarationResolver {
+  final Map<Identifier, TypeDeclaration> _knownDeclarations;
+
+  SimpleTypeDeclarationResolver(this._knownDeclarations);
+
+  @override
+  Future<TypeDeclaration> declarationOf(
+          covariant Identifier identifier) async =>
+      _knownDeclarations[identifier] ??
+      (throw UnsupportedError(
+          'Could not resolve identifier ${identifier.name}'));
+}
+
+class FakeTypeInferrer extends Fake implements TypeInferrer {}
+
+/// Only supports named types with no type arguments.
+class SimpleTypeResolver implements TypeResolver {
+  @override
+  Future<StaticType> resolve(TypeAnnotationCode type) async {
+    if (type is! NamedTypeAnnotationCode) {
+      throw UnsupportedError('Only named type annotations are supported');
+    }
+    if (type.typeArguments.isNotEmpty) {
+      throw UnsupportedError('Type arguments are not supported');
+    }
+    return SimpleNamedStaticType(type.name.name, isNullable: type.isNullable);
+  }
+}
+
+/// Only supports exact matching, and only goes off of the name and nullability.
+class SimpleNamedStaticType implements NamedStaticType {
+  final bool isNullable;
+  final String name;
+
+  SimpleNamedStaticType(this.name, {this.isNullable = false});
+
+  @override
+  Future<bool> isExactly(covariant SimpleNamedStaticType other) async =>
+      isNullable == other.isNullable && name == other.name;
+
+  @override
+  Future<bool> isSubtypeOf(covariant StaticType other) =>
+      throw UnimplementedError();
+}
+
+extension _ on Duration {
+  Duration dividedBy(int amount) =>
+      Duration(microseconds: (this.inMicroseconds / amount).round());
+}
+
+final boolIdentifier =
+    IdentifierImpl(id: RemoteInstance.uniqueId, name: 'bool');
+final intIdentifier = IdentifierImpl(id: RemoteInstance.uniqueId, name: 'int');
+final objectIdentifier =
+    IdentifierImpl(id: RemoteInstance.uniqueId, name: 'Object');
+final stringIdentifier =
+    IdentifierImpl(id: RemoteInstance.uniqueId, name: 'String');
+
+final boolType = NamedTypeAnnotationImpl(
+    id: RemoteInstance.uniqueId,
+    identifier: boolIdentifier,
+    isNullable: false,
+    typeArguments: const []);
+final intType = NamedTypeAnnotationImpl(
+    id: RemoteInstance.uniqueId,
+    identifier: intIdentifier,
+    isNullable: false,
+    typeArguments: const []);
+final stringType = NamedTypeAnnotationImpl(
+    id: RemoteInstance.uniqueId,
+    identifier: stringIdentifier,
+    isNullable: false,
+    typeArguments: const []);
+
+final objectClass = IntrospectableClassDeclarationImpl(
+    id: RemoteInstance.uniqueId,
+    identifier: objectIdentifier,
+    interfaces: [],
+    hasAbstract: false,
+    hasBase: false,
+    hasExternal: false,
+    hasFinal: false,
+    hasInterface: false,
+    hasMixin: false,
+    hasSealed: false,
+    mixins: [],
+    superclass: null,
+    typeParameters: []);

--- a/working/macros/example/bin/injectable_main.dart
+++ b/working/macros/example/bin/injectable_main.dart
@@ -1,0 +1,48 @@
+import 'package:macro_proposal/injectable.dart';
+
+void main() {
+  final component = DripCoffeeComponent(DripCoffeeModule());
+
+  print(component.coffeeMaker());
+}
+
+abstract class Heater {}
+
+@Injectable()
+class ElectricHeater implements Heater {
+  // TODO: This is required for now.
+  ElectricHeater();
+}
+
+abstract class Pump {}
+
+@Injectable()
+class Thermosiphon implements Pump {
+  final Heater heater;
+
+  Thermosiphon(this.heater);
+}
+
+@Injectable()
+class CoffeeMaker {
+  final Heater heater;
+  final Pump pump;
+
+  CoffeeMaker(this.heater, this.pump);
+}
+
+class DripCoffeeModule {
+  @Provides()
+  Heater provideHeater(ElectricHeater impl) => impl;
+  @Provides()
+  Pump providePump(Thermosiphon impl) => impl;
+}
+
+@Component(modules: [])
+class DripCoffeeComponent {
+  external CoffeeMaker coffeeMaker();
+
+  // TODO: Generate this from the modules given above once macro args are
+  // supported.
+  external factory DripCoffeeComponent(DripCoffeeModule dripCoffeeModule);
+}

--- a/working/macros/example/bin/injectable_main.dart
+++ b/working/macros/example/bin/injectable_main.dart
@@ -38,11 +38,10 @@ class DripCoffeeModule {
   Pump providePump(Thermosiphon impl) => impl;
 }
 
-@Component(modules: [])
+@Component()
 class DripCoffeeComponent {
   external CoffeeMaker coffeeMaker();
 
-  // TODO: Generate this from the modules given above once macro args are
-  // supported.
+  // TODO: Generate this from modules given to the macro once supported
   external factory DripCoffeeComponent(DripCoffeeModule dripCoffeeModule);
 }

--- a/working/macros/example/bin/run.dart
+++ b/working/macros/example/bin/run.dart
@@ -9,7 +9,10 @@ import 'package:_fe_analyzer_shared/src/macros/bootstrap.dart';
 import 'package:_fe_analyzer_shared/src/macros/executor/serialization.dart';
 import 'package:frontend_server/compute_kernel.dart';
 
-void main() async {
+void main(List<String> args) async {
+  var scriptUri = Uri.base
+      .resolve(args.isEmpty ? 'bin/user_main.dart' : args.single)
+      .toFilePath();
   watch.start();
   var dartToolDir = Directory('.dart_tool/macro_proposal')
     ..createSync(recursive: true);
@@ -21,6 +24,7 @@ void main() async {
   var autoDisposableUri = Uri.parse('package:macro_proposal/auto_dispose.dart');
   var jsonSerializableUri =
       Uri.parse('package:macro_proposal/json_serializable.dart');
+  var injectableUri = Uri.parse('package:macro_proposal/injectable.dart');
   var bootstrapContent = bootstrapMacroIsolate({
     dataClassUri.toString(): {
       'AutoConstructor': [''],
@@ -37,6 +41,11 @@ void main() async {
     },
     jsonSerializableUri.toString(): {
       'JsonSerializable': [''],
+    },
+    injectableUri.toString(): {
+      'Component': [''],
+      'Injectable': [''],
+      'Provides': [''],
     }
   }, SerializationMode.byteDataClient);
   bootstrapFile.writeAsStringSync(bootstrapContent);
@@ -63,6 +72,7 @@ void main() async {
     '--source=${bootstrapFile.path}',
     '--source=lib/auto_dispose.dart',
     '--source=lib/data_class.dart',
+    '--source=lib/injectable.dart',
     '--source=lib/json_serializable.dart',
     '--source=lib/observable.dart',
     for (var source in await _allSources(feAnalyzerSharedRoot.path))
@@ -89,7 +99,7 @@ void main() async {
     '--output',
     output.path,
     '--source',
-    Uri.base.resolve('bin/user_main.dart').toFilePath(),
+    scriptUri,
     '--packages-file=.dart_tool/package_config.json',
     '--enable-experiment=macros',
     '--precompiled-macro-format=kernel',
@@ -101,6 +111,8 @@ void main() async {
     '$autoDisposableUri;${bootstrapKernelFile.path}',
     '--precompiled-macro',
     '$jsonSerializableUri;${bootstrapKernelFile.path}',
+    '--precompiled-macro',
+    '$injectableUri;${bootstrapKernelFile.path}',
     '--macro-serialization-mode=bytedata',
     '--input-linked',
     bootstrapKernelFile.path,

--- a/working/macros/example/lib/injectable.dart
+++ b/working/macros/example/lib/injectable.dart
@@ -1,0 +1,190 @@
+// Copyright (c) 2023, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// There is no public API exposed yet, the in progress api lives here.
+import 'dart:async';
+
+import 'package:_fe_analyzer_shared/src/macros/api.dart';
+
+/// A [Provider] is just a function with no arguments that returns something
+/// of the desired type when invoked.
+typedef Provider<T> = T Function();
+
+abstract class Heater {}
+
+@Injectable()
+class ElectricHeater implements Heater {
+  /// Generated, could be a separate class, extension etc
+  static Provider<ElectricHeater> provider() => ElectricHeater.new;
+}
+
+abstract class Pump {}
+
+@Injectable()
+class Thermosiphon implements Pump {
+  final Heater heater;
+
+  Thermosiphon(this.heater);
+
+  /// Generated, could be a separate class, extension etc
+  static Provider<Thermosiphon> provider(Provider<Heater> provideHeater) =>
+      () => Thermosiphon(provideHeater());
+}
+
+@Injectable()
+class CoffeeMaker {
+  final Heater heater;
+  final Pump pump;
+
+  CoffeeMaker(this.heater, this.pump);
+
+  /// Generated, could be a separate class, extension etc
+  static Provider<CoffeeMaker> provider(
+          Provider<Heater> provideHeater, Provider<Pump> providePump) =>
+      () => CoffeeMaker(provideHeater(), providePump());
+}
+
+class DripCoffeeModule {
+  @Provides()
+  Heater provideHeater(ElectricHeater impl) => impl;
+  @Provides()
+  Pump providePump(Thermosiphon impl) => impl;
+
+  /// Generated, could be in a different class, extension, etc.
+  Provider<Heater> provideHeaterProvider(
+          Provider<ElectricHeater> provideElectricHeater) =>
+      () => provideHeater(provideElectricHeater());
+
+  Provider<Pump> providePumpProvider(
+          Provider<Thermosiphon> provideThermosiphon) =>
+      () => providePump(provideThermosiphon());
+}
+
+@Component(modules: [DripCoffeeModule])
+class DripCoffeeComponent {
+  external CoffeeMaker coffeeMaker();
+
+  /// Generated
+  final Provider<CoffeeMaker> _coffeeMakerProvider;
+
+  DripCoffeeComponent._(this._coffeeMakerProvider);
+
+  // The body of this has been filled in
+  CoffeeMaker coffeeMaker() => _coffeeMakerProvider();
+
+  factory DripCoffeeComponent(DripCoffeeModule dripCoffeeModule) {
+    final electricHeaterProvider = ElectricHeater.provider();
+    final heaterProvider =
+        dripCoffeeModule.provideHeaterProvider(electricHeaterProvider);
+    final thermosiphonProvider = Thermosiphon.provider(heaterProvider);
+    final pumpProvider =
+        dripCoffeeModule.providePumpProvider(thermosiphonProvider);
+    final coffeeMakerProvider =
+        CoffeeMaker.provider(heaterProvider, pumpProvider);
+
+    return DripCoffeeComponent._(coffeeMakerProvider);
+  }
+}
+
+/// Adds a static `provider` method, which is a factory for a Provider<T> where
+/// T is the annotated class. It will take a Provider<T> parameter corresponding
+/// to each argument of the constructor (there must be exactly one constructor).
+class Injectable implements ClassDeclarationsMacro {
+  const Injectable();
+
+  @override
+  Future<void> buildDeclarationsForClass(
+      ClassDeclaration clazz, ClassMemberDeclarationBuilder builder) async {
+    if (clazz.typeParameters.isNotEmpty) {
+      throw ArgumentError('Type parameters are not supported!');
+    }
+    // ignore: deprecated_member_use
+    final providerIdentifier = await builder.resolveIdentifier(
+        Uri.parse('package:macro_proposal/injectable.dart'), 'Provider');
+    // Declare a static method which takes all required providers, and returns
+    // a provider for this class.
+    final parts = <Object>[
+      'static ',
+      NamedTypeAnnotationCode(
+          name: providerIdentifier,
+          typeArguments: [NamedTypeAnnotationCode(name: clazz.identifier)]),
+      ' provider(',
+    ];
+
+    final constructor = (await builder.constructorsOf(clazz)).single;
+    final allParameters = constructor.positionalParameters
+        .followedBy(constructor.namedParameters);
+    for (final parameter in allParameters) {
+      final type = parameter.type;
+      parts.addAll([
+        NamedTypeAnnotationCode(
+            name: providerIdentifier, typeArguments: [type.code]),
+        ' ',
+        parameter.identifier.name,
+        'Provider, '
+      ]);
+    }
+
+    parts.addAll([
+      ') => () => ',
+      constructor.identifier,
+      '(',
+      for (final parameter in allParameters) '${parameter.identifier.name}(), ',
+      ')',
+    ]);
+
+    builder.declareInClass(DeclarationCode.fromParts(parts));
+  }
+}
+
+class Provides implements MethodDeclarationsMacro {
+  const Provides();
+
+  @override
+  FutureOr<void> buildDeclarationsForMethod(
+      MethodDeclaration method, ClassMemberDeclarationBuilder builder) async {
+    final providerIdentifier = await builder.resolveIdentifier(
+        Uri.parse('package:macro_proposal/injectable.dart'), 'Provider');
+    if (method.namedParameters.isNotEmpty) {
+      throw ArgumentError(
+          '@Provides methods should only have positional parameters');
+    }
+    final parts = [
+      NamedTypeAnnotationCode(
+          name: providerIdentifier, typeArguments: [method.returnType.code]),
+      ' ${method.identifier.name}Provider(',
+      for (final param in method.positionalParameters) ...[
+        NamedTypeAnnotationCode(
+            name: providerIdentifier, typeArguments: [param.type.code]),
+        ' provide${param.identifier.name.capitalize}, ',
+      ],
+      ') => ',
+      method.identifier,
+      '(',
+      for (final param in method.positionalParameters) ...[
+        param.identifier,
+        '(), ',
+      ],
+      ');',
+    ];
+    builder.declareInClass(new DeclarationCode.fromParts(parts));
+  }
+}
+
+class Component implements ClassDefinitionMacro {
+  final List<Identifier> modules;
+
+  const Component({required this.modules});
+
+  @override
+  FutureOr<void> buildDefinitionForClass(
+      ClassDeclaration clazz, ClassDefinitionBuilder builder) async {
+    // TODO: implement buildDefinitionForClass
+    throw UnimplementedError();
+  }
+}
+
+extension _ on String {
+  String get capitalize => '${this[0].toUpperCase()}${substring(1)}';
+}

--- a/working/macros/example/lib/injectable.dart
+++ b/working/macros/example/lib/injectable.dart
@@ -96,10 +96,8 @@ macro class Provides implements MethodDeclarationsMacro {
       ') => ',
       method.identifier,
       '(',
-      for (final param in method.positionalParameters) ...[
-        param.identifier,
-        '(), ',
-      ],
+      for (final param in method.positionalParameters)
+        'provide${param.identifier.name.capitalize}(), ',
       ');',
     ];
     builder.declareInType(new DeclarationCode.fromParts(parts));
@@ -109,7 +107,8 @@ macro class Provides implements MethodDeclarationsMacro {
 macro class Component implements ClassDeclarationsMacro, ClassDefinitionMacro {
   final List<Identifier> modules;
 
-  const Component({required this.modules});
+  // TODO: Require modules here and generate the constructor once supported.
+  const Component({this.modules = const []});
 
   @override
   FutureOr<void> buildDeclarationsForClass(IntrospectableClassDeclaration clazz,

--- a/working/macros/example/lib/injectable.dart
+++ b/working/macros/example/lib/injectable.dart
@@ -66,7 +66,8 @@ macro class Injectable implements ClassDeclarationsMacro {
           ? clazz.identifier
           : constructor.identifier,
       '(',
-      for (final parameter in allParameters) '${parameter.identifier.name}Provider(), ',
+      for (final parameter in allParameters)
+        '${parameter.identifier.name}Provider(), ',
       ');',
     ]);
 
@@ -204,7 +205,6 @@ macro class Component implements ClassDeclarationsMacro, ClassDefinitionMacro {
       '{',
     ];
 
-
     /// For each parameter to the factory, we add a map from the type provided
     /// to the providerProvider method.
     final providerProviderMethods = <Identifier, MethodDeclaration>{};
@@ -231,8 +231,8 @@ macro class Component implements ClassDeclarationsMacro, ClassDefinitionMacro {
     /// The private constructor (generated earlier), that we actually want to
     /// invoke. This will have only Providers as its parameters, one for each
     /// external method on the class.
-    final privateConstructor = constructors.singleWhere(
-        (constructor) => constructor.identifier.name == '_');
+    final privateConstructor = constructors
+        .singleWhere((constructor) => constructor.identifier.name == '_');
     // Map of Type identifiers to local variable names for zero argument
     // provider methods.
     final localProviders = <Identifier, String>{};
@@ -267,12 +267,14 @@ macro class Component implements ClassDeclarationsMacro, ClassDefinitionMacro {
       throw StateError('Only positional parameters are supported');
     }
     for (final param in method.positionalParameters) {
-      final paramType = param.type;
+      var paramType = param.type;
+      if (paramType is OmittedTypeAnnotation) {
+        paramType = await builder.inferType(paramType);
+      }
       if (paramType is! NamedTypeAnnotation ||
           paramType.identifier != providerIdentifier) {
-        throw ArgumentError(
-          'All arguments should be providers, but got a '
-          '${param.type.code.debugString()}');
+        throw ArgumentError('All arguments should be providers, but got a '
+            '${param.type.code.debugString()}');
       }
       final providedType =
           paramType.typeArguments.single as NamedTypeAnnotation;

--- a/working/macros/example/lib/injectable.dart
+++ b/working/macros/example/lib/injectable.dart
@@ -36,7 +36,13 @@ macro class Injectable implements ClassDeclarationsMacro {
       ' provider(',
     ];
 
-    final constructor = (await builder.constructorsOf(clazz)).single;
+    final constructors = await builder.constructorsOf(clazz);
+    if (constructors.length != 1) {
+      throw ArgumentError(
+          'Injectable classes should have only one constructor but '
+          '${clazz.identifier.name} has ${constructors.length}');
+    }
+    final constructor = constructors.single;
     final allParameters = constructor.positionalParameters
         .followedBy(constructor.namedParameters);
     for (final parameter in allParameters) {
@@ -58,7 +64,7 @@ macro class Injectable implements ClassDeclarationsMacro {
           ? clazz.identifier
           : constructor.identifier,
       '(',
-      for (final parameter in allParameters) '${parameter.identifier.name}(), ',
+      for (final parameter in allParameters) '${parameter.identifier.name}Provider(), ',
       ');',
     ]);
 

--- a/working/macros/example/lib/injectable.dart
+++ b/working/macros/example/lib/injectable.dart
@@ -2,9 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// There is no public API exposed yet, the in progress api lives here.
 import 'dart:async';
 
+// There is no public API exposed yet, the in progress api lives here.
 import 'package:_fe_analyzer_shared/src/macros/api.dart';
 
 import 'util.dart';

--- a/working/macros/example/lib/util.dart
+++ b/working/macros/example/lib/util.dart
@@ -1,0 +1,18 @@
+import 'package:_fe_analyzer_shared/src/macros/api.dart';
+import 'package:_fe_analyzer_shared/src/macros/executor/introspection_impls.dart';
+
+extension DebugCodeString on Code {
+  StringBuffer debugString([StringBuffer? buffer]) {
+    buffer ??= StringBuffer();
+    for (var part in parts) {
+      if (part is Code) {
+        part.debugString(buffer);
+      } else if (part is IdentifierImpl) {
+        buffer.write(part.name);
+      } else {
+        buffer.write(part as String);
+      }
+    }
+    return buffer;
+  }
+}

--- a/working/macros/example/lib/util.dart
+++ b/working/macros/example/lib/util.dart
@@ -9,8 +9,10 @@ extension DebugCodeString on Code {
         part.debugString(buffer);
       } else if (part is IdentifierImpl) {
         buffer.write(part.name);
+      } else if (part is String) {
+        buffer.write(part);
       } else {
-        buffer.write(part as String);
+        buffer.write(part);
       }
     }
     return buffer;

--- a/working/macros/example/pubspec.yaml
+++ b/working/macros/example/pubspec.yaml
@@ -4,6 +4,7 @@ environment:
   sdk: ">=3.1.0-0 <4.0.0"
 dev_dependencies:
   args: ^2.3.0
+  benchmark_harness: ^2.2.1
   dart_style: ^2.2.1
   _fe_analyzer_shared: any
   frontend_server: any


### PR DESCRIPTION
This adds a basic Dagger2-like DI framework example, loosely based on this youtube video https://www.youtube.com/watch?v=oK_XtfXPkqw. There are 3 macros, `@Injectable` (for injectable classes), `@Provides` (for modules, it is how they provide specific implementations), and `@Component` which takes a bunch of modules and uses them to provide the final instances of things.

Feel free to just rubber stamp this if you want, there is a lot of just basic restructuring I had to do in order to generalize things so I could see some actual output. But it a lot of code to just push without at least giving an opportunity to get a review :).

The interesting stuff is in `working/macros/example/lib/injectable.dart`, if you just want to look at that :).

Also keep in mind this is all quite prototype-y so I wouldn't be too rigorous :).