### PR TITLE
Small feature specification fixes

### DIFF
--- a/accepted/2.15/constructor-tearoffs/feature-specification.md
+++ b/accepted/2.15/constructor-tearoffs/feature-specification.md
@@ -61,7 +61,7 @@ _The syntax without type arguments is currently allowed by the language grammar,
 
 A named constructor tear-off expression of one of the forms above evaluates to a function value which could be created by tearing off a *corresponding constructor function*, which would be a static function defined on the class denoted by *C*, with a fresh name here represented by adding `$tearoff`:
 
-> <code>static *C* *name*$tearoff\<*typeParams*>(*params*) => *C*\<*typeArgs*>.*name*(*args*);</code>
+> <code>static *C*\<*typeArgs*> *name*$tearoff\<*typeParams*>(*params*) => *C*\<*typeArgs*>.*name*(*args*);</code>
 
 If *C* is not generic, then <code>\<*typeParams*\></code> and <code>\<*typeArgs*\></code> are omitted. Otherwise <code>\<*typeParams*\></code> are exactly the same type parameters as those of the class declaration of *C* (including bounds), and <code>\<*typeArgs*></code> applies those type parameter variables directly as type arguments to *C*.
 

--- a/accepted/future-releases/extension-types/feature-specification.md
+++ b/accepted/future-releases/extension-types/feature-specification.md
@@ -432,7 +432,7 @@ A compile-time error occurs if the extension type declaration declares any
 instance variables, unless they are `external`.
 
 *An external instance variable is just a convenient notation for an external
-getter and (if not `final`) an external setter. They are allowed.*
+getter and (if not `final`) an external setter, which are both allowed.*
 
 The _name of the representation_ in an extension type declaration with a
 representation declaration of the form `(T id)` is the identifier `id`, and


### PR DESCRIPTION
This PR changes the wording of one commentary in the extension type feature specification, and adds missing type arguments in the return type of a tear-off of a constructor of a generic class in the constructor tear-off feature specification.