### PR TITLE
fix link to macro API docs

### DIFF
--- a/working/macros/feature-specification.md
+++ b/working/macros/feature-specification.md
@@ -646,7 +646,7 @@ constructors are invoked, and their limitations.
 
 *Note: The Macro API is still being designed, and lives [here][API].*
 
-[API]: https://github.com/dart-lang/sdk/blob/main/pkg/_fe_analyzer_shared/lib/src/macros/api.dart
+[API]: https://github.com/dart-lang/sdk/tree/main/pkg/_macros/lib/src/api.dart
 
 ### Writing a Macro
 


### PR DESCRIPTION
fixes https://github.com/dart-lang/language/issues/3709