### PR TITLE
specify the annotation introspection API and constant evaluation API

### DIFF
--- a/working/macros/aspect-macros.md
+++ b/working/macros/aspect-macros.md
@@ -58,7 +58,7 @@ identifier for the resulting declaration.
 ### Applying an Aspect Macro
 
 Aspect Macros can only be applied by other macros (including aspect macros),
-while the macro is running. They do this through the following api:
+while the macro is running. They do this through the following API:
 
 ```dart
 Future<Identifier> applyAspect(AspectMacro macro, Declaration declaration);
@@ -110,7 +110,7 @@ macro class FromJson extends ClassDeclarationsAspectMacro {
 - The serializable aspect is enforced by not permitting Aspect Macros to have
   any fields, and they only have a single const constructor with no arguments.
   - **TODO**: Should we make this constructor explicit?
-  - **TODO**: Should the api only take the Type of the aspect instead of an
+  - **TODO**: Should the API only take the Type of the aspect instead of an
     instance?
 
 ### Ordering of Aspect Macros

--- a/working/macros/example/benchmark/src/shared.dart
+++ b/working/macros/example/benchmark/src/shared.dart
@@ -1,4 +1,4 @@
-// There is no public API exposed yet, the in progress api lives here.
+// There is no public API exposed yet, the in progress API lives here.
 import 'package:_fe_analyzer_shared/src/macros/api.dart';
 import 'package:_fe_analyzer_shared/src/macros/executor/introspection_impls.dart';
 import 'package:_fe_analyzer_shared/src/macros/executor/remote_instance.dart';

--- a/working/macros/feature-specification.md
+++ b/working/macros/feature-specification.md
@@ -777,9 +777,9 @@ is available in all phases, with the following restrictions:
 - No identifier in `code` may refer to a constant which refers to any
   system environment variable, Dart define, or other configuration which is not
   otherwise visible to macros.
-- All identifiers in `code` must be defined outside of current strongly
-  connected component (that is, the strongly connected component which triggered
-  the current macro expansion).
+- All identifiers in `code` must be defined outside of the current
+  [strongly connected component][] (that is, the strongly connected component
+  which triggered the current macro expansion).
 
 The `DartObject` API is an abstract representation of an object, which can
 represent types which are not visible to the macro itself. It will closely
@@ -1106,7 +1106,7 @@ a Dart program containing macro applications:
 
 Starting at the entrypoint library, traverse all imports, exports, and
 augmentation imports to collect the full graph of libraries to be compiled.
-Calculate the [strongly connected components][] of this graph. Each component is
+Calculate the [strongly connected component][]s of this graph. Each component is
 a library cycle, and the edges between them determine how the cycles depend on
 each other. Sort the library cycles in topological order based on the connected
 component graph.
@@ -1119,7 +1119,7 @@ library cycle, it is guaranteed that all macros used by the cycle have already
 been compiled. Also, any types or other declarations used by that cycle have
 either already been compiled, or are defined in that cycle.
 
-[strongly connected components]: https://en.wikipedia.org/wiki/Strongly_connected_component
+[strongly connected component]: https://en.wikipedia.org/wiki/Strongly_connected_component
 
 #### 2. Compile each cycle
 

--- a/working/macros/feature-specification.md
+++ b/working/macros/feature-specification.md
@@ -87,7 +87,7 @@ There are two things you can do with an `OmittedTypeAnnotation`:
       file as the macro annotation, so they can always do this.
   - When the final augmentation library is created, the actual type that was
     inferred will be used (or `dynamic` if no type was inferred).
-- Explicitly ask to infer the type of it through the builder apis (only
+- Explicitly ask to infer the type of it through the builder APIs (only
   available in phase 3).
   - We don't allow augmentations of existing declarations to contribute to
     inference, so in phase 3 type inference can be performed.
@@ -658,9 +658,9 @@ constructors are invoked, and their limitations.
       types in the user code instantiating the macro are not necessarily present
       in the macros own transitive imports.
 
-*Note: The Macro API is still being designed, and lives [here][api].*
+*Note: The Macro API is still being designed, and lives [here][API].*
 
-[api]: https://github.com/dart-lang/sdk/blob/main/pkg/_fe_analyzer_shared/lib/src/macros/api.dart
+[API]: https://github.com/dart-lang/sdk/blob/main/pkg/_fe_analyzer_shared/lib/src/macros/api.dart
 
 ### Writing a Macro
 
@@ -716,7 +716,7 @@ return results. For instance when generating a constructor, a macro will likely
 just iterate over the fields and create a parameter for each.
 
 We need generated augmentations to be identical on all platforms for all the
-same inputs, so we need to have a defined ordering when introspection apis are
+same inputs, so we need to have a defined ordering when introspection APIs are
 returning lists of declarations.
 
 Therefore, whenever an implementation is returning a list of declarations, they
@@ -771,7 +771,7 @@ constants (see next section).
 Macros may want the ability to evaluate constant expressions, in particular
 those found as arguments to metadata annotations.
 
-We expose this ability through the `DartObject evaluate(Code code)` api, which
+We expose this ability through the `DartObject evaluate(Code code)` API, which
 is available in all phases, with the following restrictions:
 
 - No identifier in `code` may refer to a constant which refers to any
@@ -781,7 +781,7 @@ is available in all phases, with the following restrictions:
   connected component (that is, the strongly connected component which triggered
   the current macro expansion).
 
-The `DartObject` api is an abstract representation of an object, which can
+The `DartObject` API is an abstract representation of an object, which can
 represent types which are not visible to the macro itself. It will closely
 mirror the [same API in the analyzer][DartObject].
 
@@ -1578,7 +1578,7 @@ resources outside of `lib`, which has both benefits and drawbacks.
 
 **TODO**: Evaluate APIs for listing files and directories.
 
-**TODO**: Consider adding `RandomAccessResource` api.
+**TODO**: Consider adding `RandomAccessResource` API.
 
 The specific API is as follows, and would only be available at compile time:
 

--- a/working/macros/motivation.md
+++ b/working/macros/motivation.md
@@ -313,7 +313,7 @@ stated more concretely as:
 4. We propose to consider designing a quotation syntax so that macros that
    generate Dart code can generate code in a readable fashion. This also means
    code generators only depend on language *syntax* for code generation and not
-   an imperative api, which will better stand the test of time.
+   an imperative API, which will better stand the test of time.
 
 Most of this is as-yet-undesigned, but the key piece is that **we think macros
 should be written in normal imperative Dart code which is executed at compile
@@ -417,7 +417,7 @@ you should:
   * Possibly provide an opt out for this, if feasible/desirable.
 * Be able to trace errors that flow through generated code, as well as navigate
   back to the line in the macro implementation that produced the code.
-* Be able to auto-complete macro generated apis.
+* Be able to auto-complete macro generated APIs.
 
 ### Performance
 


### PR DESCRIPTION
Updates to annotation introspection based on recent discussions, and in anticipation of changing the rules around shadowing.

The primary concrete change here is that we only allow access to identifiers/constructors from separate strongly connected components. This works around any issues with the constants changing between phases.

I decided not to try and restrict the API to code objects that came from annotations, so this does enable general purpose const evaluation, but it doesn't seem any more problematic to me than allowing the evaluation of const expressions from annotations. Please correct me if I am wrong :).

cc @scheglov @johnniwinther 
