### PR TITLE
Clarify extension member resolution

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -41,6 +41,9 @@
 % version of the language which will actually be specified by the next stable
 % release of this document.
 %
+% Sep 2024
+% - Clarify extension member invocation rule.
+%
 % Jun 2024
 % - Add missing references to section 'Type dynamic' at the points where the
 %   static analysis of Object member invocations is specified.
@@ -6661,7 +6664,7 @@ to $e$ if the following conditions are all satisfied:
     because they do not have a type.%
   }
 \item
-  The type $S$ does not have a member with the basename $m$,
+  The type $S$ does not have an instance member with the basename $m$,
   and $S$ is neither \DYNAMIC{} nor \code{Never}.
 
   \commentary{%


### PR DESCRIPTION
See https://github.com/dart-lang/language/issues/4113 for some background information.

This PR changes the rule about extension applicability such that it is clarified that static members are irrelevant, it is only required that the static type of the receiver does not have an _instance_ member with the same basename as the selector which is potentially an extension member invocation.

There is no implementation effort associated with this specification adjustment, and it is not a breaking change, because the implementations already behavior in the way which is specified with this change.