### PR TITLE
Move up the intersection type rules in the definition of `UP`

### DIFF
--- a/resources/type-system/upper-lower-bounds.md
+++ b/resources/type-system/upper-lower-bounds.md
@@ -85,11 +85,25 @@ We define the upper bound of two types T1 and T2 to be **UP**(`T1`,`T2`) as foll
 - **UP**(`T1`, `T2`) = `T2` if **BOTTOM**(`T1`)
 - **UP**(`T1`, `T2`) = `T1` if **BOTTOM**(`T2`)
 
+- **UP**(`X1 extends B1`, `T2`) =
+  - `T2` if `X1 <: T2`
+  - otherwise `X1` if `T2 <: X1`
+  - otherwise **UP**(`B1a`, `T2`)
+    where `B1a` is the greatest closure of `B1` with respect to `X1`,
+    as defined in [inference.md].
+
 - **UP**(`X1 & B1`, `T2`) =
   - `T2` if `X1 <: T2`
   - otherwise `X1` if `T2 <: X1`
   - otherwise **UP**(`B1a`, `T2`)
     where `B1a` is the greatest closure of `B1` with respect to `X1`,
+    as defined in [inference.md].
+
+- **UP**(`T1`, `X2 extends B2`) =
+  - `X2` if `T1 <: X2`
+  - otherwise `T1` if `X2 <: T1`
+  - otherwise **UP**(`T1`, `B2a`)
+    where `B2a` is the greatest closure of `B2` with respect to `X2`,
     as defined in [inference.md].
 
 - **UP**(`T1`, `X2 & B2`) =
@@ -136,20 +150,6 @@ We define the upper bound of two types T1 and T2 to be **UP**(`T1`,`T2`) as foll
 - **UP**(`T1?`, `T2?`) = `S?` where `S` is **UP**(`T1`, `T2`)
 - **UP**(`T1?`, `T2`) = `S?` where `S` is **UP**(`T1`, `T2`)
 - **UP**(`T1`, `T2?`) = `S?` where `S` is **UP**(`T1`, `T2`)
-
-- **UP**(`X1 extends B1`, `T2`) =
-  - `T2` if `X1 <: T2`
-  - otherwise `X1` if `T2 <: X1`
-  - otherwise **UP**(`B1a`, `T2`)
-    where `B1a` is the greatest closure of `B1` with respect to `X1`,
-    as defined in [inference.md].
-
-- **UP**(`T1`, `X2 extends B2`) =
-  - `X2` if `T1 <: X2`
-  - otherwise `T1` if `X2 <: T1`
-  - otherwise **UP**(`T1`, `B2a`)
-    where `B2a` is the greatest closure of `B2` with respect to `X2`,
-    as defined in [inference.md].
 
 - **UP**(`T Function<...>(...)`, `Function`) = `Function`
 - **UP**(`Function`, `T Function<...>(...)`) = `Function`

--- a/resources/type-system/upper-lower-bounds.md
+++ b/resources/type-system/upper-lower-bounds.md
@@ -85,25 +85,11 @@ We define the upper bound of two types T1 and T2 to be **UP**(`T1`,`T2`) as foll
 - **UP**(`T1`, `T2`) = `T2` if **BOTTOM**(`T1`)
 - **UP**(`T1`, `T2`) = `T1` if **BOTTOM**(`T2`)
 
-- **UP**(`X1 extends B1`, `T2`) =
-  - `T2` if `X1 <: T2`
-  - otherwise `X1` if `T2 <: X1`
-  - otherwise **UP**(`B1a`, `T2`)
-    where `B1a` is the greatest closure of `B1` with respect to `X1`,
-    as defined in [inference.md].
-
 - **UP**(`X1 & B1`, `T2`) =
   - `T2` if `X1 <: T2`
   - otherwise `X1` if `T2 <: X1`
   - otherwise **UP**(`B1a`, `T2`)
     where `B1a` is the greatest closure of `B1` with respect to `X1`,
-    as defined in [inference.md].
-
-- **UP**(`T1`, `X2 extends B2`) =
-  - `X2` if `T1 <: X2`
-  - otherwise `T1` if `X2 <: T1`
-  - otherwise **UP**(`T1`, `B2a`)
-    where `B2a` is the greatest closure of `B2` with respect to `X2`,
     as defined in [inference.md].
 
 - **UP**(`T1`, `X2 & B2`) =
@@ -150,6 +136,20 @@ We define the upper bound of two types T1 and T2 to be **UP**(`T1`,`T2`) as foll
 - **UP**(`T1?`, `T2?`) = `S?` where `S` is **UP**(`T1`, `T2`)
 - **UP**(`T1?`, `T2`) = `S?` where `S` is **UP**(`T1`, `T2`)
 - **UP**(`T1`, `T2?`) = `S?` where `S` is **UP**(`T1`, `T2`)
+
+- **UP**(`X1 extends B1`, `T2`) =
+  - `T2` if `X1 <: T2`
+  - otherwise `X1` if `T2 <: X1`
+  - otherwise **UP**(`B1a`, `T2`)
+    where `B1a` is the greatest closure of `B1` with respect to `X1`,
+    as defined in [inference.md].
+
+- **UP**(`T1`, `X2 extends B2`) =
+  - `X2` if `T1 <: X2`
+  - otherwise `T1` if `X2 <: T1`
+  - otherwise **UP**(`T1`, `B2a`)
+    where `B2a` is the greatest closure of `B2` with respect to `X2`,
+    as defined in [inference.md].
 
 - **UP**(`T Function<...>(...)`, `Function`) = `Function`
 - **UP**(`Function`, `T Function<...>(...)`) = `Function`

--- a/resources/type-system/upper-lower-bounds.md
+++ b/resources/type-system/upper-lower-bounds.md
@@ -4,6 +4,10 @@ leafp@google.com
 
 ## CHANGELOG
 
+2023.10.27
+  - **CHANGE** Update **UP** to handle intersection types earlier. This
+    prevents **UP** from producing results of the form `(X & B)?`.
+
 2020.09.01
   - **CHANGE** Update **UP** in cases about type variables and promoted type
     variables involving F-bounds, and in two cases about function types.
@@ -81,6 +85,20 @@ We define the upper bound of two types T1 and T2 to be **UP**(`T1`,`T2`) as foll
 - **UP**(`T1`, `T2`) = `T2` if **BOTTOM**(`T1`)
 - **UP**(`T1`, `T2`) = `T1` if **BOTTOM**(`T2`)
 
+- **UP**(`X1 & B1`, `T2`) =
+  - `T2` if `X1 <: T2`
+  - otherwise `X1` if `T2 <: X1`
+  - otherwise **UP**(`B1a`, `T2`)
+    where `B1a` is the greatest closure of `B1` with respect to `X1`,
+    as defined in [inference.md].
+
+- **UP**(`T1`, `X2 & B2`) =
+  - `X2` if `T1 <: X2`
+  - otherwise `T1` if `X2 <: T1`
+  - otherwise **UP**(`T1`, `B2a`)
+    where `B2a` is the greatest closure of `B2` with respect to `X2`,
+    as defined in [inference.md].
+
 - **UP**(`T1`, `T2`) where **NULL**(`T1`) and **NULL**(`T2`) =
   - `T2` if **MOREBOTTOM**(`T1`, `T2`)
   - `T1` otherwise
@@ -126,21 +144,7 @@ We define the upper bound of two types T1 and T2 to be **UP**(`T1`,`T2`) as foll
     where `B1a` is the greatest closure of `B1` with respect to `X1`,
     as defined in [inference.md].
 
-- **UP**(`X1 & B1`, `T2`) =
-  - `T2` if `X1 <: T2`
-  - otherwise `X1` if `T2 <: X1`
-  - otherwise **UP**(`B1a`, `T2`)
-    where `B1a` is the greatest closure of `B1` with respect to `X1`,
-    as defined in [inference.md].
-
 - **UP**(`T1`, `X2 extends B2`) =
-  - `X2` if `T1 <: X2`
-  - otherwise `T1` if `X2 <: T1`
-  - otherwise **UP**(`T1`, `B2a`)
-    where `B2a` is the greatest closure of `B2` with respect to `X2`,
-    as defined in [inference.md].
-
-- **UP**(`T1`, `X2 & B2`) =
   - `X2` if `T1 <: X2`
   - otherwise `T1` if `X2 <: T1`
   - otherwise **UP**(`T1`, `B2a`)


### PR DESCRIPTION
This PR moves the rules about intersection types up to an earlier position in the definition of `UP`, such that no results are of the form `(X & B)?`. (Types of that form should never exist, so `UP` shouldn't produce them.)

This is a much nicer solution than https://github.com/dart-lang/language/pull/2427, but it may have to be considered as a breaking change.

We should probably try it out and see how much breaks. Otherwise we can adopt #2427.

[Edit: The `X extends B` rules are no longer moved along with the `X & B` rules, that was a more substantial breaking change, and not useful.]