### PR TITLE
[extension-types] Add rules about non-extension types

### DIFF
--- a/accepted/future-releases/extension-types/feature-specification.md
+++ b/accepted/future-releases/extension-types/feature-specification.md
@@ -1229,8 +1229,11 @@ rather than from `Object`)*.
 *This change is needed because some extension types are subtypes of
 `Object?` and not subtypes of `Object`, and they need to have a
 well-defined depth. Note that the depth of an extension type can be
-determined by its actual type arguments because type parameters of the
-extension type may occur in its representation type.*
+determined by its actual type arguments, if any, because type parameters of
+the extension type may occur in its representation type. In particular, the
+depth of an extension type is a property of the type itself, and it is not
+always possible to determine the depth from the associated extension type
+declaration.*
 
 
 ## Dynamic Semantics of Extension Types

--- a/accepted/future-releases/extension-types/feature-specification.md
+++ b/accepted/future-releases/extension-types/feature-specification.md
@@ -1179,7 +1179,7 @@ all members of `V1, .. Vk` that are not redeclared by a declaration in _DV_
 can be invoked on a receiver of the type introduced by _DV_.*
 
 
-### Changes to subtype rules
+### Changes to type functions and types
 
 The previous sections have introduced some subtype relationships involving
 extension types. This section adds further relationships where extension
@@ -1197,12 +1197,99 @@ introduced which makes `E<S1 .. Sk>` a subtype of `E<T1 .. Tk>` if
 *For example, `E<int>` is a subtype of `E<Object>` because `int` is a
 subtype of `Object`, also in the case where `E` is an extension type.*
 
-
-### Change to type functions
-
 The type function `futureValueType` is updated as follows:
 
+- `futureValueType(S?) = futureValueType(S)`, for any `S`.
+- `futureValueType(Future<S>) = S`, for any `S`.
+- `futureValueType(FutureOr<S>) = S`, for any `S`.
+- `futureValueType(void) = void`.
+- `futureValueType(dynamic) = dynamic`.
+- `futureValueType(E) = S` if `E` is an extension type
+  that implements `Future<S>`.
+- Otherwise, `futureValueType(S) = Object?`, for any `S`.
 
+The Dart 1 algorithm which is used to compute the standard upper bound of
+two distinct interface types will work in the same way as it does today,
+albeit on a different superinterface graph:
+
+We introduce an interface type `Any` which declares `operator ==`,
+`hashCode`, `runtimeType`, `noSuchMethod`, `toString` with the same
+signatures as `Object` does today, and `Object` as well as `Null` have
+`Any` as a direct superinterface.
+
+`Any` is sealed. *That is, we cannot create additional direct subtypes of
+`Any` This is required for the soundness of the rule below about `Object?`
+being a supertype of `Any`.*
+
+*This basically means that we eliminate the anomaly which is created by
+saying that `Object` declares those members, but `Null` "has them too,
+by magic". It also implies that all paths from the top type via `Object`
+are now one step longer, which is significant during the computation of the
+standard upper bound.*
+
+For subtyping, we specify that every type is a subtype of `void`, of
+`dynamic`, and of `Any`.
+
+Moreover, we specify that `Any` is a subtype of `Object?`. *This implies
+that we collapse `Any` and `Object?`, which is basically the same thing as
+promising that `Any` will never have other subtypes than `Null` and
+`Object`. Other types (type variables and extension types) will always be
+populated by objects which are of type `Object` or `Null`, which means that
+it is sound to claim that `Object?` and `Any` are "the same type" (mutual
+subtypes).*
+
+We specify that `NonNull(Any)` is `Object`. *This is sound, and it is
+needed in order to allow `Any` to be used as a more concise way to write
+`Object?`, which is presumably quite valuable.*
+
+
+### Changes to functions
+
+Let `f` be a function with declared return type `R` whose body is `async`.
+
+An existing rule states that it is a compile-time error if `R` is not a
+supertype of `Future<T>` for any `T`.
+
+This is changed as follows: If `R` is an extension type that implements
+`Future<R1>` for some `R1` which is also the representation type of `R`
+then let `S` be `Future<R1>`. Otherwise let `S` be `R`. Next, it is a
+compile-time error if `S` is not a supertype of `Future<T>` for any `T`.
+
+*In short, nothing changes, except that an `async` function can now return
+an extension type if that extension type declares that it "is a future",
+and it has a representation type which is that same future type (not, for
+example, a subtype like `MyFuture`).*
+
+We say that said `Future<T>` is _the future return type_ of `f`. The
+run-time type of the object returned by `f` is a type that implements its
+future return type.
+
+*This is sufficient to ensure that it is a sound return value both in the
+case where `f` returns an extension type and a non-extension type.*
+
+Similarly, let `f` be a function with return type `R` whose body is marked
+`sync*`. 
+
+If `R` is an extension type that implements `Iterable<R1>` for some `R1`
+which is also the representation type of `R` then let `S` be
+`Iterable<R1>`. Otherwise let `S` be `R`. Next, it is a compile-time error
+if `S` is not a supertype of `Iterable<T>` for any `T`.
+
+We say that said `Iterable<T>` is the _iterable return type_ of `f`. The
+run-time type of the object returned by `f` is a type that implements its
+iterable return type.
+
+Finally, let `f` be a function with return type `R` whose body is marked
+`async*`. 
+
+If `R` is an extension type that implements `Stream<R1>` for some `R1`
+which is also the representation type of `R` then let `S` be
+`Stream<R1>`. Otherwise let `S` be `R`. Next, it is a compile-time error
+if `S` is not a supertype of `Stream<T>` for any `T`.
+
+We say that said `Stream<T>` is the _stream return type_ of `f`. The
+run-time type of the object returned by `f` is a type that implements its
+stream return type.
 
 
 ## Dynamic Semantics of Extension Types

--- a/accepted/future-releases/extension-types/feature-specification.md
+++ b/accepted/future-releases/extension-types/feature-specification.md
@@ -1228,7 +1228,9 @@ rather than from `Object`)*.
 
 *This change is needed because some extension types are subtypes of
 `Object?` and not subtypes of `Object`, and they need to have a
-well-defined depth.*
+well-defined depth. Note that the depth of an extension type can be
+determined by its actual type arguments because type parameters of the
+extension type may occur in its representation type.*
 
 
 ## Dynamic Semantics of Extension Types

--- a/accepted/future-releases/extension-types/feature-specification.md
+++ b/accepted/future-releases/extension-types/feature-specification.md
@@ -1179,6 +1179,32 @@ all members of `V1, .. Vk` that are not redeclared by a declaration in _DV_
 can be invoked on a receiver of the type introduced by _DV_.*
 
 
+### Changes to subtype rules
+
+The previous sections have introduced some subtype relationships involving
+extension types. This section adds further relationships where extension
+types occur more indirectly.
+
+*For instance, earlier sections stated that every extension type is a
+subtype of the top types (like `Object?`), and that `implements` introduces
+a subtype relationship for extension types. Moreover:*
+
+Assume that `E` denotes an extension type that takes `k` type arguments.
+Corresponding to the subtype rule about covariance for classes, a rule is
+introduced which makes `E<S1 .. Sk>` a subtype of `E<T1 .. Tk>` if
+`Sj` is a subtype of `Tj` for each `j` in 1 .. k.
+
+*For example, `E<int>` is a subtype of `E<Object>` because `int` is a
+subtype of `Object`, also in the case where `E` is an extension type.*
+
+
+### Change to type functions
+
+The type function `futureValueType` is updated as follows:
+
+
+
+
 ## Dynamic Semantics of Extension Types
 
 For any given syntactic construct which has been characterized as an

--- a/accepted/future-releases/extension-types/feature-specification.md
+++ b/accepted/future-releases/extension-types/feature-specification.md
@@ -17,7 +17,8 @@ information about the process, including in their change logs.
 
 2023.08.17
   - Add covariance subtype rule for extension types. Add rule that it is an
-    error for an extension type member to be abstract.
+    error for an extension type member to be abstract. Mention that it is
+    allowed for extension type members to be external.
 
 2023.07.13
   - Revise many details, in particular the management of ambiguities
@@ -698,6 +699,12 @@ declaration is abstract.
 *Extension type member invocations and tear-offs are always statically
 resolved, and abstract members only make sense in the case where the given
 member is resolved at run time.*
+
+*It is not an error for an extension type member to have the modifier
+`external`. As usual, an implementation can report a compile-time error for
+external declarations, e.g., if they are not bound to an implementation,
+and the method by which they are bound to an implementation is tool
+specific.*
 
 Assume that
 <code>T<sub>1</sub>, .. T<sub>s</sub></code>

--- a/accepted/future-releases/extension-types/feature-specification.md
+++ b/accepted/future-releases/extension-types/feature-specification.md
@@ -1190,7 +1190,7 @@ all members of `V1, .. Vk` that are not redeclared by a declaration in _DV_
 can be invoked on a receiver of the type introduced by _DV_.*
 
 
-### Changes to type functions and types
+### Changes to other types and subtyping
 
 The previous sections have introduced some subtype relationships involving
 extension types. This section adds further relationships where extension
@@ -1202,15 +1202,17 @@ a subtype relationship for extension types. Moreover:*
 
 Assume that `E` denotes an extension type that takes `k` type arguments.
 Corresponding to the subtype rule about covariance for classes, a rule is
-introduced which makes `E<S1 .. Sk>` a subtype of `E<T1 .. Tk>` if
-`Sj` is a subtype of `Tj` for each `j` in 1 .. k.
+introduced which makes <code>E\<S<sub>1</sub> .. S<sub>k</sub>></code> a
+subtype of <code>E\<T<sub>1</sub> .. T<sub>k</sub>></code> if
+<code>S<sub>j</sub></code> is a subtype of <code>T<sub>j</sub></code> for
+each `j` in 1 .. k.
 
 *For example, `E<int>` is a subtype of `E<Object>` because `int` is a
 subtype of `Object`, also in the case where `E` is an extension type.*
 
 The Dart 1 algorithm which is used to compute the standard upper bound of
 two distinct interface types will work in the same way as it does today,
-albeit on a different superinterface graph:
+albeit on a slightly different superinterface graph:
 
 For the purpose of this algorithm, we consider `Object?` to be a
 superinterface of `Null` and `Object`, and the path lengths mentioned in
@@ -1218,7 +1220,8 @@ the algorithm will increase by one *(because they start from `Object?`
 rather than from `Object`)*.
 
 *This change is needed because some extension types are subtypes of
-`Object?` and not subtypes of `Object`.*
+`Object?` and not subtypes of `Object`, and they need to have a
+well-defined depth.*
 
 
 ## Dynamic Semantics of Extension Types

--- a/accepted/future-releases/extension-types/feature-specification.md
+++ b/accepted/future-releases/extension-types/feature-specification.md
@@ -18,7 +18,8 @@ information about the process, including in their change logs.
 2023.08.17
   - Add covariance subtype rule for extension types. Add rule that it is an
     error for an extension type member to be abstract. Mention that it is
-    allowed for extension type members to be external.
+    allowed for extension type members to be external. Adjust the notion of
+    the 'depth' of a type such that `UP` can be used with extension types.
 
 2023.07.13
   - Revise many details, in particular the management of ambiguities

--- a/accepted/future-releases/extension-types/feature-specification.md
+++ b/accepted/future-releases/extension-types/feature-specification.md
@@ -1279,6 +1279,10 @@ We say that said `Iterable<T>` is the _iterable return type_ of `f`. The
 run-time type of the object returned by `f` is a type that implements its
 iterable return type.
 
+The element type of `f` is defined as previously, except that it is the
+element type of the iterable return type rather than of the declared return
+type.
+
 Finally, let `f` be a function with return type `R` whose body is marked
 `async*`. 
 
@@ -1290,6 +1294,10 @@ if `S` is not a supertype of `Stream<T>` for any `T`.
 We say that said `Stream<T>` is the _stream return type_ of `f`. The
 run-time type of the object returned by `f` is a type that implements its
 stream return type.
+
+The element type of `f` is defined as previously, except that it is the
+element type of the stream return type rather than of the declared return
+type.
 
 
 ## Dynamic Semantics of Extension Types


### PR DESCRIPTION
[Edit: This PR is now much simpler. Adjusted the description accordingly.]

This PR adds a covariance rule for subtyping of extension types, specifies that it is a compile-time error for an extension type member to be abstract, and it specifies that the last case in en the type function UP (that is, the Dart 1 algorithm for computation of the 'least upper bound' of two types) will work on a slightly extended superinterface graph.