### PR TITLE
Adjust function literal return type inference

### DIFF
--- a/resources/type-system/inference.md
+++ b/resources/type-system/inference.md
@@ -356,10 +356,11 @@ With null safety: if `R` is `void`, or the function literal is marked `async`
 and `R` is `FutureOr<void>`, let `S` be `void` (without null-safety: no special
 treatment is applicable to `void`).
 
-When the function is marked `async`: if `T <: futureValueType(R)` then let `S`
-be `T`; otherwise let `S` be `futureValueType(R)`. When the function is not
-marked `async`: if `T <: R` then let `S` be `T`; otherwise let `S` be `R`. The
-inferred return type of the function literal is then defined as follows:
+If the previous paragraph did not yield a value for `S`: When the function is
+marked `async`: if `T <: futureValueType(R)` then let `S` be `T`; otherwise let
+`S` be `futureValueType(R)`. When the function is not marked `async`: if `T <:
+R` then let `S` be `T`; otherwise let `S` be `R`. The inferred return type of
+the function literal is then defined as follows:
 
   - If the function literal is marked `async` then the inferred return type is
     `Future<S>`.

--- a/resources/type-system/inference.md
+++ b/resources/type-system/inference.md
@@ -6,6 +6,10 @@ Status: Draft
 
 ## CHANGELOG
 
+2023.06.15
+  - Adjust function literal return type inference to avoid spurious application
+    of `flatten`.
+
 2022.05.12
   - Define the notions of "constraint solution for a set of type variables" and
     "Grounded constraint solution for a set of type variables".  These
@@ -349,11 +353,12 @@ With null safety: if `R` is `void`, or the function literal is marked `async`
 and `R` is `FutureOr<void>`, let `S` be `void` (without null-safety: no special
 treatment is applicable to `void`).
 
-Otherwise, if `T <: R` then let `S` be `T`.  Otherwise, let `S` be `R`.  The
-inferred return type of the function literal is then defined as follows:
+Otherwise, if `T <: R` then let `S` be `T`.  Otherwise, let `S` be 
+`flatten(R)` if the function literal is marked `async`, and `R` otherwise.
+The inferred return type of the function literal is then defined as follows:
 
   - If the function literal is marked `async` then the inferred return type is
-    `Future<flatten(S)>`.
+    `Future<S>`.
   - If the function literal is marked `async*` then the inferred return type is
     `Stream<S>`.
   - If the function literal is marked `sync*` then the inferred return type is

--- a/resources/type-system/inference.md
+++ b/resources/type-system/inference.md
@@ -359,8 +359,9 @@ treatment is applicable to `void`).
 If the previous paragraph did not yield a value for `S`: When the function is
 marked `async`: if `T <: futureValueType(R)` then let `S` be `T`; otherwise let
 `S` be `futureValueType(R)`. When the function is not marked `async`: if `T <:
-R` then let `S` be `T`; otherwise let `S` be `R`. The inferred return type of
-the function literal is then defined as follows:
+R` then let `S` be `T`; otherwise let `S` be `R`.
+
+The inferred return type of the function literal is then defined as follows:
 
   - If the function literal is marked `async` then the inferred return type is
     `Future<S>`.

--- a/resources/type-system/inference.md
+++ b/resources/type-system/inference.md
@@ -353,9 +353,10 @@ With null safety: if `R` is `void`, or the function literal is marked `async`
 and `R` is `FutureOr<void>`, let `S` be `void` (without null-safety: no special
 treatment is applicable to `void`).
 
-Otherwise, if `T <: R` then let `S` be `T`.  Otherwise, let `S` be 
-`flatten(R)` if the function literal is marked `async`, and `R` otherwise.
-The inferred return type of the function literal is then defined as follows:
+When the function is marked `async`: if `T <: flatten(R)` then let `S` be `T`;
+otherwise let `S` be `flatten(R)`. When the function is not marked `async`: if
+`T <: R` then let `S` be `T`; otherwise let `S` be `R`. The inferred return
+type of the function literal is then defined as follows:
 
   - If the function literal is marked `async` then the inferred return type is
     `Future<S>`.

--- a/resources/type-system/inference.md
+++ b/resources/type-system/inference.md
@@ -349,14 +349,17 @@ all `return` and `yield` statements in the block body have been considered.
 Let `T` be the **actual returned type** of a function literal as computed above.
 Let `R` be the greatest closure of the typing context `K` as computed above.
 
+*Now compute `S`, which is the future value type of an `async` function, the
+element type of a generator function, and the return type of other functions.*
+
 With null safety: if `R` is `void`, or the function literal is marked `async`
 and `R` is `FutureOr<void>`, let `S` be `void` (without null-safety: no special
 treatment is applicable to `void`).
 
-When the function is marked `async`: if `T <: flatten(R)` then let `S` be `T`;
-otherwise let `S` be `flatten(R)`. When the function is not marked `async`: if
-`T <: R` then let `S` be `T`; otherwise let `S` be `R`. The inferred return
-type of the function literal is then defined as follows:
+When the function is marked `async`: if `T <: futureValueType(R)` then let `S`
+be `T`; otherwise let `S` be `futureValueType(R)`. When the function is not
+marked `async`: if `T <: R` then let `S` be `T`; otherwise let `S` be `R`. The
+inferred return type of the function literal is then defined as follows:
 
   - If the function literal is marked `async` then the inferred return type is
     `Future<S>`.


### PR DESCRIPTION
Issue https://github.com/dart-lang/language/issues/3148 showed that we need to adjust the rules about function literal return type inference. This PR changes the rules accordingly.

The basic idea is that the last step in the inference of an `async` function used to use the inferred return type of `Future<flatten(S)>` where `S` is taken from the context or from the returned expressions, but it should instead be `Future<S>`. Also, `flatten` then needs to be applied to the type obtained from the context, such that we still have the same return type as before when the context type gets to decide the outcome.