### PR TITLE
update the specification validation workflow

### DIFF
--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Spec
 
 on:
   # Run on PRs and pushes to the default branch.
@@ -6,27 +6,20 @@ on:
     branches: [ main ]
     paths:
       - 'specification/**'
-      - '.github/workflows/ci.yml'
+      - '.github/workflows/spec.yml'
   pull_request:
     branches: [ main ]
     paths:
       - 'specification/**'
-      - '.github/workflows/ci.yml'
+      - '.github/workflows/spec.yml'
 
 jobs:
   specification:
     runs-on: ubuntu-latest
-    if: |
-      (
-        (github.event_name == 'push'
-          && github.ref == 'refs/heads/main'
-          && github.repository == 'dart-lang/language'
-        ) ||
-        (github.event.pull_request.head.repo.full_name == github.repository)
-      )
 
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
+
       - name: Install latex tools
         run: |
           sudo apt-get update -qq
@@ -35,13 +28,17 @@ jobs:
             texlive-latex-extra \
             texlive-fonts-recommended \
             lmodern
+
       - name: Build specification
         run: |
           cd specification
           make
           mkdir firebase
           cp dartLangSpec.pdf firebase/DartLangSpecDraft.pdf
-      - uses: FirebaseExtended/action-hosting-deploy@120e124148ab7016bec2374e5050f15051255ba2
+
+      - name: Upload specification
+        if: ${{ github.event.pull_request.merged }}
+        uses: FirebaseExtended/action-hosting-deploy@120e124148ab7016bec2374e5050f15051255ba2
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_DART_SPECIFICATION }}'


### PR DESCRIPTION
Update the specification validation workflow:
- always validate the specification - try to create the spec pdf
- only perform the firebase upload step if the triggering event is a PR merge

This should address the issue where automated dependabot PRs to update our github actions deps fail CI (ala https://github.com/dart-lang/language/pull/3316).

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
