### PR TITLE
Add functional widget macro example

### DIFF
--- a/working/macros/example/analysis_options.yaml
+++ b/working/macros/example/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: ../../../analysis_options.yaml
+
+analyzer:
+  enable-experiment:
+    - macros

--- a/working/macros/example/analysis_options.yaml
+++ b/working/macros/example/analysis_options.yaml
@@ -3,3 +3,5 @@ include: ../../../analysis_options.yaml
 analyzer:
   enable-experiment:
     - macros
+  exclude:
+    - bin/**

--- a/working/macros/example/benchmark/simple.dart
+++ b/working/macros/example/benchmark/simple.dart
@@ -29,6 +29,7 @@ import 'package:_fe_analyzer_shared/src/macros/executor/multi_executor.dart'
     as multiExecutor;
 
 import 'src/data_class.dart' as data_class;
+import 'src/functional_widget.dart' as functional_widget;
 import 'src/injectable.dart' as injectable;
 
 final _watch = Stopwatch()..start();
@@ -50,7 +51,8 @@ final argParser = ArgParser()
       defaultsTo: 'stdio',
       help: 'The communication channel to use when running as a separate'
           ' process.')
-  ..addOption('macro', allowed: ['DataClass', 'Injectable'], mandatory: true)
+  ..addOption('macro',
+      allowed: ['DataClass', 'Injectable', 'FunctionalWidget'], mandatory: true)
   ..addFlag('help', negatable: false, hide: true);
 
 // Run this script to print out the generated augmentation library for an example class.
@@ -102,6 +104,7 @@ Macro: $macro
   var macroFile = switch (macro) {
     'DataClass' => File('lib/data_class.dart'),
     'Injectable' => File('lib/injectable.dart'),
+    'FunctionalWidget' => File('lib/functional_widget.dart'),
     _ => throw UnsupportedError('Unrecognized macro $macro'),
   };
   if (!macroFile.existsSync()) {
@@ -113,6 +116,8 @@ Macro: $macro
     var macroUri = switch (macro) {
       'DataClass' => Uri.parse('package:macro_proposal/data_class.dart'),
       'Injectable' => Uri.parse('package:macro_proposal/injectable.dart'),
+      'FunctionalWidget' =>
+        Uri.parse('package:macro_proposal/functional_widget.dart'),
       _ => throw UnsupportedError('Unrecognized macro $macro'),
     };
     var macroConstructors = switch (macro) {
@@ -123,6 +128,9 @@ Macro: $macro
           'Injectable': [''],
           'Provides': [''],
           'Component': [''],
+        },
+      'FunctionalWidget' => {
+          'FunctionalWidget': [''],
         },
       _ => throw UnsupportedError('Unrecognized macro $macro'),
     };
@@ -165,6 +173,7 @@ Macro: $macro
     await switch (macro) {
       'DataClass' => data_class.runBenchmarks(executor, macroUri),
       'Injectable' => injectable.runBenchmarks(executor, macroUri),
+      'FunctionalWidget' => functional_widget.runBenchmarks(executor, macroUri),
       _ => throw UnsupportedError('Unrecognized macro $macro'),
     };
     await executor.close();

--- a/working/macros/example/benchmark/src/functional_widget.dart
+++ b/working/macros/example/benchmark/src/functional_widget.dart
@@ -1,0 +1,120 @@
+import 'package:_fe_analyzer_shared/src/macros/api.dart';
+import 'package:_fe_analyzer_shared/src/macros/executor.dart';
+import 'package:_fe_analyzer_shared/src/macros/executor/introspection_impls.dart';
+import 'package:_fe_analyzer_shared/src/macros/executor/remote_instance.dart';
+import 'package:benchmark_harness/benchmark_harness.dart';
+
+import 'shared.dart';
+
+Future<void> runBenchmarks(MacroExecutor executor, Uri macroUri) async {
+  final identifierResolver = SimpleIdentifierResolver({
+    Uri.parse('dart:core'): {
+      'int': intIdentifier,
+      'String': stringIdentifier,
+    },
+    Uri.parse('package:flutter/flutter.dart'): {
+      'BuildContext': buildContextIdentifier,
+      'Widget': widgetIdentifier,
+    }
+  });
+  final identifierDeclarations = <Identifier, Declaration>{};
+  final instantiateBenchmark =
+      FunctionalWidgetInstantiateBenchmark(executor, macroUri);
+  await instantiateBenchmark.report();
+  final instanceId = instantiateBenchmark.instanceIdentifier;
+  final typesBenchmark = FunctionalWidgetTypesPhaseBenchmark(
+      executor, macroUri, identifierResolver, instanceId);
+  await typesBenchmark.report();
+  BuildAugmentationLibraryBenchmark.reportAndPrint(
+      executor,
+      [if (typesBenchmark.result != null) typesBenchmark.result!],
+      identifierDeclarations);
+}
+
+class FunctionalWidgetInstantiateBenchmark extends AsyncBenchmarkBase {
+  final MacroExecutor executor;
+  final Uri macroUri;
+  late MacroInstanceIdentifier instanceIdentifier;
+
+  FunctionalWidgetInstantiateBenchmark(this.executor, this.macroUri)
+      : super('FunctionalWidgetInstantiate');
+
+  Future<void> run() async {
+    instanceIdentifier = await executor.instantiateMacro(
+        macroUri, 'FunctionalWidget', '', Arguments([], {}));
+  }
+}
+
+class FunctionalWidgetTypesPhaseBenchmark extends AsyncBenchmarkBase {
+  final MacroExecutor executor;
+  final Uri macroUri;
+  final IdentifierResolver identifierResolver;
+  final MacroInstanceIdentifier instanceIdentifier;
+  MacroExecutionResult? result;
+
+  FunctionalWidgetTypesPhaseBenchmark(this.executor, this.macroUri,
+      this.identifierResolver, this.instanceIdentifier)
+      : super('FunctionalWidgetTypesPhase');
+
+  Future<void> run() async {
+    if (instanceIdentifier.shouldExecute(
+        DeclarationKind.function, Phase.types)) {
+      result = await executor.executeTypesPhase(
+          instanceIdentifier, myFunction, identifierResolver);
+    }
+  }
+}
+
+final buildContextIdentifier =
+    IdentifierImpl(id: RemoteInstance.uniqueId, name: 'BuildContext');
+final buildContextType = NamedTypeAnnotationImpl(
+    id: RemoteInstance.uniqueId,
+    isNullable: false,
+    identifier: buildContextIdentifier,
+    typeArguments: []);
+final widgetIdentifier =
+    IdentifierImpl(id: RemoteInstance.uniqueId, name: 'Widget');
+final widgetType = NamedTypeAnnotationImpl(
+    id: RemoteInstance.uniqueId,
+    isNullable: false,
+    identifier: widgetIdentifier,
+    typeArguments: []);
+final myFunction = FunctionDeclarationImpl(
+    id: RemoteInstance.uniqueId,
+    identifier: IdentifierImpl(id: RemoteInstance.uniqueId, name: '_myWidget'),
+    library: fooLibrary,
+    isAbstract: false,
+    isExternal: false,
+    isGetter: false,
+    isOperator: false,
+    isSetter: false,
+    namedParameters: [
+      ParameterDeclarationImpl(
+          id: RemoteInstance.uniqueId,
+          identifier:
+              IdentifierImpl(id: RemoteInstance.uniqueId, name: 'title'),
+          isNamed: true,
+          isRequired: true,
+          library: fooLibrary,
+          type: stringType),
+    ],
+    positionalParameters: [
+      ParameterDeclarationImpl(
+          id: RemoteInstance.uniqueId,
+          identifier:
+              IdentifierImpl(id: RemoteInstance.uniqueId, name: 'context'),
+          isNamed: false,
+          isRequired: true,
+          library: fooLibrary,
+          type: buildContextType),
+      ParameterDeclarationImpl(
+          id: RemoteInstance.uniqueId,
+          identifier:
+              IdentifierImpl(id: RemoteInstance.uniqueId, name: 'count'),
+          isNamed: false,
+          isRequired: true,
+          library: fooLibrary,
+          type: intType),
+    ],
+    returnType: widgetType,
+    typeParameters: []);

--- a/working/macros/example/bin/run.dart
+++ b/working/macros/example/bin/run.dart
@@ -20,6 +20,8 @@ void main(List<String> args) async {
       File(dartToolDir.uri.resolve('bootstrap.dart').toFilePath());
   log('Bootstrapping macro program (${bootstrapFile.path}).');
   var dataClassUri = Uri.parse('package:macro_proposal/data_class.dart');
+  var functionalWidgetUri =
+      Uri.parse('package:macro_proposal/functional_widget.dart');
   var observableUri = Uri.parse('package:macro_proposal/observable.dart');
   var autoDisposableUri = Uri.parse('package:macro_proposal/auto_dispose.dart');
   var jsonSerializableUri =
@@ -32,6 +34,9 @@ void main(List<String> args) async {
       'DataClass': [''],
       'HashCode': [''],
       'ToString': [''],
+    },
+    functionalWidgetUri.toString(): {
+      'FunctionalWidget': [''],
     },
     observableUri.toString(): {
       'Observable': [''],
@@ -72,6 +77,7 @@ void main(List<String> args) async {
     '--source=${bootstrapFile.path}',
     '--source=lib/auto_dispose.dart',
     '--source=lib/data_class.dart',
+    '--source=lib/functional_widget.dart',
     '--source=lib/injectable.dart',
     '--source=lib/json_serializable.dart',
     '--source=lib/observable.dart',

--- a/working/macros/example/lib/auto_dispose.dart
+++ b/working/macros/example/lib/auto_dispose.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// There is no public API exposed yet, the in progress api lives here.
+// There is no public API exposed yet, the in-progress API lives here.
 import 'package:_fe_analyzer_shared/src/macros/api.dart';
 
 // Interface for disposable things.

--- a/working/macros/example/lib/auto_dispose.dart
+++ b/working/macros/example/lib/auto_dispose.dart
@@ -43,7 +43,7 @@ macro class AutoDispose implements ClassDeclarationsMacro, ClassDefinitionMacro 
     for (var field in fields) {
       var type = await builder.resolve(field.type.code);
       if (!await type.isSubtypeOf(disposableType)) continue;
-      disposeCalls.add(Code.fromParts([
+      disposeCalls.add(RawCode.fromParts([
         '\n',
         field.identifier,
         if (field.type.isNullable) '?',

--- a/working/macros/example/lib/data_class.dart
+++ b/working/macros/example/lib/data_class.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// There is no public API exposed yet, the in progress api lives here.
+// There is no public API exposed yet, the in-progress API lives here.
 import 'package:_fe_analyzer_shared/src/macros/api.dart';
 
 macro class DataClass

--- a/working/macros/example/lib/functional_widget.dart
+++ b/working/macros/example/lib/functional_widget.dart
@@ -45,7 +45,8 @@ class FunctionalWidget implements FunctionTypesMacro {
               in positionalFieldParams.followedBy(function.namedParameters))
             DeclarationCode.fromParts([
               'final ',
-              param.type,
+              param.type.code,
+              ' ',
               param.identifier.name,
               ';',
             ]),

--- a/working/macros/example/lib/functional_widget.dart
+++ b/working/macros/example/lib/functional_widget.dart
@@ -5,7 +5,7 @@
 // There is no public API exposed yet, the in progress api lives here.
 import 'package:_fe_analyzer_shared/src/macros/api.dart';
 
-class FunctionalWidget implements FunctionTypesMacro {
+macro class FunctionalWidget implements FunctionTypesMacro {
   final Identifier? widgetIdentifier;
 
   const FunctionalWidget(

--- a/working/macros/example/lib/functional_widget.dart
+++ b/working/macros/example/lib/functional_widget.dart
@@ -1,0 +1,75 @@
+// Copyright (c) 2023, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// There is no public API exposed yet, the in progress api lives here.
+import 'package:_fe_analyzer_shared/src/macros/api.dart';
+
+class FunctionalWidget implements FunctionTypesMacro {
+  final Identifier? widgetIdentifier;
+
+  const FunctionalWidget(
+      {
+      // Defaults to removing the leading `_` from the function name and calling
+      // `toUpperCase` on the next character.
+      this.widgetIdentifier});
+
+  @override
+  void buildTypesForFunction(
+      FunctionDeclaration function, TypeBuilder builder) {
+    if (!function.identifier.name.startsWith('_')) {
+      throw ArgumentError(
+          'FunctionalWidget should only be used on private declarations');
+    }
+    if (function.positionalParameters.isEmpty ||
+        // TODO: A proper type check here.
+        (function.positionalParameters.first.type as NamedTypeAnnotation)
+                .identifier
+                .name !=
+            'BuildContext') {
+      throw ArgumentError(
+          'FunctionalWidget functions must have a BuildContext argument as the '
+          'first positional argument');
+    }
+
+    var widgetName = widgetIdentifier?.name ??
+        function.identifier.name
+            .replaceRange(0, 2, function.identifier.name[1].toUpperCase());
+    var positionalFieldParams = function.positionalParameters.skip(1);
+    builder.declareType(
+        widgetName,
+        DeclarationCode.fromParts([
+          'class $widgetName extends StatelessWidget {',
+          // Fields
+          for (var param
+              in positionalFieldParams.followedBy(function.namedParameters))
+            DeclarationCode.fromParts([
+              'final ',
+              param.type,
+              param.identifier.name,
+              ';',
+            ]),
+          // Constructor
+          'const $widgetName(',
+          for (var param in positionalFieldParams)
+            'this.${param.identifier.name}, ',
+          '{',
+          for (var param in function.namedParameters)
+            '${param.isRequired ? 'required ' : ''}this.${param.identifier.name}, ',
+          'Key? key,',
+          '}',
+          ') : super(key: key);',
+          // Build method
+          '''
+          @override
+          Widget build(BuildContext context) => ''',
+          function.identifier,
+          '(context, ',
+          for (var param in positionalFieldParams) '${param.identifier.name}, ',
+          for (var param in function.namedParameters)
+            '${param.identifier.name}: ${param.identifier.name}, ',
+          ');',
+          '}',
+        ]));
+  }
+}

--- a/working/macros/example/lib/functional_widget.dart
+++ b/working/macros/example/lib/functional_widget.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// There is no public API exposed yet, the in progress api lives here.
+// There is no public API exposed yet, the in-progress API lives here.
 import 'package:_fe_analyzer_shared/src/macros/api.dart';
 
 macro class FunctionalWidget implements FunctionTypesMacro {

--- a/working/macros/example/lib/injectable.dart
+++ b/working/macros/example/lib/injectable.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-// There is no public API exposed yet, the in progress api lives here.
+// There is no public API exposed yet, the in-progress API lives here.
 import 'package:_fe_analyzer_shared/src/macros/api.dart';
 
 import 'util.dart';

--- a/working/macros/example/lib/injectable.dart
+++ b/working/macros/example/lib/injectable.dart
@@ -113,6 +113,7 @@ macro class Provides implements MethodDeclarationsMacro {
   @override
   FutureOr<void> buildDeclarationsForMethod(
       MethodDeclaration method, MemberDeclarationBuilder builder) async {
+    // ignore: deprecated_member_use
     final providerIdentifier = await builder.resolveIdentifier(
         Uri.parse('package:macro_proposal/injectable.dart'), 'Provider');
     if (method.namedParameters.isNotEmpty) {
@@ -194,6 +195,7 @@ macro class Component implements ClassDeclarationsMacro, ClassDefinitionMacro {
   @override
   FutureOr<void> buildDeclarationsForClass(IntrospectableClassDeclaration clazz,
       MemberDeclarationBuilder builder) async {
+    // ignore: deprecated_member_use
     final providerIdentifier = await builder.resolveIdentifier(
         Uri.parse('package:macro_proposal/injectable.dart'), 'Provider');
     final methods = await builder.methodsOf(clazz);
@@ -243,6 +245,7 @@ macro class Component implements ClassDeclarationsMacro, ClassDefinitionMacro {
   @override
   FutureOr<void> buildDefinitionForClass(IntrospectableClassDeclaration clazz,
       TypeDefinitionBuilder builder) async {
+    // ignore: deprecated_member_use
     final providerIdentifier = await builder.resolveIdentifier(
         Uri.parse('package:macro_proposal/injectable.dart'), 'Provider');
     final methods = await builder.methodsOf(clazz);

--- a/working/macros/example/lib/json_serializable.dart
+++ b/working/macros/example/lib/json_serializable.dart
@@ -56,7 +56,7 @@ macro class JsonSerializable
     var jsonParam = fromJson.positionalParameters.single.identifier;
     fromJsonBuilder.augment(initializers: [
       for (var field in fields)
-        Code.fromParts([
+        RawCode.fromParts([
           field.identifier,
           ' = ',
           await _convertField(field, jsonParam, builder),
@@ -94,14 +94,14 @@ macro class JsonSerializable
         .firstWhereOrNull((c) => c.identifier.name == 'fromJson')
         ?.identifier;
     if (fieldTypeFromJson != null) {
-      return Code.fromParts([
+      return RawCode.fromParts([
         fieldTypeFromJson,
         '(',
         jsonParam,
         '["${field.identifier.name}"])',
       ]);
     } else {
-      return Code.fromParts([
+      return RawCode.fromParts([
         jsonParam,
         // TODO: support nested serializable types.
         '["${field.identifier.name}"] as ',

--- a/working/macros/example/lib/json_serializable.dart
+++ b/working/macros/example/lib/json_serializable.dart
@@ -4,7 +4,7 @@
 //
 // ignore_for_file: deprecated_member_use
 
-// There is no public API exposed yet, the in progress api lives here.
+// There is no public API exposed yet, the in-progress API lives here.
 import 'package:_fe_analyzer_shared/src/macros/api.dart';
 
 final dartCore = Uri.parse('dart:core');

--- a/working/macros/example/lib/observable.dart
+++ b/working/macros/example/lib/observable.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// There is no public API exposed yet, the in progress api lives here.
+// There is no public API exposed yet, the in-progress API lives here.
 import 'dart:async';
 
 import 'package:_fe_analyzer_shared/src/macros/api.dart';


### PR DESCRIPTION
This adds a new macro `@FunctionalWidget(<identifier>)`. It generates a widget with the given name (from the identifier) from a function. Fields are inferred from the parameters, for example:

```dart
@FunctionalWidget(MyApp)
Widget _buildApp(BuildContext context, ValueNotifier<int> counter,
    {String? appTitle, String? homePageTitle}) {
  return MaterialApp(
      title: appTitle ?? 'Flutter Demo',
      theme: ThemeData(primarySwatch: Colors.blue),
      home: MyHomePage(counter,
          title: homePageTitle ?? 'Flutter Demo Home Page'));
}
```
Would generate this widget class:
```dart
class MyApp extends StatelessWidget {
  final ValueNotifier<int> counter;
  final String? appTitle;
  final String? homePageTitle;
  
  const MyApp(this.counter, {this.appTitle, this.homePageTitle, Key? key})
      : super(key: key);
      
  @override
  Widget build(BuildContext context) => _buildApp(context, counter,
      appTitle: appTitle, homePageTitle: homePageTitle);
}
```

I also applied some fixes to other macros to update them to the latest apis.