### PR TITLE
Make it an error for the representation type of an extension type to be a bottom type

### DIFF
--- a/accepted/future-releases/extension-types/feature-specification.md
+++ b/accepted/future-releases/extension-types/feature-specification.md
@@ -766,8 +766,20 @@ the treatment of expressions like `e as V`.*
 
 A compile-time error occurs if a type parameter of an extension type
 declaration occurs in a non-covariant position in the representation type.
+
 A compile-time error occurs if the representation type of an extension type
 declaration is a bottom type.
+
+*Note that it is still possible for the instantiated representation type 
+of a given extension type to be a bottom type. For example, assuming
+`extension type E<X>(X x) {}`, `E<Never>` would be an extension type whose
+instantiated representation type is `Never`. The reason for this error is that
+we could otherwise have, for example, an extension type that `implements int,
+double`, and the ability to have such subtypes of arbitrary sets of interface
+types would make other parts of the type system more complex. Such types could
+never be the type of an actual object anyway because the representation object
+would have to have type `Never`. If these types turn out to be useful in some
+way then they could still be added to a future version of the language.*
 
 When `s` is zero *(that is, the declaration of `V` is not generic)*,
 <code>V\<T<sub>1</sub>, .. T<sub>s</sub>&gt;</code>

--- a/accepted/future-releases/extension-types/feature-specification.md
+++ b/accepted/future-releases/extension-types/feature-specification.md
@@ -766,6 +766,8 @@ the treatment of expressions like `e as V`.*
 
 A compile-time error occurs if a type parameter of an extension type
 declaration occurs in a non-covariant position in the representation type.
+A compile-time error occurs if the representation type of an extension type
+declaration is a bottom type.
 
 When `s` is zero *(that is, the declaration of `V` is not generic)*,
 <code>V\<T<sub>1</sub>, .. T<sub>s</sub>&gt;</code>
@@ -1005,7 +1007,7 @@ has any compile-time errors.
 which is an error.*
 
 
-#### Extension Type Constructors and Their Static Analysis
+### Extension Type Constructors and Their Static Analysis
 
 An extension type declaration _DV_ named `Name` may declare one or
 more constructors. A constructor which is declared in an extension type


### PR DESCRIPTION
In response to the discussion in https://github.com/dart-lang/language/issues/3383, this PR introduces a new compile-time error to the extension type feature specification: It is an error if the representation type is `Never` (or something with the same meaning).