### PR TITLE
Updates to the JsonSerialization macro example.

### DIFF
--- a/working/macros/example/benchmark/simple.dart
+++ b/working/macros/example/benchmark/simple.dart
@@ -118,6 +118,8 @@ Macro: $macro
   }
   var tmpDir = Directory.systemTemp.createTempSync('macro_benchmark');
   try {
+    var jsonSerializableUri =
+        Uri.parse('package:macro_proposal/json_serializable.dart');
     var macroUri = switch (macro) {
       'ChecksExtensions' =>
         Uri.parse('package:macro_proposal/checks_extensions.dart'),
@@ -125,8 +127,9 @@ Macro: $macro
       'Injectable' => Uri.parse('package:macro_proposal/injectable.dart'),
       'FunctionalWidget' =>
         Uri.parse('package:macro_proposal/functional_widget.dart'),
-      'JsonSerializable' =>
-        Uri.parse('package:macro_proposal/json_serializable.dart'),
+      'JsonSerializable' => jsonSerializableUri,
+      'FromJson' => jsonSerializableUri,
+      'ToJson' => jsonSerializableUri,
       _ => throw UnsupportedError('Unrecognized macro $macro'),
     };
     var macroConstructors = switch (macro) {
@@ -147,6 +150,8 @@ Macro: $macro
         },
       'JsonSerializable' => {
           'JsonSerializable': [''],
+          'FromJson': [''],
+          'ToJson': [''],
         },
       _ => throw UnsupportedError('Unrecognized macro $macro'),
     };

--- a/working/macros/example/lib/json_serializable.dart
+++ b/working/macros/example/lib/json_serializable.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// Copyright (c) 2024, the Dart project authors. Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 //
@@ -7,7 +7,7 @@
 // There is no public API exposed yet, the in-progress API lives here.
 import 'package:_fe_analyzer_shared/src/macros/api.dart';
 
-// TODO: Support `toJson`, collections, and probably some other things :).
+// TODO: Support collections, extending serializable classes, and more.
 macro class JsonSerializable implements ClassDeclarationsMacro {
   const JsonSerializable();
 
@@ -80,7 +80,7 @@ macro class FromJson implements ConstructorDefinitionMacro {
     ]);
   }
 
-  // TODO: Support nested List, Map, etc conversion, including deep casting.
+  // TODO: Support nested collections.
   Future<Code> _convertFieldFromJson(FieldDeclaration field,
       Identifier jsonParam, DefinitionBuilder builder) async {
     var fieldType = field.type;
@@ -163,7 +163,7 @@ macro class ToJson implements MethodDefinitionMacro {
     ]));
   }
 
-  // TODO: Support nested List, Map, etc conversion.
+  // TODO: Support nested collections.
   Future<Code> _convertFieldToJson(
       FieldDeclaration field, DefinitionBuilder builder) async {
     var fieldType = field.type;
@@ -194,7 +194,7 @@ macro class ToJson implements MethodDefinitionMacro {
         ?.identifier;
     if (fieldToJson != null) {
       return RawCode.fromParts([
-        fieldToJson,
+        field.identifier,
         '.toJson()',
       ]);
     } else {

--- a/working/macros/example/lib/json_serializable.dart
+++ b/working/macros/example/lib/json_serializable.dart
@@ -7,10 +7,8 @@
 // There is no public API exposed yet, the in-progress API lives here.
 import 'package:_fe_analyzer_shared/src/macros/api.dart';
 
-final dartCore = Uri.parse('dart:core');
-
 // TODO: Support `toJson`, collections, and probably some other things :).
-macro class JsonSerializable implements ClassDeclarationsMacro, ClassDefinitionMacro {
+macro class JsonSerializable implements ClassDeclarationsMacro {
   const JsonSerializable();
 
   @override
@@ -22,50 +20,69 @@ macro class JsonSerializable implements ClassDeclarationsMacro, ClassDefinitionM
           '`${clazz.identifier.name}`, so one could not be added.');
     }
 
-    var map = await builder.resolveIdentifier(dartCore, 'Map');
+    var map = await builder.resolveIdentifier(_dartCore, 'Map');
     var string = NamedTypeAnnotationCode(
-        name: await builder.resolveIdentifier(dartCore, 'String'));
+        name: await builder.resolveIdentifier(_dartCore, 'String'));
     var dynamic = NamedTypeAnnotationCode(
-        name: await builder.resolveIdentifier(dartCore, 'dynamic'));
+        name: await builder.resolveIdentifier(_dartCore, 'dynamic'));
     var mapStringDynamic =
         NamedTypeAnnotationCode(name: map, typeArguments: [string, dynamic]);
+
     builder.declareInType(DeclarationCode.fromParts([
+      '@',
+      await builder.resolveIdentifier(_thisLibrary, 'FromJson'),
+      '()\n  ',
       clazz.identifier.name,
       '.fromJson(',
       mapStringDynamic,
       ' json);',
     ]));
-  }
 
+    builder.declareInType(DeclarationCode.fromParts([
+      '@',
+      await builder.resolveIdentifier(_thisLibrary, 'ToJson'),
+      '()\n  ',
+      mapStringDynamic,
+      'toJson();',
+    ]));
+  }
+}
+
+/// A macro applied to a fromJson constructor, which fills in the initializer list.
+macro class FromJson implements ConstructorDefinitionMacro {
   @override
-  Future<void> buildDefinitionForClass(
-      ClassDeclaration clazz, TypeDefinitionBuilder builder) async {
+  Future<void> buildDefinitionForConstructor(ConstructorDeclaration constructor,
+      ConstructorDefinitionBuilder builder) async {
+    // TODO: Validate we are running on a valid fromJson constructor.
+
     // TODO: support extending other classes.
-    var object = await builder.resolve(NamedTypeAnnotationCode(name: await builder.resolveIdentifier(dartCore, 'Object')));
-    if (clazz.superclass != null && !await (await builder.resolve(NamedTypeAnnotationCode(name: clazz.superclass!.identifier))).isExactly(object)) {
+    final clazz = (await builder.typeDeclarationOf(constructor.definingType))
+        as ClassDeclaration;
+    var object = await builder.resolve(NamedTypeAnnotationCode(
+        name: await builder.resolveIdentifier(_dartCore, 'Object')));
+    if (clazz.superclass != null &&
+        !await (await builder.resolve(
+                NamedTypeAnnotationCode(name: clazz.superclass!.identifier)))
+            .isExactly(object)) {
       throw UnsupportedError(
           'Serialization of classes that extend other classes is not supported.');
     }
 
-    var constructors = await builder.constructorsOf(clazz);
-    var fromJson =
-        constructors.firstWhere((c) => c.identifier.name == 'fromJson');
-    var fromJsonBuilder = await builder.buildConstructor(fromJson.identifier);
     var fields = await builder.fieldsOf(clazz);
-    var jsonParam = fromJson.positionalParameters.single.identifier;
-    fromJsonBuilder.augment(initializers: [
+    var jsonParam = constructor.positionalParameters.single.identifier;
+    builder.augment(initializers: [
       for (var field in fields)
         RawCode.fromParts([
           field.identifier,
           ' = ',
-          await _convertField(field, jsonParam, builder),
+          await _convertFieldFromJson(field, jsonParam, builder),
         ]),
     ]);
   }
 
   // TODO: Support nested List, Map, etc conversion, including deep casting.
-  Future<Code> _convertField(FieldDeclaration field, Identifier jsonParam,
-      DefinitionBuilder builder) async {
+  Future<Code> _convertFieldFromJson(FieldDeclaration field,
+      Identifier jsonParam, DefinitionBuilder builder) async {
     var fieldType = field.type;
     if (fieldType is! NamedTypeAnnotation) {
       throw ArgumentError(
@@ -109,6 +126,88 @@ macro class JsonSerializable implements ClassDeclarationsMacro, ClassDefinitionM
     }
   }
 }
+
+/// A macro applied to a toJson instance method, which fills in the body.
+macro class ToJson implements MethodDefinitionMacro {
+  @override
+  Future<void> buildDefinitionForMethod(
+      MethodDeclaration method, FunctionDefinitionBuilder builder) async {
+    // TODO: Validate we are running on a valid toJson method.
+
+    // TODO: support extending other classes.
+    final clazz = (await builder.typeDeclarationOf(method.definingType))
+        as ClassDeclaration;
+    var object = await builder.resolve(NamedTypeAnnotationCode(
+        name: await builder.resolveIdentifier(_dartCore, 'Object')));
+    if (clazz.superclass != null &&
+        !await (await builder.resolve(
+                NamedTypeAnnotationCode(name: clazz.superclass!.identifier)))
+            .isExactly(object)) {
+      throw UnsupportedError(
+          'Serialization of classes that extend other classes is not supported.');
+    }
+
+    var fields = await builder.fieldsOf(clazz);
+    builder.augment(FunctionBodyCode.fromParts([
+      ' => {',
+      for (var field in fields)
+        RawCode.fromParts([
+          '\n    \'',
+          field.identifier.name,
+          '\'',
+          ': ',
+          await _convertFieldToJson(field, builder),
+          ',',
+        ]),
+      '\n  };',
+    ]));
+  }
+
+  // TODO: Support nested List, Map, etc conversion.
+  Future<Code> _convertFieldToJson(
+      FieldDeclaration field, DefinitionBuilder builder) async {
+    var fieldType = field.type;
+    if (fieldType is! NamedTypeAnnotation) {
+      throw ArgumentError(
+          'Only fields with named types are allowed on serializable classes, '
+          'but `${field.identifier.name}` was not a named type.');
+    }
+    var fieldTypeDecl = await builder.declarationOf(fieldType.identifier);
+    while (fieldTypeDecl is TypeAliasDeclaration) {
+      var aliasedType = fieldTypeDecl.aliasedType;
+      if (aliasedType is! NamedTypeAnnotation) {
+        throw ArgumentError(
+            'Only fields with named types are allowed on serializable classes, '
+            'but `${field.identifier.name}` did not resolve to a named type.');
+      }
+    }
+    if (fieldTypeDecl is! ClassDeclaration) {
+      throw ArgumentError(
+          'Only classes are supported in field types for serializable classes, '
+          'but the field `${field.identifier.name}` does not have a class '
+          'type.');
+    }
+
+    var fieldTypeMethods = await builder.methodsOf(fieldTypeDecl);
+    var fieldToJson = fieldTypeMethods
+        .firstWhereOrNull((c) => c.identifier.name == 'toJson')
+        ?.identifier;
+    if (fieldToJson != null) {
+      return RawCode.fromParts([
+        fieldToJson,
+        '.toJson()',
+      ]);
+    } else {
+      // TODO: Check that it is a valid type we can serialize.
+      return RawCode.fromParts([
+        field.identifier,
+      ]);
+    }
+  }
+}
+
+final _dartCore = Uri.parse('dart:core');
+final _thisLibrary = Uri.parse('package:macro_proposal/json_serializable.dart');
 
 extension _FirstWhereOrNull<T> on Iterable<T> {
   T? firstWhereOrNull(bool Function(T) compare) {


### PR DESCRIPTION
- Add support for a `toJson` method.
- Directly apply separate FromJson/ToJson macros in the declaration phase, instead of scanning the class for methods.

This is a precursor to moving this macro into the SDK as a language test, possibly the last update to this macro in this repo.