### PR TITLE
[extension types] Member conflicts ignore precluded members 

### DIFF
--- a/accepted/future-releases/extension-types/feature-specification.md
+++ b/accepted/future-releases/extension-types/feature-specification.md
@@ -918,8 +918,8 @@ conflict.*
 
 A compile-time error occurs if an extension type declaration _DV_ has
 two extension type superinterfaces `V1` and `V2`, and both `V1` and `V2`
-has an extension type member named `m`, and the two members have distinct
-declarations.
+has an extension type member named `m` that is not precluded by _DV_, and
+the two members have distinct declarations.
 
 *In other words, an extension type member conflict is always an error, even
 in the case where they agree perfectly on the types. _DV_ must override the

--- a/accepted/future-releases/extension-types/feature-specification.md
+++ b/accepted/future-releases/extension-types/feature-specification.md
@@ -906,8 +906,9 @@ On the other hand, it can occur in other ways, e.g., as a type argument of
 a superinterface of a class.*
 
 It is a compile-time error if _DV_ is an extension type declaration, and
-_DV_ has a non-extension type member named `m` as well as an extension type
-member named `m`, for any `m`. *In case of conflicts, _DV_ must declare a
+_DV_ has a non-extension type member named `m` which is not precluded by
+_DV_ as well as an extension type member named `m` which is not precluded
+by _DV_, for any `m`. *In case of conflicts, _DV_ must declare a
 member named `m` to resolve the conflict.*
 
 It is a compile-time error if _DV_ is an extension type declaration, and


### PR DESCRIPTION
See https://github.com/dart-lang/sdk/issues/53719#issuecomment-1828272923 for some background.

This PR adds rules to specify that a precluded member does not contribute to a conflict. This is a small adjustment to the rules which were added in https://github.com/dart-lang/language/pull/3470.

For example:

```dart
extension type E1(int it) {
  void foo() {}
}

extension type E2(int it) {
  int get foo => 0;
}

extension type E3(int it) implements E1, E2 {
  set foo(_) {} // No setter/method conflict occurs here.
}

void main() {
  var e3 = E3(1);
  e3.foo = true; // OK, `E3` has this setter.
  e3.foo; // OK, `E3` has this getter.
  e3.foo(); // Error, `E3` does not have this method, and the getter doesn't return a function.
}
```

The rationale is as follows: If `E3` had had `implements E1` then `E3` would have had the setter named `foo=` and it would _not_ have had the method named `foo`, because it is precluded. With `implements E2`, `E3` would have had the setter and the getter, and there is no conflict (and no error). Hence, we might as well let `E3` have the setter and the getter when it has `implements E1, E2`, because the consistent choice is in any case that `E3` has the getter and not the method, so there is no ambiguity in `E3` about the meaning of `foo`.
