### PR TITLE
Allow augmentations of metadata and doc comments only for all kinds of augmentations

### DIFF
--- a/working/augmentation-libraries/feature-specification.md
+++ b/working/augmentation-libraries/feature-specification.md
@@ -467,7 +467,7 @@ The augmenting function does not have to pass the same arguments to
 `augmented(…)` as were passed to it. It may invoke `augmented` once, more than
 once, or not at all.
 
-Augmenting function declarations may also omit the body, in order to only
+An augmenting function declaration may have an empty body (`;`) in order to only
 augment the metadata or doc comments of the function. In this case the body of
 the augmented member is not altered.
 
@@ -549,9 +549,9 @@ More specifically:
     with the body of the augmenting getter. Inside the augmenting getter’s
     body, an `augmented` expression executes the augmented getter’s body.
 
-    Augmenting getter declarations may also omit the body, in order to only
-    augment the metadata or doc comments of the getter. In this case the body of
-    the augmented getter is not altered.
+    An augmenting getter declaration may have an empty body (`;`) in order to
+    only augment the metadata or doc comments of the getter. In this case the
+    body of the augmented getter is not altered.
 
     Synthetic getters cannot be augmented with metadata or doc comments.
 
@@ -562,9 +562,9 @@ More specifically:
     `augmented = <expression>` assignment invokes the augmented setter with the
     value of the expression.
 
-    Augmenting setter declarations may also omit the body, in order to only
-    augment the metadata or doc comments of the setter. In this case the body of
-    the augmented setter is not altered.
+    An augmenting setter declaration may have an empty body (`;`) in order to
+    only augment the metadata or doc comments of the setter. In this case the
+    body of the augmented setter is not altered.
 
     Synthetic setters cannot be augmented with metadata or doc comments.
 

--- a/working/augmentation-libraries/feature-specification.md
+++ b/working/augmentation-libraries/feature-specification.md
@@ -1,7 +1,7 @@
 # Augmentations
 
 Author: rnystrom@google.com, jakemac@google.com, lrn@google.com <br>
-Version: 1.21 (see [Changelog](#Changelog) at end)
+Version: 1.24 (see [Changelog](#Changelog) at end)
 
 Augmentations allow spreading your implementation across multiple locations,
 both within a single file and across multiple files. They can add new top-level
@@ -1216,6 +1216,11 @@ original documentation comments, but instead provide comments that are specific
 to the augmentation.
 
 ## Changelog
+
+### 1.24
+
+* Allow augmentations which only alter the metadata and/or doc comments on
+  various types, and specify behavior.
 
 ### 1.23
 

--- a/working/augmentation-libraries/feature-specification.md
+++ b/working/augmentation-libraries/feature-specification.md
@@ -648,10 +648,10 @@ It is a **compile-time error** if:
 
 *   A non-writable variable declaration is augmented with a setter. (Instead,
     the author can declare a *non-augmenting* setter that goes alongside the
-    implicit getter defined by the final variable.) _Non-writable variable
-    declarations are any that does not introduce a setter, including
-    non-`late`  `final` variables, `late final` variables with an initializer,
-    and `const` variables._
+    implicit getter defined by the final variable.) _A non-writable variable
+    declaration is any that does not introduce a setter, including non-`late`
+    `final` variables, `late final` variables with an initializer, and `const`
+    variables._
 
 *   A non-final variable is augmented with a final variable. We don't want to
     leave the original setter in a weird state.

--- a/working/augmentation-libraries/feature-specification.md
+++ b/working/augmentation-libraries/feature-specification.md
@@ -183,7 +183,7 @@ augmenting declarations (function bodies, constructor bodies, and variable
 initializers). Inside an expression of a member marked `augment`, the identifier
 `augmented` can be used to refer to the augmented function, getter, or setter
 body, or variable initializer. This is a contextual keyword within `augment`
-members, and has no special meaning outside of that context. See the next
+declarations, and has no special meaning outside of that context. See the next
 section for a full specification of what `augmented` means, and how it must be
 used, in the various contexts.
 
@@ -553,7 +553,7 @@ More specifically:
     augment the metadata or doc comments of the getter. In this case the body of
     the augmented getter is not altered.
 
-    Only concrete getters are allowed to augment with metadata or doc comments.
+    Synthetic getters cannot be augmented with metadata or doc comments.
 
 *   **Augmenting with a setter:** An augmenting setter can augment a setter
     declaration, or the implicit setter of a variable declaration, with all
@@ -566,7 +566,7 @@ More specifically:
     augment the metadata or doc comments of the setter. In this case the body of
     the augmented setter is not altered.
 
-    Only concrete setters are allowed to augment with metadata or doc comments.
+    Synthetic setters cannot be augmented with metadata or doc comments.
 
 *   **Augmenting a getter and/or setter with a variable:** This is a
     compile-time error in all cases. Augmenting an abstract or external variable


### PR DESCRIPTION
Closes https://github.com/dart-lang/language/issues/3957.

- Allows all declarations to be augmented with metadata/doc comments explicitly.
- Allows fields to be augmented with fields that contain no initializer. The augmented initializer is left in tact.
- Allow enum values to be augmented with no argument list. The augmented enum value keeps its original argument list in tact.
- Allow all function, getter, setter augmentations to have no body. The augmented body is left in tact.
- Unrelated, but I cleaned up many usages of "original" => "augmented"

I did not introduce an error to have a totally useless augmentation with no initializer/body, doc comments, or metadata, but I didn't see the need to introduce one. We could though if people think we should.