### PR TITLE
Fix typo in comment about `augmented`

### DIFF
--- a/working/augmentation-libraries/feature-specification.md
+++ b/working/augmentation-libraries/feature-specification.md
@@ -361,7 +361,7 @@ enclosing declaration is not an augmenting declaration. In this case, the
 identifier is taken to be a reference to a declaration which is in scope.
 
 *In other words, `augmented` is just a normal identifier when it occurs
-anywhere other than inside an augmented declaration.*
+anywhere other than inside an augmenting declaration.*
 
 *Note that, for example, `augmented()` is an invocation of the augmented
 function or method when it occurs in an augmenting function or method

--- a/working/augmentation-libraries/feature-specification.md
+++ b/working/augmentation-libraries/feature-specification.md
@@ -374,14 +374,14 @@ keyword because it is unable to refer to a declaration in scope when it
 occurs inside an augmenting declaration, it always has the special meaning
 which is associated with augmentations.*
 
-A compile-time error occurs if a declaration with the name `augmented`
+A compile-time error occurs if a declaration with the basename `augmented`
 occurs in a location where the outermost enclosing declaration is
 augmenting. *This error is applicable to all such declarations, e.g.,
 local functions, local variables, parameters, and type parameters.*
 
-A compile-time error occurs if `augmented` occurs in a non-augmenting
-declaration, of a kind that can be augmenting, inside an augmenting
-declaration.
+A compile-time error occurs if the identifier `augmented` occurs in a
+non-augmenting declaration, of a kind that can be augmenting, inside an
+augmenting declaration.
 
 *For example, inside `augment class C` we could have a declaration like
 `void f() {...augmented()...}`.


### PR DESCRIPTION
Thanks to @sgrekhov for pointing out that the following is a typo:

> *... `augmented` is just a normal identifier when it occurs anywhere other than inside an augmented declaration.

This PR corrects 'augmented' to 'augmenting'.
