### PR TITLE
Adjust function literal return type inference to avoid spurious null

### DIFF
--- a/resources/type-system/inference.md
+++ b/resources/type-system/inference.md
@@ -6,6 +6,11 @@ Status: Draft
 
 ## CHANGELOG
 
+2024.12.17
+  - Change the function literal return type inference rules to ignore
+    `return;` statements in generators (it doesn't actually cause null to be
+    returned).
+
 2022.05.12
   - Define the notions of "constraint solution for a set of type variables" and
     "Grounded constraint solution for a set of type variables".  These
@@ -324,7 +329,8 @@ schema.
     `e`, using the local type inference algorithm described below with typing
     context `K`, and update `T` to be `UP(flatten(S), T)` if the enclosing
     function is `async`, or `UP(S, T)` otherwise.
-  - For each `return;` statement in the block, update `T` to be `UP(Null, T)`.
+  - If the enclosing function is not marked `sync*` or `async*`: For each
+    `return;` statement in the block, update `T` to be `UP(Null, T)`.
   - For each `yield e;` statement in the block, let `S` be the inferred type of
     `e`, using the local type inference algorithm described below with typing
     context `K`, and update `T` to be `UP(S, T)`.


### PR DESCRIPTION
See https://github.com/dart-lang/sdk/issues/59669 where this topic came up.

This PR changes one item in the list of actions taken during function literal return type inference: A `return;` statement _only_ adds `Null` to the return type in cases where the given function literal is a non-generator.

With the current version, `Null` is added to the return type also in cases like `() sync* { yield 1; return; }` such that this function literal gets the inferred return type `Iterable<int?>`. This is an unnecessary loss of typing precision because null is never actually added to the returned iterable. With this update, the inferred return type is `Iterable<int>`.
