### PR TITLE
Extension augment can't specify `on` and other clauses

### DIFF
--- a/working/augmentation-libraries/feature-specification.md
+++ b/working/augmentation-libraries/feature-specification.md
@@ -371,10 +371,10 @@ This means that instead of creating a new declaration, the augmentation modifies
 a corresponding declaration in the augmented library or one of its other
 augmentations.
 
-A class, enum, extension, extension type, or mixin augmentation may specify
-`extends`, `implements`, `on`, and `with` clauses (when generally supported).
-The types in these clauses are appended to the original declarations clauses of
-the same kind, and if that clause did not exist previously then it is added with
+A class, enum, extension type, or mixin augmentation may specify `extends`,
+`implements`, `on`, and `with` clauses (when generally supported). The types
+in these clauses are appended to the original declarations clauses of the same
+kind, and if that clause did not exist previously then it is added with
 the new types. All regular rules apply after this appending process, so you
 cannot have multiple `extends` on a class, or an `on` clause on an enum, etc.
 


### PR DESCRIPTION
It is a compile-time error for an extension augment to specify `on` clause. Extension also cannot specify `extends`, `implements` or `with` clauses, so it's unecessery in this list