### PR TITLE
Fix records type inference rules to match implementations.

### DIFF
--- a/accepted/3.0/records/feature-specification.md
+++ b/accepted/3.0/records/feature-specification.md
@@ -524,7 +524,7 @@ dm : K{n+m}})` then:
       appropriate implicit coercion(s) on `ei`.  Let `Ti` be the type of the
       resulting coerced value (which must be a subtype of `Ri`, possibly
       proper).
-    - Otherwise, it is a static error.
+    - Otherwise, let `Ti` be `Si`.
   - The type of `E` is `(T1, ..., Tn, {d1 : T{n+1}, ...., dm : T{n+m}})`
 
 If `K` is any other type schema:


### PR DESCRIPTION
If the context of a record literal is the same shape as the record literal, but the actual type of one or more fields is not a subtype of the corresponding field in the context type, and no coercion is possible, then the implementations do not necessarily issue an error. They only issue an error if the type mismatch leads to an assignability error during subsequent analysis.

An example of a circumstance where the type mismatch doesn't lead to an assignability error is if the context resulted from assignment to a previously promoted local variable. For example:

    f(Object o) {
      if (o is (int,)) {
        o = ('',); // OK; demotes `o` back to `Object`.
      }
    }

This change adjusts the spec to agree with what was implemented.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
