### PR TITLE
Add exception about extension members in error about nullable receivers

### DIFF
--- a/accepted/2.12/nnbd/feature-specification.md
+++ b/accepted/2.12/nnbd/feature-specification.md
@@ -6,6 +6,10 @@ Status: Draft
 
 ## CHANGELOG
 
+2025.04.03
+  - Add an exception for extension members in the error about nullable
+    receivers.
+
 2021.07.28
   - Allow a constant factory constructor in a class with a late final instance
     variable.
@@ -531,7 +535,7 @@ location outside of the statement.
 
 It is an error to call a method, setter, getter or operator on an expression
 whose type is potentially nullable and not `dynamic`, except for the methods,
-setters, getters, and operators on `Object`.
+setters, getters, and operators on `Object`, and except for extension members.
 
 It is an error to read a field or tear off a method from an expression whose
 type is potentially nullable and not `dynamic`, except for the methods and


### PR DESCRIPTION
Consider the following example:

```dart
extension on int? {
  bool get isEvenOrNull {
    var self = this; // To get promotion.
    return self == null || self.isEven;
  }
}

void main() {
  int? iq = 2 > 1 ? null : 42;
  bool b = iq.isEvenOrNull; // OK.
}
```

As implemented, the analyzer and CFE do not report any errors for `iq.isEvenOrNull`. However, the NNBD feature specification says that

> > It is an error to call a method, setter, getter or operator on an expression whose type is potentially nullable and not `dynamic`, except for the methods, setters, getters, and operators on `Object`.

Arguably, this makes extension member invocations an error when the receiver is potentially nullable, even in the case where the given extension is applicable to a receiver whose type is nullable (as in the example).

I believe the implemented behavior is the desired behavior, and the specification should be adjusted.

This change is non-breaking because the implementations already accept this kind of invocation.
