### PR TITLE
Update augmentation specification.

### DIFF
--- a/working/augmentation-libraries/feature-specification.md
+++ b/working/augmentation-libraries/feature-specification.md
@@ -344,7 +344,7 @@ being augmented.
     induced getter of the augmented variable declaration.
     _This applies even to `late` variable declarations, where the implicit
     getter does more than just access the underlying storage._
-    The reserved words parses as a `<primary>` expression.
+    The reserved word parses as a `<primary>` expression.
     Evaluating `augmented` invokes the augmented declaration's getter
     function, and evaluates to the returned value.
     The static type of `augmented` is the declared return type of the augmented

--- a/working/augmentation-libraries/feature-specification.md
+++ b/working/augmentation-libraries/feature-specification.md
@@ -375,7 +375,7 @@ being augmented.
     `augmented.call()`._
     The expression `augmented` must not occur in an optional parameter
     default value expressions _It is a reserved word in such expressions,
-    but is currently cannot be used._
+    but it currently cannot be used._
     The term <code>'augmented' \<argumentPart\></code> words parses
     as a `<primary>` expression.
     Evaluating the function invocation, after having evaluated the


### PR DESCRIPTION
*   Says that the entire class scope is in the lexical scope for members.
*   Update `augemented` specification, include constructors.
    *   Only reserved inside expressions and bodies of augmenting
        member-like declarations, not type-like declarations.
    *   Try to give grammar. It's really a parameterized grammar
        per kind of declaration. We don't have good parameterized grammars,
        so it's said in prose.
*   Changes specification for non-redirecting generative constructors.
    *   Adds order of initialization of instance variables with initializers.
    *   Says that body cannot use `augmented`.
    *   Therefore no longer needs to reuse variable bindings, so don't.
    *   Each augmenting declaration binds actuals to formals,
        remember any super parameters or super initializers,
        executes initializer list entries,
        and then executes its augmented declaration.
        When that comes back, it executes its body.
    *   (Layering an augmentation on top of an NRG-constructor
        auto-calls augmented at the end of its initializer list.)

    The initializing formals and super parameters need more work.
*   Some small tweaks to disallow invalid combinations.
