### PR TITLE
Tweak some wordings in the extension type specification.

### DIFF
--- a/accepted/future-releases/extension-types/feature-specification.md
+++ b/accepted/future-releases/extension-types/feature-specification.md
@@ -435,9 +435,13 @@ instance variables, unless they are `external`.
 *An external instance variable is just a convenient notation for an external
 getter and (if not `final`) an external setter, which are both allowed.*
 
+A compile-time error occurs if the extension type declaration declares any
+abstract members.
+
 The _name of the representation_ in an extension type declaration with a
-representation declaration of the form `(T id)` is the identifier `id`, and
-the _type of the representation_ is `T`.
+representation declaration, for example of the form `(T id)`,
+is the `<identifier>` after the `<type>` (`id` here), and
+the _type of the representation_ is the type denoted by `<type>` (by `T` here).
 
 *There are no special rules for static members in extension types. They can
 be declared and called or torn off as usual, e.g.,
@@ -769,7 +773,7 @@ declaration occurs in a non-covariant position in the representation type.
 A compile-time error occurs if the representation type of an extension type
 declaration is a bottom type.
 
-*Note that it is still possible for the instantiated representation type 
+*Note that it is still possible for the instantiated representation type
 of a given extension type to be a bottom type. For example, assuming
 `extension type E<X>(X x) {}`, `E<Never>` would be an extension type whose
 instantiated representation type is `Never`. The reason for this error is that
@@ -797,8 +801,8 @@ _is the extension type_
 and that its static type _is an extension type_.
 
 It is a compile-time error if `await e` occurs, and the static type of
-`e` is an extension type which is not a subtype of `Future<T>` for any
-`T`.
+`e` is `S` bounded where `S` is an extension type which is not a subtype
+of `Future<T>` for any `T`.
 
 A compile-time error occurs if an extension type declares a member whose
 basename is the basename of an instance member declared by `Object` as
@@ -820,13 +824,14 @@ restrictions, in a future version of Dart.*
 A compile-time error occurs if an extension type has a non-extension
 superinterface whose transitive alias expansion is a type variable, a
 deferred type, any top type *(including `dynamic` and `void`)*, the type
-`Null`, any function type, the type `Function`, any record type, the type
-`Record`, or any type of the form `T?` or `FutureOr<T>` for any type `T`.
+`Null`, the type `Never`, any function type, the type `Function`,
+any record type, the type `Record`, or the type `T?` or `FutureOr<T>`
+for any type `T`.
 
 *Note that it is not an error to have `implements int` and similar platform
 types, and it is not an error to have `implements T` where `T` is a type
 that denotes a `sealed`, `final`, or `base` class in a different library,
-or `T` is an enumerated type.*
+or an enumerated type.*
 
 A compile-time error occurs if an extension type is used as a
 superinterface of a class, mixin, or enum declaration, or if an extension
@@ -1111,8 +1116,11 @@ Assume that _DV_ is an extension type declaration named `Name`, and
 this case we say that `V1` is a _superinterface_ of _DV_.
 
 If _DV_ does not include an `<interfaces>` clause then _DV_ has
-`Object?` or `Object` as a direct superinterface, according to the subtype
-relation which was specified earlier.
+`Object` as direct superinterface if the declared representation type
+is non-nullable, otherwise it has `Object?` as direct superinterface.
+_(In the latter case, some instantiations of the extension type may still
+have `Object` as a superinterface, if their instantiated representation
+type is non-nullable.)_
 
 A compile-time error occurs if `V1` is a type name or a parameterized type
 which occurs as a superinterface in an extension type declaration _DV_, and
@@ -1338,7 +1346,7 @@ with instantiated representation type `R` and instantiated superinterface
 types `V1 .. Vk`, as well as other typing relationships involving `V0`:*
 
 - *`V0` is a proper subtype of `Object?`.*
-- *`V0` is a supertype of `Never`.*
+- *`V0` is a proper supertype of `Never`.*
 - *If `R` is a non-nullable type then `V0` is a proper subtype of
   `Object`, and a non-nullable type.*
 - *`V0` is a proper subtype of each of `V1 .. Vk`.*


### PR DESCRIPTION
Tweak some wordings in the extension type specification to be more precise.

Only actual change is saying that it's an early error to declare an abstract member.