### PR TITLE
Adjust objectPattern to allow `Function()`

### DIFF
--- a/accepted/3.0/patterns/feature-specification.md
+++ b/accepted/3.0/patterns/feature-specification.md
@@ -740,7 +740,9 @@ pattern with the field name omitted (see name inference below).
 ### Object pattern
 
 ```
-objectPattern ::= (typeName typeArguments? | 'Function') '(' patternFields? ')'
+objectPattern ::=
+    (typeName typeArguments? | (typeIdentifier '.')? 'Function')
+    '(' patternFields? ')'
 ```
 
 An object pattern matches values of a given named type and then extracts values
@@ -1924,7 +1926,7 @@ To type check a pattern `p` being matched against a value of type `M`:
     performed. Otherwise *(when `M` is not `dynamic` or `Never`)*:
 
     1.  A compile-time error occurs if `M` does not have an operator `op`,
-        and there is no available and applicable extension operator `op`. 
+        and there is no available and applicable extension operator `op`.
         Let `A` be the type of the formal parameter of the given operator
         declaration, and let `R` be the return type.
 

--- a/accepted/3.0/patterns/feature-specification.md
+++ b/accepted/3.0/patterns/feature-specification.md
@@ -740,7 +740,7 @@ pattern with the field name omitted (see name inference below).
 ### Object pattern
 
 ```
-objectPattern ::= typeName typeArguments? '(' patternFields? ')'
+objectPattern ::= (typeName typeArguments? | 'Function') '(' patternFields? ')'
 ```
 
 An object pattern matches values of a given named type and then extracts values
@@ -3549,6 +3549,11 @@ Here is one way it could be broken down into separate pieces:
     *   Parenthesized patterns
 
 ## Changelog
+
+### 2.34 (after shipping)
+
+-   Adjust `objectPattern` to allow `Function(...)`, which is already
+    the implemented behavior (#3468).
 
 ### 2.33 (after shipping)
 


### PR DESCRIPTION
See https://github.com/dart-lang/sdk/issues/54246 where @modulovalue raised this issue.

This PR changes the syntax of `<objectPattern>` such that it allows `Function` to be the denotation of a type (for example: `Function(: var toString)`).

The analyzer and the common front end already implement this behavior, hence there's no implementation effort.