### PR TITLE
Enhance the definition of "derives a future type"

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -11721,13 +11721,36 @@ We say that $S$ is the
 $T$ in the following cases, using the first applicable case:
 
 \begin{itemize}
-\item $T$ implements $S$
-  (\ref{interfaceSuperinterfaces}),
-  and there is a $U$ such that $S$ is \code{Future<$U$>}.
-\item $T$ is $S$ bounded
+\item
+  If $T$ implements \code{Future<$U$>}
+  (\ref{interfaceSuperinterfaces})
+  for some $U$ then
+  $T$ derives the future type \code{Future<$U$>}.
+\item
+  Whenever $S$ is of the form
+  \code{FutureOr<$U$>}, \code{Future<$U$>?}, or \code{FutureOr<$U$>?},
+  the following holds:
+  If $T$ is $S$ bounded
   (\ref{bindingActualsToFormals}),
-  and there is a $U$ such that
-  $S$ is \code{FutureOr<$U$>}, \code{Future<$U$>?}, or \code{FutureOr<$U$>?}.
+  then $T$ derives the future type $S$.
+\item
+  If $T$ is \code{$T_1$?} for some $T_1$ and
+  $T_1$ derives the future type $S_1$
+  then $T$ derives the future type \code{$S_1$?}.
+\item
+  If $T$ is a type variable with bound $B$ and
+  $B$ derives the future type $S$
+  then $T$ derives the future type $S$.
+\item
+  If $T$ is of the form \code{$X$\,\,\&\,\,$B$} then the following holds:
+  \begin{itemize}
+  \item
+    if $B$ derives the future type $S$ then $T$ derives $S$.
+  \item
+    if $B$ does not derive a future type,
+    but $X$ derives the future type $S$
+    then $T$ derives $S$.
+  \end{itemize}
 \end{itemize}
 
 \LMHash{}%

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -11765,7 +11765,7 @@ and $F$ is always of the form \code{$G$<...>} or \code{$G$<...>?},
 where $G$ is \code{Future} or \code{FutureOr}.
 Also note that 'derives' in this context refers to the computation
 where a type $T$ is given, the supertypes of $T$ are searched,
-and a type of one of those forms is selected.
+and a type $F$ of one of those forms is selected.
 There is no connection to the notion of a 'derived class' meaning 'subclass'
 that some programming language communities use.%
 }

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -11735,11 +11735,11 @@ $T$ in the following cases, using the first applicable case:
   then $T$ derives the future type $S$.
 \item
   If $T$ is \code{$T_1$?} for some $T_1$, and
-  $T_1$ derives the future type $S_1$
+  $T_1$ derives the future type $S_1$,
   then $T$ derives the future type \code{$S_1$?}.
 \item
   If $T$ is a type variable with bound $B$, and
-  $B$ derives the future type $S$
+  $B$ derives the future type $S$,
   then $T$ derives the future type $S$.
 \item
   If $T$ is of the form \code{$X$\,\,\&\,\,$B$} then the following holds:
@@ -11748,7 +11748,7 @@ $T$ in the following cases, using the first applicable case:
     if $B$ derives the future type $S$ then $T$ derives $S$.
   \item
     if $B$ does not derive a future type,
-    but $X$ derives the future type $S$
+    but $X$ derives the future type $S$,
     then $T$ derives $S$.
   \end{itemize}
 \end{itemize}

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -11722,9 +11722,9 @@ $T$ in the following cases, using the first applicable case:
 
 \begin{itemize}
 \item
-  If $T$ implements \code{Future<$U$>}
+  If \code{Future<$U$>} is a superinterface of $T$
   (\ref{interfaceSuperinterfaces})
-  for some $U$ then
+  for some $U$, then
   $T$ derives the future type \code{Future<$U$>}.
 \item
   If $T$ is \code{FutureOr<$U$>} bounded

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -11725,9 +11725,9 @@ if one of the following cases applies:
 \begin{itemize}
 \item
   %% TODO(eernst): Come mixin classes and extension types: add them.
-  Assume that $T$ is a type which is introduced by
-  a class, mixin, or enum declaration.
-  If a direct or indirect superinterface
+  If $T$ is a type which is introduced by
+  a class, mixin, or enum declaration,
+  and if a direct or indirect superinterface
   (\ref{interfaceSuperinterfaces})
   of $T$ is \code{Future<$U$>} for some $U$,
   then $T$ derives the future type \code{Future<$U$>}.

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -11718,18 +11718,15 @@ where inferred types have already been added.%
 \LMHash{}%
 We say that a type $T$
 \IndexCustom{derives a future type}{type!derives a future type}
-$S$,
-or, equivalently, that $S$ is the
-\IndexCustom{future type derived from}{type!future type derived from}
-a type $T$ in the following cases, using the first applicable case:
+$S$ in the following cases, using the first applicable case:
 
 %% TODO(eernst): Note that `X extends X?` can create an infinite loop.
 %% We will probably make that kind of bound an error.
 \begin{itemize}
 \item
-  % A type induced by a class, mixin, mixin class, enum, or extension type
-  % has superinterfaces, and may have `Future` as a superinterface; no other
-  % type can have that.
+  %% TODO(eernst): Come mixin classes, extension types: add them.
+  Assume that $T$ is a type which is introduced by
+  a class, mixin, or enum declaration.
   If a direct or indirect superinterface
   (\ref{interfaceSuperinterfaces})
   of $T$ is \code{Future<$U$>} for some $U$,

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -11775,9 +11775,6 @@ We define the auxiliary function
 as follows, using the first applicable case:
 
 \begin{itemize}
-\item If $T$ is \code{$S$?}\ for some $S$
-  then \DefEquals{\flatten{T}}{\code{\flatten{S}?}}.
-
 \item If $T$ is \code{$X$\,\&\,$S$}
   for some type variable $X$ and type $S$ then
   \begin{itemize}

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -11734,7 +11734,7 @@ $T$ in the following cases, using the first applicable case:
   (\ref{bindingActualsToFormals}),
   then $T$ derives the future type $S$.
 \item
-  If $T$ is \code{$T_1$?} for some $T_1$ and
+  If $T$ is \code{$T_1$?} for some $T_1$, and
   $T_1$ derives the future type $S_1$
   then $T$ derives the future type \code{$S_1$?}.
 \item

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -11722,13 +11722,12 @@ $T$ in the following cases, using the first applicable case:
 
 \begin{itemize}
 \item
-  If \code{Future<$U$>} is a superinterface of $T$
+  If a superinterface 
   (\ref{interfaceSuperinterfaces})
-  for some $U$, then
+  of $T$ is \code{Future<$U$>} for some $U$ then
   $T$ derives the future type \code{Future<$U$>}.
 \item
-  If $T$ is \code{FutureOr<$U$>} bounded
-  (\ref{bindingActualsToFormals})
+  If $T$ is \code{FutureOr<$U$>} for some $U$
   then $T$ derives the future type \code{FutureOr<$U$>}.
 \item
   If $T$ is \code{$T_1$?} for some $T_1$, and

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -11718,13 +11718,13 @@ where inferred types have already been added.%
 \LMHash{}%
 We say that a type $T$
 \IndexCustom{derives a future type}{type!derives a future type}
-$S$ in the following cases:
+as follows:
 
 %% TODO(eernst): Note that `X extends X?` can create an infinite loop.
 %% We will probably make that kind of bound an error.
 \begin{itemize}
 \item
-  %% TODO(eernst): Come mixin classes, extension types: add them.
+  %% TODO(eernst): Come mixin classes and extension types: add them.
   Assume that $T$ is a type which is introduced by
   a class, mixin, or enum declaration.
   If a direct or indirect superinterface
@@ -11732,26 +11732,26 @@ $S$ in the following cases:
   of $T$ is \code{Future<$U$>} for some $U$,
   then $T$ derives the future type \code{Future<$U$>}.
 \item
-  If $T$ is \code{FutureOr<$U$>} for some $U$,
+  If $T$ is the type \code{FutureOr<$U$>} for some $U$,
   then $T$ derives the future type \code{FutureOr<$U$>}.
 \item
-  If $T$ is \code{$T_1$?} for some $T_1$, and
-  $T_1$ derives the future type $S_1$,
-  then $T$ derives the future type \code{$S_1$?}.
+  If $T$ is \code{$S$?} for some $S$, and
+  $S$ derives the future type $F$,
+  then $T$ derives the future type \code{$F$?}.
 \item
   If $T$ is a type variable with bound $B$, and
-  $B$ derives the future type $S$,
-  then $T$ derives the future type $S$.
+  $B$ derives the future type $F$,
+  then $T$ derives the future type $F$.
 \item
-  If $T$ is of the form \code{$X$\,\&\,$B$} then:
+  If $T$ is of the form \code{$X$\,\&\,$S$} then:
   \begin{itemize}
   \item
-    if $B$ derives the future type $S$,
-    then $T$ derives the future type $S$.
+    if $S$ derives the future type $F$,
+    then $T$ derives the future type $F$.
   \item
     if $B$ does not derive a future type,
-    but $X$ derives the future type $S$,
-    then $T$ derives the future type $S$.
+    but $X$ derives the future type $F$,
+    then $T$ derives the future type $F$.
   \end{itemize}
 \end{itemize}
 

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -11739,7 +11739,7 @@ $T$ in the following cases, using the first applicable case:
   $B$ derives the future type $S$,
   then $T$ derives the future type $S$.
 \item
-  If $T$ is of the form \code{$X$\,\,\&\,\,$B$} then the following holds:
+  If $T$ is of the form \code{$X$\,\&\,$B$} then the following holds:
   \begin{itemize}
   \item
     if $B$ derives the future type $S$ then $T$ derives $S$.

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -11718,7 +11718,7 @@ where inferred types have already been added.%
 \LMHash{}%
 We say that a type $T$
 \IndexCustom{derives a future type}{type!derives a future type}
-as follows:
+if one of the following cases applies:
 
 %% TODO(eernst): Note that `X extends X?` can create an infinite loop.
 %% We will probably make that kind of bound an error.

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -11727,12 +11727,9 @@ $T$ in the following cases, using the first applicable case:
   for some $U$ then
   $T$ derives the future type \code{Future<$U$>}.
 \item
-  Whenever $S$ is of the form
-  \code{FutureOr<$U$>}, \code{Future<$U$>?}, or \code{FutureOr<$U$>?},
-  the following holds:
-  If $T$ is $S$ bounded
-  (\ref{bindingActualsToFormals}),
-  then $T$ derives the future type $S$.
+  If $T$ is \code{FutureOr<$U$>} bounded
+  (\ref{bindingActualsToFormals})
+  then $T$ derives the future type \code{FutureOr<$U$>}.
 \item
   If $T$ is \code{$T_1$?} for some $T_1$, and
   $T_1$ derives the future type $S_1$,

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -11727,7 +11727,10 @@ a type $T$ in the following cases, using the first applicable case:
 %% We will probably make that kind of bound an error.
 \begin{itemize}
 \item
-  If a superinterface 
+  % A type induced by a class, mixin, mixin class, enum, or extension type
+  % has superinterfaces, and may have `Future` as a superinterface; no other
+  % type can have that.
+  If a direct or indirect superinterface
   (\ref{interfaceSuperinterfaces})
   of $T$ is \code{Future<$U$>} for some $U$,
   then $T$ derives the future type \code{Future<$U$>}.

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -41,7 +41,7 @@
 % version of the language which will actually be specified by the next stable
 % release of this document.
 %
-% Jan 2024
+% Feb 2024
 % - Correct the rule about deriving a future type from a type (which is used
 %   by `flatten`).
 %

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -11762,7 +11762,12 @@ we say that $T$ does not derive a future type.
 \commentary{%
 Note that if $T$ derives a future type $F$ then \SubtypeNE{T}{F},
 and $F$ is always of the form \code{$G$<...>} or \code{$G$<...>?},
-where $G$ is \code{Future} or \code{FutureOr}.%
+where $G$ is \code{Future} or \code{FutureOr}.
+Also note that 'derives' in this context refers to the computation
+where a type $T$ is given, the supertypes of $T$ are searched,
+and a type of one of those forms is selected.
+There is no connection to the notion of a 'derived class' meaning 'subclass'
+that some programming language communities use.%
 }
 
 \LMHash{}%

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -11716,36 +11716,42 @@ where inferred types have already been added.%
 }
 
 \LMHash{}%
-We say that $S$ is the
-\IndexCustom{future type derived from a type}{type!future type derived from}
-$T$ in the following cases, using the first applicable case:
+We say that a type $T$
+\IndexCustom{derives a future type}{type!derives a future type}
+$S$,
+or, equivalently, that $S$ is the
+\IndexCustom{future type derived from}{type!future type derived from}
+a type $T$ in the following cases, using the first applicable case:
 
+%% TODO(eernst): Note that `X extends X?` can create an infinite loop.
+%% We will probably make that kind of bound an error.
 \begin{itemize}
 \item
   If a superinterface 
   (\ref{interfaceSuperinterfaces})
   of $T$ is \code{Future<$U$>} for some $U$,
-  then $T$ derives \code{Future<$U$>}.
+  then $T$ derives the future type \code{Future<$U$>}.
 \item
   If $T$ is \code{FutureOr<$U$>} for some $U$,
-  then $T$ derives \code{FutureOr<$U$>}.
+  then $T$ derives the future type \code{FutureOr<$U$>}.
 \item
   If $T$ is \code{$T_1$?} for some $T_1$, and
   $T_1$ derives the future type $S_1$,
-  then $T$ derives \code{$S_1$?}.
+  then $T$ derives the future type \code{$S_1$?}.
 \item
   If $T$ is a type variable with bound $B$, and
   $B$ derives the future type $S$,
-  then $T$ derives $S$.
+  then $T$ derives the future type $S$.
 \item
-  If $T$ is of the form \code{$X$\,\&\,$B$} then the following holds:
+  If $T$ is of the form \code{$X$\,\&\,$B$} then:
   \begin{itemize}
   \item
-    if $B$ derives the future type $S$ then $T$ derives $S$.
+    if $B$ derives the future type $S$,
+    then $T$ derives the future type $S$.
   \item
     if $B$ does not derive a future type,
     but $X$ derives the future type $S$,
-    then $T$ derives $S$.
+    then $T$ derives the future type $S$.
   \end{itemize}
 \end{itemize}
 

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -11718,7 +11718,7 @@ where inferred types have already been added.%
 \LMHash{}%
 We say that a type $T$
 \IndexCustom{derives a future type}{type!derives a future type}
-if one of the following cases applies:
+$F$ in the following cases, using the first applicable case:
 
 %% TODO(eernst): Note that `X extends X?` can create an infinite loop.
 %% We will probably make that kind of bound an error.

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -11725,18 +11725,18 @@ $T$ in the following cases, using the first applicable case:
   If a superinterface 
   (\ref{interfaceSuperinterfaces})
   of $T$ is \code{Future<$U$>} for some $U$,
-  then $T$ derives the future type \code{Future<$U$>}.
+  then $T$ derives \code{Future<$U$>}.
 \item
   If $T$ is \code{FutureOr<$U$>} for some $U$,
-  then $T$ derives the future type \code{FutureOr<$U$>}.
+  then $T$ derives \code{FutureOr<$U$>}.
 \item
   If $T$ is \code{$T_1$?} for some $T_1$, and
   $T_1$ derives the future type $S_1$,
-  then $T$ derives the future type \code{$S_1$?}.
+  then $T$ derives \code{$S_1$?}.
 \item
   If $T$ is a type variable with bound $B$, and
   $B$ derives the future type $S$,
-  then $T$ derives the future type $S$.
+  then $T$ derives $S$.
 \item
   If $T$ is of the form \code{$X$\,\&\,$B$} then the following holds:
   \begin{itemize}

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -41,6 +41,10 @@
 % version of the language which will actually be specified by the next stable
 % release of this document.
 %
+% Jan 2024
+% - Correct the rule about deriving a future type from a type (which is used
+%   by `flatten`).
+%
 % Dec 2023
 % - Allow `~/` on operands of type `double` in constant expressions, aligning
 %   the specification with already implemented behavior.
@@ -11743,16 +11747,11 @@ $F$ in the following cases, using the first applicable case:
   $B$ derives the future type $F$,
   then $T$ derives the future type $F$.
 \item
-  If $T$ is of the form \code{$X$\,\&\,$S$} then:
-  \begin{itemize}
-  \item
-    if $S$ derives the future type $F$,
-    then $T$ derives the future type $F$.
-  \item
-    if $B$ does not derive a future type,
-    but $X$ derives the future type $F$,
-    then $T$ derives the future type $F$.
-  \end{itemize}
+  \commentary{%
+    There is no rule for the case where $T$ is of the form \code{$X$\,\&\,$S$}
+    because this will never occur
+    (this concept is only used in \flattenName, which is defined below).%
+  }
 \end{itemize}
 
 \LMHash{}%

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -11727,7 +11727,7 @@ $F$ in the following cases, using the first applicable case:
   %% TODO(eernst): Come mixin classes and extension types: add them.
   If $T$ is a type which is introduced by
   a class, mixin, or enum declaration,
-  and if a direct or indirect superinterface
+  and if $T$ or a direct or indirect superinterface
   (\ref{interfaceSuperinterfaces})
   of $T$ is \code{Future<$U$>} for some $U$,
   then $T$ derives the future type \code{Future<$U$>}.

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -11738,7 +11738,7 @@ $T$ in the following cases, using the first applicable case:
   $T_1$ derives the future type $S_1$
   then $T$ derives the future type \code{$S_1$?}.
 \item
-  If $T$ is a type variable with bound $B$ and
+  If $T$ is a type variable with bound $B$, and
   $B$ derives the future type $S$
   then $T$ derives the future type $S$.
 \item

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -11718,7 +11718,7 @@ where inferred types have already been added.%
 \LMHash{}%
 We say that a type $T$
 \IndexCustom{derives a future type}{type!derives a future type}
-$S$ in the following cases, using the first applicable case:
+$S$ in the following cases:
 
 %% TODO(eernst): Note that `X extends X?` can create an infinite loop.
 %% We will probably make that kind of bound an error.

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -11724,10 +11724,10 @@ $T$ in the following cases, using the first applicable case:
 \item
   If a superinterface 
   (\ref{interfaceSuperinterfaces})
-  of $T$ is \code{Future<$U$>} for some $U$ then
-  $T$ derives the future type \code{Future<$U$>}.
+  of $T$ is \code{Future<$U$>} for some $U$,
+  then $T$ derives the future type \code{Future<$U$>}.
 \item
-  If $T$ is \code{FutureOr<$U$>} for some $U$
+  If $T$ is \code{FutureOr<$U$>} for some $U$,
   then $T$ derives the future type \code{FutureOr<$U$>}.
 \item
   If $T$ is \code{$T_1$?} for some $T_1$, and


### PR DESCRIPTION
See https://github.com/dart-lang/sdk/issues/54628 for some background information.

This PR changes the definition of 'derives a future type' (which is used to define _flatten_) such that it includes some additional cases (in particular, it will recursively handle `?` on types, which was not the case previously).