### PR TITLE
Specify precisely where it is an error to declare an initializing formal

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -41,6 +41,7 @@
 % version of the language which will actually be specified by the next stable
 % release of this document.
 %
+<<<<<<< HEAD
 % Dec 2023
 % - Allow `~/` on operands of type `double` in constant expressions, aligning
 %   the specification with already implemented behavior.
@@ -79,6 +80,13 @@
 % - Change the definition of the 'element type of a generator function', due to
 %   soundness issue with the current definition.
 %
+||||||| parent of db1018c (Improve wording)
+=======
+% Dec 2023
+% - Specify in which situations it is an error to declare an initializing
+%   formal parameter.
+%
+>>>>>>> db1018c (Improve wording)
 % Mar 2023
 % - Clarify how line breaks are handled in a multi-line string literal. Rename
 %   the lexical token NEWLINE to LINE\_BREAK (clarifying that it is not `\n`).
@@ -4005,10 +4013,10 @@ an instance variable of the immediately enclosing class or enum.
 
 \LMHash{}%
 It is a compile-time error for an initializing formal parameter
-to occur in any function which is not
-a non-redirecting, non-external, generative constructor
-(\ref{requiredFormals}).
-\commentary{This implies that there is always an enclosing class or enum.}
+to occur in any function which is not a generative constructor.
+Also, it is a compile-time error for an initializing formal parameter
+to occur in a redirecting and in an external constructor.
+\commentary{In particuar, there is always an enclosing class or enum.}
 
 \LMHash{}%
 Assume that $p$ is a declaration of an initializing formal parameter named \id.

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -4009,7 +4009,7 @@ an instance variable of the immediately enclosing class or enum.
 It is a compile-time error for an initializing formal parameter
 to occur in any function which is not a generative constructor.
 Also, it is a compile-time error for an initializing formal parameter
-to occur in a redirecting and in an external constructor.
+to occur in a redirecting or external constructor.
 \commentary{In particuar, there is always an enclosing class or enum.}
 
 \LMHash{}%

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -4003,12 +4003,12 @@ and \id{} is the \NoIndex{name} of $p$.
 It is a compile-time error if \id{} is not also the name of
 an instance variable of the immediately enclosing class or enum.
 
-\commentary{%
-Note that it is a compile-time error for an initializing formal
-to occur in any function which is not a non-redirecting generative constructor
-(\ref{requiredFormals}),
-so there is always an enclosing class or enum.%
-}
+\LMHash{}%
+It is a compile-time error for an initializing formal parameter
+to occur in any function which is not
+a non-redirecting, non-external, generative constructor
+(\ref{requiredFormals}).
+\commentary{This implies that there is always an enclosing class or enum.}
 
 \LMHash{}%
 Assume that $p$ is a declaration of an initializing formal parameter named \id.

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -41,13 +41,14 @@
 % version of the language which will actually be specified by the next stable
 % release of this document.
 %
-<<<<<<< HEAD
 % Dec 2023
 % - Allow `~/` on operands of type `double` in constant expressions, aligning
 %   the specification with already implemented behavior.
 % - Broaden the grammar rule about `initializerExpression` to match the
 %   implemented behavior. Specify that an initializer expression can not be
 %   a function literal.
+% - Specify in which situations it is an error to declare an initializing
+%   formal parameter.
 %
 % Nov 2023
 % - Specify that the dynamic error for calling a function in a deferred and
@@ -80,13 +81,6 @@
 % - Change the definition of the 'element type of a generator function', due to
 %   soundness issue with the current definition.
 %
-||||||| parent of db1018c (Improve wording)
-=======
-% Dec 2023
-% - Specify in which situations it is an error to declare an initializing
-%   formal parameter.
-%
->>>>>>> db1018c (Improve wording)
 % Mar 2023
 % - Clarify how line breaks are handled in a multi-line string literal. Rename
 %   the lexical token NEWLINE to LINE\_BREAK (clarifying that it is not `\n`).


### PR DESCRIPTION
The compile-time error which is reported by the common front end for a declaration of a formal parameter as an initializing formal (`this.name`) was not specified precisely until now (it was just mentioned in commentary and never spelled out in normative text).

This PR changes the commentary to normative text.

One question may still give rise to debate: Can external constructors have initializing formals? This would be an enhancement, and it is handled in https://github.com/dart-lang/language/issues/3516. If that enhancement is accepted then we will change the specification later on in a different PR&mdash;this PR just specifies the current situation and makes it an error.

There will be an implementation effort in any case: If this PR is landed and the error reported by the CFE follows the updated specification then the analyzer would need to be changed to report that error. If an enhancement is accepted then all tools would need to implement it.
