### PR TITLE
Specify that implicit `call` tear-offs are supported for extension types

### DIFF
--- a/accepted/future-releases/extension-types/feature-specification.md
+++ b/accepted/future-releases/extension-types/feature-specification.md
@@ -1000,10 +1000,9 @@ in particular that `V` must match the on-type of the extension
 *(again, this is an `extension` declaration that we have today, not an
 `extension type` declaration)*.
 
-Consider the situation where an expression `e` has a static type which is
-an extension type that has a method named `call`. Assume that the context
-type for `e` is a function type or the type `Function`. In this situation,
-`e` is treated as `e.call`.
+Let `e` be an expression whose static type is an extension type that has a
+method named `call`. In the case where the context type for `e` is a function
+type or the type `Function`, `e` is treated as `e.call`.
 
 *In other words, an implicit `call` tear-off is supported for extension
 types in the same way as it is supported for a type which is introduced by

--- a/accepted/future-releases/extension-types/feature-specification.md
+++ b/accepted/future-releases/extension-types/feature-specification.md
@@ -1000,6 +1000,15 @@ in particular that `V` must match the on-type of the extension
 *(again, this is an `extension` declaration that we have today, not an
 `extension type` declaration)*.
 
+Consider the situation where an expression `e` has a static type which is
+an extension type that has a method named `call`. Assume that the context
+type for `e` is a function type or the type `Function`. In this situation,
+`e` is treated as `e.call`.
+
+*In other words, an implicit `call` tear-off is supported for extension
+types in the same way as it is supported for a type which is introduced by
+the declaration of a class, mixin, enum, or mixin class.*
+
 *In the body of an extension type declaration _DV_ with name `Name`
 and type parameters
 <code>X<sub>1</sub>, .. X<sub>s</sub></code>, for an invocation like


### PR DESCRIPTION
This PR adds a rule to the extension type feature specification saying that if `e` is an expression whose type is an extension type that has a method named `call`, and `e` has a context type which is a function type or the type `Function`, then it is treated as `e.call`. This is just a word-for-word replication of the [corresponding rule](https://github.com/dart-lang/language/blob/d4813d54ccc04bfc6ff2470eb74d2202be6707ef/specification/dartLangSpec.tex#L14742) for other kinds of type, except that it's about extension types.

This mechanism is also known as "implicit `call` tear-offs".

The language team decided that we should allow implicit `call` tear-offs here: https://github.com/dart-lang/language/issues/3467#issuecomment-1854515768.

The implementation was handled here: https://github.com/dart-lang/sdk/issues/54339, and the work has already been done. Hence, there is no implementation effort associated with this spec change.

Resolves https://github.com/dart-lang/language/issues/3512.