### PR TITLE
Update grammar rules of augmentation library feature specification

### DIFF
--- a/working/augmentation-libraries/feature-specification.md
+++ b/working/augmentation-libraries/feature-specification.md
@@ -850,7 +850,7 @@ topLevelDeclaration ::= classDeclaration
   | 'augment'? functionSignature functionBody
   | 'augment'? getterSignature functionBody
   | 'augment'? setterSignature functionBody
-  | 'augment'? ('final' | 'const') type? staticFinalDeclarationList ';'
+  | ('final' | 'const') type? staticFinalDeclarationList ';'
   | 'augment'? 'late' 'final' type? initializedIdentifierList ';'
   | 'augment'? 'late'? varOrType initializedIdentifierList ';'
 
@@ -891,8 +891,8 @@ declaration ::= 'external' factoryConstructorSignature
   | 'external' ('static'? finalVarOrType | 'covariant' varOrType) identifierList
   | 'external'? operatorSignature
   | 'abstract' (finalVarOrType | 'covariant' varOrType) identifierList
-  | 'augment'? 'static' 'const' type? staticFinalDeclarationList
-  | 'augment'? 'static' 'final' type? staticFinalDeclarationList
+  | 'static' 'const' type? staticFinalDeclarationList
+  | 'static' 'final' type? staticFinalDeclarationList
   | 'augment'? 'static' 'late' 'final' type? initializedIdentifierList
   | 'augment'? 'static' 'late'? varOrType initializedIdentifierList
   | 'covariant' 'late' 'final' type? identifierList

--- a/working/augmentation-libraries/feature-specification.md
+++ b/working/augmentation-libraries/feature-specification.md
@@ -872,8 +872,8 @@ extensionTypeDeclaration ::= 'augment'? 'extension' 'type' 'const'? typeIdentifi
   '{' (metadata classMemberDeclaration)* '}'
 
 enumType ::= 'augment'? 'enum' typeIdentifier
-  typeParameters? mixins? interfaces? 
-  '{' enumEntry (',' enumEntry)* (',')? 
+  typeParameters? mixins? interfaces?
+  '{' enumEntry (',' enumEntry)* (',')?
   (';' (metadata classMemberDeclaration)*)? '}'
 
 typeAlias ::= 'augment'? 'typedef' typeIdentifier typeParameters? '=' type ';'

--- a/working/augmentation-libraries/feature-specification.md
+++ b/working/augmentation-libraries/feature-specification.md
@@ -850,7 +850,7 @@ topLevelDeclaration ::= classDeclaration
   | 'augment'? functionSignature functionBody
   | 'augment'? getterSignature functionBody
   | 'augment'? setterSignature functionBody
-  | ('final' | 'const') type? staticFinalDeclarationList ';'
+  | 'augment'? ('final' | 'const') type? staticFinalDeclarationList ';'
   | 'augment'? 'late' 'final' type? initializedIdentifierList ';'
   | 'augment'? 'late'? varOrType initializedIdentifierList ';'
 
@@ -891,11 +891,11 @@ declaration ::= 'external' factoryConstructorSignature
   | 'external' ('static'? finalVarOrType | 'covariant' varOrType) identifierList
   | 'external'? operatorSignature
   | 'abstract' (finalVarOrType | 'covariant' varOrType) identifierList
-  | 'static' 'const' type? staticFinalDeclarationList
-  | 'static' 'final' type? staticFinalDeclarationList
+  | 'augment'? 'static' 'const' type? staticFinalDeclarationList
+  | 'augment'? 'static' 'final' type? staticFinalDeclarationList
   | 'augment'? 'static' 'late' 'final' type? initializedIdentifierList
   | 'augment'? 'static' 'late'? varOrType initializedIdentifierList
-  | 'covariant' 'late' 'final' type? identifierList
+  | 'augment'? 'covariant' 'late' 'final' type? identifierList
   | 'augment'? 'covariant' 'late'? varOrType initializedIdentifierList
   | 'augment'? 'late'? 'final' type? initializedIdentifierList
   | 'augment'? 'late'? varOrType initializedIdentifierList

--- a/working/augmentation-libraries/feature-specification.md
+++ b/working/augmentation-libraries/feature-specification.md
@@ -830,7 +830,7 @@ TODO: Create special augmentation grammar, similar to library/part files?
 
 ```
 libraryName ::= metadata 'augment'? 'library'
-    ( dottedIdentifierList |  uri ) ';'
+    ( dottedIdentifierList? |  uri ) ';'
 ```
 
 In an augmentation, the grammar is slightly modified to allow an `augment`
@@ -840,11 +840,13 @@ modifier before various declarations:
 topLevelDeclaration ::= classDeclaration
   | mixinDeclaration
   | extensionDeclaration
+  | extensionTypeDeclaration
   | enumType
   | typeAlias
   | 'external' functionSignature ';'
   | 'external' getterSignature ';'
   | 'external' setterSignature ';'
+  | 'external' finalVarOrType identifierList ';'
   | 'augment'? functionSignature functionBody
   | 'augment'? getterSignature functionBody
   | 'augment'? setterSignature functionBody
@@ -852,12 +854,30 @@ topLevelDeclaration ::= classDeclaration
   | 'augment'? 'late' 'final' type? initializedIdentifierList ';'
   | 'augment'? 'late'? varOrType initializedIdentifierList ';'
 
-classDeclaration ::=
-  'augment'? 'abstract'? 'class' identifier typeParameters?
-  // Rest of rule...
+classDeclaration ::= 'augment'? (classModifiers | mixinClassModifiers)
+    'class' typeWithParameters superclass? interfaces?
+    '{' (metadata classMemberDeclaration)* '}'
+  | 'augment'? classModifiers 'mixin'? 'class' mixinApplicationClass
 
-mixinDeclaration ::= 'augment'? 'mixin' identifier typeParameters?
-  // Rest of rule...
+mixinDeclaration ::= 'augment'? 'base'? 'mixin' typeIdentifier
+  typeParameters? ('on' typeNotVoidNotFunctionList)? interfaces?
+  '{' (metadata mixinMemberDeclaration)* '}'
+
+extensionDeclaration ::= 'augment'? 'extension' typeIdentifierNotType?
+  typeParameters? 'on' type
+  '{' (metadata classMemberDeclaration)* '}'
+
+extensionTypeDeclaration ::= 'augment'? 'extension' 'type' 'const'? typeIdentifier
+  typeParameters? representationDeclaration interfaces?
+  '{' (metadata classMemberDeclaration)* '}'
+
+enumType ::= 'augment'? 'enum' typeIdentifier
+  typeParameters? mixins? interfaces? 
+  '{' enumEntry (',' enumEntry)* (',')? 
+  (';' (metadata classMemberDeclaration)*)? '}'
+
+typeAlias ::= 'augment'? 'typedef' typeIdentifier typeParameters? '=' type ';'
+  | 'augment'? 'typedef' functionTypeAlias
 
 classMemberDeclaration ::= declaration ';'
   | 'augment'? methodSignature functionBody
@@ -868,11 +888,14 @@ declaration ::= 'external' factoryConstructorSignature
   | ('external' 'static'?)? getterSignature
   | ('external' 'static'?)? setterSignature
   | ('external' 'static'?)? functionSignature
+  | 'external' ('static'? finalVarOrType | 'covariant' varOrType) identifierList
   | 'external'? operatorSignature
+  | 'abstract' (finalVarOrType | 'covariant' varOrType) identifierList
   | 'augment'? 'static' 'const' type? staticFinalDeclarationList
   | 'augment'? 'static' 'final' type? staticFinalDeclarationList
   | 'augment'? 'static' 'late' 'final' type? initializedIdentifierList
   | 'augment'? 'static' 'late'? varOrType initializedIdentifierList
+  | 'covariant' 'late' 'final' type? identifierList
   | 'augment'? 'covariant' 'late'? varOrType initializedIdentifierList
   | 'augment'? 'late'? 'final' type? initializedIdentifierList
   | 'augment'? 'late'? varOrType initializedIdentifierList
@@ -992,6 +1015,11 @@ consider removing support for part files entirely, which would simplify the
 language and our tools.
 
 ## Changelog
+
+## 1.16
+
+*   Update grammar rules and add support for augmented type declarations of
+    all kinds (class, mixin, extension, extension type, enum, typedef).
 
 ## 1.15
 


### PR DESCRIPTION
This PR updates various grammar rules of the augmentation library feature specification. In particular, it adds rules to specify augmented extension, extension type, and enumerated declarations, and it makes several adjustments to the `topLevelDecrlaration` and `declaration` derivation rules in order to be up to date with other features.
