### PR TITLE
[macros] Fix data_class_main.dart macros example

### DIFF
--- a/working/macros/example/bin/data_class_main.dart
+++ b/working/macros/example/bin/data_class_main.dart
@@ -14,9 +14,9 @@ void main() {
 
 @DataClass()
 class User {
-  final int age;
-  final String name;
-  final String username;
+  final int? age;
+  final String? name;
+  final String? username;
 }
 
 @DataClass()


### PR DESCRIPTION
`CopyWith().buildDeclarationsForClass(clazz, context)` generates parameters for `copyWith()` constructor as 
```dart
        ParameterCode(
            name: field.identifier.name,
            type: field.type.code.asNullable,
            keywords: const [],
            defaultValue: null)
```
So, non-nullable parameters can't have `null` as default value, therefore code, generated by macros has a compile-time error. This change fixes it