### PR TITLE
A little copy-editing on the enum shorthand proposal.

### DIFF
--- a/working/3616 - enum value shorthand/proposal-simple-lrhn.md
+++ b/working/3616 - enum value shorthand/proposal-simple-lrhn.md
@@ -250,8 +250,8 @@ second operand.
 Examples of allowed comparisons:
 
 ```dart
-if (Endian.host == .big);       // ok!
-if (Endian.host case == .big);  // ok!
+if (Endian.host == .big) ok!;
+if (Endian.host case == .big) ok!;
 ```
 
 Not allowed:


### PR DESCRIPTION
I was reading the latest changes and noticed a duplicated sentence. And once I fixed that, I started noticing other things...

There are no semantic changes. This is just making it hopefully easier to read.
