### PR TITLE
Change switches to accept instances with primitive equality

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -18733,7 +18733,7 @@ and are independent of any type annotations.%
 
 \LMHash{}%
 It is a compile-time error if one or more of said instances of the class $C$
-does not have primitive equality
+do not have primitive equality
 (\ref{theOperatorEqualsEquals}).
 
 \rationale{%

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -18732,7 +18732,7 @@ and are independent of any type annotations.%
 }
 
 \LMHash{}%
-It is a compile-time error if the class $C$
+It is a compile-time error if one or more of said instances of the class $C$
 does not have primitive equality
 (\ref{theOperatorEqualsEquals}).
 


### PR DESCRIPTION
See https://github.com/dart-lang/sdk/issues/60375 for background. This PR changes the rule about (pre-nnbd) switches such that they accept cases of the form `case e` where `e` is a constant expression whose value is an instance that has primitive equality (previously it was required that the class of this instance must have primitive equality, which is not true for, say, type literals).