### PR TITLE
Augmentation grammar: Adjust `libraryName` and remove `methodSignature` rule

### DIFF
--- a/working/augmentation-libraries/feature-specification.md
+++ b/working/augmentation-libraries/feature-specification.md
@@ -829,8 +829,10 @@ as an augmentation:
 TODO: Create special augmentation grammar, similar to library/part files?
 
 ```
-libraryName ::= metadata 'augment'? 'library'
-    ( dottedIdentifierList? |  uri ) ';'
+libraryName ::= metadata libraryNameBody ';'
+
+libraryNameBody ::= 'library' dottedIdentifierList?
+  | 'augment' 'library' uri
 ```
 
 In an augmentation, the grammar is slightly modified to allow an `augment`
@@ -839,8 +841,8 @@ modifier before various declarations:
 ```
 topLevelDeclaration ::= classDeclaration
   | mixinDeclaration
-  | extensionDeclaration
   | extensionTypeDeclaration
+  | extensionDeclaration
   | enumType
   | typeAlias
   | 'external' functionSignature ';'
@@ -902,14 +904,6 @@ declaration ::= 'external' factoryConstructorSignature
   | 'augment'? redirectingFactoryConstructorSignature
   | 'augment'? constantConstructorSignature (redirection | initializers)?
   | 'augment'? constructorSignature (redirection | initializers)?
-
-methodSignature ::= constructorSignature initializers?
-  | factoryConstructorSignature
-  | 'augment'? 'static'? functionSignature
-  | 'augment'? 'static'? getterSignature
-  | 'augment'? 'static'? setterSignature
-  | 'augment'? operatorSignature
-
 ```
 
 **TODO: Define the grammar for the various `augmented` expressions.**


### PR DESCRIPTION
Just noted a couple of places where I think the augmentation grammar should be adjusted. We used to have this:

```ebnf
libraryName ::= metadata 'augment'? 'library'
    ( dottedIdentifierList? |  uri ) ';'
```

but that allows for things like `library 'package:whatever/whatever.dart';` which is not useful. So I adjusted the rule to allow the `uri` with an `augment library` and not with a plain `library`.

I removed the rule for `methodSignature` because it only changed by having `'augment'?` in some alternatives, but `classMemberDefinition` already has `'augment'?` in front of `methodSignature`, and we don't need to allow two occurrences of `augment` on the same declaration.

Finally, I swapped the alternatives for `extensionDeclaration` and `extensionTypeDeclaration` in the `topLevelDeclaration` rule, to match the approach taken in `Dart.g` (we may as well parse `extension type ...` as an extension type rather than trying to make it an `extension` named `type`, and then retrying).
