### PR TITLE
[patterns] Adjust cast pattern space definition

### DIFF
--- a/accepted/3.0/patterns/exhaustiveness.md
+++ b/accepted/3.0/patterns/exhaustiveness.md
@@ -429,7 +429,7 @@ The lifted space union for a pattern with matched value type `M` is:
 
     test(A a) => switch (a) { // `a` should be a `B` or a `C`.
       B() => 0,
-      final b as C => 1,
+      _ as C => 1,
     };
     ```
 

--- a/accepted/3.0/patterns/exhaustiveness.md
+++ b/accepted/3.0/patterns/exhaustiveness.md
@@ -417,24 +417,24 @@ The lifted space union for a pattern with matched value type `M` is:
     exhaustiveness algorithm doesn't model "all objects that are not `int`", so
     it can't tell that this is exhaustive.*
 
-    *However, in the case where the matched value type is sealed we can
-    have a situation where a cast pattern is guaranteed to "handle" all
-    objects (that is, it will match or it will throw).*
+    *However, we can have a situation where a cast pattern is used to ensure
+    that a case "handles" all possible matched values because it will match
+    or it will throw.*
 
     ```dart
-    sealed class S {}
-    class A implements S {}
-    class B implements S {}
-    class C implements S {}
+    abstract class A {}
+    class B implements A {}
+    class C implements A {}
+    class D implements A {}
 
-    test(S s) => switch (s) { // `s` should be an `A` or a `B`.
-      A() => 0,
-      final b as B => 1,
+    test(A a) => switch (a) { // `a` should be a `B` or a `C`.
+      B() => 0,
+      final b as C => 1,
     };
     ```
 
-    *In this example, `test` should deal with instances of `A` and instances of
-    `B`, but it should simply throw if `s` has any other type. So we use the
+    *In this example, `test` should deal with instances of `B` and instances of
+    `C`, but it should simply throw if `a` has any other type. So we use the
     cast pattern in the last case to ensure that the switch is exhaustive, which
     is true because all instances of `B` will be handled by the subpattern, and
     all other objects will cause the cast to throw.*

--- a/accepted/3.0/patterns/exhaustiveness.md
+++ b/accepted/3.0/patterns/exhaustiveness.md
@@ -447,7 +447,19 @@ The lifted space union for a pattern with matched value type `M` is:
     1.  If `C` is a *subset* (see below) of `S` then the result is the lifted
         space union of `M`.
 
+        *The subpattern won't refute any value that passes the cast. This means
+        that every incoming value is handled: either it passes the cast and
+        then matches the subpattern, or it fails the cast and throws. So the
+        space is all incoming values, `M`.*
+
     2.  Otherwise, the result is `S`.
+
+        *There are values that may pass the cast but then get refuted by the
+        inner subpattern. To model this space precisely, we would need to be
+        able to represent the union of the subspace `S` and the *negation* of
+        the lifted space of `C`. Our formalism isn't sophisticated enough for
+        that, so instead we conservatively don't take into account values which
+        will be handled by the cast pattern throwing an exception.*
 
 *   **Null-check pattern:**
 


### PR DESCRIPTION
This PR changes the definition of the lifted space union of a cast pattern, cf. the discussion in https://github.com/dart-lang/sdk/issues/54125 and the soundness issue https://github.com/dart-lang/language/issues/3488. The specification is intended to be well aligned with the [upcoming implementation](https://dart-review.googlesource.com/c/sdk/+/333922).
