### PR TITLE
Removed incorrect claim about promotability

### DIFF
--- a/accepted/future-releases/extension-types/feature-specification.md
+++ b/accepted/future-releases/extension-types/feature-specification.md
@@ -274,6 +274,7 @@ leaves, and nothing else.
 ```dart
 extension type TinyJson(Object it) {
   Iterable<num> get leaves sync* {
+    final it = this.it; // To get promotion.
     if (it is num) {
       yield it;
     } else if (it is List<dynamic>) {
@@ -292,9 +293,6 @@ void main() {
   tiny.add("Hello!"); // Error.
 }
 ```
-
-Note that `it` is subject to promotion in the above example. This is safe
-because there is no way to override this would-be final instance variable.
 
 An instance creation of an extension type, `V<T>(o)`, will evaluate to a
 reference to the representation object, with the static type `V<T>` (and
@@ -356,11 +354,11 @@ class TinyJson {
   TinyJson(this.it);
 
   Iterable<num> get leaves sync* {
-    var localIt = it; // To get promotion.
-    if (localIt is num) {
-      yield localIt;
-    } else if (localIt is List<dynamic>) {
-      for (var element in localIt) {
+    final it = this.it; // To get promotion.
+    if (it is num) {
+      yield it;
+    } else if (it is List<dynamic>) {
+      for (var element in it) {
         yield* TinyJson(element).leaves;
       }
     } else {


### PR DESCRIPTION
We used to have a hint in the extension type feature specification that the representation variable can be promoted just like a final local variable. This is not true (cf. https://github.com/dart-lang/sdk/issues/53446#issuecomment-1715131920). This PR changes the feature specification such that it does not make that claim any more.

Correction: Promotion of the representation variable _is_ sound, cf. https://github.com/dart-lang/sdk/issues/53446#issuecomment-1715782114. However, this PR still cleans up the text.

Another PR will follow when we have decided on the applicability of promotion to representation variables, cf. https://github.com/dart-lang/language/issues/3342.