### PR TITLE
Add commentary to clarify the rule about `.` at the beginning of expression statements

### DIFF
--- a/working/3616 - enum value shorthand/proposal-simple-lrhn.md
+++ b/working/3616 - enum value shorthand/proposal-simple-lrhn.md
@@ -42,7 +42,7 @@ We introduce grammar productions of the form:
     | 'const' '.' (<identifier> | 'new') <arguments>  -- shorthand object creation
 ```
 
-We also add `.` to the tokens that an expression statement cannot start with.
+We also add `.` to the tokens that an expression statement cannot start with. *Note that the number `.123` does not start with the token `.` because all four characters are recognized as a single token. So we can still have expression statements starting with such a number.*
 
 That means you can write things like the following (with the intended meaning as
 comments, specification to achieve that below):


### PR DESCRIPTION
This PR adds a sentence of commentary to clarify the static access shorthand rule "We also add `.` to the tokens that an expression statement cannot start with". The point is that `.` as a token does not occur in numbers like `.123`, because the number is a single token.