### PR TITLE
Correct grammar rule for `<typeNotVoidNotFunction>` to allow prefix

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -20756,7 +20756,7 @@ but it is the least upper bound of all function types.%
   \alt <typeNotVoidNotFunction> `?'?
 
 <typeNotVoidNotFunction> ::= <typeName> <typeArguments>?
-  \alt \FUNCTION{}
+  \alt (<typeIdentifier> '.')? \FUNCTION{}
 
 <typeName> ::= <typeIdentifier> (`.' <typeIdentifier>)?
 


### PR DESCRIPTION
Thanks to @modulovalue for [reporting](https://github.com/dart-lang/sdk/issues/54218) this grammar fault!

It is possible to import 'dart:core' with a prefix `p`. This causes the built-in class `Function` to be denoted by the term `p.Function` (whereas the plain identifier `Function` is a lookup failure, or it denotes something else, or it actually works because we're _also_ explicitly importing 'dart:core' without a prefix).

In any case, we should allow `p.Function` in the grammar. This PR changes said grammar rule such that this is achieved.
