### PR TITLE
Adjust the rule about await e where the type of e is an extension type

### DIFF
--- a/accepted/future-releases/extension-types/feature-specification.md
+++ b/accepted/future-releases/extension-types/feature-specification.md
@@ -873,8 +873,10 @@ one of the following criteria holds:
 
 - `T` is an extension type, and `T` does not implement `Future`.
 - `T` is `S?`, and `S` is incompatible with await.
-- `T` is `X & B`, `B` does not derive a future type, and `X` is
-  incompatible with await.
+- `T` is `X & B`, and either:
+  - `B` is incompatible with await, or
+  - `B` does not derive a future type, and `X` is
+    incompatible with await.
 - `T` is `S` bounded, and `S` is incompatible with await.
 
 Consider an expression of the form `await e`. A compile-time error 

--- a/accepted/future-releases/extension-types/feature-specification.md
+++ b/accepted/future-releases/extension-types/feature-specification.md
@@ -864,9 +864,16 @@ _is the extension type_
 <code>V\<T<sub>1</sub>, .. T<sub>s</sub>&gt;</code>,
 and that its static type _is an extension type_.
 
-It is a compile-time error if `await e` occurs, and the static type of
-`e` is an extension type which is not a subtype of `Future<T>` for any
-`T`.
+We say that a type `T` is _incompatible with await_ if at least 
+one of the following criteria holds:
+
+- `T` implements an extension type that does not implement `Future`.
+- `T` is `S?` bounded, where `S` is incompatible with await.
+- `T` is `X & B`, where `B` does not derive a future type and `X` is
+  incompatible with await.
+
+Consider an expression `e` of the form `await e1`. A compile-time error 
+occurs if `T` is incompatible with await.
 
 A compile-time error occurs if an extension type declares a member whose
 basename is the basename of an instance member declared by `Object` as

--- a/accepted/future-releases/extension-types/feature-specification.md
+++ b/accepted/future-releases/extension-types/feature-specification.md
@@ -15,7 +15,7 @@ information about the process, including in their change logs.
 [1]: https://github.com/dart-lang/language/blob/master/working/1426-extension-types/feature-specification-views.md
 [2]: https://github.com/dart-lang/language/blob/master/working/extension_structs/overview.md
 
-2024.01.16
+2024.01.17
   - Specify that a type is 'incompatible with await', and use that to specify
     a compile-time error at `await e;`.
 
@@ -871,13 +871,14 @@ and that its static type _is an extension type_.
 We say that a type `T` is _incompatible with await_ if at least 
 one of the following criteria holds:
 
-- `T` is an extension type, and `T` does not implement `Future`.
+- `T` is an extension type that does not implement `Future`.
 - `T` is `S?`, and `S` is incompatible with await.
 - `T` is `X & B`, and either:
   - `B` is incompatible with await, or
   - `B` does not derive a future type, and `X` is
     incompatible with await.
-- `T` is `S` bounded, and `S` is incompatible with await.
+- `T` is a type variable with bound `S`, and `S` is incompatible 
+  with await.
 
 Consider an expression of the form `await e`. A compile-time error 
 occurs if the static type of `e` is incompatible with await.

--- a/accepted/future-releases/extension-types/feature-specification.md
+++ b/accepted/future-releases/extension-types/feature-specification.md
@@ -872,8 +872,8 @@ one of the following criteria holds:
 - `T` is `X & B`, where `B` does not derive a future type and `X` is
   incompatible with await.
 
-Consider an expression `e` of the form `await e1`. A compile-time error 
-occurs if `T` is incompatible with await.
+Consider an expression of the form `await e`. A compile-time error 
+occurs if the static type of `e` is incompatible with await.
 
 A compile-time error occurs if an extension type declares a member whose
 basename is the basename of an instance member declared by `Object` as

--- a/accepted/future-releases/extension-types/feature-specification.md
+++ b/accepted/future-releases/extension-types/feature-specification.md
@@ -871,7 +871,7 @@ and that its static type _is an extension type_.
 We say that a type `T` is _incompatible with await_ if at least 
 one of the following criteria holds:
 
-- `T` implements an extension type, and `T` does not implement `Future`.
+- `T` is an extension type, and `T` does not implement `Future`.
 - `T` is `S?`, and `S` is incompatible with await.
 - `T` is `X & B`, `B` does not derive a future type, and `X` is
   incompatible with await.

--- a/accepted/future-releases/extension-types/feature-specification.md
+++ b/accepted/future-releases/extension-types/feature-specification.md
@@ -15,6 +15,10 @@ information about the process, including in their change logs.
 [1]: https://github.com/dart-lang/language/blob/master/working/1426-extension-types/feature-specification-views.md
 [2]: https://github.com/dart-lang/language/blob/master/working/extension_structs/overview.md
 
+2024.01.16
+  - Specify that a type is 'incompatible with await', and use that to specify
+    a compile-time error at `await e;`.
+
 2023.11.14
   - Specify that a method declaration will shadow an otherwise "inherited"
     setter with the same basename, and vice versa. This eliminates a

--- a/accepted/future-releases/extension-types/feature-specification.md
+++ b/accepted/future-releases/extension-types/feature-specification.md
@@ -867,10 +867,11 @@ and that its static type _is an extension type_.
 We say that a type `T` is _incompatible with await_ if at least 
 one of the following criteria holds:
 
-- `T` implements an extension type that does not implement `Future`.
-- `T` is `S?` bounded, where `S` is incompatible with await.
-- `T` is `X & B`, where `B` does not derive a future type and `X` is
+- `T` implements an extension type, and `T` does not implement `Future`.
+- `T` is `S?`, and `S` is incompatible with await.
+- `T` is `X & B`, `B` does not derive a future type, and `X` is
   incompatible with await.
+- `T` is `S` bounded, and `S` is incompatible with await.
 
 Consider an expression of the form `await e`. A compile-time error 
 occurs if the static type of `e` is incompatible with await.


### PR DESCRIPTION
See the discussion in https://github.com/dart-lang/language/issues/2710.

This PR introduces the notion of a type which is _incompatible with await_ and uses that to specify the compile-time error which occurs in the case where `await e` is encountered, and the static type of `e` is incompatible with await. The main case is when said static type is an extension type that does not implement `Future` (that's the case that we had already), but this new rule includes more cases, e.g., the case where the static type is `E?` where `E` is an extension type that does not implement `Future`.
