### PR TITLE
Specify errors about wrong `import augment`/`import` structures

### DIFF
--- a/working/augmentation-libraries/feature-specification.md
+++ b/working/augmentation-libraries/feature-specification.md
@@ -1038,6 +1038,12 @@ language and our tools.
 
 ## Changelog
 
+## 1.17
+
+*   Introduce compile-time errors about wrong structures in the graph of
+    libraries and augmentation libraries formed by directives like `import`
+    and `import augment`.
+
 ## 1.16
 
 *   Update grammar rules and add support for augmented type declarations of

--- a/working/augmentation-libraries/feature-specification.md
+++ b/working/augmentation-libraries/feature-specification.md
@@ -145,9 +145,16 @@ It is a compile-time error if:
 *   A library augmentation contains a normal `library` directive. They are not
     self-contained libraries, only pieces of the augmented library.
 
-*   There is a cycle in the graph whose edges are the `import augment` 
-    directives of an augmented library and any augmentation library which is
-    directly or indirectly reachable from there via said edges.
+*   An `import augment` directive has a `<uri>` that denotes an entity which
+    is not an augmentation library. *For example, it can not be a library.*
+    
+*   An `import` (not `import augment`) directive has a `<uri>` that denotes
+    an entity which is not a library. *For example, it cannot be an 
+    augmentation library.*
+
+*   There is a cycle in the graph whose edges are the `import augment`
+    directives of an augmented library and of any augmentation libraries which
+    are directly or indirectly reachable from there via said edges.
 
 ### Applying an augmentation
 

--- a/working/augmentation-libraries/feature-specification.md
+++ b/working/augmentation-libraries/feature-specification.md
@@ -145,6 +145,10 @@ It is a compile-time error if:
 *   A library augmentation contains a normal `library` directive. They are not
     self-contained libraries, only pieces of the augmented library.
 
+*   There is a cycle in the graph whose edges are the `import augment` 
+    directives of an augmented library and any augmentation library which is
+    directly or indirectly reachable from there via said edges.
+
 ### Applying an augmentation
 
 A library applies an augmentation to itself using a new import directive with

--- a/working/augmentation-libraries/feature-specification.md
+++ b/working/augmentation-libraries/feature-specification.md
@@ -146,11 +146,11 @@ It is a compile-time error if:
     self-contained libraries, only pieces of the augmented library.
 
 *   An `import augment` directive has a `<uri>` that denotes an entity which
-    is not an augmentation library. *For example, it can not be a library.*
-    
-*   An `import` (not `import augment`) directive has a `<uri>` that denotes
-    an entity which is not a library. *For example, it cannot be an 
-    augmentation library.*
+    is not a library augmentation. *For example, it can not be a library.*
+
+*   An `export` or `import` (not `import augment`) refers to an entity which
+    is not a library. *For example, it cannot be a library augmentation or
+    a part file.*
 
 *   There is a cycle in the graph whose edges are the `import augment`
     directives of an augmented library and of any augmentation libraries which
@@ -1042,7 +1042,7 @@ language and our tools.
 
 *   Introduce compile-time errors about wrong structures in the graph of
     libraries and augmentation libraries formed by directives like `import`
-    and `import augment`.
+    and `import augment` (#3646).
 
 ## 1.16
 


### PR DESCRIPTION
Based on the response in https://github.com/dart-lang/language/issues/3646, this PR specifies a compile-time error which occurs if a main library _L_ which is being augmented along with all augmentation libraries _A<sub>1</sub> .. A<sub>k</sub>_ reachable from _L_ via one or more `import augment` links forms a graph that has a cycle.

This PR also makes it an error for a `<uri>` in an `import augment` directive to denote a regular library, it must be an augmentation library. This change is also based on #3646.

Finally, this PR makes it an error for a `<uri>` in a regular `import` directive (not `import augment`) to denote an entity which is not a library (including: it's an error if it is an augmentation library).
