### PR TITLE
Stop pinning deps in working/macros/example/pubspec.yaml.

### DIFF
--- a/working/macros/example/pubspec.yaml
+++ b/working/macros/example/pubspec.yaml
@@ -17,84 +17,84 @@ dependency_overrides:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/_fe_analyzer_shared
-      ref: 3.4.0-56.0.dev
+      ref: main
   _js_interop_checks:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/_js_interop_checks
-      ref: 3.4.0-56.0.dev
+      ref: main
   analyzer:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/analyzer
-      ref: 3.4.0-56.0.dev
+      ref: main
   build_integration:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/build_integration
-      ref: 3.4.0-56.0.dev
+      ref: main
   compiler:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/compiler
-      ref: 3.4.0-56.0.dev
+      ref: main
   dart2js_info:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/dart2js_info
-      ref: 3.4.0-56.0.dev
+      ref: main
   dart2wasm:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/dart2wasm
-      ref: 3.4.0-56.0.dev
+      ref: main
   dev_compiler:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/dev_compiler
-      ref: 3.4.0-56.0.dev
+      ref: main
   front_end:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/front_end
-      ref: 3.4.0-56.0.dev
+      ref: main
   frontend_server:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/frontend_server
-      ref: 3.4.0-56.0.dev
+      ref: main
   js_ast:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/js_ast
-      ref: 3.4.0-56.0.dev
+      ref: main
   js_runtime:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/js_runtime
-      ref: 3.4.0-56.0.dev
+      ref: main
   js_shared:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/js_shared
-      ref: 3.4.0-56.0.dev
+      ref: main
   kernel:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/kernel
-      ref: 3.4.0-56.0.dev
+      ref: main
   mmap:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/mmap
-      ref: 3.4.0-56.0.dev
+      ref: main
   vm:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/vm
-      ref: 3.4.0-56.0.dev
+      ref: main
   wasm_builder:
     git:
       url: https://github.com/dart-lang/sdk.git
       path: pkg/wasm_builder
-      ref: 3.4.0-56.0.dev
+      ref: main


### PR DESCRIPTION
Pinning the deps was creating a version skew problem in continuous integration (which is configured in `.github/workflows/dart.yml`). The continuous integration configuration uses `sdk: main` (meaning that the code will be analyzed using the latest bleeding edge build of Dart). But the macros in `working/macros/example` import macro support functionality from `package:_fe_analyzer_shared/src`, so they use whatever version of that package that is configured in the pubspec (which, prior to this change, was pinned to version `3.4.0-56.0.dev`).

The reason this creates a version skew problem is that the macro support functionality in `package:_fe_analyzer_shared/src` includes deserialization logic that decodes data structures created during analysis and compilation. Which means that any time the serialization format changes, that could potentially break the continuous integration bot.

Eventually we plan to move the macro support functionality into a `dart:` library that will ship as part of the SDK, so there will be no more version skew problem. Until then, an easy way to work around the version skew is simply to pin the pubspec to the `main` branch rather than a specific release, so that it matches what's configured in continuous integration.

A side effect of this change is that if the API for writing macros gets changed in a way that breaks the examples in
`working/macros/example`, that will cause the continuous integration bot to immediately start failing. (Previously it wouldn't cause a failure because the API was pinned to `3.4.0-56.0.dev`). Considering that the API for macros is under active development, this is probably a good thing; it will mean that if we make inadvertent API changes that break the examples, we'll be more likely to find out about it.

- Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
