### PR TITLE
Make adjustments following issue #4015

### DIFF
--- a/working/augmentation-libraries/feature-specification.md
+++ b/working/augmentation-libraries/feature-specification.md
@@ -726,7 +726,18 @@ It is a **compile-time error** if:
 
 *   An `external` variable is augmented with an `abstract` variable.
 
-### Augmenting enum values
+### Augmenting enum members
+
+Some enum members can not be augmented: It is a compile-time error if an
+augmenting declaration in an enum declaration (introductory or augmenting)
+has the name `values`, `index`, `hashCode`, `==`, or `name`.
+
+*It has always been an error for an enum declaration to declare a member
+named `index`, `hashCode`, `==`, or `values`, and this rule just clarifies
+that this error is applicable for augmenting declarations as well. This
+rule also protects the extension instance member `name` against being
+shadowed by another declaration. This is not technically necessary, but it
+seems helpful in practice.*
 
 Enum values can _only_ be augmented by enum values, and the implicit getter
 introduced by them is not augmentable. The only thing you are allowed to do

--- a/working/augmentation-libraries/feature-specification.md
+++ b/working/augmentation-libraries/feature-specification.md
@@ -730,14 +730,11 @@ It is a **compile-time error** if:
 
 Some enum members can not be augmented: It is a compile-time error if an
 augmenting declaration in an enum declaration (introductory or augmenting)
-has the name `values`, `index`, `hashCode`, `==`, or `name`.
+has the name `values`, `index`, `hashCode`, or `==`.
 
 *It has always been an error for an enum declaration to declare a member
 named `index`, `hashCode`, `==`, or `values`, and this rule just clarifies
-that this error is applicable for augmenting declarations as well. This
-rule also protects the extension instance member `name` against being
-shadowed by another declaration. This is not technically necessary, but it
-seems helpful in practice.*
+that this error is applicable for augmenting declarations as well.*
 
 Enum values can _only_ be augmented by enum values, and the implicit getter
 introduced by them is not augmentable. The only thing you are allowed to do


### PR DESCRIPTION
In issue #4015, it is argued that several system provided members of an enumerated declaration should not be augmentable, namely: `index`, `hashCode`, operator `==`, and `values`. This PR makes it a compile-time error to augment them.

It was also suggested that it should be an error to declare or augment a member of an enum named `name`, because this identifier should denote the system provided extension getter `name`. This PR does not introduce any rules about `name`, because it would be a breaking change to prevent `enum` declarations from declaring a member whose name is `name` (instance or static).

Resolves https://github.com/dart-lang/language/pull/4015.