### PR TITLE
Add rule to make it an error for a mixin `on` type to be super-bounded

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -7692,9 +7692,10 @@ when it is used in any of the following ways:
 \item $T$ is an immediate subterm of an \EXTENDS{} clause of a class
   (\ref{superclasses}),
   or it occurs as an element in the type list of an \IMPLEMENTS{} clause
-  (\ref{superinterfaces}),
+  %% TODO(eernst): Come extension types, add ref. Maybe mixin class?
+  (\ref{superinterfaces}, \ref{enums}, \ref{mixins}),
   or a \WITH{} clause
-  (\ref{classes}),
+  (\ref{classes}, \ref{enums}),
   or it occurs as an element in the type list of an \ON{} clause of a mixin
   (\ref{mixins}).
 \end{itemize}

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -7694,7 +7694,9 @@ when it is used in any of the following ways:
   or it occurs as an element in the type list of an \IMPLEMENTS{} clause
   (\ref{superinterfaces}),
   or a \WITH{} clause
-  (\ref{classes}).
+  (\ref{classes}),
+  or it occurs as an element in the type list of an \ON{} clause of a mixin
+  (\ref{mixins}).
 \end{itemize}
 
 \commentary{%


### PR DESCRIPTION
See https://github.com/dart-lang/language/issues/3491 where this change was discussed.

This PR makes it a compile-time error for a mixin `on` type to be super-bounded. This rule is similar to several other cases (it is an error for a type in an `extends`, `implements`, or `with` clause to be super-bounded as well). For mixins it is justified by the fact that it is impossible to use a mixin with a super-bounded `on` type.

There is no implementation effort because this is already the implemented behavior.