### PR TITLE
Make it an error to generate macro applications that apply to previous phases

### DIFF
--- a/working/macros/feature-specification.md
+++ b/working/macros/feature-specification.md
@@ -899,7 +899,7 @@ macro applications. These macro applications must be from either the current
 phase or a later phase, but cannot be from previous phases.
 
 It is an error for a macro application to be added which would have applied to
-it's declaration in an earlier phase.
+its declaration in an earlier phase.
 
 If a macro application is added which runs in the same phase as the current
 one, then it is immediately expanded after execution of the current macro,

--- a/working/macros/feature-specification.md
+++ b/working/macros/feature-specification.md
@@ -894,17 +894,18 @@ implement their own declarations (#1908).
 
 #### Adding macro applications to new declarations
 
-When creating [Code][] instances, a macro may generate code which includes
+When creating [DeclarationCode][] instances, a macro may generate code which includes
 macro applications. These macro applications must be from either the current
 phase or a later phase, but cannot be from previous phases.
 
-If a macro application is added which implements an earlier phase, that phase
-is not ran. This should result in a warning if the macro does not also
-implement some phase that will be ran.
+It is an error for a macro application to be added which would have applied to
+it's declaration in an earlier phase.
 
 If a macro application is added which runs in the same phase as the current
 one, then it is immediately expanded after execution of the current macro,
 following the normal ordering rules.
+
+[DeclarationCode]: https://github.com/dart-lang/sdk/blob/main/pkg/_fe_analyzer_shared/lib/src/macros/api/code.dart#L37
 
 #### Ordering violations
 


### PR DESCRIPTION
Related to https://github.com/dart-lang/language/issues/1931 and https://github.com/dart-lang/language/issues/1908