### PR TITLE
[flow analysis] Update the spec to match implementation of `==`.

### DIFF
--- a/resources/type-system/flow-analysis.md
+++ b/resources/type-system/flow-analysis.md
@@ -558,8 +558,12 @@ then they are all assigned the same value as `after(N)`.
     - Let `false(N) = unreachable(after(E2))`.
   - Otherwise, if `equivalentToNull(T1)` and `T2` is non-nullable, or
     `equivalentToNull(T2)` and `T1` is non-nullable, then:
-    - Let `true(N) = unreachable(after(E2))`.
-    - Let `false(N) = after(E2)`.
+    - Let `after(N) = after(E2)`.
+    - *Note that now that Dart no longer supports unsound null safety mode, it
+      would be sound (and probably preferable) to let `true(N) =
+      unreachable(after(E2))` and `false(N) = after(E2)`. This improvement is
+      being contemplated as part of
+      https://github.com/dart-lang/language/issues/3100.*
   - Otherwise, if `stripParens(E1)` is a `null` literal, then:
     - Let `true(N) = after(E2)`.
     - Let `false(N) = promoteToNonNull(E2, after(E2))`.


### PR DESCRIPTION
In fully sound null safety mode, flow analysis should know that a test like `expr == null` is guaranteed to evaluate to `false` if the static type of `expr` is non-nullable. But in unsound null safety mode, no such guarantee can be made.

Since support for unsound null safety was only recently removed from the CFE (see
https://github.com/dart-lang/sdk/commit/0060b0f665ac5b6865fdb9d91e8735a20ee3b160), flow analysis still conservatively assumes that an expression with a non-nullable static type might, nonetheless, still be `null`.

This change updates the spec to match the implementation in this regard, and adds a reference to
https://github.com/dart-lang/language/issues/3100, where we are discussing the possibility of changing the behavior.

- Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
