### PR TITLE
Adjust incompatible-with-await to be more strict on intersections

### DIFF
--- a/accepted/future-releases/extension-types/feature-specification.md
+++ b/accepted/future-releases/extension-types/feature-specification.md
@@ -885,10 +885,7 @@ one of the following criteria holds:
 
 - `T` is an extension type that does not implement `Future`.
 - `T` is `S?`, and `S` is incompatible with await.
-- `T` is `X & B`, and either:
-  - `B` is incompatible with await, or
-  - `B` does not derive a future type, and `X` is
-    incompatible with await.
+- `T` is `X & B`, and `B` is incompatible with await.
 - `T` is a type variable with bound `S`, and `S` is incompatible
   with await.
 


### PR DESCRIPTION
The PR https://github.com/dart-lang/language/pull/3560 introduced the notion of a type which is 'incompatible with await' and used that to introduce an error on `await e` when the static type of `e` is such a type.

This PR adjusts the definition of 'incompatible with await' such that `X & S` is incompatible with await when `S` is incompatible with await. This is a bit more strict than the previous version. It is motivated by the fact that a promotion of a variable of type `X` to a type `X & S` where `S` isn't compatible with await is a strong signal that it should not be awaited.

Of course, `await (e as T)` for some suitable value of `T` can always be used to force the await.

The change is not breaking because 'incompatible with await' has not yet been implemented in any release.
