### PR TITLE
Clarify that an extension type _can_ have instance variables which are external

### DIFF
--- a/accepted/future-releases/extension-types/feature-specification.md
+++ b/accepted/future-releases/extension-types/feature-specification.md
@@ -429,7 +429,10 @@ disambiguate the extension type declaration with a fixed lookahead.*
 Some errors can be detected immediately from the syntax:
 
 A compile-time error occurs if the extension type declaration declares any
-instance variables.
+instance variables, unless they are `external`.
+
+*An external instance variable is just a convenient notation for an external
+getter and (if not `final`) an external setter. They are allowed.*
 
 The _name of the representation_ in an extension type declaration with a
 representation declaration of the form `(T id)` is the identifier `id`, and


### PR DESCRIPTION
The current rule about instance variable declarations in an extension type declaration is that every instance variable declaration is a compile-time error (we only allow the implicitly induced instance variable which is caused by the parameter declaration in the primary constructor which is now syntactically the `<representationDeclaration>`, because we don't yet have primary constructors).

However, it is not an error to declare an external getter and/or setter, and an `external` instance variable declaration is just a convenient notation for exactly that.

This PR just clarifies that an external instance variable is not an error.

Fixes https://github.com/dart-lang/language/issues/3301.