### PR TITLE
Specify error for `await e` where the type of `e` has something to do with an extension type

### DIFF
--- a/accepted/future-releases/extension-types/feature-specification.md
+++ b/accepted/future-releases/extension-types/feature-specification.md
@@ -15,6 +15,9 @@ information about the process, including in their change logs.
 [1]: https://github.com/dart-lang/language/blob/master/working/1426-extension-types/feature-specification-views.md
 [2]: https://github.com/dart-lang/language/blob/master/working/extension_structs/overview.md
 
+2023.11.17
+  - Correct the rule about extension types and `await` expressions.
+
 2023.10.31
   - Simplify the rules about the relationship between extension types and the
     types `Object` and `Object?`.
@@ -826,9 +829,18 @@ _is the extension type_
 <code>V\<T<sub>1</sub>, .. T<sub>s</sub>&gt;</code>,
 and that its static type _is an extension type_.
 
+We say that an extension type is _unrelated to `Future`_ in the case where
+it does not implement `Future<U>` for any `U` *(this means that it has no
+direct or indirect superinterface of the form `Future<...>`)*.
+
 It is a compile-time error if `await e` occurs, and the static type of
-`e` is an extension type which is not a subtype of `Future<T>` for any
-`T`.
+`e` satisfiers at least one of the following criteria:
+
+- an extension type which is unrelated to `Future`.
+- a type of the form `E?`, `FutureOr<E>`, or `FutureOr<E>?` where `E` is an
+  extension type which is unrelated to `Future`.
+- a type which is `T` bounded, where `T` matches one of the earlier items
+  *(this covers type variables and intersection types)*.
 
 A compile-time error occurs if an extension type declares a member whose
 basename is the basename of an instance member declared by `Object` as

--- a/accepted/future-releases/extension-types/feature-specification.md
+++ b/accepted/future-releases/extension-types/feature-specification.md
@@ -837,8 +837,8 @@ It is a compile-time error if `await e` occurs, and the static type of
 `e` satisfiers at least one of the following criteria:
 
 - an extension type which is unrelated to `Future`.
-- a type of the form `E?`, `FutureOr<E>`, or `FutureOr<E>?` where `E` is an
-  extension type which is unrelated to `Future`.
+- a type of the form `T?` or `FutureOr<T>` where `T` is a type that matches
+  one of the items in this list.
 - a type which is `T` bounded, where `T` matches one of the earlier items
   *(this covers type variables and intersection types)*.
 


### PR DESCRIPTION
This PR adds several missing cases to the error about `await e` where the static type of `e` is an extension type, or it is one of several other types where an extension type occurs.

The basic idea is that we wish to make it an error to `await e` in the case where type static type of `e` is an extension type that does not declare that it implements `Future<U>` for any `U` (that is, `Future` is not reachable, neither directly nor indirectly, in the superinterface graph). There are several other cases where the static type of `e` is a type that contains such an extension type, and which basically unions of the basic case and something else. For instance, when it's an error to await `E` then it should also be an error to await `E?` and `FutureOr<E>` and `FutureOr<E?>?` and so on.

The conceptual reason why we want to make it an error when the static type is an extension type that does not declare that it implements `Future` is that we wish to eliminate the support for awaiting anything which is not a future (except that we may wish to keep allowing `await null` or something like that in order to support an explicit suspend operation), and awaiting an extension type that isn't declared to be a `Future` is such a case.

We could also have eliminated the extension type entirely by taking the extension type erasure first, which means that we would have relied on the representation type, and we would have ignored that the type was specified to be an extension type. This would be possible (and sound), but it would eliminate the compile-time encapsulation that the extension type provides. For instance, it would make the code more susceptible to subtle breakage if the representation type is changed due to evolution of the code. Of course, it  is always possible to break this kind of encapsulation, but there is no need to break it gratuitously and systematically.
