### PR TITLE
Move language spec upload from Github actions to cloud build: Add cloudbuild.yaml

### DIFF
--- a/.cloud_build/specification/cloudbuild.yaml
+++ b/.cloud_build/specification/cloudbuild.yaml
@@ -1,2 +1,3 @@
 steps:
-- name:  'gcr.io/cloud-builders/docker'
+- name: 'bash'
+  args: ['specification/scripts/build_pdf']

--- a/.cloud_build/specification/cloudbuild.yaml
+++ b/.cloud_build/specification/cloudbuild.yaml
@@ -1,0 +1,2 @@
+steps:
+- name:  'gcr.io/cloud-builders/docker'

--- a/specification/.gitignore
+++ b/specification/.gitignore
@@ -10,3 +10,4 @@ dartLangSpec*.toc
 *-list.txt
 .dart_tool/
 .packages
+firebase/

--- a/specification/scripts/build_pdf
+++ b/specification/scripts/build_pdf
@@ -1,0 +1,12 @@
+#!/bin/bash --norc
+
+sudo apt-get update -qq
+sudo apt-get install \
+    texlive-latex-base \
+    texlive-latex-extra \
+    texlive-fonts-recommended \
+    lmodern
+cd specification
+make
+mkdir firebase
+cp dartLangSpec.pdf firebase/DartLangSpecDraft.pdf


### PR DESCRIPTION
This PR adds a 'cloudbuild.yaml' specification file to the language repository such that the provision of a PDF of the language specification can be achieved via a Cloud Build.