### PR TITLE
Adjust the constant expression rules for lists, maps, and conditional expressions

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -8692,7 +8692,10 @@ are the following:
   \code{\CONST{} <$K$, $V$>\{$k_1$: $v_1$, \ldots, $k_n$: $v_n$\}}, or
   \code{<$K$, $V$>\{$k_1$: $v_1$, \ldots, $k_n$: $v_n$\}}
   that occurs in a constant context,
-  is a potentially constant expression.
+  is a potentially constant expression
+  if $K$ and $V$ are constant type expressions,
+  and $k_1$, \ldots{} , $k_n$ as well as $v_1$, \ldots{} , $v_n$
+  are constant expressions.
   It is further a constant expression
   if the map literal evaluates to an object.
 
@@ -8813,7 +8816,7 @@ are the following:
 \item An expression of the form \code{$e_1$\,?\,$e_2$\,:\,$e_3$}
   is potentially constant if $e_1$, $e_2$, and $e_3$
   are all potentially constant expressions.
-  It is constant if $e_1$ is a constant expression and either
+  It is further constant if $e_1$ is a constant expression and either
   \begin{enumerate}
   \item $e_1$ evaluates to \TRUE{} and $e_2$ is a constant expression, or
   \item $e_1$ evaluates to \FALSE{} and $e_3$ is a constant expression.


### PR DESCRIPTION
See https://github.com/dart-lang/language/issues/4311#issuecomment-2769391705 for background information.

This PR changes the rule about constant expressions of the form `b ? e1 : e2` such that it is required that every constant expression of this form is also a potentially constant expression. The point is that this maintains the subset relationship "every constant expression is also a potentially constant expression", which is otherwise maintained in all cases. Also, this implies that the checks that are applied to conditional expressions are slightly stronger than they have been so far.

The PR also changes the rule about constant map literals. Before this PR, these constant expressions are underspecified. In particular, there are no constraints at all on the key and value expressions in order to make the map literal as a whole a potentially constant expression, and the expression is constant if it evaluates to an object. In other words, a map literal can contain code with arbitrary side effecting constructs in a key and/or a value expression, and the whole map literal can still be a constant expression. So we definitely need to fix this.
