### PR TITLE
[wildcard-variables] Fix a typo in the super parameters example.

### DIFF
--- a/working/wildcards/feature-specification.md
+++ b/working/wildcards/feature-specification.md
@@ -331,7 +331,7 @@ class B {
   B(this._);
 }
 
-class C {
+class C extends B {
   C(super._); // Error.
 }
 ```


### PR DESCRIPTION
Missing `extends` added

cc @kallentu 