### PR TITLE
Update life of a language feature documentation

### DIFF
--- a/doc/life_of_a_language_feature.md
+++ b/doc/life_of_a_language_feature.md
@@ -41,6 +41,10 @@ As mentioned, alternative proposals should have their own issue and writeup.
 All proposals should be linked from and link to the 'request' for
 the user problem/feature request they are trying to address.
 
+For smaller and non-controversial features, we will sometimes skip this step and
+proceed directly to the [Acceptance and
+implementation](#acceptance-and-implementation) phase.
+
 ### External (outside of the language team) feedback
 
 We expect to use the github issue tracker as the primary place for accepting
@@ -55,40 +59,23 @@ significant changes.
 
 If consensus is reached on a specific proposal and we decide to accept it, a
 member of the language team will be chosen to shepherd the implementation.
-The implementation will be tracked via three artifacts:
-
-  - An implementation plan document
+The implementation will be tracked via two artifacts:
 
   - A 'implementation' issue.
 
   - A feature specification document
 
-The implementation plan must be located in a sub-directory with the name of the
-feature (`/[feature-name]/`) located inside the `accepted/future-releases/`
-folder. The filename should be `implementation-plan.md`. The implementation
-plan should generally include at least:
-
-  - Affected implementation teams.
-
-  - Schedule and release milestones.
-
-  - Release flag if required, plan for shipping.
-
 The 'feature specification' is **a single canonical writeup of the language
 feature** which is to serve as the implementation reference. Feature
 specifications use Markdown format. The file name should be
-`feature-specification.md`, and the feature specification should
-be located in the same sub-directory as the implementation plan.
+`feature-specification.md`, and the feature specification should be located
+inside the `accepted/future-releases/` folder.
 
-A meta-issue (labelled `implementation`) will be filed in the language
-repository for tracking the implementation process. This top of this issue must
-contain links to:
+The implementation issue (labelled `implementation`) will be filed in the
+language repository for tracking the implementation process. This top of this
+issue must contain links to:
 
-  - The related `request` issue
-
-  - The related `feature` issue
-
-  - A link to the implementation plan
+  - The related `request` and `feature` issues (if they exist)
 
   - A link to the feature specification
 
@@ -145,11 +132,9 @@ shipped (e.g. `2.1`).
     2.0/
     2.1/
       super-mixins/
-        implementation-plan.md
         feature-specification.md
     future-releases/
       spread-operator/
-        implementation-plan.md
         feature-specification.md
   /resources/
     [various supporting documents and resources]

--- a/doc/life_of_a_language_feature.md
+++ b/doc/life_of_a_language_feature.md
@@ -61,9 +61,9 @@ If consensus is reached on a specific proposal and we decide to accept it, a
 member of the language team will be chosen to shepherd the implementation.
 The implementation will be tracked via two artifacts:
 
-  - A 'implementation' issue.
-
   - A feature specification document
+
+  - A 'implementation' issue.
 
 The 'feature specification' is **a single canonical writeup of the language
 feature** which is to serve as the implementation reference. Feature
@@ -86,19 +86,31 @@ relevant implementation teams indicating that they understand the proposal,
 believe that it can reasonably be implemented, and feel that they have
 sufficient details to proceed.
 
-At a minimum, the set of relevant implementation teams should nearly always
-include both the analyzer and CFE teams. Often, back-end teams (Dart native
-runtime, Dart for web, and Wasm) should be included too. Note that if a feature
-consists entirely of a new piece of syntactic sugar, it can be tempting to
-assume that it's not necessary to consult with any back-end teams (since the CFE
-will lower the new syntax into a kernel form that is already supported). But
-this can be a dangerous assumption. It's easy to forget that even in features
-that appear to consist purely of syntactic sugar, some back-end support may be
-needed in order to properly support single-step debugging or hot reload. Also,
-some work may need to be done on back-end code generators in order to make sure
-that the new feature is lowered into a form that can be well optimized. To avoid
-missing things, we prefer to err on the side of asking teams whether they're
-affected, rather than assuming they won't be.
+Consider getting sign-off from the following teams:
+
+- The analyzer team.
+
+- The CFE team.
+
+- Back-end teams:
+
+  - Dart native runtime
+
+  - Dart for web
+
+  - Wasm
+
+Note that if a feature consists entirely of a new piece of syntactic sugar, it
+can be tempting to assume that it's not necessary to consult with any back-end
+teams (since the CFE will lower the new syntax into a kernel form that is
+already supported). But this can be a dangerous assumption. It's easy to forget
+that even in features that appear to consist purely of syntactic sugar, some
+back-end support may be needed in order to properly support single-step
+debugging or hot reload. Also, some work may need to be done on back-end code
+generators in order to make sure that the new feature is lowered into a form
+that can be well optimized. To avoid missing things, we prefer to err on the
+side of asking teams whether they're affected, rather than assuming they won't
+be.
 
 Since feature specification documents are usually long and very detailed, we
 like to begin this sign-off process with a set of kick-off meetings, typically


### PR DESCRIPTION
This PR adds the following information:
- Information about kick-off meetings
- How to create implementation tracking issues
- How to create a feature flag
- How to do language testing
- A note to remember to do Google3 testing (details of which will be described in a separate Google-internal document).

It also removes references to implementation plan documents, since we haven't created implementation plan documents for years.