### PR TITLE
allow macro analysis step to fail without stopping other jobs

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -23,6 +23,8 @@ jobs:
       - name: dart pub get (working/macros/example)
         run: dart pub get
         working-directory: working/macros/example
+        # This gets broken fairly often by SDK updates, allow it to fail.
+        cointinue-on-error: true
       - name: dart pub get (accepted/2.3/spread-collections/benchmarks)
         run: dart pub get
         working-directory: accepted/2.3/spread-collections/benchmarks

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -24,7 +24,7 @@ jobs:
         run: dart pub get
         working-directory: working/macros/example
         # This gets broken fairly often by SDK updates, allow it to fail.
-        cointinue-on-error: true
+        continue-on-error: true
       - name: dart pub get (accepted/2.3/spread-collections/benchmarks)
         run: dart pub get
         working-directory: accepted/2.3/spread-collections/benchmarks

--- a/working/macros/example/lib/auto_dispose.dart
+++ b/working/macros/example/lib/auto_dispose.dart
@@ -5,8 +5,6 @@
 // There is no public API exposed yet, the in-progress API lives here.
 import 'package:_fe_analyzer_shared/src/macros/api.dart';
 
-int x = 'error!';
-
 // Interface for disposable things.
 abstract class Disposable {
   void dispose();

--- a/working/macros/example/lib/auto_dispose.dart
+++ b/working/macros/example/lib/auto_dispose.dart
@@ -5,6 +5,8 @@
 // There is no public API exposed yet, the in-progress API lives here.
 import 'package:_fe_analyzer_shared/src/macros/api.dart';
 
+int x = 'error!';
+
 // Interface for disposable things.
 abstract class Disposable {
   void dispose();


### PR DESCRIPTION
Fixes https://github.com/dart-lang/language/issues/3656

~This should resolve it, I am going to push an intentional failure and then revert to test the behavior, so please wait to land until I have a chance to do that :).~ Tested and it works as expected.

Note that if there is a particular job we always want to run, we could also try adding `if: always()` to that, which might actually be an additional change we want to make.