### PR TITLE
Remove spurious reference to `~/` in constant rule

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -8771,7 +8771,7 @@ are the following:
   It is further constant if both $e_1$ and $e_2$ are constant expressions that
   both evaluate to an instance of \code{int},
   such that the operator symbol
-  \lit{\gtilde/}, \lit{\gtgt}, \lit{\gtgtgt}, respectively \lit{\ltlt}
+  \lit{\gtgt}, \lit{\gtgtgt}, respectively \lit{\ltlt}
   denotes an instance operator invocation.
 
 \item An expression of the form \code{$e_1$\,+\,$e_2$} is


### PR DESCRIPTION
The PR https://github.com/dart-lang/language/pull/3495 changed the rule about `e1 ~/ e2` as a constant expression. This PR removes a spurious reference to the operator symbol `~/` (it should no longer be mentioned in the rule which doesn't cover `e1 ~/ e2` any more).