### PR TITLE
Adjust terminology

### DIFF
--- a/working/augmentation-libraries/feature-specification.md
+++ b/working/augmentation-libraries/feature-specification.md
@@ -153,7 +153,7 @@ It is a compile-time error if:
     a part file.*
 
 *   There is a cycle in the graph whose edges are the `import augment`
-    directives of an augmented library and of any augmentation libraries which
+    directives of an augmented library and of any library augmentations which
     are directly or indirectly reachable from there via said edges.
 
 ### Applying an augmentation
@@ -314,7 +314,7 @@ It is a compile-time error if:
     apply to.
 
 *   An augmenting declaration appears in a library before the library where the
-    original declaration occurs, according to merge order. *An library
+    original declaration occurs, according to merge order. *A library
     augmentation can both declare a new declaration and augment it in the same
     file.*
 
@@ -1041,6 +1041,11 @@ consider removing support for part files entirely, which would simplify the
 language and our tools.
 
 ## Changelog
+
+## 1.19
+
+*   Change the phrase 'augmentation library' to 'library augmentation',
+    to be consistent with the rename which was done in 1.15.
 
 ## 1.18
 

--- a/working/augmentation-libraries/feature-specification.md
+++ b/working/augmentation-libraries/feature-specification.md
@@ -1034,11 +1034,11 @@ fairly often used by code generators because it gives generated code access to
 the main library's private namespace. However, it means that the generated part
 file cannot have its own imports.
 
-Library augmentation can do everything part files can do but also support their
-own imports and can modify members. With these, we can more strongly recommend
-the few users using them migrate to library augmentations. In Dart 4.0, we can
-consider removing support for part files entirely, which would simplify the
-language and our tools.
+Library augmentations can do everything part files can do but also support 
+their own imports and can modify members. With these, we can more strongly
+recommend the few users using them migrate to library augmentations. In Dart
+4.0, we can consider removing support for part files entirely, which would
+simplify the language and our tools.
 
 ## Changelog
 


### PR DESCRIPTION
Version 1.15 performed a rename such that the augmentations feature specification used 'library augmentation' rather than 'augmentation library'. This PR updates a couple of locations where the old terminology was used such that they also use the new terminology. The PR also fixes a couple of typos.