### PR TITLE
fix (apparent) typo in the null-aware-elements example

### DIFF
--- a/accepted/future-releases/0323-null-aware-elements/feature-specification.md
+++ b/accepted/future-releases/0323-null-aware-elements/feature-specification.md
@@ -252,8 +252,8 @@ final tag = Tag()
       'comment': comms!
           .asMap()
           .map((key, value) => MapEntry<String, Comment>(value.key, value)),
-    'track': Song.numberInAlbum?.toString(),
-    'genre': Song.genre,
+    'track': ?Song.numberInAlbum?.toString(),
+    'genre': ?Song.genre,
     if (Song.albumArt != null) 'picture': {pic.key: pic},
   }
   ..type = 'ID3'


### PR DESCRIPTION
It seems in the second example given in the specification, both `'track'` and `'genre'` should be prefixed with `?`, as their initial form are exactly the same as `'title'` and `'year'`, respectively.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
