### PR TITLE
Add compile-time errors about `augmented`

### DIFF
--- a/working/augmentation-libraries/feature-specification.md
+++ b/working/augmentation-libraries/feature-specification.md
@@ -1,7 +1,7 @@
 # Augmentations
 
 Author: rnystrom@google.com, jakemac@google.com
-Version: 1.20 (see [Changelog](#Changelog) at end)
+Version: 1.21 (see [Changelog](#Changelog) at end)
 
 Augmentations allow spreading your implementation across multiple locations,
 both within a single file and across multiple files. They can add new top-level
@@ -458,6 +458,11 @@ It is a compile-time error if:
 
 *   The function augmentation specifies any default values. *Default values are
     defined solely by the original function.*
+
+*   An augmenting declaration uses `augmented` when the original declaration has
+    no concrete implementation. Note that all external declarations are assumed
+    to have an implementation provided by another external source, and they will
+    throw a runtime exception when called if not.
 
 **TODO: Should we allow augmenting functions to add parameters? If so, how does
 this interact with type checking calls to the function?**
@@ -1041,6 +1046,11 @@ recommend the few users using them migrate to library augmentations. In Dart
 simplify the language and our tools.
 
 ## Changelog
+
+## 1.21
+
+*   Add a compile-time error for `augmented(...)` whose target is abstract.
+
 
 ## 1.20
 

--- a/working/augmentation-libraries/feature-specification.md
+++ b/working/augmentation-libraries/feature-specification.md
@@ -379,6 +379,16 @@ occurs in a location where the outermost enclosing declaration is
 augmenting. *This error is applicable to all such declarations, e.g.,
 local functions, local variables, parameters, and type parameters.*
 
+A compile-time error occurs if `augmented` is used as an identifier
+expression in a non-augmenting declaration of a kind that can be augmenting
+inside an augmenting declaration.
+
+*For example, inside `augment class C` we could have a declaration like
+`void f() {...augmented()...}`. 
+This is an error because the outer `augment` forces the meaning of `augmented`
+to be about augmentation in the entire scope, but the method declaration is an
+introduction, not an augmentation.*
+
 ### Augmenting types
 
 A class, enum, extension, extension type, or mixin declaration can be marked

--- a/working/augmentation-libraries/feature-specification.md
+++ b/working/augmentation-libraries/feature-specification.md
@@ -384,7 +384,7 @@ declaration, of a kind that can be augmenting, inside an augmenting
 declaration.
 
 *For example, inside `augment class C` we could have a declaration like
-`void f() {...augmented()...}`. 
+`void f() {...augmented()...}`.
 This is an error because the outer `augment` forces the meaning of `augmented`
 to be about augmentation in the entire scope, but the method declaration is an
 introduction, not an augmentation.*
@@ -610,28 +610,32 @@ It is a compile-time error if:
 
 *   The original and augmenting declarations do not have the same type.
 
-*   An augmenting declaration uses `augmented` when the original declaration has
-    no concrete implementation. Note that all external declarations are assumed
-    to have an implementation provided by another external source, and they will
-    throw a runtime exception when called if not.
+*   An augmenting declaration uses `augmented` when the original declaration
+    has no concrete implementation. Note that all external declarations are
+    assumed to have an implementation provided by another external source,
+    and they will throw a runtime exception when called if not.
 
-*   An augmenting initializer uses `augmented` and the augmented variable is not
-    a variable with an initializer.
+*   An augmenting initializer uses `augmented` and the augmented declaration
+    is not an initializing variable declaration.
 
-*   A final variable is augmented with a setter. (Instead, the augmentation
-    can declare a *non-augmenting* setter that goes alongside the implicit
-    getter defined by the final variable.)
+*   A final variable declaration is augmented with a setter declaration.
+    *Instead, the augmentation can declare a non-augmenting setter that
+    goes alongside the implicit getter defined by the final variable.*
 
-*   A non-final variable is augmented with a final variable. We don't want to
-    leave the original setter in a weird state.
+*   A non-final variable declaration is augmented with a final variable
+    declaration. *We don't want to leave the original setter declaration in
+    a weird state.*
 
-*  A `late` variable is augmented with a non-`late` variable.
+*   A `late` variable declaration is augmented with a non-`late` variable
+    declaration.
 
-*  A non-`late` variable is augmented with a `late` variable.
+*   A non-`late` variable declaration is augmented with a `late` variable
+    declaration.
 
-*  A getter or setter are augmented by a variable.
+*   A getter or setter declaration is augmented by a variable declaration.
 
-*  An abstract or external variable are augmented by a variable.
+*   An `abstract` or `external` variable declaration is augmented by a
+    variable declaration.
 
 ### Augmenting enum values
 
@@ -925,15 +929,15 @@ mixinDeclaration ::= 'augment'? 'base'? 'mixin' typeIdentifier
   typeParameters? ('on' typeNotVoidNotFunctionList)? interfaces?
   '{' (metadata mixinMemberDeclaration)* '}'
 
-extensionDeclaration ::= 
-    'extension' typeIdentifierNotType? typeParameters? 'on' type 
+extensionDeclaration ::=
+    'extension' typeIdentifierNotType? typeParameters? 'on' type
     extensionBody
-  | 'augment' 'extension' typeIdentifierNotType typeParameters? 
+  | 'augment' 'extension' typeIdentifierNotType typeParameters?
     extensionBody
 
 extensionBody ::= '{' (metadata classMemberDeclaration)* '}'
 
-extensionTypeDeclaration ::= 
+extensionTypeDeclaration ::=
   'augment'? 'extension' 'type' 'const'? typeIdentifier
   typeParameters? representationDeclaration interfaces?
   '{' (metadata classMemberDeclaration)* '}'
@@ -950,7 +954,7 @@ classMemberDeclaration ::= declaration ';'
   | 'augment'? methodSignature functionBody
 
 enumEntry ::= metadata 'augment'? identifier argumentPart?
-  | metadata 'augment'? identifier typeArguments? 
+  | metadata 'augment'? identifier typeArguments?
     '.' identifierOrNew arguments
 
 declaration ::= 'external' factoryConstructorSignature
@@ -1072,7 +1076,7 @@ fairly often used by code generators because it gives generated code access to
 the main library's private namespace. However, it means that the generated part
 file cannot have its own imports.
 
-Library augmentations can do everything part files can do but also support 
+Library augmentations can do everything part files can do but also support
 their own imports and can modify members. With these, we can more strongly
 recommend the few users using them migrate to library augmentations. In Dart
 4.0, we can consider removing support for part files entirely, which would

--- a/working/augmentation-libraries/feature-specification.md
+++ b/working/augmentation-libraries/feature-specification.md
@@ -356,15 +356,28 @@ augmented, but it generally follows the same rules as any normal identifier:
 In all relevant cases, if the augmented member is an instance member, it is
 invoked with the same value for `this`.
 
-Assume that the identifier `augmented` occurs in a scope which is not
-an augmenting declaration. In this case, the treatment of this identifier
-follows all the normal rules.
+Assume that the identifier `augmented` occurs such that the outermost
+enclosing declaration is not an augmenting declaration. In this case, the
+identifier is taken to be a reference to a declaration which is in scope.
 
-*For example, `augmented` could be an unknown identifier, or it could be the
-name of a function declaration in scope, and the static analysis and dynamic
-semantics follows all the normal rules for such situations. We could say that
-`augmented` is a contextual keyword because it gets a special treatment when 
-it occurs inside an augmenting declaration, but only there.*
+*In other words, `augmented` is just a normal identifier when it occurs
+anywhere other than inside an augmented declaration.*
+
+*Note that, for example, `augmented()` is an invocation of the augmented
+function or method when it occurs in an augmenting function or method
+declaration. (In the latter case, the augmenting method declaration must
+occur inside an augmenting type-introducing declaration, e.g., an
+augmenting class or mixin declaration). This is also true if `augmented()`
+occurs inside a local function declaration inside the body of that function
+or method declaration. We could say that `augmented` is a contextual
+keyword because it is unable to refer to a declaration in scope when it
+occurs inside an augmenting declaration, it always has the special meaning
+which is associated with augmentations.*
+
+A compile-time error occurs if a declaration with the name `augmented`
+occurs in a location where the outermost enclosing declaration is
+augmenting. *This error is applicable to all such declarations, e.g.,
+local functions, local variables, parameters, and type parameters.*
 
 ### Augmenting types
 

--- a/working/augmentation-libraries/feature-specification.md
+++ b/working/augmentation-libraries/feature-specification.md
@@ -379,9 +379,9 @@ occurs in a location where the outermost enclosing declaration is
 augmenting. *This error is applicable to all such declarations, e.g.,
 local functions, local variables, parameters, and type parameters.*
 
-A compile-time error occurs if `augmented` is used as an identifier
-expression in a non-augmenting declaration of a kind that can be augmenting
-inside an augmenting declaration.
+A compile-time error occurs if `augmented` occurs in a non-augmenting
+declaration, of a kind that can be augmenting, inside an augmenting
+declaration.
 
 *For example, inside `augment class C` we could have a declaration like
 `void f() {...augmented()...}`. 

--- a/working/augmentation-libraries/feature-specification.md
+++ b/working/augmentation-libraries/feature-specification.md
@@ -321,7 +321,7 @@ It is a compile-time error if:
 ### Augmented Expression
 
 The exact result of an `augmented` expression depends on what is being
-augmented, but it follows generally the same rules as any normal identifier:
+augmented, but it generally follows the same rules as any normal identifier:
 
 *   **Augmenting getters**: Within an augmenting getter `augmented` invokes the
     getter and evaluates to the return value. If augmenting a field with a
@@ -355,6 +355,16 @@ augmented, but it follows generally the same rules as any normal identifier:
 
 In all relevant cases, if the augmented member is an instance member, it is
 invoked with the same value for `this`.
+
+Assume that the identifier `augmented` occurs in a scope which is not
+an augmenting declaration. In this case, the treatment of this identifier
+follows all the normal rules.
+
+*For example, `augmented` could be an unknown identifier, or it could be the
+name of a function declaration in scope, and the static analysis and dynamic
+semantics follows all the normal rules for such situations. We could say that
+`augmented` is a contextual keyword because it gets a special treatment when 
+it occurs inside an augmenting declaration, but only there.*
 
 ### Augmenting types
 
@@ -1050,6 +1060,8 @@ simplify the language and our tools.
 ## 1.21
 
 *   Add a compile-time error for `augmented(...)` whose target is abstract.
+*   Add a compile-time error for `augmented(...)` that occurs in a
+    declaration that isn't augmenting.
 
 
 ## 1.20

--- a/working/augmentation-libraries/feature-specification.md
+++ b/working/augmentation-libraries/feature-specification.md
@@ -1082,10 +1082,7 @@ simplify the language and our tools.
 
 ## 1.21
 
-*   Add a compile-time error for `augmented(...)` whose target is abstract.
-*   Add a compile-time error for `augmented(...)` that occurs in a
-    declaration that isn't augmenting.
-
+*   Add a compile-time errors for wrong usages of `augmented`.
 
 ## 1.20
 


### PR DESCRIPTION
This PR adds a compile-time error to the feature specification about augmentations. See https://github.com/dart-lang/language/issues/3702 for some background.

The newly specified error occurs when a function augmentation body contains `augmented(...)`, and the augmented declaration has no implementation, for example:

```dart
// Library 'main.dart'.
import augment 'augment.dart';

class C {
  void f(); // Allowed when implemented in an augmentation.
}

// Library augmentation 'augment.dart'.
augment library 'main.dart';

augment class C {
  augment void f() {
    augmented(); // Compile-time error (not today, but if this PR is landed).
  }
}
```

I do not think there is any other reasonable response than reporting a compile-time error:

Another option could be to allow this at compile time and throw at run time (just like some superinvocations involving mixins), but that would contradict the trend in several years of evolution of Dart.

A third option would be to allow the invocation, and make it do nothing. However, this is not compatible with the fact that `augmented` could have a return type which is non-trivial (such that we can't "invent" an object with the required type).

Update: I added some extra rules about `augmented`: It should be an error to declare anything (a parameter, a local variable, a local function, etc.) named `augmented` in a scope where the meaning of `augmented` is that it refers to the augmented entity in the context of an augmentation. I also mentioned explicitly that there is nothing special about the word `augmented` for occurrences that are not inside an augmenting declaration.

The approach I've used is to say that `augmented` has the special augmentation-related meaning whenever it occurs inside an augmenting declaration. For instance, `augmented()` is an invocation of the augmented method in an augmenting method declaration (and it is an error inside a non-augmenting method declaration inside an augmenting class declaration). Also no declaration in the scope of an augmenting declaration can have the name `augmented`, not even inside a non-augmenting declaration which is again inside an augmenting declaration.

But for an occurrence of `augmented` which isn't inside any augmenting (directly or indirectly enclosing) declarations, the static analysis and dynamic semantics is standard: This is just an identifier, and it may or may not refer to a declaration which is in scope, and there's nothing special about the treatment of a reference to such a declaration when it has the name `augmented` vs. when it has any other name.
