### PR TITLE
Specify the interaction between record expressions and constant contexts

### DIFF
--- a/accepted/3.0/records/feature-specification.md
+++ b/accepted/3.0/records/feature-specification.md
@@ -133,6 +133,10 @@ not captured by the grammar. It is a compile-time error if a record has any of:
     field. *For example: `('pos', $1: 'named')` since the named field "$1"
     collides with the getter for the first positional field.*
 
+Let _R_ be a record expression that occurs in a constant context, or a
+record expression whose first token is `const`. In this case, each record
+field in _R_ occurs in a constant context.
+
 In order to avoid ambiguity with parenthesized expressions, a record with
 only a single positional field must have a trailing comma:
 


### PR DESCRIPTION
See https://github.com/dart-lang/sdk/issues/55008#issuecomment-1964229795 for some background information.

The feature specification about records does not specify the meaning of `const` in front of a record expression, but it does allow `const` in that position. This PR adds a paragraph about this question. The idea is that `e` occurs in a constant context if it occurs as `const (..., e, ...)` or if `e` occurs in a record expression `(..., e, ...)` that occurs in a constant context.

This would not be a breaking change: The CFE already behaves in this way. The analyzer accepts `const (...)` where `(...)` is a record expressions where one or more field expressions are non-constant, so there is a certain amount of work to do on the analyzer.