### PR TITLE
Enable various variables and factories with no implementation

### DIFF
--- a/working/augmentation-libraries/feature-specification.md
+++ b/working/augmentation-libraries/feature-specification.md
@@ -1126,7 +1126,7 @@ topLevelDeclaration ::= classDeclaration
   | 'augment'? functionSignature functionBody
   | 'augment'? getterSignature functionBody
   | 'augment'? setterSignature functionBody
-  | 'augment'? ('final' | 'const') type? staticFinalDeclarationList ';'
+  | 'augment'? ('final' | 'const') type? initializedIdentifierList ';'
   | 'augment'? 'late' 'final' type? initializedIdentifierList ';'
   | 'augment'? 'late'? varOrType initializedIdentifierList ';'
 
@@ -1171,17 +1171,17 @@ enumEntry ::= metadata 'augment'? identifier argumentPart?
   | metadata 'augment'? identifier typeArguments?
     '.' identifierOrNew arguments
 
-declaration ::= 'external' factoryConstructorSignature
+declaration ::= 'external'? factoryConstructorSignature
   | 'external' constantConstructorSignature
   | 'external' constructorSignature
-  | ('external' 'static'?)? getterSignature
-  | ('external' 'static'?)? setterSignature
-  | ('external' 'static'?)? functionSignature
+  | 'external'? 'static'? getterSignature
+  | 'external'? 'static'? setterSignature
+  | 'external'? 'static'? functionSignature
   | 'external' ('static'? finalVarOrType | 'covariant' varOrType) identifierList
   | 'external'? operatorSignature
   | 'abstract' (finalVarOrType | 'covariant' varOrType) identifierList
-  | 'augment'? 'static' 'const' type? staticFinalDeclarationList
-  | 'augment'? 'static' 'final' type? staticFinalDeclarationList
+  | 'augment'? 'static' 'const' type? initializedIdentifierList
+  | 'augment'? 'static' 'final' type? initializedIdentifierList
   | 'augment'? 'static' 'late' 'final' type? initializedIdentifierList
   | 'augment'? 'static' 'late'? varOrType initializedIdentifierList
   | 'augment'? 'covariant' 'late' 'final' type? identifierList


### PR DESCRIPTION
With support for augmentation, variables can be declared with no initializing expression in a couple of new cases where this was previously a syntax error, namely constant and final top-level variables as well as constant and final static variables. This PR changes the grammar to allow this kind of declaration. The point is that the omitted initializing expression can be provided by augmentation. Similarly for factory constructor declarations, they do not have to have a body when the body can be provided by augmentation. Finally, static getters, setters, and methods are also generalized to allow omitting the body, that is, they are allowed to look like "abstract static members", again because the body can be provided by augmentation.

The set of elements that are required for each definition are unchanged, but parsing will now succeed, and it is a non-syntax compile-time error if an element is omitted, e.g., if a constant top-level variable has no initializing expression.