### PR TITLE
[wildcard-variables] Fix typo in 'imports' example.

### DIFF
--- a/working/wildcards/feature-specification.md
+++ b/working/wildcards/feature-specification.md
@@ -166,7 +166,7 @@ because the function is unreachable.
 
 ```dart
 // a.dart
-extension on String {
+extension MyString on String {
   bool get isBlank => trim().isEmpty;
 }
 ```
@@ -181,7 +181,7 @@ main() {
 ```
 
 Import prefixes named `_` are non-binding and will provide access to the
-extensions in that library.
+non-private extensions in that library.
 
 ### Other declarations
 

--- a/working/wildcards/feature-specification.md
+++ b/working/wildcards/feature-specification.md
@@ -180,7 +180,7 @@ main() {
 }
 ```
 
-Import prefixes named `_` are non-binding and will provide access to the
+Import prefixes named `_` are non-binding but will provide access to the
 non-private extensions in that library.
 
 ### Other declarations

--- a/working/wildcards/feature-specification.md
+++ b/working/wildcards/feature-specification.md
@@ -166,7 +166,7 @@ because the function is unreachable.
 
 ```dart
 // a.dart
-extension MyString on String {
+extension ExtendedString on String {
   bool get isBlank => trim().isEmpty;
 }
 ```


### PR DESCRIPTION
Unnamed (and private) extensions are non visible after the import. To make the example valid an extension should have a name