### PR TITLE
Correct forwarding link about archived import shorthand proposal

### DIFF
--- a/working/0649 - Import shorthand/proposal.md
+++ b/working/0649 - Import shorthand/proposal.md
@@ -1,3 +1,3 @@
 This document [has moved].
 
-[has moved]: https://github.com/dart-lang/language/blob/main/archive/0649%20-%20Import%20shorthand/feature-specification.md
+[has moved]: https://github.com/dart-lang/language/blob/main/archive/0649%20-%20Import%20shorthand/proposal.md


### PR DESCRIPTION
The file `working/0649 - Import shorthand/proposal.md` no longer contains said proposal, it has been moved to `archive/...`. The file in the original location just contains a link to the new location. Said link was broken, this PR corrects it.