### PR TITLE
[extension types] Adjust the paragraph about Object members: They do not need special treatment

### DIFF
--- a/accepted/future-releases/extension-types/feature-specification.md
+++ b/accepted/future-releases/extension-types/feature-specification.md
@@ -550,11 +550,10 @@ or a subtype of the corresponding instantiated representation type
 expression is an extension type member invocation, but it is already
 ensured by normal static analysis of subexpressions like `e`.*
 
-If the name of `m` is a name in the interface of `Object` (that is,
-`toString`, `==`, `hashCode`, `runtimeType`, or `noSuchMethod`), the static
-analysis of the invocation is treated as an ordinary instance member
-invocation on a receiver of type `Object?` and with the same `args` or
-`typeArgs`, if any.
+*Note that if the name of `m` is a name in the interface of `Object` (that
+is, `toString`, `==`, `hashCode`, `runtimeType`, or `noSuchMethod`), the
+denoted member is necessarily a non-extension type member, which determines
+the static analysis and dynamic semantics.*
 
 Otherwise, a compile-time error occurs if `V` does not have a member
 named `m`.


### PR DESCRIPTION
The extension type feature specification used to have a paragraph about invocations of members of `Object` (`hashCode`, operator `==`, etc). It stated that the signature was taken from `Object?`. This is not consistent with a situation like the following, because all other non-extension type members would be treated according to the signature known from the traversal of the superinterface graph.

This PR changes the given paragraph to commentary, and changes the text to simply say that members of `Object` receive exactly the same treatment as all other non-extension type members. This yields the following behavior:

```dart
class A {
  void foo() {}
}

class B implements A {
  @override
  void foo([int i = 0]) {}

  @override
  String toString([bool whatever = true]) => super.toString();
}


extension type E1(B b) implements A {}

extension type E2(B b) implements E1, B {}

void main() {
  var e2 = E2(B());
  var e1 = e2; // OK, `E2 <: E1`.
  
  e2.foo(42); // OK, signature is `void foo([int])`.
  e2.toString(true); // OK, signature is `String toString([bool])`.
  
  e1.foo(42); // Compile-time error, signature `void foo()`.
  e1.toString(true); // Compile-time error, signature `String toString()`.
}
```

Note that we need to take the combined member signature of `foo` in `E2`: `E1` contributes the signature `void foo()` and `B` contributes the signature `void foo([int])`, and the combined member signature is then `void foo([int])`. The signature for `toString` in `E2` is computed in the same manner (as mentioned in the title: there is no need to special-case members of `Object`).