### PR TITLE
Add an error and adjust the terminology slightly about augmented redirecting constructors

### DIFF
--- a/working/augmentation-libraries/feature-specification.md
+++ b/working/augmentation-libraries/feature-specification.md
@@ -947,7 +947,7 @@ constructor.
 
 It is a compile-time error if:
 
-*   The augmented factory constructor has a body, or it is already redirecting.
+*   The augmented factory constructor has a body, or it is redirecting.
 
 #### Extension types
 

--- a/working/augmentation-libraries/feature-specification.md
+++ b/working/augmentation-libraries/feature-specification.md
@@ -932,7 +932,8 @@ potentially non-redirecting property of the constructor.
 
 It is a compile-time error if:
 
-*   The augmented constructor has any initializers or a body.
+*   The augmented constructor has an initializer list or a body, or it has a
+    redirection.
 
 #### Redirecting factory constructors
 

--- a/working/augmentation-libraries/feature-specification.md
+++ b/working/augmentation-libraries/feature-specification.md
@@ -855,8 +855,8 @@ It is a compile-time error if:
     replace a declared super constructor._ **(TODO: Why not? We allow
     "replacing implementation", and this is *something* like that.)**
 
-*   The resulting constructor is not valid (has a redirecting initializer and
-    other initializers, multiple `super` initializers, etc).
+*   The resulting constructor is not valid (has a redirection as well as
+    some initializer list elements, multiple `super` initializers, etc).
 
 *   A non-redirecting constructor augments a constructor which is not
     potentially non-redirecting.
@@ -923,8 +923,8 @@ present), and it may invoke the augmented body by calling
 
 #### Redirecting generative constructors
 
-A redirecting generative constructor marked `augment` adds its redirecting
-initializer to the augmented constructors initializer list.
+A redirecting generative constructor marked `augment` adds its redirection
+to the augmented constructor.
 
 This converts it into a redirecting generative constructor, removing the
 potentially non-redirecting property of the constructor.
@@ -936,6 +936,7 @@ It is a compile-time error if:
 #### Redirecting factory constructors
 
 A redirecting factory constructor marked `augment` adds its factory redirection
+*(that is `=` and a constructor designation, e.g., `= C<int>.name`)*
 to the augmented constructor.
 
 The result of applying the augmenting constructor is a redirecting factory
@@ -945,7 +946,8 @@ constructor.
 
 It is a compile-time error if:
 
-*   The augmented constructor has a body.
+*   The augmented constructor is not potentially redirecting *(that is, if it
+    has a body or one or more initializer list elements)*.
 
 #### Extension types
 

--- a/working/augmentation-libraries/feature-specification.md
+++ b/working/augmentation-libraries/feature-specification.md
@@ -947,7 +947,7 @@ constructor.
 
 It is a compile-time error if:
 
-*   The augmented factory constructor has a body.
+*   The augmented factory constructor has a body, or it is already redirecting.
 
 #### Extension types
 

--- a/working/augmentation-libraries/feature-specification.md
+++ b/working/augmentation-libraries/feature-specification.md
@@ -946,8 +946,7 @@ constructor.
 
 It is a compile-time error if:
 
-*   The augmented constructor is not potentially redirecting *(that is, if it
-    has a body or one or more initializer list elements)*.
+*   The augmented constructor has a body.
 
 #### Extension types
 
@@ -1202,8 +1201,6 @@ declaration ::= 'external'? factoryConstructorSignature
   | constantConstructorSignature (redirection | initializers)?
   | constructorSignature (redirection | initializers)?
 ```
-
-**TODO: Define the grammar for the various `augmented` expressions.**
 
 It is a compile-time error if:
 

--- a/working/augmentation-libraries/feature-specification.md
+++ b/working/augmentation-libraries/feature-specification.md
@@ -936,8 +936,7 @@ It is a compile-time error if:
 #### Redirecting factory constructors
 
 A redirecting factory constructor marked `augment` adds its factory redirection
-*(that is `=` and a constructor designation, e.g., `= C<int>.name`)*
-to the augmented constructor.
+*(e.g., `= C<int>.name`)* to the augmented constructor.
 
 The result of applying the augmenting constructor is a redirecting factory
 constructor with the same target constructor designation as the augmenting
@@ -946,7 +945,7 @@ constructor.
 
 It is a compile-time error if:
 
-*   The augmented constructor has a body.
+*   The augmented factory constructor has a body.
 
 #### Extension types
 

--- a/working/augmentation-libraries/feature-specification.md
+++ b/working/augmentation-libraries/feature-specification.md
@@ -855,8 +855,9 @@ It is a compile-time error if:
     replace a declared super constructor._ **(TODO: Why not? We allow
     "replacing implementation", and this is *something* like that.)**
 
-*   The resulting constructor is not valid (has a redirection as well as
-    some initializer list elements, multiple `super` initializers, etc).
+*   The resulting constructor is not valid *(it has a redirection as well as
+    some initializer list elements, or it has multiple `super` initializers,
+    etc)*.
 
 *   A non-redirecting constructor augments a constructor which is not
     potentially non-redirecting.


### PR DESCRIPTION
This PR introduces an error for the case where a redirection (`this(...)`) is augmented by another redirection, and similarly for a redirecting factory.

This follows the treatment of super-initializers, for which it is also an error to include one in an augmenting declaration if the augmented declaration already has an explicitly declared super-initializer.

Other than that, it clarifies the terminology of the augmentation feature specification slightly, such that we keep `this(...)` and `this.x = 42` clearly separated.

'redirecting initializer' is changed to 'redirection' when talking about generative redirecting constructors. The term is derived from `<redirection>`, and the word redirection is used in other specification documents about this kind of term. This also helps avoiding the confusion about `this(...)` possibly being an initializer list element (like `x = 42` or `assert(b)`).

I also added a few words of commentary right after the phrase 'factory redirection' because this phrase is new (the grammar rule actually doesn't have a separate name for the token sequence covered by this phrase). Finally, I deleted a TODO comment which is obsolete today (there are no special grammar rules about `augmented`).
