### PR TITLE
Update macros readme to make phases example easier to understand

### DIFF
--- a/working/macros/feature-specification.md
+++ b/working/macros/feature-specification.md
@@ -427,7 +427,7 @@ class Human {
 @JsonSerializable()
 class Pet {
   final String name;
-  final Owner? owner; // Optional, might be feral.
+  final Human? owner; // Optional, might be feral.
 }
 ```
 


### PR DESCRIPTION
In the phases example, it uses an unnamed type `Owner`. This changes it to `Human` so it is easier for the reader to follow.

Fixes: [#3225](https://github.com/dart-lang/language/issues/3225)

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
