### PR TITLE
update extension type augmentations to be more strict

### DIFF
--- a/working/augmentation-libraries/feature-specification.md
+++ b/working/augmentation-libraries/feature-specification.md
@@ -1,7 +1,7 @@
 # Augmentations
 
 Author: rnystrom@google.com, jakemac@google.com, lrn@google.com <br>
-Version: 1.27 (see [Changelog](#Changelog) at end)
+Version: 1.30 (see [Changelog](#Changelog) at end)
 
 Augmentations allow spreading your implementation across multiple locations,
 both within a single file and across multiple files. They can add new top-level
@@ -1372,6 +1372,11 @@ original documentation comments, but instead provide comments that are specific
 to the augmentation.
 
 ## Changelog
+
+### 1.30
+
+*   Simplify extension type augmentations, don't allow them to contain the
+    representation type at all.
 
 ### 1.27
 

--- a/working/augmentation-libraries/feature-specification.md
+++ b/working/augmentation-libraries/feature-specification.md
@@ -924,13 +924,29 @@ It is a compile-time error if:
 When augmenting an extension type declaration, the parenthesized clause where
 the representation type is specified is treated as a constructor that has a
 single positional parameter, a single initializer from the parameter to the
-representation field, and an empty body.
+representation field, and an empty body. This clause must be present on the
+declaration which introduces the extension type, and must be ommitted from all
+augmentations of the extension type.
 
-This means that an augmentation can add a body to an extension type's
-constructor, which isn't otherwise possible. *(But note that there is no
+**TODO**: Update the grammar to allow extension types to omit the parenthesized
+clause with the representation type (or possibly only augmentations of extension
+types, but it is probably better to make this a semantic error and not a
+syntactic one to provide a better dev experience).
+
+This means that an augmentation can add a body to an extension type's implicit
+constructor, which isn't otherwise possible. This is done by augmenting the
+constructor in the body of the extension type *(But note that there is no
 guarantee that any instance of an extension type will have necessarily executed
 that body, since you can get instances of extension types through casts or other
-conversions that sidestep the constructor.)*
+conversions that sidestep the constructor.)*. For example:
+
+```dart
+extension type A(int b) {
+  augment A(int b) {
+    assert(b > 0);
+  }
+}
+```
 
 *This is designed in anticipation of supporting [primary constructors][] on
 other types in which case the extension type syntax will then be understood by
@@ -940,6 +956,11 @@ The extension type's representation object is _not_ a variable, even though it
 looks and behaves much like one, and it cannot be augmented as such. It is a
 compile time error to have any augmenting declaration with the same name as the
 representation object.
+
+It is a compile time error if:
+
+*   An extension type augmentation contains a parenthesized clause after the type
+    name.
 
 [primary constructors]:
 https://github.com/dart-lang/language/blob/main/working/2364%20-%20primary%20constructors/feature-specification.md

--- a/working/augmentation-libraries/feature-specification.md
+++ b/working/augmentation-libraries/feature-specification.md
@@ -924,9 +924,9 @@ It is a compile-time error if:
 When augmenting an extension type declaration, the parenthesized clause where
 the representation type is specified is treated as a constructor that has a
 single positional parameter, a single initializer from the parameter to the
-representation field, and an empty body. This clause must be present on the
-declaration which introduces the extension type, and must be ommitted from all
-augmentations of the extension type.
+representation field, and an empty body. The representation field clause must
+be present on the declaration which introduces the extension type, and must be
+omitted from all augmentations of the extension type.
 
 **TODO**: Update the grammar to allow extension types to omit the parenthesized
 clause with the representation type (or possibly only augmentations of extension
@@ -959,8 +959,7 @@ representation object.
 
 It is a compile time error if:
 
-*   An extension type augmentation contains a parenthesized clause after the type
-    name.
+*   An extension type augmentation contains a representation field clause.
 
 [primary constructors]:
 https://github.com/dart-lang/language/blob/main/working/2364%20-%20primary%20constructors/feature-specification.md


### PR DESCRIPTION
Closes https://github.com/dart-lang/language/issues/3694, will merge after https://github.com/dart-lang/language/pull/4002 for changelog consistency purposes.

I went for the simplest answer here, since I don't see a motivating use case for anything more complex.

- The "original" extension type declaration _must_ include the representation type.
- Augmentations of extension types _must not_ include the representation type.

There is a TODO for updating the grammar, I think the simplest option is to make the representation type optional for both regular extension type declarations and augmenting ones, and have the error introduced at a later stage. This would have better behavior for tooling so that the file can still be parsed (ie: the formatter can still format in the face of this error). But, that is just a suggestion and I don't feel strongly if we would prefer to make the grammar more complex and have special rules for each.