### PR TITLE
Update the primary constructors proposal

### DIFF
--- a/working/2364 - primary constructors/feature-specification.md
+++ b/working/2364 - primary constructors/feature-specification.md
@@ -249,10 +249,6 @@ class Point {
 class Point(int x, {required int y});
 ```
 
-In this declaration it is possible to omit the modifier `required` on the
-named parameter `y`, because it is implied by the fact that the type of `y`
-is non-nullable (potentially non-nullable is enough).
-
 The class header can have additional elements, just like class headers
 where there is no primary constructor:
 
@@ -416,9 +412,7 @@ parameters preserve the name and the modifier `required`, if any.  An
 optional positional or named parameter remains optional; if it has a
 default value `d` in _L_ then it has the transformed default value `_n` in
 _L2_, where `_n` is the name of the constant variable created for that
-default value. Finally, if `p` is an optional named parameter in _L_ with
-no default value whose type is potentially non-nullable then `required` is
-added to `p` in _L2_.
+default value.
 
 - An initializing formal parameter *(e.g., `this.x`)* is copied from _L_ to
   _L2_, using said transformed default value, if any, and otherwise
@@ -594,15 +588,15 @@ class E extends A {
   final List<String> w;
 
   primary E({
-    LongTypeExpression x1,
-    LongTypeExpression x2,
-    LongTypeExpression x3,
-    LongTypeExpression x4,
-    LongTypeExpression x5,
-    LongTypeExpression x6,
-    LongTypeExpression x7,
-    LongTypeExpression x8,
-    this.y,
+    required LongTypeExpression x1,
+    required LongTypeExpression x2,
+    required LongTypeExpression x3,
+    required LongTypeExpression x4,
+    required LongTypeExpression x5,
+    required LongTypeExpression x6,
+    required LongTypeExpression x7,
+    required LongTypeExpression x8,
+    required this.y,
   }) : z = 1,
        w = const <Never>[],
        super('Something') {
@@ -610,6 +604,12 @@ class E extends A {
   }
 }
 ```
+
+We may get rid of all those occurrences of `required` in the situation
+where it is a compile-time error to not have them, but that is a 
+[separate proposal][inferred-required].
+
+[inferred-required]: https://github.com/dart-lang/language/blob/main/working/0015-infer-required/feature-specification.md
 
 ### Changelog
 

--- a/working/2364 - primary constructors/feature-specification.md
+++ b/working/2364 - primary constructors/feature-specification.md
@@ -101,9 +101,7 @@ and normal instance variable declarations, and it is probably a useful property
 that the primary constructor uses a formal parameter syntax which is completely
 like that of any other formal parameter list.
 
-Just use a normal declaration and use an initializing formal in a primary
-constructor to initialize it from the primary constructor, if needed.  An
-`external` instance variable amounts to an `external` getter and an
+An `external` instance variable amounts to an `external` getter and an
 `external` setter. Such "variables" cannot be initialized by an
 initializing formal anyway, so they will just need to be declared using a
 normal `external` variable declaration.
@@ -276,32 +274,32 @@ for extension type declarations, because they're intended to use primary
 constructors as well.
 
 ```
-<topLevelDefinition> ::=
-     <classDeclaration>
-   | <extensionTypeDeclaration> // New alternative.
-   | ...;
-
 <classDeclaration> ::= // First alternative modified.
      (<classModifiers> | <mixinClassModifiers>)
      'class' <classNamePart> <superclass>? <interfaces>? <classBody>
    | ...;
 
-<classNamePart> ::= // New rule.
-     'const'? <constructorName> <typeParameters>? <formalParameterList>
+<primaryConstructorNoConst> ::= // New rule.
+     <typeIdentifier> <typeParameters>?
+     ('.' <identifierOrNew>)? <formalParameterList>
+   
+<classNamePartNoConst> ::= // New rule.
+     <primaryConstructorNoConst>
    | <typeWithParameters>;
+   
+<classNamePart> ::= // New rule.
+     'const'? <primaryConstructorNoConst>
+   | <typeWithParameters>;
+   
+<typeWithParameters> ::= <typeIdentifier> <typeParameters>?
 
 <classBody> ::= // New rule.
      '{' (<metadata> <classMemberDeclaration>)* '}'
    | ';';
 
-<extensionTypeDeclaration> ::=
-     'extension' 'type' 'const'? <typeWithParameters>
-     <representationDeclaration>
-     <interfaces>?
+<extensionTypeDeclaration> ::= // Modified rule.
+     'extension' 'type' <classNamePartNoConst> <interfaces>?
      <extensionTypeBody>;
-
-<representationDeclaration> ::=
-     ('.' <identifierOrNew>)? '(' <metadata> <type> <identifier> ')';
 
 <extensionTypeMemberDeclaration> ::= <classMemberDeclaration>;
 
@@ -310,17 +308,11 @@ constructors as well.
    | ';';
 
 <enumType> ::= // Modified rule.
-     'enum' <classNamePart> <mixins>? <interfaces>? '{'
+     'enum' <classNamePartNoConst> <mixins>? <interfaces>? '{'
         <enumEntry> (',' <enumEntry>)* (',')?
         (';' (<metadata> <classMemberDeclaration>)*)?
      '}';
 ```
-
-The word `type` is now used in the grammar, but it is not a reserved word
-or a built-in identifier. A parser that encounters the tokens `extension`
-and then `type` at a location where top-level declaration is expected shall
-commit to parsing it as an `<extensionTypeDeclaration>`. *This eliminates
-an ambiguity with `extension` (not `extension type`) declarations.*
 
 A class declaration whose class body is `;` is treated as a class declaration
 whose class body is `{}`.
@@ -400,8 +392,8 @@ then _k_ has the name `C`.
 If it exists, _D2_ omits the part derived from `'.' <identifierOrNew>` that
 follows the name and type parameter list, if any, in _D_.
 
-_D2_ omits the formal parameter list _L_ that follows the name, type
-parameter list, if any, and `.id`, if any.
+Moreover, _D2_ omits the formal parameter list _L_ that follows the name,
+type parameter list, if any, and `.id`, if any.
 
 The formal parameter list _L2_ of _k_ is identical to _L_, except that each
 formal parameter is processed as follows.
@@ -490,11 +482,6 @@ text. Also, it could be helpful to be able to search for the named
 constructor using `D.named`, and that would fail if we use the approach
 where it occurs as `new.named` or `const.named` because that particular
 constructor has been expressed as a primary constructor.
-
-A variant of this idea, from Leaf, is that we could allow one constructor
-in a class with no primary constructor in the header to be marked as a
-"primary constructor in the body". This proposal has now been made part
-of the proposal.
 
 A proposal which was mentioned during the discussions about primary
 constructors was that the keyword `final` could be used in order to specify

--- a/working/2364 - primary constructors/feature-specification.md
+++ b/working/2364 - primary constructors/feature-specification.md
@@ -13,11 +13,6 @@ one constructor and a set of instance variables to be specified in a concise
 form in the header of the declaration. In order to use this feature, the given
 constructor must satisfy certain constraints, e.g., it cannot have a body.
 
-A primary constructor can also be declared in the body of a class or
-similar declaration, using the modifier `primary`, in which case it can
-have an initializer list and a body, and it still has the ability to
-introduce instance variable declarations implicitly.
-
 One variant of this feature has been proposed in the [struct proposal][],
 several other proposals have appeared elsewhere, and prior art exists in
 languages like [Kotlin][kotlin primary constructors] and Scala (with
@@ -270,92 +265,10 @@ class D<TypeVariable extends Bound> extends A with M implements B, C {
 }
 
 // Using a primary constructor.
-class const D<TypeVariable extends Bound>.named(int x, [int y = 0])
-    extends A with M implements B, C;
-```
-
-In the case where the header gets unwieldy it is possible to declare the
-primary constructor in the body of the class using the `primary` keyword:
-
-```dart
-// Current syntax.
-class D<TypeVariable extends Bound> extends A with M implements B, C {
-  final int x;
-  final int y;
-  const D.named(this.x, [this.y = 0]);
-}
-
-// Using a primary constructor.
-class D<TypeVariable extends Bound> extends A with M implements B, C {
-  primary const D.named(int x, [int y = 0]);
-}
-```
-
-This approach offers more flexibility in that a primary constructor in the
-body of the declaration can have initializers and a body, just like other
-constructors. In other words, `primary` on a constructor has one effect
-only, which is to introduce instance variables for formal parameters in the
-same way as a primary constructor in the header of the declaration. For
-example:
-
-```dart
-// Current syntax.
-class A {
-  A(String _);
-}
-
-class E extends A {
-  LongTypeExpression x1;
-  LongTypeExpression x2;
-  LongTypeExpression x3;
-  LongTypeExpression x4;
-  LongTypeExpression x5;
-  LongTypeExpression x6;
-  LongTypeExpression x7;
-  LongTypeExpression x8;
-  external int y;
-  int z;
-  final List<String> w;
-
-  E({
-    required this.x1,
-    required this.x2,
-    required this.x3,
-    required this.x4,
-    required this.x5,
-    required this.x6,
-    required this.x7,
-    required this.x8,
-    required this.y,
-  })  : z = 1,
-        w = const <Never>[],
-        super('Something') {
-    // A normal constructor body.
-  }
-}
-
-// Using a primary constructor.
-class E extends A {
-  external int y;
-  int z;
-  final List<String> w;
-
-  primary E({
-    LongTypeExpression x1,
-    LongTypeExpression x2,
-    LongTypeExpression x3,
-    LongTypeExpression x4,
-    LongTypeExpression x5,
-    LongTypeExpression x6,
-    LongTypeExpression x7,
-    LongTypeExpression x8,
-    this.y,
-  })  : z = 1,
-        w = const <Never>[],
-        super('Something') {
-    // A normal constructor body.
-  }
-}
+class const D<TypeVariable extends Bound>.named(
+  int x, [
+  int y = 0
+]) extends A with M implements B, C;
 ```
 
 ## Specification
@@ -405,18 +318,6 @@ constructors as well.
         <enumEntry> (',' <enumEntry>)* (',')?
         (';' (<metadata> <classMemberDeclaration>)*)?
      '}';
-
-<methodSignature> ::=
-     'primary'? <constructorSignature> <initializers>
-   | 'primary'? <factoryConstructorSignature>
-   | ... // Other cases unchanged.
-   | 'primary'? <constructorSignature>;
-
-<declaration> ::=
-     ... // Other cases unchanged.
-   | 'primary'? <redirectingFactoryConstructorSignature>
-   | 'primary'? <constantConstructorSignature> (<redirection> | <initializers>)?
-   | 'primary'? <constructorSignature> (<redirection> | <initializers>)?;
 ```
 
 The word `type` is now used in the grammar, but it is not a reserved word
@@ -445,10 +346,6 @@ it's just a syntax error)*. This declaration is desugared to a class or
 extension type declaration without a primary constructor. An enum
 declaration with a primary constructor is desugared using the same
 steps. This determines the dynamic semantics of a primary constructor.
-
-A compile-time error occurs if a class, extension type, or enum declaration
-has a primary constructor in the header as well as a constructor with the
-modifier `primary` in the body.
 
 The following errors apply to formal parameters of a primary constructor.
 Let _p_ be a formal parameter of a primary constructor in a class `C`:
@@ -543,13 +440,6 @@ added to `p` in _L2_.
 
 Finally, _k_ is added to _D2_, and _D_ is replaced by _D2_.
 
-Assume that _D_ is a class, extension type, or enum declaration in the
-program that includes a constructor declaration _k_ in the body which has
-the modifier `primary`. In this case, no transformations are applied to the
-default values of formal parameters of _k_, but otherwise the formal
-parameters of _k_ are processed in the same way as they are with a primary
-constructor in the declaration header.
-
 ### Discussion
 
 It could be argued that primary constructors should support arbitrary
@@ -635,7 +525,97 @@ class Point {
 class final Point(int x, int y); // Not supported!
 ```
 
+Finally, we could allow a primary constructor to be declared in the body of
+a class or similar declaration, using the modifier `primary`, in which case
+it could have an initializer list and a body, and it would still have the
+ability to introduce instance variable declarations implicitly:
+
+```dart
+// Current syntax.
+class D<TypeVariable extends Bound> extends A with M implements B, C {
+  final int x;
+  final int y;
+  const D.named(this.x, [this.y = 0]);
+}
+
+// Using a primary constructor in the class body.
+class D<TypeVariable extends Bound> extends A with M implements B, C {
+  primary const D.named(int x, [int y = 0]);
+}
+```
+
+This approach offers more flexibility in that a primary constructor in the
+body of the declaration can have initializers and a body, just like other
+constructors. In other words, `primary` on a constructor has one effect
+only, which is to introduce instance variables for formal parameters in the
+same way as a primary constructor in the header of the declaration. For
+example:
+
+```dart
+// Current syntax.
+class A {
+  A(String _);
+}
+
+class E extends A {
+  LongTypeExpression x1;
+  LongTypeExpression x2;
+  LongTypeExpression x3;
+  LongTypeExpression x4;
+  LongTypeExpression x5;
+  LongTypeExpression x6;
+  LongTypeExpression x7;
+  LongTypeExpression x8;
+  external int y;
+  int z;
+  final List<String> w;
+
+  E({
+    required this.x1,
+    required this.x2,
+    required this.x3,
+    required this.x4,
+    required this.x5,
+    required this.x6,
+    required this.x7,
+    required this.x8,
+    required this.y,
+  })  : z = 1,
+        w = const <Never>[],
+        super('Something') {
+    // A normal constructor body.
+  }
+}
+
+// Using a primary constructor in the class body.
+class E extends A {
+  external int y;
+  int z;
+  final List<String> w;
+
+  primary E({
+    LongTypeExpression x1,
+    LongTypeExpression x2,
+    LongTypeExpression x3,
+    LongTypeExpression x4,
+    LongTypeExpression x5,
+    LongTypeExpression x6,
+    LongTypeExpression x7,
+    LongTypeExpression x8,
+    this.y,
+  }) : z = 1,
+       w = const <Never>[],
+       super('Something') {
+    // A normal constructor body.
+  }
+}
+```
+
 ### Changelog
+
+1.2 - May 24, 2024
+
+* Remove support for primary constructors in the body of a declaration.
 
 1.1 - August 22, 2023
 

--- a/working/2364 - primary constructors/feature-specification.md
+++ b/working/2364 - primary constructors/feature-specification.md
@@ -298,7 +298,7 @@ constructors as well.
    | ';';
 
 <extensionTypeDeclaration> ::= // Modified rule.
-     'extension' 'type' <classNamePartNoConst> <interfaces>?
+     'extension' 'type' <classNamePart> <interfaces>?
      <extensionTypeBody>;
 
 <extensionTypeMemberDeclaration> ::= <classMemberDeclaration>;

--- a/working/2364 - primary constructors/scripts/inline_class.json
+++ b/working/2364 - primary constructors/scripts/inline_class.json
@@ -1,5 +1,5 @@
 {
-  "isInline": true,
+  "isExtensionType": true,
   "name": "Point",
   "fields": [
     {

--- a/working/2364 - primary constructors/scripts/inline_const_class.json
+++ b/working/2364 - primary constructors/scripts/inline_const_class.json
@@ -1,5 +1,5 @@
 {
-  "isInline": true,
+  "isExtensionType": true,
   "name": "Point",
   "isConst": true,
   "fields": [

--- a/working/2364 - primary constructors/scripts/inline_generic_class.json
+++ b/working/2364 - primary constructors/scripts/inline_generic_class.json
@@ -1,5 +1,5 @@
 {
-  "isInline": true,
+  "isExtensionType": true,
   "name": "Point",
   "typeParameters": "<TypeVariable extends Bound>",
   "fields": [

--- a/working/2364 - primary constructors/scripts/inline_named_class.json
+++ b/working/2364 - primary constructors/scripts/inline_named_class.json
@@ -1,5 +1,5 @@
 {
-  "isInline": true,
+  "isExtensionType": true,
   "name": "Point",
   "constructorName": "_",
   "fields": [

--- a/working/2364 - primary constructors/scripts/inline_named_const_class.json
+++ b/working/2364 - primary constructors/scripts/inline_named_const_class.json
@@ -1,5 +1,5 @@
 {
-  "isInline": true,
+  "isExtensionType": true,
   "name": "Point",
   "isConst": true,
   "constructorName": "_",

--- a/working/2364 - primary constructors/scripts/inline_subtyped_class.json
+++ b/working/2364 - primary constructors/scripts/inline_subtyped_class.json
@@ -1,5 +1,5 @@
 {
-  "isInline": true,
+  "isExtensionType": true,
   "name": "Point",
   "superinterfaces": "implements B, C",
   "fields": [

--- a/working/2364 - primary constructors/scripts/inline_subtyped_const_class.json
+++ b/working/2364 - primary constructors/scripts/inline_subtyped_const_class.json
@@ -1,5 +1,5 @@
 {
-  "isInline": true,
+  "isExtensionType": true,
   "name": "Point",
   "isConst": true,
   "superinterfaces": "implements B, C",

--- a/working/2364 - primary constructors/scripts/inline_subtyped_generic_class.json
+++ b/working/2364 - primary constructors/scripts/inline_subtyped_generic_class.json
@@ -1,5 +1,5 @@
 {
-  "isInline": true,
+  "isExtensionType": true,
   "name": "Point",
   "typeParameters": "<TypeVariable extends Bound>",
   "superinterfaces": "implements B, C",

--- a/working/2364 - primary constructors/scripts/inline_subtyped_generic_const_class.json
+++ b/working/2364 - primary constructors/scripts/inline_subtyped_generic_const_class.json
@@ -1,5 +1,5 @@
 {
-  "isInline": true,
+  "isExtensionType": true,
   "name": "Point",
   "isConst": true,
   "typeParameters": "<TypeVariable extends Bound>",

--- a/working/2364 - primary constructors/scripts/show_primary_constructors.dart
+++ b/working/2364 - primary constructors/scripts/show_primary_constructors.dart
@@ -135,7 +135,7 @@ class ClassSpec {
   final String provenance; // Identify where we got this class from.
   final String name;
   final String? constructorName;
-  final bool isInline;
+  final bool isExtensionType;
   final List<FieldSpec> fields;
   final bool isConst;
   final String? superinterfaces;
@@ -145,7 +145,7 @@ class ClassSpec {
     this.provenance,
     this.name,
     this.constructorName,
-    this.isInline,
+    this.isExtensionType,
     this.fields,
     this.isConst,
     this.typeParameters,
@@ -155,7 +155,7 @@ class ClassSpec {
   factory ClassSpec.fromJson(String source, Map<String, dynamic> jsonSpec) {
     var name = jsonSpec['name']!;
     var constructorName = jsonSpec['constructorName'];
-    var isInline = jsonSpec['isInline'] ?? false;
+    var isExtensionType = jsonSpec['isExtensionType'] ?? false;
     var jsonFields = jsonSpec['fields']!;
     var isConst = jsonSpec['isConst'] ?? false;
     var typeParameters = jsonSpec['typeParameters'];
@@ -170,7 +170,7 @@ class ClassSpec {
       source,
       name,
       constructorName,
-      isInline,
+      isExtensionType,
       fields,
       isConst,
       typeParameters,
@@ -270,7 +270,7 @@ String ppNormal(ClassSpec classSpec) {
     superinterfaces = ' $specSuperinterfaces';
   }
 
-  var inlinity = classSpec.isInline ? 'inline ' : '';
+  var inlinity = classSpec.isExtensionType ? 'extension type ' : '';
 
   var body = Options.includeBody ? '  // ...\n' : '';
   return "${inlinity}class $className$typeParameters$superinterfaces"
@@ -294,7 +294,7 @@ String ppKeyword(ClassSpec classSpec) {
     }
     var finality = '';
     if (field.isFinal) {
-      if (classSpec.isConst || classSpec.isInline) {
+      if (classSpec.isConst || classSpec.isExtensionType) {
         if (Options.explicitFinal) finality = 'final ';
       } else {
         finality = 'final ';
@@ -341,7 +341,7 @@ String ppKeyword(ClassSpec classSpec) {
     constructorPhrase = '$keyword.$constructorNameSpec';
   }
 
-  var inlinity = classSpec.isInline ? 'inline ' : '';
+  var inlinity = classSpec.isExtensionType ? 'extension type ' : '';
   var classHeader =
       "${inlinity}class $className$typeParameters$superinterfaces"
       " $constructorPhrase($parametersSource)";
@@ -366,7 +366,7 @@ String ppStruct(ClassSpec classSpec) {
     }
     var finality = '';
     if (field.isFinal) {
-      if (classSpec.isConst || classSpec.isInline) {
+      if (classSpec.isConst || classSpec.isExtensionType) {
         if (Options.explicitFinal) finality = 'final ';
       } else {
         finality = 'final ';
@@ -415,7 +415,7 @@ String ppStruct(ClassSpec classSpec) {
     constructorNamePart = '$className$typeParameters';
   }
 
-  var inlinity = classSpec.isInline ? 'inline ' : '';
+  var inlinity = classSpec.isExtensionType ? 'extension type ' : '';
   var classHeader =
       "${inlinity}class $constNess$constructorNamePart"
       "($parametersSource)"

--- a/working/2364 - primary constructors/scripts/show_primary_constructors.dart
+++ b/working/2364 - primary constructors/scripts/show_primary_constructors.dart
@@ -270,10 +270,10 @@ String ppNormal(ClassSpec classSpec) {
     superinterfaces = ' $specSuperinterfaces';
   }
 
-  var inlinity = classSpec.isExtensionType ? 'extension type ' : '';
+  var classKind = classSpec.isExtensionType ? 'extension type' : 'class';
 
   var body = Options.includeBody ? '  // ...\n' : '';
-  return "${inlinity}class $className$typeParameters$superinterfaces"
+  return "$classKind $className$typeParameters$superinterfaces"
       " {$fieldsSource$constructorSource$body}";
 }
 
@@ -341,9 +341,9 @@ String ppKeyword(ClassSpec classSpec) {
     constructorPhrase = '$keyword.$constructorNameSpec';
   }
 
-  var inlinity = classSpec.isExtensionType ? 'extension type ' : '';
+  var classKind = classSpec.isExtensionType ? 'extension type' : 'class';
   var classHeader =
-      "${inlinity}class $className$typeParameters$superinterfaces"
+      "$classKind $className$typeParameters$superinterfaces"
       " $constructorPhrase($parametersSource)";
   var body = Options.includeBody ? ' {\n  // ...\n\}' : ';';
   return "$classHeader$body";
@@ -415,9 +415,9 @@ String ppStruct(ClassSpec classSpec) {
     constructorNamePart = '$className$typeParameters';
   }
 
-  var inlinity = classSpec.isExtensionType ? 'extension type ' : '';
+  var classKind = classSpec.isExtensionType ? 'extension type' : 'class';
   var classHeader =
-      "${inlinity}class $constNess$constructorNamePart"
+      "$classKind $constNess$constructorNamePart"
       "($parametersSource)"
       "$superinterfaces";
   var body = Options.includeBody ? ' {\n  // ...\n\}' : ';';

--- a/working/2364 - primary constructors/scripts/show_primary_constructors.dart
+++ b/working/2364 - primary constructors/scripts/show_primary_constructors.dart
@@ -338,12 +338,12 @@ String ppKeyword(ClassSpec classSpec) {
   String constructorPhrase = '$keyword';
   var constructorNameSpec = classSpec.constructorName;
   if (constructorNameSpec != null) {
-    constructorPhrase = '$keyword.$constructorNameSpec';
+    constructorPhrase = '$keyword$typeParameters.$constructorNameSpec';
   }
 
   var classKind = classSpec.isExtensionType ? 'extension type' : 'class';
   var classHeader =
-      "$classKind $className$typeParameters$superinterfaces"
+      "$classKind $className$superinterfaces"
       " $constructorPhrase($parametersSource)";
   var body = Options.includeBody ? ' {\n  // ...\n\}' : ';';
   return "$classHeader$body";
@@ -410,7 +410,7 @@ String ppStruct(ClassSpec classSpec) {
   String constructorNamePart = '$className';
   var constructorNameSpec = classSpec.constructorName;
   if (constructorNameSpec != null) {
-    constructorNamePart = '$className.$constructorNameSpec$typeParameters';
+    constructorNamePart = '$className$typeParameters.$constructorNameSpec';
   } else {
     constructorNamePart = '$className$typeParameters';
   }


### PR DESCRIPTION
This PR makes adjustments to the proposal about primary constructors such that it is in line with the results from discussions at the recent physical language team meeting.

In particular, it removes support for a `primary` constructor which is declared in the body of the class/enum/etc, and only allows for the form which is part of the header of the class declaration. It also removes the ability to infer the modifier `required` in a formal parameter declaration.

(Inferred `required` is now a separate proposal, see https://github.com/dart-lang/language/blob/main/working/0015-infer-required/feature-specification.md.)

It preserves the ability to omit `final` from every parameter when the primary constructor is constant, because we already have the ability to omit `final` in the primary constructor of an extension type declaration.