### PR TITLE
Added rule that `super` in an extension type member is an error

### DIFF
--- a/accepted/future-releases/extension-types/feature-specification.md
+++ b/accepted/future-releases/extension-types/feature-specification.md
@@ -1207,6 +1207,14 @@ superinterfaces `V1, .. Vk` is that the members declared by _DV_ as well as
 all members of `V1, .. Vk` that are not redeclared by a declaration in _DV_
 can be invoked on a receiver of the type introduced by _DV_.*
 
+Finally, a compile-time error occurs if the body of an extension type member
+contains `super`.
+
+*For example, even in the case where a superinterface declares a member
+named `m`, it is not possible to call it using `super.m(...)`. The
+rationale for this rule is that there may be multiple superinterfaces
+declaring a member with the same name.*
+
 
 ### Changes to other types and subtyping
 


### PR DESCRIPTION
The extension type feature specification does not specify how to deal with `super` when it is used in the body of a member declaration. This PR adds the rule that it is a compile-time error to do so.

We should probably indicate a different way to specify this semantics. One possible approach is to invoke a constructor that does not perform any computations (`super.m()` will then be something like `V3(this).m()`), or using a cast (`(this as V3).m()`), or using an intermediate extension type (such that we can write a forwarding member `m2` in a context where the redeclaration that gave rise to this need in the first place does not exist: `V.m` calls `VIntermediate.m2` which calls `V3.m`).