### PR TITLE
Change the specified augmentation library structure for macros

### DIFF
--- a/working/macros/feature-specification.md
+++ b/working/macros/feature-specification.md
@@ -449,7 +449,7 @@ rules).
 ```dart
 augment class A {
   void c() {} // Added in phase 2, ran before `AddTopLevelFoo()`.
-  augment c() {} // Added in phase 3, but merged into the previous augmentation.
+  augment b() {} // Added in phase 3, but merged into the previous augmentation.
 }
 
 int foo = 1; // Added in phase 2, after `c` was added to `A`.


### PR DESCRIPTION
This moves us to a more user friendly format (all augmentations for a single type grouped together), and removes the incorrect statements about source offset stability.

Closes https://github.com/dart-lang/language/issues/3350