### PR TITLE
Add missing word 'bounded' to definition of flatten

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -41,6 +41,12 @@
 % version of the language which will actually be specified by the next stable
 % release of this document.
 %
+% Jan 2024
+% - Add the word 'bounded' to a rule in the definition of 'flatten'. This is
+%   already the implemented behavior, and it is the consistent approach. The
+%   main consequence is that `await e` will await the future when the static
+%   type of `e` is, for example, `X extends Future<int>?`.
+%
 % Dec 2023
 % - Allow `~/` on operands of type `double` in constant expressions, aligning
 %   the specification with already implemented behavior.

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -11746,7 +11746,7 @@ We define the auxiliary function
 as follows, using the first applicable case:
 
 \begin{itemize}
-\item If $T$ is \code{$S$?}\ for some $S$
+\item If $T$ is \code{$S$?}\ bounded for some $S$
   then \DefEquals{\flatten{T}}{\code{\flatten{S}?}}.
 
 \item If $T$ is \code{$X$\,\&\,$S$}


### PR DESCRIPTION
This PR adds the word 'bounded' to the `S?` case in the definition of flatten. This change is needed for consistency. Here is an example:

```dart
typedef Exactly<X> = X Function(X);

extension<X> on X {
  X expectStaticType<Y extends Exactly<X>>() => this;
}

Future<void> test<X extends Future<int>?>(X x) async {
  // ignore: await_only_futures
  var y = await x;
  y.expectStaticType<Exactly<int?>>; // This is what we want.
}

void main() async {
  await test<Future<int>?>(null);
  await test<Future<int>>(Future.value(1));
}
```

If we do not have the word 'bounded' in said rule then `await x` will have the type `X` and the future will not be awaited. The type will be `int?` as shown above if the rule is changed and 'bounded' is included.

There is no breaking change, and indeed no implementation effort associated with this specification change: the implementations behave as if the spec change had already been performed.