### PR TITLE
Updates to data class macro benchmarks, add code optimizer benchmark

### DIFF
--- a/working/macros/example/benchmark/src/data_class.dart
+++ b/working/macros/example/benchmark/src/data_class.dart
@@ -51,18 +51,27 @@ Future<void> runBenchmarks(MacroExecutor executor, Uri macroUri) async {
   await declarationsBenchmark.report();
   BuildAugmentationLibraryBenchmark.reportAndPrint(
       executor,
-      [if (declarationsBenchmark.result != null) declarationsBenchmark.result!],
+      [
+        if (typesBenchmark.result != null) typesBenchmark.result!,
+        if (declarationsBenchmark.result != null) declarationsBenchmark.result!,
+      ],
       identifierDeclarations);
   final definitionsBenchmark = DataClassDefinitionPhaseBenchmark(
       executor, macroUri, instanceId, introspector);
   await definitionsBenchmark.report();
-  final library = BuildAugmentationLibraryBenchmark.reportAndPrint(
+  final rawLibrary = BuildAugmentationLibraryBenchmark.reportAndPrint(
       executor,
-      [if (definitionsBenchmark.result != null) definitionsBenchmark.result!],
+      [
+        if (typesBenchmark.result != null) typesBenchmark.result!,
+        if (declarationsBenchmark.result != null) declarationsBenchmark.result!,
+        if (definitionsBenchmark.result != null) definitionsBenchmark.result!,
+      ],
       identifierDeclarations);
 
-  CodeOptimizerBenchmark(
-          library, BenchmarkCodeOptimizer(identifiers: libraryIdentifiers))
+  final formattedLibrary = FormatLibraryBenchmark.reportAndPrint(rawLibrary);
+
+  CodeOptimizerBenchmark(formattedLibrary, {'MyClass'},
+          BenchmarkCodeOptimizer(identifiers: libraryIdentifiers))
       .reportAndPrint();
 }
 

--- a/working/macros/example/benchmark/src/shared.dart
+++ b/working/macros/example/benchmark/src/shared.dart
@@ -8,7 +8,17 @@ import 'package:_fe_analyzer_shared/src/scanner/scanner.dart';
 import 'package:benchmark_harness/benchmark_harness.dart';
 import 'package:dart_style/dart_style.dart';
 
-class BuildAugmentationLibraryBenchmark extends BenchmarkBase {
+/// A benchmark which only calls `run` once inside `excersize`.
+class RunOnceBenchmarkBase extends BenchmarkBase {
+  RunOnceBenchmarkBase(super.name);
+
+  @override
+  void exercise() {
+    run();
+  }
+}
+
+class BuildAugmentationLibraryBenchmark extends RunOnceBenchmarkBase {
   final MacroExecutor executor;
   final List<MacroExecutionResult> results;
 
@@ -84,7 +94,7 @@ class BuildAugmentationLibraryBenchmark extends BenchmarkBase {
   static final dartCore = Uri.parse('dart:core');
 }
 
-class FormatLibraryBenchmark extends BenchmarkBase {
+class FormatLibraryBenchmark extends RunOnceBenchmarkBase {
   final formatter = DartFormatter();
   final String library;
   late String _formattedResult;
@@ -129,7 +139,7 @@ class FormatLibraryBenchmark extends BenchmarkBase {
   }
 }
 
-class CodeOptimizerBenchmark extends BenchmarkBase {
+class CodeOptimizerBenchmark extends RunOnceBenchmarkBase {
   final String library;
   final Set<String> libraryDeclarationNames;
   final BenchmarkCodeOptimizer optimizer;


### PR DESCRIPTION
- When benching augmentation library creation, include results from earlier stages 
- Only do formatting at the very end
- Add code optimization at the very end
- Make comparisons fair, only call `run` once inside the synchronous benchmarks.

Results for code optimization look fairly reasonable, ~25μs (total macro execution takes around 2ms prior to that, ignoring formatting).

Formatting is slower but maybe reasonable, around 450 μs.

Example run here https://gist.github.com/jakemac53/096b8380db41aa2eda46ae189a510c29.

cc @jacob314 