### PR TITLE
Add tip for adding feature onto tracking board.

### DIFF
--- a/doc/life_of_a_language_feature.md
+++ b/doc/life_of_a_language_feature.md
@@ -117,6 +117,9 @@ This issue must contain links to:
   - [ ] A link to the feature specification
   - [ ] All implementation issues
 
+> [!NOTE]
+> Once you're done making the implementation issue, copy the link of the issue and add it to the [Dash Feature Tracker board](https://github.com/orgs/flutter/projects/82/views/1).
+
 ## Team communication
 
 One of the most important parts of the language feature process is communicating


### PR DESCRIPTION
Adding an extra tip here so we don't forget. I keep missing this step and coming back to it.

@itsjustkevin may add this part automatically through the project generation script in Aviary, but we can leave this here until that happens. It's not too hard to do manually anyways.
