### PR TITLE
Adjust the rule about `implements NonExtensionType`

### DIFF
--- a/accepted/future-releases/extension-types/feature-specification.md
+++ b/accepted/future-releases/extension-types/feature-specification.md
@@ -1072,10 +1072,9 @@ If _DV_ does not include an `<interfaces>` clause then _DV_ has
 relation which was specified earlier.
 
 A compile-time error occurs if `V1` is a type name or a parameterized type
-which occurs as a superinterface in an extension type declaration _DV_, but
-`V1` does not denote an extension type, and `V1` does not denote a
-supertype of the extension type erasure of the representation type of
-_DV_.
+which occurs as a superinterface in an extension type declaration _DV_, and
+`V1` denotes a non-extension type which is not a supertype of the
+representation type of _DV_.
 
 *In particular, in order to have `implements T` where `T` is a
 non-extension type, it must be sound to consider the representation object

--- a/accepted/future-releases/extension-types/feature-specification.md
+++ b/accepted/future-releases/extension-types/feature-specification.md
@@ -1080,9 +1080,9 @@ representation type of _DV_.
 non-extension type, it must be sound to consider the representation object
 as having type `T`.*
 
-A compile-time error occurs if any direct or indirect superinterface
-of _DV_ is the type `Name` or a type of the form `Name<...>`. *As
-usual, subtype cycles are not allowed.*
+A compile-time error occurs if any direct or indirect superinterface of
+_DV_ denotes the declaration _DV_. *As usual, subtype cycles are not
+allowed.*
 
 Assume that _DV_ has two direct or indirect superinterfaces of the form
 <code>W\<T<sub>1</sub>, .. T<sub>k</sub>&gt;</code>


### PR DESCRIPTION
This PR changes the requirement on a non-extension type `T` that occurs in `implements ... T ...` in an extension type declaration: It must be a supertype of the representation type. Before this change it had to be a supertype of the erasure of the representation type, but that rule has some counter-intuitive and conceptually dubious consequences.

Cf. https://github.com/dart-lang/language/issues/3261 for more details.
