### PR TITLE
Add rules about super and extension types to wildcard spec

### DIFF
--- a/working/wildcards/feature-specification.md
+++ b/working/wildcards/feature-specification.md
@@ -208,7 +208,7 @@ quite confusing. In practice, we expect reasonable users will not name fields
 
 ### Initializing formals
 
-A positional initializing formal named `_` does still initialize a field 
+A positional initializing formal named `_` does still initialize a field
 named `_` (and you can still have a field with that name):
 
 ```dart
@@ -226,7 +226,7 @@ error for a named formal parameter to have a name that starts with `_`.*
 ```dart
 class C {
   var _;
-  
+
   C({this._}); // Error.
 }
 ```
@@ -318,26 +318,6 @@ extension type E(int _) {
 However, future generalizations such as primary constructors could
 introduce it into a scope. At that time it does matter that there is no
 formal parameter name.*
-
-```dart
-// Hypothetical example using primary constructors with support for
-// superconstructor invocations in the header.
-
-class A {
-  A(int i) {
-    print(i);
-  }
-}
-
-class B(int x) extends A(x + 1);
-```
-
-*In this example, `(int x)` would work like a `<representationDeclaration>`
-in an extension type (introducing an instance variable named `x` as well as
-a constructor with one positional parameter), but it also refers to the
-parameter `x` in the invocation of the superconstructor which is denoted by
-the syntax `A(x + 1)`. If `x` is renamed to `_` then the superconstructor
-invocation can't refer to it.*
 
 ### Unused variable warnings
 

--- a/working/wildcards/feature-specification.md
+++ b/working/wildcards/feature-specification.md
@@ -219,7 +219,9 @@ class C {
 }
 ```
 
-It is a compile-time error if a named initializing formal has the name `_`:
+*Note that it is already a compile-time error if a named initializing
+formal has the name `_`. This is a special case of the rule that it is an
+error for a named formal parameter to have a name that starts with `_`.*
 
 ```dart
 class C {


### PR DESCRIPTION
This PR adds rules to the wildcards feature specification about super parameters of the form `super._`, and about representation declarations in extension types whose representation variable name is `_`.

In particular, `super._` is an error because super parameters that can't be referenced from the initializer list are inherently broken. In contrast, `extension type E(int _) {}` is allowed: The representation variable name will be `_` and the formal parameter will be inaccessible (which makes no difference at this time, but will matter if a more general primary constructors feature is introduced).
