### PR TITLE
Create a script to simplify the language specification

### DIFF
--- a/specification/.gitignore
+++ b/specification/.gitignore
@@ -6,6 +6,7 @@ dartLangSpec*.log
 dartLangSpec*.out
 dartLangSpec*.pdf
 dartLangSpec*.toc
+dartLangSpec-simple.tex
 *-hash.tex
 *-list.txt
 .dart_tool/

--- a/specification/.gitignore
+++ b/specification/.gitignore
@@ -6,7 +6,7 @@ dartLangSpec*.log
 dartLangSpec*.out
 dartLangSpec*.pdf
 dartLangSpec*.toc
-dartLangSpec-simple.tex
+dartLangSpec-terse.tex
 *-hash.tex
 *-list.txt
 .dart_tool/

--- a/specification/Makefile
+++ b/specification/Makefile
@@ -52,6 +52,6 @@ cleanish:
 clean: cleanish
 	rm -f *.dvi *.pdf $(HASH) $(LIST)
 
-simple:
+terse:
 	dart scripts/simplify_specification.dart
 

--- a/specification/Makefile
+++ b/specification/Makefile
@@ -51,3 +51,7 @@ cleanish:
 
 clean: cleanish
 	rm -f *.dvi *.pdf $(HASH) $(LIST)
+
+simple:
+	dart scripts/simplify_specification.dart
+

--- a/specification/Makefile
+++ b/specification/Makefile
@@ -2,6 +2,8 @@ NAME=dartLangSpec
 SPEC=$(NAME).tex
 HASH=$(NAME)-hash.tex
 LIST=$(NAME)-list.txt
+TERSE_SPEC=$(NAME)-terse.tex
+TERSE_IDX=$(NAME)-terse.idx
 HASHER=scripts/addlatexhash.dart
 
 pdf:
@@ -39,6 +41,17 @@ dvihash: hash_and_list
 hash_and_list:
 	dart $(HASHER) $(SPEC) $(HASH) $(LIST)
 
+terse:
+	dart scripts/simplify_specification.dart
+
+tersepdf:
+	pdflatex $(TERSE_SPEC)
+	makeindex $(TERSE_IDX)
+	pdflatex $(TERSE_SPEC)
+	makeindex $(TERSE_IDX)
+	pdflatex $(TERSE_SPEC)
+	pdflatex $(TERSE_SPEC)
+
 help:
 	@echo "Goals:"
 	@echo "  pdf, dvi: generate the pdf/dvi file containing the spec"
@@ -51,7 +64,3 @@ cleanish:
 
 clean: cleanish
 	rm -f *.dvi *.pdf $(HASH) $(LIST)
-
-terse:
-	dart scripts/simplify_specification.dart
-

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -6725,7 +6725,7 @@ to $e$ if the following conditions are all satisfied:
     (\ref{typeVoid}),
     so extensions are never applicable to receivers of
     any of the types \DYNAMIC, \code{Never}, or \VOID.%
-   }
+  }
 
   For the purpose of determining extension applicability,
   function types and the type \code{Function}

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -728,7 +728,7 @@ When the specification says that one piece of syntax $s$ is
 \Index{treated as}
 another piece of syntax $s'$,
 it means that the static analysis of $s$ is the static analysis of $s'$
-(\commentary{in particular, exactly the same compile-time errors occur}).
+\commentary{(in particular, exactly the same compile-time errors occur)}.
 Moreover, if $s$ has no compile-time errors then
 the behavior of $s$ at run time is exactly the behavior of $s'$.
 
@@ -767,7 +767,7 @@ and others are better described as mere abbreviations of existing constructs.%
 The specification uses one syntactic construct, the
 \IndexCustom{\LET{} expression}{let expression@\LET{} expression},
 which is not derivable in the grammar
-(\commentary{that is, no Dart source code contains such an expression}).
+\commentary{(that is, no Dart source code contains such an expression)}.
 This expression is helpful in specifying certain syntactic forms
 that are treated as other syntactic forms,
 because it allows for introducing and initializing one or more fresh variables,
@@ -836,7 +836,7 @@ The right margin also contains symbols.
 Whenever a symbol
 \BlindDefineSymbol{\textcolor{commentaryColor}{C}}%
 \BlindDefineSymbol{\textcolor{commentaryColor}{x_j}}%
-(\commentary{say, $C$ or $x_j$})
+\commentary{(say, $C$ or $x_j$)}
 is introduced and used in more than a few lines of text,
 it is shown in the margin.
 
@@ -954,7 +954,7 @@ The method used to enable or disable assertions is implementation specific.
 A \IndexCustom{compile-time namespace}{namespace!compile-time}
 is a partial function that maps names to namespace values.
 Compile-time namespaces are used much more frequently than run-time namespaces
-(\commentary{defined later in this section}),
+\commentary{(defined later in this section)},
 so when the word \Index{namespace} is used alone,
 it means compile-time namespace.
 A \Index{name} is a lexical token which is an \synt{IDENTIFIER},
@@ -1613,7 +1613,7 @@ class, mixin, enum, or extension declaration.
 An instance variable introduces an instance getter into
 the body scope of the immediately enclosing
 class, mixin, or enum declaration
-(\commentary{an extension cannot declare instance variables}).
+\commentary{(an extension cannot declare instance variables)}.
 
 \LMHash{}%
 A non-local variable introduces a setter if{}f
@@ -1629,7 +1629,7 @@ class, mixin, enum, or extension declaration.
 An instance variable that introduces a setter will introduce
 an instance setter into the body scope of the immediately enclosing
 class, mixin, or enum declaration
-(\commentary{an extension cannot declare instance variables}).
+\commentary{(an extension cannot declare instance variables)}.
 
 \LMHash{}%
 Let \id{} be a variable declared by a variable declaration
@@ -2003,8 +2003,10 @@ A function body is either:
   %
   Unless it is statically known that the body of the function
   cannot complete normally
-  (\commentary{that is, it cannot reach the end and ``fall through''},
-  cf.~\ref{statementCompletion}),
+  \commentary{%
+    (that is, it cannot reach the end and ``fall through''},
+    cf.~\ref{statementCompletion)%
+  },
   it is a compile-time error if
   the addition of \code{\RETURN;} at the end of the body
   would be a compile-time error.
@@ -2152,7 +2154,7 @@ then the element type of $f$ is $U$.
 %
 Otherwise, if $f$ is a generator (synchronous or asynchronous)
 and $S$ is a supertype of \code{Object}
-(\commentary{which includes \code{Object} itself})
+\commentary{(which includes \code{Object} itself)}
 then the element type of $f$ is \DYNAMIC.
 \commentary{No further cases are possible.}
 
@@ -2880,7 +2882,7 @@ the body scope of the class in which it is declared.
 
 \LMHash{}%
 The current instance
-(\commentary{and hence its members})
+\commentary{(and hence its members)}
 can only be accessed at specific locations in a class:
 We say that a location $\ell$
 \IndexCustom{has access to \THIS}{has access to this@has access to \THIS}
@@ -3393,10 +3395,10 @@ one of the following is true:
   the interface of $C$ contains a member signature $S$ named $m$,
   and $C$ has no concrete member named $m$ and accessible to $L$
   that correctly overrides $S$
-  (\commentary{%
-    that is, no member named $m$ is declared or inherited by $C$,
+  \commentary{%
+    (that is, no member named $m$ is declared or inherited by $C$,
     or one is inherited, but it does not have the required signature%
-  }).
+  )}.
   In this case we also say that $S$ is noSuchMethod forwarded.
 \item
   \textbf{Forced by privacy:}
@@ -3533,10 +3535,10 @@ with formal type parameters
 positional formal parameters
 \BlindDefineSymbol{a_j, k, x_j, n}%
 \code{$a_1,\ \ldots,\ a_k$}
-(\commentary{some of which may be optional when $n = 0$}),
+\commentary{(some of which may be optional when $n = 0$)},
 and named formal parameters with names
 \code{$x_1,\ \ldots,\ x_n$}
-(\commentary{with default values as mentioned above}).
+\commentary{(with default values as mentioned above)}.
 
 \commentary{%
 For this purpose we need not distinguish between
@@ -6066,7 +6068,10 @@ It is a compile-time error to apply $M$ to $S$ if $S$ does not implement,
 directly or indirectly, all of $T_1$, \ldots, $T_n$.
 It is a compile-time error if any of \metavar{members} contains a
 super-invocation of a member $m$
-(\commentary{ for example \code{super.foo}, \code{super\,\,+\,\,2}, or \code{super[1]\,=\,2}}),
+\commentary{%
+  (for example \code{super.foo}, \code{super\,\,+\,\,2},
+  or \code{super[1]\,=\,2}),%
+}
 and $S$ does not have a concrete
 implementation of $m$ which is a valid override of the member $m$ in
 the interface $M_S$.
@@ -6182,7 +6187,7 @@ It introduces an
 \Index{extension}
 with the given \synt{identifier}, if present,
 into the namespace of the enclosing library
-(\commentary{and hence into the library scope}),
+\commentary{(and hence into the library scope)},
 and provides a scope for the declaration of
 extension members.
 Additionally, the extension is introduced into the library namespace
@@ -6270,10 +6275,10 @@ in this section and its subsections.%
 \LMHash{}%
 The declared name of an extension does not denote a type,
 but it can be used to denote the extension itself
-(\commentary{%
-e.g., in order to access static members of the extension,
-or in order to resolve an invocation explicitly%
-}).
+\commentary{%
+  (e.g., in order to access static members of the extension,
+  or in order to resolve an invocation explicitly)%
+}.
 
 \LMHash{}%
 An extension declaration introduces two scopes:
@@ -6431,7 +6436,7 @@ on the type parameters of $E$
 A compile-time error occurs unless
 \SubtypeNE{T_j}{[T_1/X_1, \ldots, T_s/X_s]B_j},
 $j \in 1 .. s$
-(\commentary{that is, the bounds cannot be violated}).
+\commentary{(that is, the bounds cannot be violated)}.
 %
 A compile-time error occurs unless the static type of $e$ is assignable to
 the instantiated \ON{} type of $a$.
@@ -6472,7 +6477,7 @@ Let $i$ be a simple member invocation
 whose receiver $r$ is an extension application of the form
 \BlindDefineSymbol{E, T_j, k, e}%
 \code{$E$<\List{T}{1}{k}>($e$)}
-(\commentary{which is \code{$E$($e$)} when $k$ is zero})
+\commentary({which is \code{$E$($e$)} when $k$ is zero)}
 whose corresponding member name is \DefineSymbol{n},
 and assume that $r$ has no compile-time errors.
 A compile-time error occurs unless the extension denoted by $E$
@@ -6572,7 +6577,7 @@ which is unlikely to be desirable.%
 
 \LMHash{}%
 Instance members of an extension can be invoked or closurized implicitly
-(\commentary{without mentioning the name of the extension}),
+\commentary{(without mentioning the name of the extension)},
 as if they were instance members of the receiver of
 the given member invocation.
 
@@ -7000,7 +7005,7 @@ If \id{} is a method then $e$ is known as an
   extension!instance method closurization}
 of \id{} on $a$,
 and evaluation of $e$
-(\commentary{which is \code{$E$<\List{S}{1}{m}>($e_1$).\id}})
+\commentary{(which is \code{$E$<\List{S}{1}{m}>($e_1$).\id})}
 proceeds as follows:
 
 \LMHash{}%
@@ -7160,7 +7165,7 @@ and $i$ an expression of the form
 \code{$a$<$A_1, \ldots,\ A_r$>($a_1, \ldots,\ a_n,\ x_{n+1}$:\ $a_{n+1}, \ldots,\ x_{n+k}$:\ $a_{n+k}$)}
 
 \noindent
-(\commentary{where the type argument list is omitted when $r$ is zero}).
+\commentary{(where the type argument list is omitted when $r$ is zero)}.
 $i$ is then treated as
 (\ref{notation})
 
@@ -7183,7 +7188,7 @@ and let $i$ be an expression of the form
 \code{$e$<$A_1, \ldots,\ A_r$>($a_1, \ldots,\ a_n,\ x_{n+1}$:\ $a_{n+1}, \ldots,\ x_{n+k}$:\ $a_{n+k}$)}
 
 \noindent
-(\commentary{where the type argument list is again omitted when $r$ is zero}).
+\commentary{(where the type argument list is again omitted when $r$ is zero)}.
 If $S$ is \DYNAMIC, \FUNCTION, or a function type,
 or the interface of $S$ has a method named \CALL,
 $i$ is specified elsewhere
@@ -8069,7 +8074,7 @@ does not have a simple bound.%
 \LMHash{}%
 Let $T$ be a type of the form \synt{typeName}
 which denotes a generic class or a generic type alias
-(\commentary{so $T$ is raw}).
+\commentary{(so $T$ is raw)}.
 Then $T$ is equivalent to the parameterized type which is
 the result obtained by applying instantiation to bound to $T$.
 It is a compile-time error if the instantiation to bound fails.
@@ -8129,7 +8134,7 @@ So each type variable is related to, that is, depends on,
 every type variable in its bound, which might include itself.%
 }
 Let \TransitivelyDepends{} be the transitive
-(\commentary{but not reflexive})
+\commentary{(but not reflexive)}
 closure of \Depends.
 For each $m$, let $U_{i,m+1}$, for $i \in 1 .. k$,
 be determined by the following iterative process, where $V_m$ denotes
@@ -8139,7 +8144,7 @@ be determined by the following iterative process, where $V_m$ denotes
 \item[1.]
   If there exists a $j \in 1 .. k$ such that
   $X_j \TransitivelyDepends X_j$
-  (\commentary{that is, if the dependency graph has a cycle})
+  \commentary{(that is, if the dependency graph has a cycle)}
   let \List{M}{1}{p} be the strongly connected components (SCCs)
   with respect to \Depends.
   \commentary{%
@@ -8151,7 +8156,7 @@ be determined by the following iterative process, where $V_m$ denotes
   and the order does not matter for this algorithm.%
   }
   Let $M$ be the union of \List{M}{1}{p}
-  (\commentary{that is, all variables that participate in a dependency cycle}).
+  \commentary{(that is, all variables that participate in a dependency cycle)}.
   Let $i \in 1 .. k$.
   If $X_i$ does not belong to $M$ then $U_{i,m+1}$ is $U_{i,m}$.
   Otherwise there exists a $q$ such that $X_i \in M_q$;
@@ -8163,13 +8168,13 @@ be determined by the following iterative process, where $V_m$ denotes
 
 \item[2.]
   Otherwise
-  (\commentary{when there are no dependency cycles}),
+  \commentary{(when there are no dependency cycles)},
   let $j$ be the lowest number such that $X_j$ occurs in $U_{p,m}$ for some $p$
   and $X_j \not\rightarrow_m X_q$ for all $q$ in $1 .. k$
-  (\commentary{%
-  that is, the bound of $X_j$ does not contain any type variables,
-  but $X_j$ occurs in the bound of some other type variable%
-  }).
+  \commentary{%
+    (that is, the bound of $X_j$ does not contain any type variables,
+    but $X_j$ occurs in the bound of some other type variable)%
+  }.
   Then, for all $i \in 1 .. k$,
   $U_{i,m+1}$ is obtained from $U_{i,m}$
   by substituting $U_{j,m}$ for every occurrence of $X_j$
@@ -8179,7 +8184,7 @@ be determined by the following iterative process, where $V_m$ denotes
 
 \item[3.]
   Otherwise
-  (\commentary{when there are no dependencies at all}),
+  \commentary{(when there are no dependencies at all)},
   terminate with the result \code{<$U_{1,m},\ \ldots,\ U_{k,m}$>}.
 \end{itemize}
 
@@ -9603,7 +9608,7 @@ In the rule for \synt{RAW\_MULTI\_LINE\_STRING},
 the two occurrences of \lit{.*?}
 denote a non-greedy token recognition step:
 It terminates as soon as the lookahead is the specified next token
-(\commentary{that is, \lit{\sqsqsq} or \lit{"""}}).
+\commentary{(that is, \lit{\sqsqsq} or \lit{"""})}.
 
 \commentary{%
 Note that multi-line string interpolation relies on
@@ -9813,7 +9818,7 @@ of the form
 \code{Symbol($e$)}, \code{\NEW\,\,Symbol($e$)},
 or \code{\CONST\,\,Symbol($e$)},
 where $e$ is an expression
-(\commentary{constant if necessary})
+\commentary{(constant if necessary)}
 that evaluates to a string $s$,
 we say that $o$ is a \NoIndex{non-private symbol based on} $s$.
 
@@ -9831,7 +9836,7 @@ If \code{$s_1$\,==\,$s_2$} then $o_1$ and $o_2$ is the same object.
 
 \LMHash{}%
 If $o_1$ and $o_2$ are non-private symbols
-(\commentary{not necessarily constant})
+\commentary{(not necessarily constant)}
 based on strings $s_1$ and $s_2$
 then $o_1$ and $o_2$ are equal according to operator \lit{==}
 if and only if \code{$s_1$ == $s_2$}
@@ -10079,8 +10084,8 @@ A \synt{forElement} can never occur in a constant collection literal.%
 %%   map or $V$ is not assignable to the value type of the map".
 %%   This is an error, \ref{maps}.
 %%
-%% - "The variable in a \synt{forElement} (\commentary{either a for-in
-%%   element or C-style}) is declared outside of the element to be final or
+%% - "The variable in a \synt{forElement} \commentary{(either a for-in
+%%   element or C-style)} is declared outside of the element to be final or
 %%   to not have a setter".
 %%   This error is specified in \ref{listLiteralInference} and
 %%   \ref{setAndMapLiteralInference}.
@@ -10111,7 +10116,7 @@ A \synt{forElement} can never occur in a constant collection literal.%
 %%   \AWAIT{} can only be used with for-in loops".
 %%   Same text again.
 %%
-%% - "The type of the condition expression (\commentary{the second clause})
+%% - "The type of the condition expression \commentary{(the second clause)}
 %%   in a C-style \FOR{} element may not be assigned to \code{bool}".
 %%   Same text again.
 
@@ -10164,7 +10169,7 @@ We use the notation
   \ensuremath{[\hspace{-0.6mm}[\ldots]\hspace{-0.6mm}]}}
 to denote an object sequence with explicitly listed elements,
 and we use `$+$' to compute the concatenation of object sequences
-(\commentary{as in $s_1 + s_2$}),
+\commentary{(as in $s_1 + s_2$)},
 which is an operation that will succeed and has no side-effects.
 Each element in the sequence is an object $o$ or a pair $o_1: o_2$.
 There is no notion of an element type for an object sequence,
@@ -10305,7 +10310,7 @@ Evaluate $e$ to an object $o_{\metavar{spread}}$.
   If \metavar{target} is a list or a set then
   let $S_{\metavar{spread}}$ be \code{Iterable<\DYNAMIC>};
   otherwise
-  (\commentary{where \metavar{target} is a map}),
+  \commentary{(where \metavar{target} is a map)},
   let $S_{\metavar{spread}}$ be \code{Map<\DYNAMIC,\,\,\DYNAMIC>}.
 
   \begin{itemize}
@@ -10509,7 +10514,7 @@ Let $e$ be the expression of $\ell$.
 If $\ell$ is `\code{...$e$}',
 let $S$ be the inferred type of $e$ in context \code{Iterable<$P$>}.
 Otherwise
-(\commentary{when $\ell$ is `\code{...?$e$}'}),
+\commentary{(when $\ell$ is `\code{...?$e$}')},
 %% TODO(eernst): Come NNBD, add a \ref{} to the specification of
 %% 'the non-nullable type of'.
 let $S$ be the non-nullable type of
@@ -10575,10 +10580,10 @@ then the variable \code{v} is in scope for $\ell$.%
 }
 
 Inference for the parts
-(\commentary{%
-such as the iterable expression of a for-in,
-or the \synt{forInitializerStatement} of a for loop%
-})
+\commentary{%
+  (such as the iterable expression of a for-in,
+  or the \synt{forInitializerStatement} of a for loop)%
+}
 is done as for the corresponding \FOR{} statement,
 including \AWAIT{} if and only if the element includes \AWAIT.
 Then, if the inferred element type of $\ell_1$ is $S$,
@@ -10696,7 +10701,7 @@ which means that \CONST{} modifiers need not be specified explicitly.%
 It is a compile-time error
 if an element of a constant list literal is not constant.
 It is a compile-time error if the type argument of a constant list literal
-(\commentary{no matter whether it is explicit or inferred})
+\commentary{(no matter whether it is explicit or inferred)}
 is not a constant type expression
 (\ref{constants}).
 
@@ -10844,7 +10849,7 @@ the first applicable entry in the following list:
   $e$ is a map literal.
 \item
   When ${\cal L} \not= \emptyset$
-  (\commentary{that is, $e$ has leaf elements}):
+  \commentary{(that is, $e$ has leaf elements)}:
   If $\cal L$ contains a \synt{mapElement}
   as well as an \synt{expressionElement},
   a compile-time error occurs.
@@ -11214,10 +11219,10 @@ then the variable \code{v} is in scope for $\ell$.%
 }
 
 Inference for the parts
-(\commentary{%
-such as the iterable expression of a for-in,
-or the \synt{forInitializerStatement} of a for loop%
-})
+\commentary{%
+  (such as the iterable expression of a for-in,
+  or the \synt{forInitializerStatement} of a for loop)%
+}
 is done as for the corresponding \FOR{} statement,
 including \AWAIT{} if and only if the element includes \AWAIT.
 
@@ -11444,7 +11449,7 @@ It is a compile-time error if two elements of a constant set literal are equal
 according to their \lit{==} operator
 (\ref{equality}).
 It is a compile-time error if the type argument of a constant set literal
-(\commentary{no matter whether it is explicit or inferred})
+\commentary{(no matter whether it is explicit or inferred)}
 is not a constant type expression
 (\ref{constants}).
 
@@ -11467,7 +11472,7 @@ evaluation of \List{\ell}{1}{m}
 (\ref{collectionLiteralElementEvaluation}).
 The elements of $o$ occur in the same order as
 the objects in said object sequence
-(\commentary{which can be observed by iteration}).
+\commentary{(which can be observed by iteration)}.
 
 \LMHash{}%
 Let \code{\CONST?\,\,<$T_1$>\{\,$\ell_{11}, \ldots, \ell_{1m_1}$\,\}}
@@ -11578,12 +11583,12 @@ and the value for a given key is retrieved from a map using operator \lit{[]}.
 The keys of a map are treated similarly to a set
 (\ref{sets}):
 When binding a key $k_{\metavar{new}}$ to a value $v$ in a map $m$
-(\commentary{as in \code{$m$[$k_{\metavar{new}}$]\,=\,$v$}}),
+\commentary{(as in \code{$m$[$k_{\metavar{new}}$]\,=\,$v$})},
 if $m$ already has a key $k_{\metavar{old}}$ such that
 \code{$k_{\metavar{old}}$ == $k_{\metavar{new}}$} evaluates to \TRUE,
 $m$ will bind $k_{\metavar{old}}$ to $v$;
 otherwise
-(\commentary{when no such key $k_{\metavar{old}}$ exists}),
+\commentary{(when no such key $k_{\metavar{old}}$ exists)},
 a binding from $k_{\metavar{new}}$ to $v$ is added to $m$.
 
 \LMHash{}%
@@ -11641,7 +11646,7 @@ It is a compile-time error if two keys of a constant map literal are equal
 according to their \lit{==} operator
 (\ref{equality}).
 It is a compile-time error if a type argument of a constant map literal
-(\commentary{no matter whether it is explicit or inferred})
+\commentary{(no matter whether it is explicit or inferred)}
 is not a constant type expression
 (\ref{constants}).
 
@@ -12922,7 +12927,7 @@ and let $\parameterList{P}$ be the formal parameter list
 
 \noindent
 where each parameter may be marked \COVARIANT{}
-(\commentary{not shown, but allowed}).
+\commentary{(not shown, but allowed)}.
 
 \LMHash{}%
 We say that $\argumentList{S}$ is
@@ -12948,7 +12953,7 @@ and let $\parameterList{P}$ be the formal parameter list
 
 \noindent
 where each parameter may be marked \COVARIANT{}
-(\commentary{not shown, but allowed}).
+\commentary{(not shown, but allowed)}.
 
 \LMHash{}%
 We say that $\argumentList{S}$ is
@@ -13122,7 +13127,7 @@ which is the unique function type $T_0$ such that $T$ is $T_0$ bounded.
 \LMHash{}%
 If the static type of $f$ is \DYNAMIC{} bounded or \FUNCTION{} bounded,
 no further static checks are performed on the invocation $i$
-(\commentary{apart from separate static checks on subterms like arguments}),
+\commentary{(apart from separate static checks on subterms like arguments)},
 and the static type of $i$ is \DYNAMIC.
 Otherwise, it is a compile-time error if the static type of $f$ is not
 function-type bounded.
@@ -13399,7 +13404,7 @@ Let $D$ be the declaration yielded by the lexical lookup of \id.
 \item
   Otherwise, if $D$ is
   a static method or getter
-  (\commentary{which may be implicitly induced by a static variable})
+  \commentary{(which may be implicitly induced by a static variable)}
   in the enclosing class or mixin $C$,
   $i$ is treated as
   (\ref{notation})
@@ -13796,7 +13801,7 @@ Evaluate $f$ to an object $o$.
 %% TODO(eernst): Come null-safety, remove the next line.
 A dynamic error occurs if $o$ is the null object.
 Let \RawFunctionType{S_0}{Y}{B'}{s}{$q$} be the dynamic type of $o$
-(\commentary{by soundness, this type is a subtype of $G$}).
+\commentary{(by soundness, this type is a subtype of $G$)}.
 $f$ then evaluates to a function object $o'$ with dynamic type
 $[t_1/Y_1, \ldots, t_s/Y_s](\FunctionTypeSimple{S_0}{$q$})$,
 where $t_j$ is the actual value of $T_j$, for $j \in 1 .. k$.
@@ -13824,7 +13829,7 @@ As a consequence, they are also equal according to operator \lit{==}.%
 
 \LMHash{}%
 Let $g_1$ and $g_2$ be two expressions
-(\commentary{which may or may not be constant})
+\commentary{(which may or may not be constant)}
 that are subject to generic function instantiation.
 Assume that $g_1$ and $g_2$ without a context type evaluate to $o_1$
 respectively $o_2$ such that \code{$o_1$ == $o_2$)} is true.
@@ -14191,7 +14196,7 @@ The meaning of each occurrence of $r'$ is determined as follows:
 When the receiver $r$ is an extension application
 (\ref{explicitExtensionInvocations})
 of the form \code{$E$<\List{T}{1}{k}>($e_r$)}
-(\commentary{where $k = 0$ means that the type argument list is absent}):
+\commentary{(where $k = 0$ means that the type argument list is absent)}:
 Let $v_r$ be a fresh variable bound to the value of $e_r$
 and with the same static type as $e_r$,
 then $r'$ is \code{$E$<\List{T}{1}{k}>($v_r$)} when it occurs
@@ -14365,7 +14370,7 @@ instance member named $m$, unless either:
 \item
   $T$ is \DYNAMIC{} bounded;
   in this case no further static checks are performed on $i$
-  (\commentary{apart from separate static checks on subterms like arguments})
+  \commentary{(apart from separate static checks on subterms like arguments)}
   and the static type of $i$ is \DYNAMIC.
   Or
 \item
@@ -14373,7 +14378,7 @@ instance member named $m$, unless either:
   (\ref{bindingActualsToFormals})
   and $m$ is \CALL;
   in this case no further static checks are performed on $i$
-  (\commentary{apart from separate static checks on subterms like arguments})
+  \commentary{(apart from separate static checks on subterms like arguments)}
   and the static type of $i$ is \DYNAMIC.
 \rationale{%
 This means that for invocations of an instance method named \CALL,
@@ -14391,9 +14396,9 @@ some potential overriding declarations.%
 If $T$ did not have an accessible member named $m$
 the static type of $i$ is \DYNAMIC,
 and no further static checks are performed on $i$
-(\commentary{%
-except that subexpressions of $i$ are subject to their own static analysis%
-}).
+\commentary{%
+  (except that subexpressions of $i$ are subject to their own static analysis)%
+}.
 
 \LMHash{}%
 If $i$ is a dynamic \code{Object} member invocation
@@ -14420,9 +14425,9 @@ and if the method lookup succeeded then let $F$ be the static type of $d$.
 Otherwise, let $d$ be the result of getter lookup
 for $m$ in $T$ with respect to $L$,
 and let $F$ be the return type of $d$.
-(\commentary{%
+\commentary{%
 Since \code{$T$.$m$} exists we cannot have a failure in both lookups.%
-})
+}
 If the getter return type $F$ is an interface type
 that has a method named \CALL,
 $i$ is treated as
@@ -14770,7 +14775,7 @@ If both lookups failed, a compile-time error occurs.
 
 \LMHash{}%
 Otherwise
-(\commentary{when one of the lookups succeeded}),
+\commentary{(when one of the lookups succeeded)},
 the static analysis of $i$ is performed
 as specified in Section~\ref{bindingActualsToFormals},
 considering the function to have static type $F$,
@@ -14817,7 +14822,7 @@ If the lookup succeeded,
 let $f$ denote the function associated with $D$.
 %
 Otherwise
-(\commentary{when method lookup failed}),
+\commentary{(when method lookup failed)},
 let the declaration $D$ be the result of looking up
 the getter $m$ with respect to $L$ in $o$ starting with \SuperClass{}
 (\ref{lookup}).
@@ -15197,7 +15202,8 @@ or a super closurization (\ref{superClosurization}).
 Let $o$ be an object, and let $u$ be a fresh final variable bound to $o$.
 The \Index{closurization of method} $f$ on object $o$
 is defined to be equivalent
-(\commentary{except for equality, as noted below}) to:
+\commentary{(except for equality, as noted below)}
+to:
 
 \begin{itemize}
 %\item $(a) \{\RETURN{}$ $u$ $op$ $a;$\} if $f$ is named $op$
@@ -15352,7 +15358,8 @@ A \Index{super closurization}
 is a closurization of a method with respect to a class, as defined next.
 The \Index{closurization of a method} $f$ with respect to the class $S$
 is defined to be equivalent
-(\commentary{except for equality, as noted below}) to:
+\commentary{(except for equality, as noted below)}
+to:
 
 \begin{itemize}
 %\item $(a) \{\RETURN{}$ \SUPER{} $op$ $a;$\} if $f$ is named $op$
@@ -15540,7 +15547,7 @@ and let $G$ be the static type of $i$.
 Consider the situation where $G$ is a function type of the form
 \RawFunctionType{T_0}{X}{B}{s}{\metavar{parameters}}
 with $s > 0$
-(\commentary{that is, $G$ is a generic function type}),
+\commentary{(that is, $G$ is a generic function type)},
 and the context type is a non-generic function type $F$.
 In this situation a compile-time error occurs
 (\ref{variables},
@@ -15745,14 +15752,14 @@ Perform a lexical lookup of \code{\id=} from the location of \id.
 \begin{itemize}
 \item
   When the lexical lookup yields a declaration $D$ of a local variable $v$
-  (\commentary{which may be a formal parameter}),
+  \commentary{(which may be a formal parameter)},
   a compile-time error occurs if $v$ is final
   or if the static type of $e$ is not assignable to the declared type of $v$.
 \item
   When the lexical lookup yields a declaration $D$
   which is not a local variable,
   it is guaranteed to be a setter
-  (\commentary{that may be explicit or induced implicitly by a variable})
+  \commentary{(that may be explicit or induced implicitly by a variable)}
   because other declarations do not have a name
   of the form \code{\id=}.
 
@@ -15792,7 +15799,7 @@ Perform a lexical lookup of \code{\id=} from the location of \id.
 
 \LMHash{}%
 In all cases
-(\commentary{whether or not \id{} is a local variable, etc.}),
+\commentary{(whether or not \id{} is a local variable, etc.)},
 the static type of $a$ is the static type of $e$.
 
 \LMHash{}%
@@ -15804,7 +15811,7 @@ Perform a lexical lookup of \code{\id=} from the location of \id.
 \item
   In the case where the lexical lookup yields
   a declaration $D$ of a local variable $v$,
-  (\commentary{which may be a formal parameter}),
+  \commentary{(which may be a formal parameter)},
   the expression $e$ is evaluated to an object $o$,
   and the variable $v$ is bound to $o$.
   Then $a$ evaluates to the object $o$
@@ -15814,7 +15821,7 @@ Perform a lexical lookup of \code{\id=} from the location of \id.
   from the location of \id{}
   yields a declaration $D$,
   $D$ is necessarily a top level setter $s$
-  (\commentary{possibly implicitly induced by a variable}).
+  \commentary{(possibly implicitly induced by a variable)}.
 
   The expression $e$ is evaluated to an object $o$.
   Then the setter $s$ is invoked
@@ -15846,7 +15853,7 @@ where $p$ is an import prefix and \id{} is an identifier.
 \LMHash{}%
 A compile-time error occurs,
 unless $p$ has a member which is a setter $s$ named \code{id=}
-(\commentary{which may be implicitly induced by a variable declaration})
+\commentary{(which may be implicitly induced by a variable declaration)}
 such that the static type of $e$
 is assignable to the parameter type of $s$.
 
@@ -17017,7 +17024,7 @@ Consider a postfix expression $e$ of the form \code{$C$.$v$\,\op},
 where $C$ is a type literal and \op{} is either \lit{++} or \lit{-{}-}.
 A compile-time error occurs unless \code{$C$.$v$} denotes a static getter
 and there is an associated static setter \code{$v$=}
-(\commentary{possibly implicitly induced by a static variable}).
+\commentary{(possibly implicitly induced by a static variable)}.
 Let $T$ be the return type of said getter.
 A compile-time error occurs if $T$ is not \DYNAMIC{}
 and $T$ does not have an operator \lit{+} (when \op{} is \lit{++})
@@ -17045,7 +17052,7 @@ where \op{} is either \lit{++} or \lit{-{}-}.
 Let $S$ be the static type of $e_1$.
 A compile-time error occurs unless $S$ has
 a getter named $v$ and a setter named \code{$v$=}
-(\commentary{possibly implicitly induced by an instance variable}).
+\commentary{(possibly implicitly induced by an instance variable)}.
 Let $T$ be the return type of said getter.
 A compile-time error occurs if $T$ is not \DYNAMIC{}
 and $T$ does not have an operator \lit{+} (when \op{} is \lit{++})
@@ -17174,16 +17181,17 @@ specifies the static analysis and dynamic semantics of
 various forms of assignment.
 Each of those cases is applicable when the specified subterms satisfy
 the given side conditions
-(\commentary{%
-e.g., one case of the form \code{$e_1$.$v$\,\,??=\,\,$e_2$} requires $e_1$
-to be an expression, whereas \code{$C$.$v$\,\,??=\,\,$e$}
-requires $C$ to be a type literal%
-}).
+\commentary{%
+  (e.g., one case of the form \code{$e_1$.$v$\,\,??=\,\,$e_2$} requires $e_1$
+  to be an expression, whereas \code{$C$.$v$\,\,??=\,\,$e$}
+  requires $C$ to be a type literal)%
+}.
 The cases requiring subterms to be expressions are considered least specific,
 that is, they are only used if no other case matches
-(\commentary{%
-so the case containing $C$ is used if the corresponding term is a type literal%
-}).
+\commentary{%
+  (so the case containing $C$ is used
+  if the corresponding term is a type literal)%
+}.
 
 \commentary{%
 Syntactically, these expressions are not derived from \synt{expression},
@@ -17333,7 +17341,7 @@ In this case, at least one declaration with basename \id{}
 is in scope at the location $\ell$.
 It is a compile-time error if the name of $D$ is not $n$,
 unless $D$ is an instance member or a local variable
-(\commentary{which may be a formal parameter}).
+\commentary{(which may be a formal parameter)}.
 
 \commentary{%
 That is, it is an error if we look for a setter and find a getter,
@@ -17585,7 +17593,7 @@ Let $D$ be the declaration yielded by the lexical lookup of \id.
   the static type of $e$ is \code{Type}.
 \item
   If $D$ is the declaration of a library getter
-  (\commentary{which may be implicitly induced by a library variable}),
+  \commentary{(which may be implicitly induced by a library variable)},
   the static type of $e$ is the static type of the
   library getter invocation \id{}
   (\ref{topLevelGetterInvocation}).
@@ -17600,13 +17608,13 @@ Let $D$ be the declaration yielded by the lexical lookup of \id.
   }
 \item
   If $D$ is the declaration of a static getter
-  (\commentary{which may be implicitly induced by a static variable})
+  \commentary{(which may be implicitly induced by a static variable)}
   and $D$ occurs in the class $C$,
   the static type of $e$ is the return type of the getter
   \code{$C$.\id}.
 \item
   If $D$ is a local variable declaration
-  (\commentary{which can be a formal parameter})
+  \commentary{(which can be a formal parameter)}
   the static type of $e$ is the type of the variable $v$ declared by $D$,
   unless $v$ is known to have some type $T$,
   where $T$ is a subtype of any other type $S$
@@ -17693,7 +17701,7 @@ The evaluation of $e$ proceeds as follows:
   the current binding of \THIS.
 \item
   If $D$ is the declaration of a library getter
-  (\commentary{which may be implicitly induced by a library variable}),
+  \commentary{(which may be implicitly induced by a library variable)},
   evaluation of $e$ is equivalent to evaluation of an invocation of
   the library getter \id{}
   (\ref{topLevelGetterInvocation}).
@@ -17723,7 +17731,7 @@ The evaluation of $e$ proceeds as follows:
   (\ref{extensionMethodClosurization}).
 \item
   If $D$ is a local variable $v$
-  (\commentary{which can be a formal parameter})
+  \commentary{(which can be a formal parameter)}
   then $e$ evaluates to the current binding of $v$.
 \end{itemize}
 
@@ -17745,7 +17753,7 @@ This situation cannot arise,
 because it is a compile-time error
 to evaluate an import prefix as an expression,
 and no constructs involving an import prefix
-(\commentary{e.g., such as a property extraction \code{$p$.$m$}})
+\commentary{(e.g., such as a property extraction \code{$p$.$m$})}
 will evaluate the import prefix.
 \EndCase
 
@@ -17798,7 +17806,7 @@ The is-expression \code{$e$ \IS{}! $T$} is equivalent to
 
 \LMHash{}%
 Let $v$ be a local variable
-(\commentary{which can be a formal parameter}).
+\commentary{(which can be a formal parameter)}.
 An is-expression of the form \code{$v$ \IS{} $T$}
 shows that $v$ has type $T$
 if $T$ is a subtype of the type of the expression $v$.
@@ -18252,7 +18260,7 @@ then $v$ is bound to $o$.
 If an object $o$ is assigned to $v$
 in a situation where $v$ is bound to an object $o'$
 then a dynamic error occurs
-(\commentary{it does not matter whether $o$ is the same object as $o'$}).
+\commentary{(it does not matter whether $o$ is the same object as $o'$)}.
 
 
 \subsection{Local Function Declaration}
@@ -20173,10 +20181,10 @@ among names imported with the same prefix.
 When $I_i$ has prefix $p_i$,
 let \List{I'}{1}{k} be the sublist of \List{I}{1}{m} that have prefix $p_i$,
 and let \List{L'}{1}{k} be the corresponding libraries
-(\commentary{which is a sublist of \List{L}{1}{m}}).
+\commentary{(which is a sublist of \List{L}{1}{m})}.
 Let \NamespaceName{\metavar{exported},j}, $j \in 1 .. k$,
 be the namespace provided by the import directive $I'_j$
-(\commentary{which takes \SHOW{} and \HIDE{} into account}).
+\commentary{(which takes \SHOW{} and \HIDE{} into account)}.
 
 \LMHash{}%
 When $I_i$ is a non-deferred import:
@@ -20188,7 +20196,7 @@ conflict merging to
 \LMHash{}%
 When $I_i$ is a deferred import:
 In this case $k$ is 1
-(\commentary{otherwise a compile-time error would occur}),
+\commentary{(otherwise a compile-time error would occur)},
 and \NamespaceName{\metavar{prefix},i} is the namespace obtained by
 adding a binding of the name \code{loadLibrary}
 to an implicitly induced declaration of a function with signature
@@ -20238,12 +20246,12 @@ with the following members:
 An extension declaration $E$ is a member of $\cal E$
 if there is an $i \in 1 .. m$ such that
 $E$ is in the namespace provided by the import directive $I_i$
-(\commentary{%
-note that this takes \SHOW{} and \HIDE{} into account,
-and it includes extensions imported both without and with a prefix%
-}),
+\commentary{%
+  (note that this takes \SHOW{} and \HIDE{} into account,
+  and it includes extensions imported both without and with a prefix)%
+},
 and $E$ is not declared in the current library
-(\commentary{which could be the case if it imports itself}).
+\commentary{(which could be the case if it imports itself)}.
 Let \NamespaceName{\metavar{extensions}} be a namespace that
 for each extension $E$ in $\cal E$ maps a fresh name to $E$.
 
@@ -20698,7 +20706,7 @@ that this name is conflicted.
 
 \LMHash{}%
 Let \List{\metavar{NS}}{1}{m} be a list of namespaces
-(\commentary{the list may or may not contain duplicates}).
+\commentary{(the list may or may not contain duplicates)}.
 The
 \IndexCustom{conflict merging}{namespace!conflict merging}
 of \List{\metavar{NS}}{1}{m} is then
@@ -21211,7 +21219,7 @@ under the assumption that all deferred libraries have successfully been loaded.
 \LMHash{}%
 The static type system ascribes a static type to every expression.
 In some cases, the type of a local variable
-(\commentary{which can be a formal parameter})
+\commentary{(which can be a formal parameter)}
 may be promoted from the declared type, based on control flow.
 
 \LMHash{}%
@@ -21363,10 +21371,10 @@ Consider a type alias declaration $D$ of the form
 declared in a library $L$.
 The effect of $D$ is to introduce \id{} into the library scope of $L$.
 When $s = 0$
-(\commentary{where the type alias is non-generic})
+\commentary{(where the type alias is non-generic)}
 \id{} is bound to $T$.
 When $s > 0$
-(\commentary{where the type alias is generic})
+\commentary{(where the type alias is generic)}
 \id{} is bound to a mapping from a type argument list
 \List{U}{1}{s}
 to the type
@@ -21535,7 +21543,7 @@ and we are just replacing the type alias name by its body.%
 If $U$ is a type we may repeatedly replace each subterm of $U$
 which is a parameterized type applying a type alias to some type arguments
 by its alias expansion in one step
-(\commentary{including the non-generic case where there are no type arguments}).
+\commentary{(including the non-generic case where there are no type arguments)}.
 When no further steps are possible we say that the resulting type is the
 \IndexCustom{transitive alias expansion}{%
   type alias!transitive alias expansion}
@@ -21566,7 +21574,7 @@ a type of the form $C$ or \code{$q$.$C$},
 optionally followed by \synt{typeArguments},
 where $q$ is an identifier denoting an import prefix,
 and $C$ respectively \code{$q$.$C$} denotes a class or mixin
-(\commentary{in particular, $C$ can not be a type variable}).
+\commentary{(in particular, $C$ can not be a type variable)}.
 Assume that $U$ occurs in an expression $e$ of the form
 `\code{$U$.\id\;\metavar{args}}'
 where \metavar{args} is derived from \syntax{<argumentPart>?},
@@ -21977,7 +21985,7 @@ bounds of type variables.
 $\Delta$ is a partial function that maps type variables to types.
 At a given location where the type variables in scope are
 \TypeParametersStd{}
-(\commentary{as declared by enclosing classes and/or functions}),
+\commentary{(as declared by enclosing classes and/or functions)},
 we define the environment as follows:
 $\Delta = \{\,X_1 \mapsto B_1,\ \ldots\ X_s \mapsto B_s\,\}$.
 \commentary{%
@@ -22530,7 +22538,7 @@ whenever doing so is sound.
   where the static type of $d$ is \DYNAMIC,
   and \id{} is the name of a method declared in \code{Object}
   whose method signature has type $F$
-  (\commentary{which is a function type}).
+  \commentary{(which is a function type)}.
   The static type of $e$ is then $F$.
   \commentary{%
     For instance, \code{$d$.toString} has type \code{String \FUNCTION()}.%

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -6056,10 +6056,14 @@ super-invocation of a member $m$
 (\commentary{ for example \code{super.foo}, \code{super\,\,+\,\,2}, or \code{super[1]\,=\,2}}),
 and $S$ does not have a concrete
 implementation of $m$ which is a valid override of the member $m$ in
-the interface $M_S$. \rationale{We treat super-invocations in mixins as
-interface invocations on the combined superinterface, so we require the
-superclass of a mixin application to have valid implementations of those
-interface members that are actually super-invoked.}
+the interface $M_S$.
+\rationale{%
+We treat super-invocations in mixins as
+interface invocations on the combined superinterface,
+so we require the superclass of a mixin application to have
+valid implementations of those interface members
+that are actually super-invoked.%
+}
 
 \LMHash{}%
 The mixin application of $M$ to $S$ with name $N$ introduces a new

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -15804,7 +15804,6 @@ is assignable to the parameter type of $s$.
 The static type of $a$ is the static type of $e$.
 
 \LMHash{}%
-\LMHash{}%
 Evaluation of an assignment $a$ of the form \code{$p$.\id{} = $e$}
 proceeds as follows:
 The expression $e$ is evaluated to an object $o$.

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -6049,8 +6049,9 @@ and let $N$ be a name.
 It is a compile-time error to apply $M$ to $S$ if $S$ does not implement,
 directly or indirectly, all of $T_1$, \ldots, $T_n$.
 It is a compile-time error if any of \metavar{members} contains a
-super-invocation of a member $m$ \commentary{(for example \code{super.foo},
-\code{super + 2}, or \code{super[1] = 2})}, and $S$ does not have a concrete
+super-invocation of a member $m$
+(\commentary{ for example \code{super.foo}, \code{super\,\,+\,\,2}, or \code{super[1]\,=\,2}}),
+and $S$ does not have a concrete
 implementation of $m$ which is a valid override of the member $m$ in
 the interface $M_S$. \rationale{We treat super-invocations in mixins as
 interface invocations on the combined superinterface, so we require the
@@ -6068,9 +6069,11 @@ introduces generative constructors on $C$ as follows:
 
 \LMHash{}%
 Let $L_C$ be the library containing the mixin application.
-\commentary{That is, the library containing the clause \code{$S$ \WITH{} $M$}
-or the clause \code{$S_0$ \WITH{} $M_1$, \ldots,\ $M_k$, $M$} giving rise
-to the mixin application.}
+\commentary{%
+  That is, the library containing the clause \code{$S$ \WITH{} $M$}
+  or the clause \code{$S_0$ \WITH{} $M_1$, \ldots,\ $M_k$, $M$}
+  giving rise to the mixin application.%
+}
 
 Let $S_N$ be the name of $S$.
 
@@ -9568,7 +9571,7 @@ In the rule for \synt{RAW\_MULTI\_LINE\_STRING},
 the two occurrences of \lit{.*?}
 denote a non-greedy token recognition step:
 It terminates as soon as the lookahead is the specified next token
-(\commentary{that is, \lit{\sqsqsq}or \lit{"""}}).
+(\commentary{that is, \lit{\sqsqsq} or \lit{"""}}).
 
 \commentary{%
 Note that multi-line string interpolation relies on
@@ -20807,13 +20810,15 @@ A Dart program will typically be executed by executing a script.%
 \LMHash{}%
 It is a compile-time error if a library's export scope contains a declaration
 named \code{main}, and the library is not a script.
-\commentary{This restriction ensures that all top-level \code{main} declarations
+\commentary{%
+This restriction ensures that all top-level \code{main} declarations
 introduce a script main-function, so there cannot be a top-level getter or field
 named \code{main}, nor can it be a function that requires more than two
 arguments. The restriction allows tools to fail early on invalid \code{main}
 methods, without needing to know whether a library will be used as the entry
 point of a Dart program. It is possible that this restriction will be removed
-in the future.}
+in the future.%
+}
 
 
 \subsection{URIs}
@@ -22329,9 +22334,12 @@ If a mixin application mixes \FUNCTION{} onto a superclass, it follows the
 normal rules for mixin-application, but since the result of that mixin
 application is equivalent to a class with \code{implements Function}, and
 that clause has no effect, the resulting class also does not
-implement \FUNCTION. \commentary{The \FUNCTION{} class declares no
-concrete instance members, so the mixin application creates a sub-class
-of the superclass with no new members and no new interfaces.}
+implement \FUNCTION.
+\commentary{%
+The \FUNCTION{} class declares no concrete instance members,
+so the mixin application creates a sub-class of
+the superclass with no new members and no new interfaces.%
+}
 
 \rationale{%
 Since using \FUNCTION{} in these ways has no effect, it would be

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -8140,7 +8140,8 @@ be determined by the following iterative process, where $V_m$ denotes
   which is in a contravariant position in $V_m$.
 
 \item[2.]
-  Otherwise (\commentary{when there are no dependency cycles}),
+  Otherwise
+  (\commentary{when there are no dependency cycles}),
   let $j$ be the lowest number such that $X_j$ occurs in $U_{p,m}$ for some $p$
   and $X_j \not\rightarrow_m X_q$ for all $q$ in $1 .. k$
   (\commentary{%
@@ -8155,7 +8156,8 @@ be determined by the following iterative process, where $V_m$ denotes
   which is in a contravariant position in $V_m$.
 
 \item[3.]
-  Otherwise (\commentary{when there are no dependencies at all}),
+  Otherwise
+  (\commentary{when there are no dependencies at all}),
   terminate with the result \code{<$U_{1,m},\ \ldots,\ U_{k,m}$>}.
 \end{itemize}
 
@@ -10807,7 +10809,8 @@ the first applicable entry in the following list:
   When $S$ implements \code{Map} but not \code{Iterable},
   $e$ is a map literal.
 \item
-  When ${\cal L} \not= \emptyset$ (\commentary{that is, $e$ has leaf elements}):
+  When ${\cal L} \not= \emptyset$
+  (\commentary{that is, $e$ has leaf elements}):
   If $\cal L$ contains a \synt{mapElement}
   as well as an \synt{expressionElement},
   a compile-time error occurs.
@@ -14714,7 +14717,8 @@ and let $F$ be the return type of $D$.
 If both lookups failed, a compile-time error occurs.
 
 \LMHash{}%
-Otherwise (\commentary{when one of the lookups succeeded}),
+Otherwise
+(\commentary{when one of the lookups succeeded}),
 the static analysis of $i$ is performed
 as specified in Section~\ref{bindingActualsToFormals},
 considering the function to have static type $F$,
@@ -14760,7 +14764,8 @@ the method $m$ with respect to $L$ in $o$ starting with \SuperClass{}
 If the lookup succeeded,
 let $f$ denote the function associated with $D$.
 %
-Otherwise (\commentary{when method lookup failed}),
+Otherwise
+(\commentary{when method lookup failed}),
 let the declaration $D$ be the result of looking up
 the getter $m$ with respect to $L$ in $o$ starting with \SuperClass{}
 (\ref{lookup}).
@@ -17358,7 +17363,7 @@ proceed as described in the first applicable case from the following list:
   % - a library variable, getter, or setter;
   % - a static method/getter/setter of a class, mixin, enum, or extension;
   % - an instance method of an extension;
-  % - a local variable (\commentary{which may be a formal parameter});
+  % - a local variable (which may be a formal parameter);
   % - a local function.
   Otherwise, the lexical lookup yields $D$.
 \end{itemize}
@@ -17725,7 +17730,8 @@ The is-expression \code{$e$ \IS{}! $T$} is equivalent to
 \code{!($e$ \IS{} $T$)}.
 
 \LMHash{}%
-Let $v$ be a local variable (\commentary{which can be a formal parameter}).
+Let $v$ be a local variable
+(\commentary{which can be a formal parameter}).
 An is-expression of the form \code{$v$ \IS{} $T$}
 shows that $v$ has type $T$
 if $T$ is a subtype of the type of the expression $v$.

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -5968,6 +5968,7 @@ The mixin derived from a class declaration:
 \}
 \end{normativeDartCode}
 
+\noindent
 has \code{Object} as required superinterface
 and combined superinterface,
 $I_1$, \ldots, $I_k$ as implemented interfaces,
@@ -6047,6 +6048,7 @@ Let $M_I$ be the interface that would be defined by the class declaration
 \}
 \end{normativeDartCode}
 
+\noindent
 where $\metavar{members}'$ are the member declarations of
 the mixin declaration $M$ except that all superinvocations are treated
 as if \SUPER{} was a valid expression with static type $M_S$.
@@ -18539,7 +18541,7 @@ $T$ $\id_1$ = $e$;
 \}
 \end{normativeDartCode}
 
-\noindent
+\LMHash{}%
 If the static type of $e$ is a top type
 (\ref{superBoundedTypes})
 then $T$ is \code{Iterable<\DYNAMIC>},
@@ -18852,6 +18854,7 @@ Execution of a switch statement of the form
 \}
 \end{normativeDartCode}
 
+\noindent
 or the form
 
 \begin{normativeDartCode}
@@ -18862,6 +18865,7 @@ or the form
 \}
 \end{normativeDartCode}
 
+\noindent
 proceeds as follows:
 
 \LMHash{}%
@@ -18895,6 +18899,7 @@ Matching of a \CASE{} clause \CASE{} $e_{k}: s_{k}$ of a switch statement
 \}
 \end{normativeDartCode}
 
+\noindent
 against the value of a variable \id{} proceeds as follows:
 
 \LMHash{}%
@@ -19013,6 +19018,7 @@ Execution of the case statements $s_h$ of a switch statement
 \}
 \end{normativeDartCode}
 
+\noindent
 or a switch statement
 
 \begin{normativeDartCode}
@@ -19024,6 +19030,7 @@ or a switch statement
 \}
 \end{normativeDartCode}
 
+\noindent
 proceeds as follows:
 
 \LMHash{}%
@@ -19195,6 +19202,8 @@ Execution of a \TRY{} statement $s$ of the form:
 \ON{} $T_n$ \CATCH{} ($e_n$, $t_n$) $c_n$
 \FINALLY{} $f$
 \end{normativeDartCode}
+
+\noindent
 proceeds as follows:
 
 \LMHash{}%

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -10283,6 +10283,7 @@ and $\EvaluateElement{\ell} := \LiteralSequence{o_1:o_2}$.
 \Case{Spread element}
 The element $\ell$ is of the form `\code{...$e$}' or `\code{...?$e$}'.
 Evaluate $e$ to an object $o_{\metavar{spread}}$.
+
 \begin{enumerate}
 \item
   When $\ell$ is `\code{...$e$}':
@@ -14862,6 +14863,7 @@ much like the methods that spawn isolates.%
 \IndexCustom{Property extraction}{property extraction}
 allows for a member to be accessed as a property rather than a function.
 A property extraction can be either:
+
 \begin{enumerate}
 \item An instance method closurization,
   which converts a method into a function object
@@ -18448,6 +18450,7 @@ If $c$ is empty then let $c'$ be \TRUE{} otherwise let $c'$ be $c$.
 \LMHash{}%
 First the variable declaration statement \VAR{} $v = e_0$ is executed.
 Then:
+
 \begin{enumerate}
 \item
   \label{beginFor}
@@ -19115,6 +19118,7 @@ in a structured way.
 
 \LMHash{}%
 A try statement consists of a block statement, followed by at least one of:
+
 \begin{enumerate}
 \item
   A set of \ON{}-\CATCH{} clauses, each of which specifies
@@ -19706,6 +19710,7 @@ First, the expression $e$ is evaluated to an object $o$.
 If the immediately enclosing function $m$ is marked \code{\SYNC*}
 (\ref{functions}),
 then:
+
 \begin{enumerate}
 \item
   % This error can occur due to implicit casts.
@@ -20869,12 +20874,15 @@ in the exported namespace of $S$ is invoked (\ref{functionInvocation})
 as follows:
 If \code{main} can be called with with two positional arguments,
 it is invoked with the following two actual arguments:
+
 \begin{enumerate}
 \item An object whose run-time type implements \code{List<String>}.
 \item An object specified when the current isolate $i$ was created,
 for example through the invocation of \code{Isolate.spawnUri} that spawned $i$,
 or the null object (\ref{null}) if no such object was supplied.
 \end{enumerate}
+
+\LMHash{}%
 If \code{main} cannot be called with two positional arguments,
 but it can be called with one positional argument,
 it is invoked with an object whose run-time type implements \code{List<String>}
@@ -22351,6 +22359,7 @@ may support more strict static checks as an option.%
 \LMHash{}%
 \IndexCustom{Function types}{type!function}
 come in two variants:
+
 \begin{enumerate}
 \item
   The types of functions that only have positional parameters.

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -7,7 +7,7 @@
 \usepackage{amssymb}
 \usepackage{semantic}
 \usepackage{dart}
-\usepackage{hyperref}
+\usepackage[hidelinks]{hyperref}
 \usepackage{lmodern}
 \usepackage[T1]{fontenc}
 \usepackage{makeidx}
@@ -40,6 +40,12 @@
 % the 'Version' specified on the front page has been changed to indicate the
 % version of the language which will actually be specified by the next stable
 % release of this document.
+%
+% Apr 2025
+% - Change the rules about constants to be more consistent: Every constant
+%   expression is also a potentially constant expression. Also, eliminate
+%   redundancies in the rules about constant collection literals and constant
+%   object expressions (they are now defined just once, outside 'Constants').
 %
 % Sep 2024
 % - Clarify the extension applicability rule to explicitly state that it
@@ -519,8 +525,8 @@ At this time, non-normative text includes:
 \item[Rationale]
   Discussion of the motivation for language design decisions appears in italics.
 \rationale{%
-Distinguishing normative from non-normative helps clarify
-what part of the text is binding and what part is merely expository.%
+  Distinguishing normative from non-normative helps clarify
+  what part of the text is binding and what part is merely expository.%
 }
 \item[Commentary]
   Comments such as
@@ -531,11 +537,11 @@ what part of the text is binding and what part is merely expository.%
   serve to illustrate or clarify the specification,
   but are redundant with the normative text.
 \commentary{%
-The difference between commentary and rationale can be subtle.%
+  The difference between commentary and rationale can be subtle.%
 }
 \rationale{%
-Commentary is more general than rationale,
-and may include illustrative examples or clarifications.%
+  Commentary is more general than rationale,
+  and may include illustrative examples or clarifications.%
 }
 \end{itemize}
 
@@ -545,7 +551,7 @@ Reserved words and built-in identifiers
 appear in {\bf bold}.
 
 \commentary{%
-Examples would be \SWITCH{} or \CLASS.%
+  Examples would be \SWITCH{} or \CLASS.%
 }
 
 \LMHash{}%
@@ -568,7 +574,7 @@ a single character if there is one;
 otherwise, a single token if there is one.
 
 \commentary{%
-An example would be:%
+  An example would be:%
 }
 
 \begin{grammar}\color{commentaryColor}
@@ -637,8 +643,8 @@ Conversely, if such a replacement would put an identifier \id{}
 the relevant declarations in $E$ are systematically renamed to fresh names.
 
 \commentary{%
-In short, capture freedom ensures that the ``meaning'' of each identifier
-is preserved during substitution.%
+  In short, capture freedom ensures that the ``meaning'' of each identifier
+  is preserved during substitution.%
 }
 
 \LMHash{}%
@@ -666,10 +672,11 @@ Such specifications should be understood as a shorthand for:
 \end{itemize}
 
 \rationale{%
-This circumlocution is required because
-{\rm\code{$x$.\metavar{op}($y$)}}, where op is an operator, is not legal syntax.
-However, it is painfully verbose, and we prefer to state this rule once here,
-and use a concise and clear notation across the specification.%
+  This circumlocution is required because
+  {\rm\code{$x$.\metavar{op}($y$)}}, where op is an operator,
+  is not legal syntax.
+  However, it is painfully verbose, and we prefer to state this rule once here,
+  and use a concise and clear notation across the specification.%
 }
 
 \LMHash{}%
@@ -691,15 +698,15 @@ References to otherwise unspecified names of program entities
 are interpreted as the names of members of the Dart core library.
 
 \commentary{%
-Examples would be the classes \code{Object} and \code{Type}
-representing, respectively, the root of the class hierarchy and
-the reification of run-time types.
-%
-It would be possible to declare, e.g.,
-a local variable named \code{Object},
-so it is generally incorrect to assume that
-the name \code{Object} will actually resolve to said core class.
-However, we will generally omit mentioning this, for brevity.%
+  Examples would be the classes \code{Object} and \code{Type}
+  representing, respectively, the root of the class hierarchy and
+  the reification of run-time types.
+  %
+  It would be possible to declare, e.g.,
+  a local variable named \code{Object},
+  so it is generally incorrect to assume that
+  the name \code{Object} will actually resolve to said core class.
+  However, we will generally omit mentioning this, for brevity.%
 }
 
 %% TODO(eernst): We need to get rid of the concept of `is equivalent to`,
@@ -715,7 +722,7 @@ another piece of syntax, it means that it is equivalent in all ways,
 and the former syntax should generate the same compile-time errors
 and have the same run-time behavior as the latter, if any.
 \commentary{%
-Error messages, if any, should always refer to the original syntax.%
+  Error messages, if any, should always refer to the original syntax.%
 }
 If execution or evaluation of a construct is said to be
 equivalent to execution or evaluation of another construct,
@@ -733,34 +740,35 @@ Moreover, if $s$ has no compile-time errors then
 the behavior of $s$ at run time is exactly the behavior of $s'$.
 
 \rationale{%
-Error \emph{messages}, if any, should always refer to the original syntax $s$.%
+  Error \emph{messages}, if any,
+  should always refer to the original syntax $s$.%
 }
 
 \commentary{%
-In short, whenever $s$ is treated as $s'$,
-the reader should immediately switch to the section about $s'$
-in order to get any further information about
-the static analysis and dynamic semantics of $s$.%
+  In short, whenever $s$ is treated as $s'$,
+  the reader should immediately switch to the section about $s'$
+  in order to get any further information about
+  the static analysis and dynamic semantics of $s$.%
 }
 
 \rationale{%
-The notion of being `treated as' is similar to the notion of syntactic sugar:
-``$s$ is treated as $s'$''
-could as well have been worded
-``$s$ is desugared into $s'$''.
-Of course, it should then actually be called ``semantic sugar'',
-because the applicability of the transformation and the construction of $s'$
-may rely on information from static analysis.
+  The notion of being `treated as' is similar to the notion of syntactic sugar:
+  ``$s$ is treated as $s'$''
+  could as well have been worded
+  ``$s$ is desugared into $s'$''.
+  Of course, it should then actually be called ``semantic sugar'',
+  because the applicability of the transformation and the construction of $s'$
+  may rely on information from static analysis.
 
-The point is that we only specify the static analysis and dynamic semantics
-of a core language which is a subset of Dart
-(just slightly smaller than Dart),
-and desugaring transforms any given Dart program to
-a program in that core language.
-This helps keeping the language specification consistent and comprehensible,
-because it shows directly
-that some language features are introducing essential semantics,
-and others are better described as mere abbreviations of existing constructs.%
+  The point is that we only specify the static analysis and dynamic semantics
+  of a core language which is a subset of Dart
+  (just slightly smaller than Dart),
+  and desugaring transforms any given Dart program to
+  a program in that core language.
+  This helps keeping the language specification consistent and comprehensible,
+  because it shows directly
+  that some language features are introducing essential semantics,
+  and others are better described as mere abbreviations of existing constructs.%
 }
 
 \LMHash{}%
@@ -774,9 +782,9 @@ because it allows for introducing and initializing one or more fresh variables,
 and using them in an expression.
 
 \commentary{%
-That is, a \LET{} expression is only introduced as a tool
-to define the evaluation semantics of an expression
-in terms of other expressions containing \LET{} expressions.%
+  That is, a \LET{} expression is only introduced as a tool
+  to define the evaluation semantics of an expression
+  in terms of other expressions containing \LET{} expressions.%
 }
 
 \LMHash{}%
@@ -804,10 +812,10 @@ For $j \in 1 .. k$, $v_j$ introduces a final, local variable into $S_j$,
 with the static type of $e_j$ as its declared type.
 
 \commentary{%
-Type inference of $e_j$ and the context type used for inference of $e_j$
-are not relevant.
-It is generally assumed that type inference has occurred already
-(\ref{overview}).%
+  Type inference of $e_j$ and the context type used for inference of $e_j$
+  are not relevant.
+  It is generally assumed that type inference has occurred already
+  (\ref{overview}).%
 }
 
 \LMHash{}%
@@ -841,16 +849,16 @@ is introduced and used in more than a few lines of text,
 it is shown in the margin.
 
 \commentary{%
-The point is that it is easy to find the definition of a symbol
-by scanning back in the text until that symbol occurs in the margin.
-To avoid useless verbosity, some symbols are not mentioned in the margin.
-For instance, we may introduce \List{e}{1}{k},
-but only show $e_j$ and $k$ in the margin.
+  The point is that it is easy to find the definition of a symbol
+  by scanning back in the text until that symbol occurs in the margin.
+  To avoid useless verbosity, some symbols are not mentioned in the margin.
+  For instance, we may introduce \List{e}{1}{k},
+  but only show $e_j$ and $k$ in the margin.
 
-Note that it may be necessary to look at a few lines of text
-above the `$\diamond$' or symbol,
-because the margin markers can be pushed down one line
-when there is more than one marker for a single line.%
+  Note that it may be necessary to look at a few lines of text
+  above the `$\diamond$' or symbol,
+  because the margin markers can be pushed down one line
+  when there is more than one marker for a single line.%
 }
 
 
@@ -874,16 +882,16 @@ about a library or program at the point
 where it is known to have a compile-time error.
 
 \commentary{%
-However, tools may choose to support execution of some programs with errors.
-For instance, a compiler may compile certain constructs with errors such that
-a dynamic error will be raised if an attempt is made to
-execute such a construct,
-or an IDE integrated runtime may support opening
-an editor window when such a construct is executed,
-allowing developers to correct the error.
-It is expected that such features would amount to a natural extension of the
-dynamic semantics of Dart as specified here, but, as mentioned,
-this specification makes no attempt to specify exactly what that means.%
+  However, tools may choose to support execution of some programs with errors.
+  For instance, a compiler may compile certain constructs with errors such that
+  a dynamic error will be raised if an attempt is made to
+  execute such a construct,
+  or an IDE integrated runtime may support opening
+  an editor window when such a construct is executed,
+  allowing developers to correct the error.
+  It is expected that such features would amount to a natural extension of the
+  dynamic semantics of Dart as specified here, but, as mentioned,
+  this specification makes no attempt to specify exactly what that means.%
 }
 
 \LMHash{}%
@@ -892,13 +900,14 @@ dynamic checks are guaranteed to be performed in certain situations,
 and certain violations of the type system throw exceptions at run time.
 
 \commentary{%
-An implementation is free to omit such checks whenever they are
-guaranteed to succeed, e.g., based on results from the static analysis.%
+  An implementation is free to omit such checks whenever they are
+  guaranteed to succeed, e.g., based on results from the static analysis.%
 }
 
 \commentary{%
-The coexistence between optional typing and reification
-is based on the following:
+  The coexistence between optional typing and reification
+  is based on the following:
+
 \begin{enumerate}
 \item
   Reified type information reflects the types of objects at run time
@@ -922,13 +931,13 @@ is based on the following:
 
 %% TODO(eernst): Update when we add inference.
 \commentary{%
-Dart as implemented includes extensive support for inference of omitted types.
-This specification makes the assumption that inference has taken place,
-and hence inferred types are considered to be present in the program already.
-However, in some cases no information is available
-to infer an omitted type annotation,
-and hence this specification still needs to specify how to deal with that.
-A future version of this specification will also specify type inference.%
+  Dart as implemented includes extensive support for inference of omitted types.
+  This specification makes the assumption that inference has taken place,
+  and hence inferred types are considered to be present in the program already.
+  However, in some cases no information is available
+  to infer an omitted type annotation,
+  and hence this specification still needs to specify how to deal with that.
+  A future version of this specification will also specify type inference.%
 }
 
 \LMHash{}%
@@ -937,9 +946,9 @@ units called \NoIndex{libraries} (\ref{librariesAndScripts}).
 Libraries are units of encapsulation and may be mutually recursive.
 
 \commentary{%
-However they are not first class.
-To get multiple copies of a library running simultaneously,
-one needs to spawn an isolate.%
+  However they are not first class.
+  To get multiple copies of a library running simultaneously,
+  one needs to spawn an isolate.%
 }
 
 \LMHash{}%
@@ -977,11 +986,11 @@ and that \NamespaceName{}
 \IndexCustom{has the binding}{namespace!has a binding}
 $n\mapsto{}V$.
 \commentary{%
-The fact that \NamespaceName{} is a partial function just means that
-each name is mapped to at most one namespace value.
-That is, if \NamespaceName{} has the bindings
-$n\mapsto{}V_1$ and $n\mapsto{}V_2$
-then $V_1 = V_2$.%
+  The fact that \NamespaceName{} is a partial function just means that
+  each name is mapped to at most one namespace value.
+  That is, if \NamespaceName{} has the bindings
+  $n\mapsto{}V_1$ and $n\mapsto{}V_2$
+  then $V_1 = V_2$.%
 }
 
 \LMHash{}%
@@ -1000,25 +1009,25 @@ a specific entity \DefineSymbol{V} into $S_0$,
 which means that the binding $n\mapsto{}V$ is added to \NamespaceName{0}.
 
 \commentary{%
-In some cases, the name of the declaration differs from
-the identifier that occurs in the declaration syntax used to declare it.
-Setters have names that are distinct from the corresponding getters
-because they always have an \lit{=} automatically added at the end,
-and the unary minus operator has the special name \code{unary-}.%
+  In some cases, the name of the declaration differs from
+  the identifier that occurs in the declaration syntax used to declare it.
+  Setters have names that are distinct from the corresponding getters
+  because they always have an \lit{=} automatically added at the end,
+  and the unary minus operator has the special name \code{unary-}.%
 }
 
 \commentary{%
-It is typically the case that $V$ is the declaration $D$ itself,
-but there are exceptions.
-For example,
-a variable declaration introduces an implicitly induced getter declaration,
-and in some cases also an implicitly induced setter declaration into the
-given scope.%
+  It is typically the case that $V$ is the declaration $D$ itself,
+  but there are exceptions.
+  For example,
+  a variable declaration introduces an implicitly induced getter declaration,
+  and in some cases also an implicitly induced setter declaration into the
+  given scope.%
 }
 
 \commentary{%
-Note that labels (\ref{labels}) are not included in the namespace of a scope.
-They are resolved lexically rather then being looked up in a namespace.%
+  Note that labels (\ref{labels}) are not included in the namespace of a scope.
+  They are resolved lexically rather then being looked up in a namespace.%
 }
 
 \LMHash{}%
@@ -1026,11 +1035,11 @@ It is a compile-time error if there is more than one entity with the same name
 declared in the same scope.
 
 \commentary{%
-It is therefore impossible, e.g., to define a class that declares
-a method and a getter with the same name in Dart.
-Similarly one cannot declare a top-level function with
-the same name as a library variable or a class
-which is declared in the same library.%
+  It is therefore impossible, e.g., to define a class that declares
+  a method and a getter with the same name in Dart.
+  Similarly one cannot declare a top-level function with
+  the same name as a library variable or a class
+  which is declared in the same library.%
 }
 
 \LMHash{}%
@@ -1042,18 +1051,18 @@ Each run-time namespace corresponds to a namespace with the same keys,
 but with values that correspond to the semantics of the namespace values.
 
 \rationale{%
-A namespace typically maps a name to a declaration,
-and it can be used statically to figure out what that name refers to.
-For example,
-a variable is associated with an actual storage location at run time.
-We introduce the notion of a run-time namespace based on a namespace,
-such that the dynamic semantics can access run-time entities
-like that storage location.
-The same code may be executed multiple times with the same run-time namespace,
-or with different run-time namespaces for each execution.
-E.g., local variables declared inside a function
-are specific to each invocation of the function,
-and instance variables are specific to an object.%
+  A namespace typically maps a name to a declaration,
+  and it can be used statically to figure out what that name refers to.
+  For example,
+  a variable is associated with an actual storage location at run time.
+  We introduce the notion of a run-time namespace based on a namespace,
+  such that the dynamic semantics can access run-time entities
+  like that storage location.
+  The same code may be executed multiple times with the same run-time namespace,
+  or with different run-time namespaces for each execution.
+  E.g., local variables declared inside a function
+  are specific to each invocation of the function,
+  and instance variables are specific to an object.%
 }
 
 \LMHash{}%
@@ -1071,10 +1080,10 @@ then $d$ \Index{hides} any declaration named $n$ that is available
 in the lexically enclosing scope of $S$.
 
 \commentary{%
-A consequence of these rules is that it is possible to hide a type
-with a method or variable.
-Naming conventions usually prevent such abuses.
-Nevertheless, the following program is legal:%
+  A consequence of these rules is that it is possible to hide a type
+  with a method or variable.
+  Naming conventions usually prevent such abuses.
+  Nevertheless, the following program is legal:%
 }
 
 \begin{dartCode}
@@ -1088,16 +1097,16 @@ Names may be introduced into a scope by declarations within the scope
 or by other mechanisms such as imports or inheritance.
 
 \rationale{%
-The interaction of lexical scoping and inheritance is a subtle one.
-Ultimately, the question is whether lexical scoping
-takes precedence over inheritance or vice versa.
-Dart chooses the former.
+  The interaction of lexical scoping and inheritance is a subtle one.
+  Ultimately, the question is whether lexical scoping
+  takes precedence over inheritance or vice versa.
+  Dart chooses the former.
 
-Allowing inherited names to take precedence over locally declared names
-could create unexpected situations as code evolves.
-Specifically, the behavior of code in a subclass could silently change
-if a new name is introduced in a superclass.
-Consider:%
+  Allowing inherited names to take precedence over locally declared names
+  could create unexpected situations as code evolves.
+  Specifically, the behavior of code in a subclass could silently change
+  if a new name is introduced in a superclass.
+  Consider:%
 }
 
 \begin{dartCode}
@@ -1111,7 +1120,7 @@ foo() => 42;
 \end{dartCode}
 
 \rationale{%
-Now assume a method \code{foo()} is added to \code{S}.%
+  Now assume a method \code{foo()} is added to \code{S}.%
 }
 
 \begin{dartCode}
@@ -1120,31 +1129,31 @@ Now assume a method \code{foo()} is added to \code{S}.%
 \end{dartCode}
 
 \rationale{%
-If inheritance took precedence over the lexical scope,
-the behavior of \code{C} would change in an unexpected way.
-Neither the author of \code{S} nor the author of \code{C}
-are necessarily aware of this.
-In Dart, if there is a lexically visible method \code{foo()},
-it will always be called.
+  If inheritance took precedence over the lexical scope,
+  the behavior of \code{C} would change in an unexpected way.
+  Neither the author of \code{S} nor the author of \code{C}
+  are necessarily aware of this.
+  In Dart, if there is a lexically visible method \code{foo()},
+  it will always be called.
 
-Now consider the opposite scenario.
-We start with a version of \code{S} that contains \code{foo()},
-but do not declare \code{foo()} in library \code{L2}.
-Again, there is a change in behavior---but the author of \code{L2}
-is the one who introduced the discrepancy that effects their code,
-and the new code is lexically visible.
-Both these factors make it more likely that the problem will be detected.
+  Now consider the opposite scenario.
+  We start with a version of \code{S} that contains \code{foo()},
+  but do not declare \code{foo()} in library \code{L2}.
+  Again, there is a change in behavior---but the author of \code{L2}
+  is the one who introduced the discrepancy that effects their code,
+  and the new code is lexically visible.
+  Both these factors make it more likely that the problem will be detected.
 
-These considerations become even more important
-if one introduces constructs such as nested classes,
-which might be considered in future versions of the language.
+  These considerations become even more important
+  if one introduces constructs such as nested classes,
+  which might be considered in future versions of the language.
 
-Good tooling should of course endeavor to inform programmers
-of such situations (discreetly).
-For example, an identifier that is both inherited and lexically visible
-could be highlighted (via underlining or colorization).
-Better yet, tight integration of source control with language aware tools
-would detect such changes when they occur.%
+  Good tooling should of course endeavor to inform programmers
+  of such situations (discreetly).
+  For example, an identifier that is both inherited and lexically visible
+  could be highlighted (via underlining or colorization).
+  Better yet, tight integration of source control with language aware tools
+  would detect such changes when they occur.%
 }
 
 
@@ -1168,32 +1177,32 @@ A declaration $m$ is \Index{accessible to a library} $L$
 if $m$ is declared in $L$ or if $m$ is public.
 
 \commentary{%
-This means private declarations may only be accessed within
-the library in which they are declared.%
+  This means private declarations may only be accessed within
+  the library in which they are declared.%
 }
 
 \rationale{%
-Privacy applies only to declarations within a library,
-not to the library declaration as a whole.
-This is because libraries do not reference each other by name,
-and so the idea of a private library is meaningless
-(\ref{imports}).
-Thus, if the name of a library begins with an underscore,
-it has no effect on the accessibility of the library or its members.%
+  Privacy applies only to declarations within a library,
+  not to the library declaration as a whole.
+  This is because libraries do not reference each other by name,
+  and so the idea of a private library is meaningless
+  (\ref{imports}).
+  Thus, if the name of a library begins with an underscore,
+  it has no effect on the accessibility of the library or its members.%
 }
 
 \rationale{%
-Privacy is, at this point, a static notion tied to
-a particular piece of code (a library).
-It is designed to support software engineering concerns
-rather than security concerns.
-Untrusted code should always run in an another isolate.
+  Privacy is, at this point, a static notion tied to
+  a particular piece of code (a library).
+  It is designed to support software engineering concerns
+  rather than security concerns.
+  Untrusted code should always run in an another isolate.
 
-Privacy is indicated by the name of a declaration---hence
-privacy and naming are not orthogonal.
-This has the advantage that both humans and machines
-can recognize access to private declarations at the point of use
-without knowledge of the context from which the declaration is derived.%
+  Privacy is indicated by the name of a declaration---hence
+  privacy and naming are not orthogonal.
+  This has the advantage that both humans and machines
+  can recognize access to private declarations at the point of use
+  without knowledge of the context from which the declaration is derived.%
 }
 
 
@@ -1226,34 +1235,34 @@ A compile-time error must be reported by a Dart compiler
 before the erroneous code is executed.
 
 \rationale{%
-A Dart implementation has considerable freedom
-as to when compilation takes place.
-Modern programming language implementations
-often interleave compilation and execution,
-so that compilation of a method may be delayed, e.g.,
-until it is first invoked.
-Consequently, compile-time errors in a method $m$ may be reported
-as late as the time of $m$'s first invocation.
+  A Dart implementation has considerable freedom
+  as to when compilation takes place.
+  Modern programming language implementations
+  often interleave compilation and execution,
+  so that compilation of a method may be delayed, e.g.,
+  until it is first invoked.
+  Consequently, compile-time errors in a method $m$ may be reported
+  as late as the time of $m$'s first invocation.
 
-Dart is often loaded directly from source,
-with no intermediate binary representation.
-In the interests of rapid loading, Dart implementations
-may choose to avoid full parsing of method bodies, for example.
-This can be done by tokenizing the input and
-checking for balanced curly braces on method body entry.
-In such an implementation, even syntax errors will be detected
-only when the method needs to be executed,
-at which time it will be compiled (JITed).
+  Dart is often loaded directly from source,
+  with no intermediate binary representation.
+  In the interests of rapid loading, Dart implementations
+  may choose to avoid full parsing of method bodies, for example.
+  This can be done by tokenizing the input and
+  checking for balanced curly braces on method body entry.
+  In such an implementation, even syntax errors will be detected
+  only when the method needs to be executed,
+  at which time it will be compiled (JITed).
 
-In a development environment a compiler should of course
-report compilation errors eagerly so as to best serve the programmer.
+  In a development environment a compiler should of course
+  report compilation errors eagerly so as to best serve the programmer.
 
-A Dart development environment might choose to support
- error eliminating program transformations, e.g.,
-replacing an erroneous expression by the invocation of a debugger.
-It is outside the scope of this document
-to specify how such transformations work,
-and where they may be applied.%
+  A Dart development environment might choose to support
+   error eliminating program transformations, e.g.,
+  replacing an erroneous expression by the invocation of a debugger.
+  It is outside the scope of this document
+  to specify how such transformations work,
+  and where they may be applied.%
 }
 
 \LMHash{}%
@@ -1263,18 +1272,18 @@ The only circumstance where a compile-time error could be caught would be
 via code run reflectively, where the mirror system can catch it.
 
 \rationale{%
-Typically, once a compile-time error is thrown and $A$ is suspended,
-$A$ will then be terminated.
-However, this depends on the overall environment.
-A Dart engine runs in the context of a \Index{runtime},
-a program that interfaces between the engine and
-the surrounding computing environment.
-The runtime may be, for instance, a C++ program on the server.
-When an isolate fails with a compile-time error as described above,
-control returns to the runtime,
-along with an exception describing the problem.
-This is necessary so that the runtime can clean up resources etc.
-It is then the runtime's decision whether to terminate the isolate or not.%
+  Typically, once a compile-time error is thrown and $A$ is suspended,
+  $A$ will then be terminated.
+  However, this depends on the overall environment.
+  A Dart engine runs in the context of a \Index{runtime},
+  a program that interfaces between the engine and
+  the surrounding computing environment.
+  The runtime may be, for instance, a C++ program on the server.
+  When an isolate fails with a compile-time error as described above,
+  control returns to the runtime,
+  along with an exception describing the problem.
+  This is necessary so that the runtime can clean up resources etc.
+  It is then the runtime's decision whether to terminate the isolate or not.%
 }
 
 \LMHash{}%
@@ -1339,16 +1348,16 @@ the same set of variable names, in the same order,
 with the same initialization, type, and modifiers.
 
 \commentary{%
-For example,
-\code{\VAR{} x, y;}
-is equivalent to
-\code{\VAR{} x; \VAR{} y;}
-and
-\code{\STATIC\,\,\LATE\,\,\FINAL{} String s1, s2 = "foo";}
-is equivalent to having both
-\code{\STATIC\,\,\LATE\,\,\FINAL{} String s1;}
-and
-\code{\STATIC\,\,\LATE\,\,\FINAL{} String s2 = "foo";}.%
+  For example,
+  \code{\VAR{} x, y;}
+  is equivalent to
+  \code{\VAR{} x; \VAR{} y;}
+  and
+  \code{\STATIC\,\,\LATE\,\,\FINAL{} String s1, s2 = "foo";}
+  is equivalent to having both
+  \code{\STATIC\,\,\LATE\,\,\FINAL{} String s1;}
+  and
+  \code{\STATIC\,\,\LATE\,\,\FINAL{} String s2 = "foo";}.%
 }
 
 \LMHash{}%
@@ -1359,12 +1368,12 @@ It is a \Error{compile-time error} for the declaration of a variable
 which is not an instance variable to include the modifier \COVARIANT.
 
 \commentary{%
-A formal parameter declaration induces a local variable into a scope,
-but formal parameter declarations are not variable declarations
-and do not give rise to the above error.
-The effect of having the modifier \COVARIANT{} on a formal parameter
-is described elsewhere
-(\ref{covariantParameters}).%
+  A formal parameter declaration induces a local variable into a scope,
+  but formal parameter declarations are not variable declarations
+  and do not give rise to the above error.
+  The effect of having the modifier \COVARIANT{} on a formal parameter
+  is described elsewhere
+  (\ref{covariantParameters}).%
 }
 
 \LMHash{}%
@@ -1381,10 +1390,10 @@ We also abbreviate that to say that an identifier is
 a \Index{declaring identifier} respectively an \Index{referencing identifier}.
 
 \commentary{%
-In an expression of the form \code{$e$.$\id'$} it is possible that
-$e$ has static type \DYNAMIC{} and $\id'$ cannot be associated with
-any specific declaration named $\id'$ at compile-time,
-but in this situation $\id'$ is still a referencing identifier.%
+  In an expression of the form \code{$e$.$\id'$} it is possible that
+  $e$ has static type \DYNAMIC{} and $\id'$ cannot be associated with
+  any specific declaration named $\id'$ at compile-time,
+  but in this situation $\id'$ is still a referencing identifier.%
 }
 
 \LMHash{}%
@@ -1393,12 +1402,12 @@ even though the name of a variable and the variable itself
 are very different concepts.
 
 \commentary{%
-So we will talk about ``the variable \id{}'',
-rather than introducing ``the variable $v$ named \id{}''\!,
-in order to be able to say ``the variable $v$'' later on.
-This should not create any ambiguities,
-\emph{because} the concept of a name and the concept of a variable
-are so different.%
+  So we will talk about ``the variable \id{}'',
+  rather than introducing ``the variable $v$ named \id{}''\!,
+  in order to be able to say ``the variable $v$'' later on.
+  This should not create any ambiguities,
+  \emph{because} the concept of a name and the concept of a variable
+  are so different.%
 }
 
 \LMHash{}%
@@ -1430,7 +1439,7 @@ the modifier \LATE{} or the modifier \EXTERNAL.
 A \IndexCustom{non-local variable}{variable!non-local}
 is a library variable, a static variable, or an instance variable.
 \commentary{%
-That is, any kind of variable which is not a local variable.%
+  That is, any kind of variable which is not a local variable.%
 }
 
 \LMHash{}%
@@ -1441,22 +1450,22 @@ A constant variable must be initialized to a constant expression
 or a \Error{compile-time error} occurs.
 
 \commentary{%
-An initializing expression $e$ of a constant variable declaration
-occurs in a constant context
-(\ref{constantContexts}).
-This means that \CONST{} modifiers in $e$ need not be specified explicitly.%
+  An initializing expression $e$ of a constant variable declaration
+  occurs in a constant context
+  (\ref{constantContexts}).
+  This means that \CONST{} modifiers in $e$ need not be specified explicitly.%
 }
 
 \rationale{%
-It is grammatically impossible for a constant variable declaration
-to have the modifier \LATE.
-However, even if it had been grammatically possible,
-a \LATE{} constant variable would still have to be a compile-time error,
-because being a compile-time constant is inherently incompatible
-with being computed late.
+  It is grammatically impossible for a constant variable declaration
+  to have the modifier \LATE.
+  However, even if it had been grammatically possible,
+  a \LATE{} constant variable would still have to be a compile-time error,
+  because being a compile-time constant is inherently incompatible
+  with being computed late.
 
-Similarly, an instance variable cannot be constant
-(\ref{instanceVariables}).%
+  Similarly, an instance variable cannot be constant
+  (\ref{instanceVariables}).%
 }
 
 
@@ -1477,9 +1486,9 @@ Similarly, an instance variable cannot be constant
 The following rules on implicitly induced getters and setters
 apply to all non-local variable declarations.
 \commentary{%
-Local variable declarations
-(\ref{localVariableDeclaration})
-do not induce getters or setters.%
+  Local variable declarations
+  (\ref{localVariableDeclaration})
+  do not induce getters or setters.%
 }
 
 \LMHash{}%
@@ -1550,8 +1559,8 @@ implicitly induces a setter with the header
 whose execution sets the value of \id{} to the incoming argument $x$.
 
 \commentary{%
-Type inference could have provided a type different from \DYNAMIC{}
-(\ref{overview}).%
+  Type inference could have provided a type different from \DYNAMIC{}
+  (\ref{overview}).%
 }
 \EndCase
 
@@ -1564,11 +1573,11 @@ implicitly induces a setter with the header
 whose execution sets the value of \id{} to the incoming argument $x$.
 
 \commentary{%
-Type inference has not yet been specified in this document
-(\ref{overview}).
-Note that type inference could change, e.g.,
-\code{\VAR\,\,x;} to \code{$T$\,\,x;},
-which would take us to an earlier case.%
+  Type inference has not yet been specified in this document
+  (\ref{overview}).
+  Note that type inference could change, e.g.,
+  \code{\VAR\,\,x;} to \code{$T$\,\,x;},
+  which would take us to an earlier case.%
 }
 \EndCase
 
@@ -1642,27 +1651,27 @@ is also initialized by a constructor,
 either by an initializing formal or an initializer list entry.
 
 \commentary{%
-It is a compile-time error if a final instance variable
-that has been initialized by means of
-an initializing formal of a constructor $k$
-is also initialized in the initializer list of $k$
-(\ref{initializerLists}).
+  It is a compile-time error if a final instance variable
+  that has been initialized by means of
+  an initializing formal of a constructor $k$
+  is also initialized in the initializer list of $k$
+  (\ref{initializerLists}).
 
-A non-late static variable declaration $D$ named \id{}
-that has the modifier \FINAL{} or the modifier \CONST{}
-does not induce a setter.
-However, an assignment to \id{} at a location where $D$ is in scope
-is not necessarily a compile-time error.
-For example, a setter named \code{\id=} could be found by lexical lookup
-(\ref{lexicalLookup}).
+  A non-late static variable declaration $D$ named \id{}
+  that has the modifier \FINAL{} or the modifier \CONST{}
+  does not induce a setter.
+  However, an assignment to \id{} at a location where $D$ is in scope
+  is not necessarily a compile-time error.
+  For example, a setter named \code{\id=} could be found by lexical lookup
+  (\ref{lexicalLookup}).
 
-Similarly, a non-late final instance variable \id{} does not induce a setter,
-but an assignment could be an invocation of
-a setter which is provided in some other way.
-For example, it could be that lexical lookup yields nothing,
-and the location of the assignment has access to \THIS,
-and the interface of an enclosing class has a setter named \code{\id=}
-(in this case both the getter and setter are inherited).%
+  Similarly, a non-late final instance variable \id{} does not induce a setter,
+  but an assignment could be an invocation of
+  a setter which is provided in some other way.
+  For example, it could be that lexical lookup yields nothing,
+  and the location of the assignment has access to \THIS,
+  and the interface of an enclosing class has a setter named \code{\id=}
+  (in this case both the getter and setter are inherited).%
 }
 
 \LMHash{}%
@@ -1677,9 +1686,9 @@ The initial value of \id{} is then the null object
 (\ref{null}).
 
 \commentary{%
-Note that there are many situations where such a variable declaration
-is a compile-time error,
-in which case the initial value is of course irrelevant.%
+  Note that there are many situations where such a variable declaration
+  is a compile-time error,
+  in which case the initial value is of course irrelevant.%
 }
 
 \LMHash{}%
@@ -1691,17 +1700,17 @@ with an initializing expression is initialized lazily
 (\ref{evaluationOfImplicitVariableGetters}).
 
 \rationale{%
-The lazy semantics are given because we do not want a language
-where one tends to define expensive initialization computations,
-causing long application startup times.
-This is especially crucial for Dart,
-which must support the coding of client applications.%
+  The lazy semantics are given because we do not want a language
+  where one tends to define expensive initialization computations,
+  causing long application startup times.
+  This is especially crucial for Dart,
+  which must support the coding of client applications.%
 }
 
 \commentary{%
-Initialization of an instance variable with no initializing expression
-takes place during constructor execution
-(\ref{initializerLists}).%
+  Initialization of an instance variable with no initializing expression
+  takes place during constructor execution
+  (\ref{initializerLists}).%
 }
 
 \LMHash{}%
@@ -1713,19 +1722,19 @@ $e$ is evaluated to an object $o$
 and the variable \id{} is bound to $o$.
 
 \commentary{%
-It is specified elsewhere when this initialization occurs,
-and in which environment
-(p.\,\pageref{executionOfGenerativeConstructors},
-\ref{localVariableDeclaration},
-\ref{bindingActualsToFormals}).%
+  It is specified elsewhere when this initialization occurs,
+  and in which environment
+  (p.\,\pageref{executionOfGenerativeConstructors},
+  \ref{localVariableDeclaration},
+  \ref{bindingActualsToFormals}).%
 }
 
 \commentary{%
-If the initializing expression throws then
-access to the uninitialized variable is prevented,
-because the instance creation
-that caused this initialization to take place
-will throw.%
+  If the initializing expression throws then
+  access to the uninitialized variable is prevented,
+  because the instance creation
+  that caused this initialization to take place
+  will throw.%
 }
 
 \LMHash{}%
@@ -1749,7 +1758,7 @@ A
 is a getter $g$ which is implicitly induced by a non-local variable $v$
 that has an initializing expression $e$.
 \commentary{%
-It is described below which declarations induce a late-initialized getter.%
+  It is described below which declarations induce a late-initialized getter.%
 }
 An invocation of $g$ proceeds as follows:
 
@@ -1769,20 +1778,21 @@ An invocation of $g$ in a situation where $v$ has been bound to an object $o'$
 completes immediately, returning $o'$.
 
 \commentary{%
-Consider a non-local variable declaration of the form
-\code{\LATE\,\,\VAR\,\,x = $e$;},
-whose implicitly induced getter is late-initialized.
-Perhaps surprisingly,
-if the variable \code{x} has been bound to an object
-when its getter is invoked for the first time,
-$e$ will never be executed.
-In other words, the initializing expression can be pre-empted by an assignment.%
+  Consider a non-local variable declaration of the form
+  \code{\LATE\,\,\VAR\,\,x = $e$;},
+  whose implicitly induced getter is late-initialized.
+  Perhaps surprisingly,
+  if the variable \code{x} has been bound to an object
+  when its getter is invoked for the first time,
+  $e$ will never be executed.
+  In other words, the initializing expression can be pre-empted
+  by an assignment.%
 }
 
 \commentary{%
-Also note that an initializing expression can have side effects
-that are significant during initialization.
-For example:%
+  Also note that an initializing expression can have side effects
+  that are significant during initialization.
+  For example:%
 }
 
 \begin{dartCode}
@@ -1795,32 +1805,32 @@ int i = (() => (b = !b) ? (i = 10) : i + 1)();
 \end{dartCode}
 
 \commentary{%
-In this example, \code{main} invokes
-the implicitly induced getter named \code{i},
-and the variable \code{i} has not been bound at this point.
-Hence, evaluation of the initializing expression proceeds.
-This causes \code{b} to be toggled to \FALSE,
-which again causes \code{i + 1} to be evaluated.
-This causes the getter \code{i} to be invoked again,
-and it is still true that the variable has not been bound,
-so the initializing expression is evaluated again.
-This toggles \code{b} to \TRUE,
-which causes \code{i = 10} to be evaluated,
-which causes the implicitly induced setter named \code{i=} to be invoked,
-and the most recent invocation of the getter \code{i}
-returns 10.
-This makes \code{i + 1} evaluate to 11,
-and the variable is then bound to 11.
-Finally, the invocation of the getter \code{i} in \code{main}
-completes returning 11.%
+  In this example, \code{main} invokes
+  the implicitly induced getter named \code{i},
+  and the variable \code{i} has not been bound at this point.
+  Hence, evaluation of the initializing expression proceeds.
+  This causes \code{b} to be toggled to \FALSE,
+  which again causes \code{i + 1} to be evaluated.
+  This causes the getter \code{i} to be invoked again,
+  and it is still true that the variable has not been bound,
+  so the initializing expression is evaluated again.
+  This toggles \code{b} to \TRUE,
+  which causes \code{i = 10} to be evaluated,
+  which causes the implicitly induced setter named \code{i=} to be invoked,
+  and the most recent invocation of the getter \code{i}
+  returns 10.
+  This makes \code{i + 1} evaluate to 11,
+  and the variable is then bound to 11.
+  Finally, the invocation of the getter \code{i} in \code{main}
+  completes returning 11.%
 }
 
 \commentary{%
-This is a change from the semantics of older versions of Dart:
-Throwing an exception during initializer evaluation no longer sets the
-variable to \code{null},
-and reading the variable during initializer evaluation
-no longer causes a dynamic error.%
+  This is a change from the semantics of older versions of Dart:
+  Throwing an exception during initializer evaluation no longer sets the
+  variable to \code{null},
+  and reading the variable during initializer evaluation
+  no longer causes a dynamic error.%
 }
 
 \LMHash{}%
@@ -1829,8 +1839,8 @@ A
 is a getter $g$ which is implicitly induced by a non-local variable $v$
 that does not have an initializing expression.
 \commentary{%
-Again, only \emph{some} non-local variables without an initializing expression
-induce a late-uninitialized getter, as specified below.%
+  Again, only \emph{some} non-local variables without an initializing expression
+  induce a late-uninitialized getter, as specified below.%
 }
 An invocation of $g$ proceeds as follows:
 If the variable $v$ has not been bound to an object then a dynamic error occurs.
@@ -1851,10 +1861,10 @@ then the invocation of the implicit getter of \id{} evaluates to
 the object that \id{} is bound to.
 
 \commentary{%
-It is not possible to invoke an instance getter on an object
-before the object has been initialized.
-Hence, a non-late instance variable is always bound
-when the instance getter is invoked.%
+  It is not possible to invoke an instance getter on an object
+  before the object has been initialized.
+  Hence, a non-late instance variable is always bound
+  when the instance getter is invoked.%
 }
 \EndCase
 
@@ -1876,15 +1886,15 @@ late-uninitialized getter.
 This determines the semantics of an invocation.
 
 \commentary{%
-In this case it is possible for \id{} to be unbound,
-but there are also several ways to bind \id{} to an object:
-A constructor can have an initializing formal
-(\ref{generativeConstructors})
-or an initializer list entry
-(\ref{initializerLists})
-that will initialize \id{},
-and the implicitly induced setter named \code{\id=} could
-have been invoked and completed normally.%
+  In this case it is possible for \id{} to be unbound,
+  but there are also several ways to bind \id{} to an object:
+  A constructor can have an initializing formal
+  (\ref{generativeConstructors})
+  or an initializer list entry
+  (\ref{initializerLists})
+  that will initialize \id{},
+  and the implicitly induced setter named \code{\id=} could
+  have been invoked and completed normally.%
 }
 \EndCase
 
@@ -1908,8 +1918,8 @@ the implicitly induced getter of \id{} executes as follows:
   the result of executing the implicitly induced getter is
   the value of the constant expression $e$.
   \commentary{%
-  Note that a constant expression cannot depend on itself,
-  so no cyclic references can occur.%
+    Note that a constant expression cannot depend on itself,
+    so no cyclic references can occur.%
   }
 \item \emph{Variable without an initializer.}
   If $d$ declares a variable \id{} without an initializing expression
@@ -1970,17 +1980,17 @@ if its body is marked with the \code{\SYNC*} or \code{\ASYNC*} modifier.
 Further details about these concepts are given below.
 
 \commentary{%
-Whether a function is synchronous or asynchronous is orthogonal to
-whether it is a generator or not.
-Generator functions are a sugar for functions
-that produce collections in a systematic way,
-by lazily applying a function that \emph{generates}
-individual elements of a collection.
-Dart provides such a sugar in both the synchronous case,
-where one returns an iterable,
-and in the asynchronous case, where one returns a stream.
-Dart also allows both synchronous and asynchronous functions
-that produce a single value.%
+  Whether a function is synchronous or asynchronous is orthogonal to
+  whether it is a generator or not.
+  Generator functions are a sugar for functions
+  that produce collections in a systematic way,
+  by lazily applying a function that \emph{generates}
+  individual elements of a collection.
+  Dart provides such a sugar in both the synchronous case,
+  where one returns an iterable,
+  and in the asynchronous case, where one returns a stream.
+  Dart also allows both synchronous and asynchronous functions
+  that produce a single value.%
 }
 
 \LMHash{}%
@@ -2004,29 +2014,29 @@ A function body is either:
   Unless it is statically known that the body of the function
   cannot complete normally
   \commentary{%
-    (that is, it cannot reach the end and ``fall through''},
-    cf.~\ref{statementCompletion)%
+    (that is, it cannot reach the end and ``fall through'',
+    cf.~\ref{statementCompletion})%
   },
   it is a compile-time error if
   the addition of \code{\RETURN;} at the end of the body
   would be a compile-time error.
   \commentary{%
-  For instance, it is an error if
-  the return type of a synchronous function is \code{int},
-  and the body may complete normally.
-  The precise rules are given in section~\ref{return}.%
+    For instance, it is an error if
+    the return type of a synchronous function is \code{int},
+    and the body may complete normally.
+    The precise rules are given in section~\ref{return}.%
   }
 
   \commentary{%
-  Because Dart supports dynamic function invocations,
-  we cannot guarantee that a function that does not return an object
-  will not be used in the context of an expression.
-  Therefore, every function must either throw or return an object.
-  A function body that ends without doing a throw or return
-  will cause the function to return the null object (\ref{null}),
-  as will a \RETURN{} without an expression.
-  For generator functions, the situation is more subtle.
-  See further discussion in section~\ref{return}.%
+    Because Dart supports dynamic function invocations,
+    we cannot guarantee that a function that does not return an object
+    will not be used in the context of an expression.
+    Therefore, every function must either throw or return an object.
+    A function body that ends without doing a throw or return
+    will cause the function to return the null object (\ref{null}),
+    as will a \RETURN{} without an expression.
+    For generator functions, the situation is more subtle.
+    See further discussion in section~\ref{return}.%
   }
 
 OR
@@ -2035,11 +2045,11 @@ OR
   which both return the value of the expression $e$ as if by a
   \code{return $e$}.
   \commentary{%
-  The other modifiers do not apply here,
-  because they apply only to generators, discussed below.
-  Generators are not allowed to explicitly return anything,
-  objects are added to the generated stream or iterable using
-  \YIELD{} or \YIELD*.%
+    The other modifiers do not apply here,
+    because they apply only to generators, discussed below.
+    Generators are not allowed to explicitly return anything,
+    objects are added to the generated stream or iterable using
+    \YIELD{} or \YIELD*.%
   }
   Let $T$ be the declared return type of the function that has this body.
   It is a compile-time error if one of the following conditions hold:
@@ -2051,17 +2061,18 @@ OR
     \code{\{ \RETURN{} $e$; \}}
     rather than \code{=> $e$}.
     \commentary{%
-    In particular, $e$ can have \emph{any} type when the return type is \VOID.%
+      In particular, $e$ can have \emph{any} type
+      when the return type is \VOID.%
     }
     \rationale{%
-    This enables concise declarations of \VOID{} functions.
-    It is reasonably easy to understand such a function,
-    because the return type is textually near to the returned expression $e$.
-    In contrast, \code{\RETURN{} $e$;} in a block body is only allowed
-    for an $e$ with one of a few specific static types,
-    because it is less likely that the developer understands
-    that the returned object will not be used
-    (\ref{return}).%
+      This enables concise declarations of \VOID{} functions.
+      It is reasonably easy to understand such a function,
+      because the return type is textually near to the returned expression $e$.
+      In contrast, \code{\RETURN{} $e$;} in a block body is only allowed
+      for an $e$ with one of a few specific static types,
+      because it is less likely that the developer understands
+      that the returned object will not be used
+      (\ref{return}).%
     }
   \item The function is asynchronous, \flatten{T} is not \VOID,
     and it would have been a compile-time error
@@ -2069,11 +2080,11 @@ OR
     \code{\ASYNC{} \{ \RETURN{} $e$; \}}
     rather than \code{\ASYNC{} => $e$}.
     \commentary{%
-    In particular, $e$ can have \emph{any} type
-    when the flattened return type is \VOID,%
+      In particular, $e$ can have \emph{any} type
+      when the flattened return type is \VOID,%
     }
     \rationale{%
-    and the rationale is similar to the synchronous case.%
+      and the rationale is similar to the synchronous case.%
     }
   \end{itemize}
 \end{itemize}
@@ -2131,8 +2142,8 @@ then the union-free type derived from $T$ is
 the union-free type derived from $S$.
 Otherwise, the union-free type derived from $T$ is $T$.
 \commentary{%
-For example, the union-free type derived from
-\code{FutureOr<int?>?} is \code{int}.%
+  For example, the union-free type derived from
+  \code{FutureOr<int?>?} is \code{int}.%
 }
 
 \LMHash{}%
@@ -2230,8 +2241,8 @@ The \Index{formal parameter part} of a function declaration consists of
 the formal type parameter list, if any, and the formal parameter list.
 
 \commentary{%
-The following kinds of functions cannot be generic:
-Getters, setters, operators, and constructors.%
+  The following kinds of functions cannot be generic:
+  Getters, setters, operators, and constructors.%
 }
 
 \LMHash{}%
@@ -2250,17 +2261,17 @@ otherwise the scope where $f$ is declared is
 the current scope for the signature of $f$.
 
 \commentary{%
-This means that formal type parameters are in scope
-in the bounds of parameter declarations,
-allowing for so-called F-bounded type parameters like
+  This means that formal type parameters are in scope
+  in the bounds of parameter declarations,
+  allowing for so-called F-bounded type parameters like
 
-\noindent
-\code{class C<X \EXTENDS{} Comparable<X>{}> \{ \ldots\ \}},
+  \noindent
+  \code{class C<X \EXTENDS{} Comparable<X>{}> \{ \ldots\ \}},
 
-\noindent
-and the formal type parameters are in scope for each other,
-allowing dependencies like
-\code{class D<X \EXTENDS{} Y, Y> \{ \ldots\ \}}.%
+  \noindent
+  and the formal type parameters are in scope for each other,
+  allowing dependencies like
+  \code{class D<X \EXTENDS{} Y, Y> \{ \ldots\ \}}.%
 }
 
 \LMHash{}%
@@ -2277,10 +2288,10 @@ The current scope for the function's signature is
 the scope that encloses the formal parameter scope.
 
 \commentary{%
-This means that in a generic function declaration,
-the return type and parameter type annotations can use
-the formal type parameters,
-but the formal parameters are not in scope in the signature.%
+  This means that in a generic function declaration,
+  the return type and parameter type annotations can use
+  the formal type parameters,
+  but the formal parameters are not in scope in the signature.%
 }
 
 \LMHash{}%
@@ -2374,9 +2385,9 @@ It is a compile-time error if a parameter derived from
 which is not a non-redirecting generative constructor.
 
 \commentary{%
-A \synt{fieldFormalParameter} declares an initializing formal,
-which is described elsewhere
-(\ref{generativeConstructors}).%
+  A \synt{fieldFormalParameter} declares an initializing formal,
+  which is described elsewhere
+  (\ref{generativeConstructors}).%
 }
 
 \LMHash{}%
@@ -2386,9 +2397,9 @@ The effect of doing this is described in a separate section
 (\ref{covariantParameters}).
 
 \commentary{%
-Note that the non-terminal \synt{normalFormalParameter} is also used
-in the grammar rules for optional parameters,
-which means that such parameters can also be covariant.%
+  Note that the non-terminal \synt{normalFormalParameter} is also used
+  in the grammar rules for optional parameters,
+  which means that such parameters can also be covariant.%
 }
 
 \LMHash{}%
@@ -2429,16 +2440,17 @@ It is a compile-time error if the name of a named optional parameter
 begins with an `_' character.
 
 \rationale{%
-The need for this restriction is a direct consequence of
-the fact that naming and privacy are not orthogonal.
-If we allowed named parameters to begin with an underscore,
-they would be considered private and inaccessible to
-callers from outside the library where it was defined.
-If a method outside the library overrode a method with a private optional name,
-it would not be a subtype of the original method.
-The static checker would of course flag such situations,
-but the consequence would be that adding a private named formal would break
-clients outside the library in a way they could not easily correct.%
+  The need for this restriction is a direct consequence of
+  the fact that naming and privacy are not orthogonal.
+  If we allowed named parameters to begin with an underscore,
+  they would be considered private and inaccessible to
+  callers from outside the library where it was defined.
+  If a method outside the library overrode
+  a method with a private optional name,
+  it would not be a subtype of the original method.
+  The static checker would of course flag such situations,
+  but the consequence would be that adding a private named formal would break
+  clients outside the library in a way they could not easily correct.%
 }
 
 
@@ -2451,8 +2463,8 @@ including setters and operators,
 to be declared \COVARIANT.
 
 \commentary{%
-The syntax for doing this is specified in an earlier section
-(\ref{requiredFormals}).%
+  The syntax for doing this is specified in an earlier section
+  (\ref{requiredFormals}).%
 }
 
 \LMHash{}%
@@ -2461,25 +2473,25 @@ in the declaration of a formal parameter of a function
 which is not an instance method, an instance setter, or an operator.
 
 \commentary{%
-As specified below, a parameter can also be covariant for other reasons.
-The overall effect of having a covariant parameter $p$
-in the signature of a given method $m$
-is to allow the type of $p$ to be overridden covariantly,
-which means that the type required at run time for a given actual argument
-may be a proper subtype of the type which is known at compile time
-at the call site.%
+  As specified below, a parameter can also be covariant for other reasons.
+  The overall effect of having a covariant parameter $p$
+  in the signature of a given method $m$
+  is to allow the type of $p$ to be overridden covariantly,
+  which means that the type required at run time for a given actual argument
+  may be a proper subtype of the type which is known at compile time
+  at the call site.%
 }
 
 \rationale{%
-This mechanism allows developers to explicitly request that
-a compile-time guarantee which is otherwise supported
-(namely: that an actual argument whose static type satisfies the requirement
-will also do so at run time)
-is replaced by dynamic type checks.
-In return for accepting these dynamic type checks,
-developers can use covariant parameters to express software designs
-where the dynamic type checks are known (or at least trusted) to succeed,
-based on reasoning that the static type analysis does not capture.%
+  This mechanism allows developers to explicitly request that
+  a compile-time guarantee which is otherwise supported
+  (namely: that an actual argument whose static type satisfies the requirement
+  will also do so at run time)
+  is replaced by dynamic type checks.
+  In return for accepting these dynamic type checks,
+  developers can use covariant parameters to express software designs
+  where the dynamic type checks are known (or at least trusted) to succeed,
+  based on reasoning that the static type analysis does not capture.%
 }
 
 \LMHash{}%
@@ -2511,11 +2523,11 @@ $X'_j$ from $m'$
 $X_j$ from $m$, for all $j \in 1 .. s$.
 
 \commentary{%
-This includes the case where $m$ respectively $m'$ has
-optional positional parameters,
-in which case $k = 0$ respectively $k' = 0$ must hold,
-but we can have $n \not= n'$.
-The case where the numbers of formal type parameters differ is not relevant.%
+  This includes the case where $m$ respectively $m'$ has
+  optional positional parameters,
+  in which case $k = 0$ respectively $k' = 0$ must hold,
+  but we can have $n \not= n'$.
+  The case where the numbers of formal type parameters differ is not relevant.%
 }
 
 % Being covariant is a property of a parameter of the interface of a class;
@@ -2582,16 +2594,17 @@ A formal parameter $p$ is
 if $p$ is covariant-by-declaration or $p$ is covariant-by-class.
 
 \commentary{%
-It is possible for a parameter to be simultaneously
-covariant-by-declaration and covariant-by-class.
-Note that a parameter may be
-covariant-by-declaration or covariant-by-class
-based on a declaration in any direct or indirect superinterface,
-including any superclass:
-The definitions above propagate these properties
-to an interface from each of its direct superinterfaces,
-but they will in turn receive the property from their direct superinterfaces,
-and so on.%
+  It is possible for a parameter to be simultaneously
+  covariant-by-declaration and covariant-by-class.
+  Note that a parameter may be
+  covariant-by-declaration or covariant-by-class
+  based on a declaration in any direct or indirect superinterface,
+  including any superclass:
+  The definitions above propagate these properties
+  to an interface from each of its direct superinterfaces,
+  but they will in turn receive
+  the property from their direct superinterfaces,
+  and so on.%
 }
 
 
@@ -2629,10 +2642,11 @@ when there are no optional parameters.
 
 % We promise that the two forms always get the same treatment for k=0.
 \commentary{%
-Both forms with optionals cover function types with no optionals when $k = 0$,
-and every rule in this specification is such that
-any of the two forms may be used without ambiguity
-to determine the treatment of function types with no optionals.%
+  Both forms with optionals cover function types with no optionals
+  when $k = 0$,
+  and every rule in this specification is such that
+  any of the two forms may be used without ambiguity
+  to determine the treatment of function types with no optionals.%
 }
 
 \LMHash{}%
@@ -2654,12 +2668,12 @@ can make two function types identical,
 they are considered to be the same type.
 
 \commentary{%
-It is convenient to include the formal type parameter names in function types
-because they are needed in order to express such things as relations among
-different type parameters, F-bounds, and the types of formal parameters.
-However, we do not wish to distinguish between two function types if they have
-the same structure and only differ in the choice of names.
-This treatment of names is also known as alpha-equivalence.%
+  It is convenient to include the formal type parameter names in function types
+  because they are needed in order to express such things as relations among
+  different type parameters, F-bounds, and the types of formal parameters.
+  However, we do not wish to distinguish between two function types
+  if they have the same structure and only differ in the choice of names.
+  This treatment of names is also known as alpha-equivalence.%
 }
 
 \LMHash{}%
@@ -2707,34 +2721,34 @@ and let $t$ be the actual type corresponding to $T$
 at the occasion where $o$ was created
 (\ref{actualTypes}).
 \commentary{%
-$T$ may contain free type variables, but $t$ contains their actual values.%
+  $T$ may contain free type variables, but $t$ contains their actual values.%
 }
 The following must then hold:
 $u$ is a class that implements the built-in class \FUNCTION;
 $u$ is a subtype of $t$;
 and $u$ is not a subtype of any function type which is a proper subtype of $t$.
 \commentary{%
-If we had omitted the last requirement then
-\code{f \IS{} int\,\FUNCTION([int])}
-could evaluate to \TRUE{} with the declaration
-\code{\VOID{} f()\,\{\}},
-which is obviously not the intention.%
+  If we had omitted the last requirement then
+  \code{f \IS{} int\,\FUNCTION([int])}
+  could evaluate to \TRUE{} with the declaration
+  \code{\VOID{} f()\,\{\}},
+  which is obviously not the intention.%
 }
 
 \rationale{%
-It is up to the implementation to choose
-an appropriate representation for function objects.
-For example, consider that
-a function object produced via property extraction
-treats equality differently from other function objects,
-and is therefore likely a different class.
-Implementations may also use different classes for function objects
-based on arity and or type.
-Arity may be implicitly affected by whether a function is
-an instance method (with an implicit receiver parameter) or not.
-The variations are manifold and, e.g.,
-one cannot assume that any two distinct function objects
-will necessarily have the same run-time type.%
+  It is up to the implementation to choose
+  an appropriate representation for function objects.
+  For example, consider that
+  a function object produced via property extraction
+  treats equality differently from other function objects,
+  and is therefore likely a different class.
+  Implementations may also use different classes for function objects
+  based on arity and or type.
+  Arity may be implicitly affected by whether a function is
+  an instance method (with an implicit receiver parameter) or not.
+  The variations are manifold and, e.g.,
+  one cannot assume that any two distinct function objects
+  will necessarily have the same run-time type.%
 }
 
 
@@ -2756,17 +2770,18 @@ External functions are introduced via the built-in identifier \EXTERNAL{}
 followed by the function signature.
 
 \rationale{%
-External functions allow us to introduce type information for code
-that is not statically known to the Dart compiler.%
+  External functions allow us to introduce type information for code
+  that is not statically known to the Dart compiler.%
 }
 
 \commentary{%
-Examples of external functions might be foreign functions
-(defined in C, or Javascript etc.),
-primitives of the implementation (as defined by the Dart run-time system),
-or code that was dynamically generated but whose interface is statically known.
-However, an abstract method is different from an external function,
-as it has \emph{no} body.%
+  Examples of external functions might be foreign functions
+  (defined in C, or Javascript etc.),
+  primitives of the implementation (as defined by the Dart run-time system),
+  or code that was dynamically generated
+  but whose interface is statically known.
+  However, an abstract method is different from an external function,
+  as it has \emph{no} body.%
 }
 
 \LMHash{}%
@@ -2781,9 +2796,9 @@ An implementation specific compile-time error can be raised
 at an \EXTERNAL{} function declaration.
 
 \commentary{%
-Such errors are intended to indicate that
-every invocation of that function would throw, e.g.,
-because it is known that it will not be connected to a body.%
+  Such errors are intended to indicate that
+  every invocation of that function would throw, e.g.,
+  because it is known that it will not be connected to a body.%
 }
 
 \LMHash{}%
@@ -2891,9 +2906,9 @@ an instance member or a generative constructor,
 or in the initializing expression of a \LATE{} instance variable declaration.
 
 \commentary{%
-Note that an initializing expression for a non-\LATE{} instance variable
-does not have access to \THIS,
-and neither does any part of a declaration marked \STATIC.%
+  Note that an initializing expression for a non-\LATE{} instance variable
+  does not have access to \THIS,
+  and neither does any part of a declaration marked \STATIC.%
 }
 
 \LMHash{}%
@@ -2914,22 +2929,22 @@ a \IndexCustom{concrete class}{class!concrete} is a class
 whose declaration is concrete.
 
 \rationale{%
-We want different behavior for concrete classes and abstract classes.
-If $A$ is intended to be abstract,
-we want the static checker to warn about any attempt to instantiate $A$,
-and we do not want the checker to complain about unimplemented methods in $A$.
-In contrast, if $A$ is intended to be concrete,
-the checker should warn about all unimplemented methods,
-but allow clients to instantiate it freely.%
+  We want different behavior for concrete classes and abstract classes.
+  If $A$ is intended to be abstract,
+  we want the static checker to warn about any attempt to instantiate $A$,
+  and we do not want the checker to complain about unimplemented methods in $A$.
+  In contrast, if $A$ is intended to be concrete,
+  the checker should warn about all unimplemented methods,
+  but allow clients to instantiate it freely.%
 }
 
 \commentary{%
-The interface of a class $C$ is
-an implicit interface that declares instance member signatures
-that correspond to the instance members declared by $C$,
-and whose direct superinterfaces are
-the direct superinterfaces of $C$
-(\ref{interfaces}, \ref{superinterfaces}).%
+  The interface of a class $C$ is
+  an implicit interface that declares instance member signatures
+  that correspond to the instance members declared by $C$,
+  and whose direct superinterfaces are
+  the direct superinterfaces of $C$
+  (\ref{interfaces}, \ref{superinterfaces}).%
 }
 
 \LMHash{}%
@@ -2946,12 +2961,12 @@ or if $G$ has a member whose basename is $X$,
 or if $G$ has a constructor named \code{$G$.$X$}.
 
 \commentary{%
-Here are simple examples, that illustrate the difference between
-``has a member'' and ``declares a member''.
-For example, \code{B} \IndexCustom{declares}{declares member}
-one member named \code{f},
-but it \IndexCustom{has}{has member} two such members.
-The rules of inheritance determine what members a class has.%
+  Here are simple examples, that illustrate the difference between
+  ``has a member'' and ``declares a member''.
+  For example, \code{B} \IndexCustom{declares}{declares member}
+  one member named \code{f},
+  but it \IndexCustom{has}{has member} two such members.
+  The rules of inheritance determine what members a class has.%
 }
 
 \begin{dartCode}
@@ -3000,7 +3015,7 @@ Assume that $C$ has a concrete member with
 the same name as $m$ and accessible to $L$,
 and let \DefineSymbol{m''} be its member signature.
 \commentary{%
-The concrete member may be declared in $C$ or inherited from a superclass.%
+  The concrete member may be declared in $C$ or inherited from a superclass.%
 }
 Let \DefineSymbol{m'} be the member signature which is obtained from $m''$
 by adding, if not present already, the modifier \COVARIANT{}
@@ -3013,21 +3028,21 @@ unless that concrete member is a \code{noSuchMethod} forwarder
 (\ref{theMethodNoSuchMethod}).
 
 \commentary{%
-Consider a concrete class \code{C},
-and assume that \code{C} declares or inherits
-a member implementation with the same name
-for every member signature in its interface.
-It is still an error if one or more of those member implementations
-has parameters or types such that they do not satisfy
-the corresponding member signature in the interface.
-For this check, any missing \COVARIANT{} modifiers are implicitly added
-to the signature of an inherited member (this is how we get $m'$ from $m''$).
-When the modifier \COVARIANT{} is added to one or more parameters
-(which will only happen when the concrete member is inherited),
-an implementation may choose to implicitly induce a forwarding method
-with the same signature as $m'$,
-in order to perform the required dynamic type check,
-and then invoke the inherited method.%
+  Consider a concrete class \code{C},
+  and assume that \code{C} declares or inherits
+  a member implementation with the same name
+  for every member signature in its interface.
+  It is still an error if one or more of those member implementations
+  has parameters or types such that they do not satisfy
+  the corresponding member signature in the interface.
+  For this check, any missing \COVARIANT{} modifiers are implicitly added
+  to the signature of an inherited member (this is how we get $m'$ from $m''$).
+  When the modifier \COVARIANT{} is added to one or more parameters
+  (which will only happen when the concrete member is inherited),
+  an implementation may choose to implicitly induce a forwarding method
+  with the same signature as $m'$,
+  in order to perform the required dynamic type check,
+  and then invoke the inherited method.%
 }
 
 \LMHash{}%
@@ -3037,12 +3052,13 @@ when the modifier \COVARIANT{} is added to
 one or more parameters in $m'$.
 
 \commentary{%
-This is true in spite of the fact that such forwarding methods can be observed.
-E.g., we can compare
-the run-time type of a tearoff of the method from
-a receiver of type \code{C}
-to the run-time type of a tearoff of the super-method from
-a location in the body of \code{C}.%
+  This is true in spite of the fact that
+  such forwarding methods can be observed.
+  E.g., we can compare
+  the run-time type of a tearoff of the method from
+  a receiver of type \code{C}
+  to the run-time type of a tearoff of the super-method from
+  a location in the body of \code{C}.%
 }
 
 \LMHash{}%
@@ -3050,19 +3066,20 @@ With or without a forwarding method,
 the member signature in the interface of $C$ is $m$.
 
 \commentary{%
-The forwarding method does not change the interface of \code{C},
-it is an implementation detail.
-In particular, this holds even in the case where
-an explicit declaration of the forwarding method would have
-changed the interface of \code{C}, because $m'$ is a subtype of $m$.
+  The forwarding method does not change the interface of \code{C},
+  it is an implementation detail.
+  In particular, this holds even in the case where
+  an explicit declaration of the forwarding method would have
+  changed the interface of \code{C}, because $m'$ is a subtype of $m$.
 
-When a class has a non-trivial \code{noSuchMethod},
-the class may leave some members unimplemented,
-and the class is allowed to have a \code{noSuchMethod} forwarder
-which does not satisfy the class interface
-(in which case it will be overridden by another \code{noSuchMethod} forwarder).
+  When a class has a non-trivial \code{noSuchMethod},
+  the class may leave some members unimplemented,
+  and the class is allowed to have a \code{noSuchMethod} forwarder
+  which does not satisfy the class interface
+  (in which case it will be overridden by
+  another \code{noSuchMethod} forwarder).
 
-Here is an example:%
+  Here is an example:%
 }
 
 \begin{dartCode}
@@ -3094,10 +3111,10 @@ In this situation, a compile-time error occurs
 if the type of $p$ is not a subtype and not a supertype of the type of $p_s$.
 
 \commentary{%
-This ensures that an inherited method satisfies the same constraint
-for each formal parameter which is covariant-by-declaration
-as the constraint which is specified for a declaration in $C$
-(\ref{instanceMethods}).%
+  This ensures that an inherited method satisfies the same constraint
+  for each formal parameter which is covariant-by-declaration
+  as the constraint which is specified for a declaration in $C$
+  (\ref{instanceMethods}).%
 }
 
 
@@ -3128,12 +3145,12 @@ unless $m$ is a correct member override of $m'$
 (\ref{correctMemberOverrides}).
 
 \commentary{%
-This is not the only kind of conflict that may exist:
-An instance member declaration $D$ may conflict with another declaration $D'$,
-even in the case where they do not have the same name
-or they are not the same kind of declaration.
-E.g., $D$ could be an instance getter and $D'$ a static setter
-(\ref{classMemberConflicts}).%
+  This is not the only kind of conflict that may exist:
+  An instance member declaration $D$ may conflict with another declaration $D'$,
+  even in the case where they do not have the same name
+  or they are not the same kind of declaration.
+  E.g., $D$ could be an instance getter and $D'$ a static setter
+  (\ref{classMemberConflicts}).%
 }
 
 \LMHash{}%
@@ -3146,32 +3163,32 @@ such that $m''$ has a parameter $p''$ that corresponds to $p$
 unless the type of $p$ is a subtype or a supertype of the type of $p''$.
 
 \commentary{%
-This means that
-a parameter which is covariant-by-declaration can have a type
-which is a supertype or a subtype of the type of
-a corresponding parameter in a superinterface,
-but the two types cannot be unrelated.
-Note that this requirement must be satisfied
-for each direct or indirect superinterface separately,
-because that relationship is not transitive.%
+  This means that
+  a parameter which is covariant-by-declaration can have a type
+  which is a supertype or a subtype of the type of
+  a corresponding parameter in a superinterface,
+  but the two types cannot be unrelated.
+  Note that this requirement must be satisfied
+  for each direct or indirect superinterface separately,
+  because that relationship is not transitive.%
 }
 
 \rationale{%
-The superinterface may be the statically known type of the receiver,
-so this means that we relax the potential typing relationship
-between the statically known type of a parameter and the
-type which is actually required at run time
-to the subtype-or-supertype relationship,
-rather than the strict supertype relationship
-which applies to a parameter which is not covariant.
-It should be noted that it is not statically known
-at the call site whether any given parameter is covariant,
-because the covariance could be introduced in
-a proper subtype of the statically known type of the receiver.
-We chose to give priority to flexibility rather than safety here,
-because the whole point of covariant parameters is that developers
-can make the choice to increase the flexibility
-in a trade-off where some static type safety is lost.%
+  The superinterface may be the statically known type of the receiver,
+  so this means that we relax the potential typing relationship
+  between the statically known type of a parameter and the
+  type which is actually required at run time
+  to the subtype-or-supertype relationship,
+  rather than the strict supertype relationship
+  which applies to a parameter which is not covariant.
+  It should be noted that it is not statically known
+  at the call site whether any given parameter is covariant,
+  because the covariance could be introduced in
+  a proper subtype of the statically known type of the receiver.
+  We chose to give priority to flexibility rather than safety here,
+  because the whole point of covariant parameters is that developers
+  can make the choice to increase the flexibility
+  in a trade-off where some static type safety is lost.%
 }
 
 
@@ -3257,18 +3274,18 @@ It is a compile-time error if the arity of the user-declared operator
 is not 0 or 1.
 
 \commentary{%
-The \lit{-} operator is unique
-in that two overloaded versions are permitted.
-If the operator has no arguments, it denotes unary minus.
-If it has an argument, it denotes binary subtraction.%
+  The \lit{-} operator is unique
+  in that two overloaded versions are permitted.
+  If the operator has no arguments, it denotes unary minus.
+  If it has an argument, it denotes binary subtraction.%
 }
 
 \LMHash{}%
 The name of the unary operator \lit{-} is \code{unary-}.
 
 \rationale{%
-This device allows the two methods to be distinguished
-for purposes of method lookup, override and reflection.%
+  This device allows the two methods to be distinguished
+  for purposes of method lookup, override and reflection.%
 }
 
 \LMHash{}%
@@ -3284,26 +3301,26 @@ It is a compile-time error if a user-declared operator \lit{[]=}
 declares a return type other than \VOID.
 
 \commentary{%
-If no return type is specified for a user-declared operator
-\lit{[]=},
-its return type is \VOID{} (\ref{typeOfAFunction}).%
+  If no return type is specified for a user-declared operator
+  \lit{[]=},
+  its return type is \VOID{} (\ref{typeOfAFunction}).%
 }
 
 \rationale{%
-The return type is \VOID{} because
-a return statement in an implementation of operator
-\lit{[]=}
-does not return an object.
-Consider a non-throwing evaluation of an expression $e$ of the form
-\code{$e_1$[$e_2$] = $e_3$},
-and assume that the evaluation of $e_3$ yields an object $o$.
-$e$ will then evaluate to $o$,
-and even if the executed body of operator
-\lit{[]=}
-completes with an object $o'$,
-that is, if $o'$ is returned it is simply ignored.
-The rationale for this behavior is that
-assignments should be guaranteed to evaluate to the assigned object.%
+  The return type is \VOID{} because
+  a return statement in an implementation of operator
+  \lit{[]=}
+  does not return an object.
+  Consider a non-throwing evaluation of an expression $e$ of the form
+  \code{$e_1$[$e_2$] = $e_3$},
+  and assume that the evaluation of $e_3$ yields an object $o$.
+  $e$ will then evaluate to $o$,
+  and even if the executed body of operator
+  \lit{[]=}
+  completes with an object $o'$,
+  that is, if $o'$ is returned it is simply ignored.
+  The rationale for this behavior is that
+  assignments should be guaranteed to evaluate to the assigned object.%
 }
 
 
@@ -3318,27 +3335,27 @@ in situations where one or more member lookups fail
 \ref{assignment}).
 
 \commentary{%
-We may think of \code{noSuchMethod} as a backup
-which kicks in when an invocation of a member $m$ is attempted,
-but there is no member named $m$,
-or it exists,
-but the given invocation has an argument list shape
-that does not fit the declaration of $m$
-(passing fewer positional arguments than required or more than supported,
-or passing named arguments with names not declared by $m$).
-% The next sentence covers both function objects and instances of
-% a class with a method named \CALL, because we would have a
-% compile-time error invoking \CALL{} with a wrongly shaped argument
-% list unless the type is \DYNAMIC{} or \FUNCTION.
-This can only occur for an ordinary method invocation
-when the receiver has static type \DYNAMIC,
-or for a function invocation when
-the invoked function has static type \FUNCTION{} or \DYNAMIC.
-%
-The method \code{noSuchMethod} can also be invoked in other ways, e.g.,
-it can be called explicitly like any other method,
-and it can be invoked from a \code{noSuchMethod} forwarder,
-as explained below.%
+  We may think of \code{noSuchMethod} as a backup
+  which kicks in when an invocation of a member $m$ is attempted,
+  but there is no member named $m$,
+  or it exists,
+  but the given invocation has an argument list shape
+  that does not fit the declaration of $m$
+  (passing fewer positional arguments than required or more than supported,
+  or passing named arguments with names not declared by $m$).
+  % The next sentence covers both function objects and instances of
+  % a class with a method named \CALL, because we would have a
+  % compile-time error invoking \CALL{} with a wrongly shaped argument
+  % list unless the type is \DYNAMIC{} or \FUNCTION.
+  This can only occur for an ordinary method invocation
+  when the receiver has static type \DYNAMIC,
+  or for a function invocation when
+  the invoked function has static type \FUNCTION{} or \DYNAMIC.
+  %
+  The method \code{noSuchMethod} can also be invoked in other ways, e.g.,
+  it can be called explicitly like any other method,
+  and it can be invoked from a \code{noSuchMethod} forwarder,
+  as explained below.%
 }
 
 \LMHash{}%
@@ -3347,27 +3364,28 @@ if $C$ has a concrete member named \code{noSuchMethod}
 which is distinct from the one declared in the built-in class \code{Object}.
 
 \commentary{%
-Note that it must be a method that accepts one positional argument,
-in order to correctly override \code{noSuchMethod} in \code{Object}.
-For instance, it can have signature
-\code{noSuchMethod(Invocation i)} or
-\code{noSuchMethod(Object i, [String s = ''])},
-but not
-\code{noSuchMethod(Invocation i, String s)}.
-This implies that the situation where \code{noSuchMethod} is invoked
-(explicitly or implicitly)
-with one actual argument cannot fail for the reason that
-``there is no such method'',
-such that we would enter an infinite loop trying to invoke \code{noSuchMethod}.
-It \emph{is} possible, however, to encounter a dynamic error
-during an invocation of \code{noSuchMethod}
-because the actual argument fails to satisfy a type check,
-but that situation will give rise to a dynamic type error
-rather than a repeated attempt to invoke \code{noSuchMethod}
-(\ref{bindingActualsToFormals}).
-Here is an example where a dynamic type error occurs because
-an attempt is made to pass an \code{Invocation}
-where only the null object is accepted:%
+  Note that it must be a method that accepts one positional argument,
+  in order to correctly override \code{noSuchMethod} in \code{Object}.
+  For instance, it can have signature
+  \code{noSuchMethod(Invocation i)} or
+  \code{noSuchMethod(Object i, [String s = ''])},
+  but not
+  \code{noSuchMethod(Invocation i, String s)}.
+  This implies that the situation where \code{noSuchMethod} is invoked
+  (explicitly or implicitly)
+  with one actual argument cannot fail for the reason that
+  ``there is no such method'',
+  such that we would enter an infinite loop
+  trying to invoke \code{noSuchMethod}.
+  It \emph{is} possible, however, to encounter a dynamic error
+  during an invocation of \code{noSuchMethod}
+  because the actual argument fails to satisfy a type check,
+  but that situation will give rise to a dynamic type error
+  rather than a repeated attempt to invoke \code{noSuchMethod}
+  (\ref{bindingActualsToFormals}).
+  Here is an example where a dynamic type error occurs because
+  an attempt is made to pass an \code{Invocation}
+  where only the null object is accepted:%
 }
 
 \begin{dartCode}
@@ -3397,8 +3415,8 @@ one of the following is true:
   that correctly overrides $S$
   \commentary{%
     (that is, no member named $m$ is declared or inherited by $C$,
-    or one is inherited, but it does not have the required signature%
-  )}.
+    or one is inherited, but it does not have the required signature)%
+  }.
   In this case we also say that $S$ is noSuchMethod forwarded.
 \item
   \textbf{Forced by privacy:}
@@ -3438,10 +3456,10 @@ using a property extraction
 (\ref{propertyExtraction}).
 
 \commentary{%
-The error concerned with an implictly induced forwarder
-that would override a human-written declaration
-can only occur if that concrete declaration does not
-correctly override $S$. Consider the following example:%
+  The error concerned with an implictly induced forwarder
+  that would override a human-written declaration
+  can only occur if that concrete declaration does not
+  correctly override $S$. Consider the following example:%
 }
 
 \begin{dartCode}
@@ -3460,69 +3478,69 @@ correctly override $S$. Consider the following example:%
 \end{dartCode}
 
 \commentary{%
-In this example,
-an implementation with signature \code{foo(int i)} is inherited by \code{C},
-and the superinterface \code{B} declares
-the signature \code{foo([int i])}.
-This is a compile-time error because \code{C} does not have
-a method implementation with signature \code{foo([int])}.
-We do not wish to implicitly induce
-a \code{noSuchMethod} forwarder with signature \code{foo([int])}
-because it would override \code{A.foo},
-and that is likely to be highly confusing for developers.
-%
-In particular, it would cause an invocation like \code{C().foo(42)}
-to invoke \code{noSuchMethod},
-even though that is an invocation which is correct for
-the declaration of \code{foo} in \code{A}.
-%
-Hence, we require developers to explicitly resolve the conflict
-whenever an implicitly induced \code{noSuchMethod} forwarder
-would override an explicitly declared inherited implementation.
-%
-It is no problem, however,
-to let a \code{noSuchMethod} forwarder override
-another \code{noSuchMethod} forwarder,
-and hence there is no error in that situation.%
+  In this example,
+  an implementation with signature \code{foo(int i)} is inherited by \code{C},
+  and the superinterface \code{B} declares
+  the signature \code{foo([int i])}.
+  This is a compile-time error because \code{C} does not have
+  a method implementation with signature \code{foo([int])}.
+  We do not wish to implicitly induce
+  a \code{noSuchMethod} forwarder with signature \code{foo([int])}
+  because it would override \code{A.foo},
+  and that is likely to be highly confusing for developers.
+  %
+  In particular, it would cause an invocation like \code{C().foo(42)}
+  to invoke \code{noSuchMethod},
+  even though that is an invocation which is correct for
+  the declaration of \code{foo} in \code{A}.
+  %
+  Hence, we require developers to explicitly resolve the conflict
+  whenever an implicitly induced \code{noSuchMethod} forwarder
+  would override an explicitly declared inherited implementation.
+  %
+  It is no problem, however,
+  to let a \code{noSuchMethod} forwarder override
+  another \code{noSuchMethod} forwarder,
+  and hence there is no error in that situation.%
 }
 
 \commentary{%
-This implies that a \code{noSuchMethod} forwarder has the same
-properties as an explicitly declared concrete member,
-except of course that a \code{noSuchMethod} forwarder
-does not prevent itself or another noSuchMethod forwarder from being induced.
-We do not specify the body of a \code{noSuchMethod} forwarder,
-but it will invoke \code{noSuchMethod},
-and we specify the dynamic semantics of executing it below.%
+  This implies that a \code{noSuchMethod} forwarder has the same
+  properties as an explicitly declared concrete member,
+  except of course that a \code{noSuchMethod} forwarder
+  does not prevent itself or another noSuchMethod forwarder from being induced.
+  We do not specify the body of a \code{noSuchMethod} forwarder,
+  but it will invoke \code{noSuchMethod},
+  and we specify the dynamic semantics of executing it below.%
 }
 
 \commentary{%
-At the beginning of this section we mentioned that implicit invocations
-of \code{noSuchMethod} can only occur
-with a receiver of static type \DYNAMIC{}
-or a function of static type \DYNAMIC{} or \FUNCTION.
-With a \code{noSuchMethod} forwarder,
-\code{noSuchMethod} can also be invoked
-on a receiver whose static type is not \DYNAMIC.
-No similar situation exists for functions,
-because it is impossible to induce a \code{noSuchMethod} forwarder
-into the class of a function object.%
+  At the beginning of this section we mentioned that implicit invocations
+  of \code{noSuchMethod} can only occur
+  with a receiver of static type \DYNAMIC{}
+  or a function of static type \DYNAMIC{} or \FUNCTION.
+  With a \code{noSuchMethod} forwarder,
+  \code{noSuchMethod} can also be invoked
+  on a receiver whose static type is not \DYNAMIC.
+  No similar situation exists for functions,
+  because it is impossible to induce a \code{noSuchMethod} forwarder
+  into the class of a function object.%
 }
 
 \commentary{%
-For a concrete class $C$,
-we may think of a non-trivial \code{noSuchMethod}
-(declared in or inherited by $C$)
-as a request for ``automatic implementation'' of all unimplemented members
-in the interface of $C$ as \code{noSuchMethod} forwarders.
-Similarly, there is an implicit request for
-automatic implementation of all unimplemented
-inaccessible members of any concrete class,
-whether or not there is a non-trivial \code{noSuchMethod}.
-Note that the latter cannot be written explicitly in Dart,
-because their names are inaccessible;
-but the language can still specify that they are induced implicitly,
-because compilers control the treatment of private names.%
+  For a concrete class $C$,
+  we may think of a non-trivial \code{noSuchMethod}
+  (declared in or inherited by $C$)
+  as a request for ``automatic implementation'' of all unimplemented members
+  in the interface of $C$ as \code{noSuchMethod} forwarders.
+  Similarly, there is an implicit request for
+  automatic implementation of all unimplemented
+  inaccessible members of any concrete class,
+  whether or not there is a non-trivial \code{noSuchMethod}.
+  Note that the latter cannot be written explicitly in Dart,
+  because their names are inaccessible;
+  but the language can still specify that they are induced implicitly,
+  because compilers control the treatment of private names.%
 }
 
 \LMHash{}%
@@ -3541,10 +3559,10 @@ and named formal parameters with names
 \commentary{(with default values as mentioned above)}.
 
 \commentary{%
-For this purpose we need not distinguish between
-a signature that has optional positional parameters and
-a signature that has named parameters,
-because the former is covered by $n = 0$.%
+  For this purpose we need not distinguish between
+  a signature that has optional positional parameters and
+  a signature that has named parameters,
+  because the former is covered by $n = 0$.%
 }
 
 \LMHash{}%
@@ -3577,31 +3595,31 @@ Next, \code{noSuchMethod} is invoked with $im$ as the actual argument,
 and the result obtained from there is returned by the execution of $m$.
 
 \commentary{%
-This is an ordinary method invocation of \code{noSuchMethod}
-(\ref{ordinaryInvocation}).
-That is, a \code{noSuchMethod} forwarder in a class $C$ can invoke
-an implementation of \code{noSuchMethod} that is declared in
-a subclass of $C$.
+  This is an ordinary method invocation of \code{noSuchMethod}
+  (\ref{ordinaryInvocation}).
+  That is, a \code{noSuchMethod} forwarder in a class $C$ can invoke
+  an implementation of \code{noSuchMethod} that is declared in
+  a subclass of $C$.
 
-Dynamic type checks on the actual arguments passed to $m$
-are performed in the same way as for an invocation of an
-explicitly declared method.
-In particular, an actual argument passed to a covariant parameter
-will be checked dynamically.
+  Dynamic type checks on the actual arguments passed to $m$
+  are performed in the same way as for an invocation of an
+  explicitly declared method.
+  In particular, an actual argument passed to a covariant parameter
+  will be checked dynamically.
 
-Also, like other ordinary method invocations,
-it is a dynamic type error if the result returned by
-a \code{noSuchMethod} forwarder has a type which is not a subtype
-of the return type of the forwarder.
+  Also, like other ordinary method invocations,
+  it is a dynamic type error if the result returned by
+  a \code{noSuchMethod} forwarder has a type which is not a subtype
+  of the return type of the forwarder.
 
-One special case to be aware of is where a forwarder is torn off
-and then invoked with an actual argument list which does not match
-the formal parameter list.
-In that situation we will get an invocation of
-\code{Object.noSuchMethod}
-rather than the \code{noSuchMethod} in the original receiver,
-because this is an invocation of a function object
-(and they do not override \code{noSuchMethod}):%
+  One special case to be aware of is where a forwarder is torn off
+  and then invoked with an actual argument list which does not match
+  the formal parameter list.
+  In that situation we will get an invocation of
+  \code{Object.noSuchMethod}
+  rather than the \code{noSuchMethod} in the original receiver,
+  because this is an invocation of a function object
+  (and they do not override \code{noSuchMethod}):%
 }
 
 \begin{dartCode}
@@ -3632,17 +3650,17 @@ In order to specify these constraints just once we introduce the notion of
 \Index{primitive equality}.
 
 \rationale{%
-Certain constant expressions are known to have a value
-whose equality is primitive.
-This is useful to know because it allows
-the value of equality expressions
-and the value of invocations of \code{hashCode}
-to be computed at compile-time.
-In particular, this can be used to build
-constant collections at compile-time,
-and it can be used to check that
-all elements in a constant set are distinct,
-and all keys in a constant map are distinct.%
+  Certain constant expressions are known to have a value
+  whose equality is primitive.
+  This is useful to know because it allows
+  the value of equality expressions
+  and the value of invocations of \code{hashCode}
+  to be computed at compile-time.
+  In particular, this can be used to build
+  constant collections at compile-time,
+  and it can be used to check that
+  all elements in a constant set are distinct,
+  and all keys in a constant map are distinct.%
 }
 
 \begin{itemize}
@@ -3727,13 +3745,13 @@ The \Index{static getters of a class} $C$ are
 those static getters declared by $C$.
 
 \commentary{%
-A getter declaration may conflict with other declarations
-(\ref{classMemberConflicts}).
-In particular, a getter can never override a method,
-and a method can never override a getter or an instance variable.
-The rules for when a getter correctly overrides another member
-are given elsewhere
-(\ref{correctMemberOverrides}).%
+  A getter declaration may conflict with other declarations
+  (\ref{classMemberConflicts}).
+  In particular, a getter can never override a method,
+  and a method can never override a getter or an instance variable.
+  The rules for when a getter correctly overrides another member
+  are given elsewhere
+  (\ref{correctMemberOverrides}).%
 }
 
 
@@ -3749,8 +3767,8 @@ the values of object properties.
 \end{grammar}
 
 \commentary{%
-If no return type is specified, the return type of the setter is \VOID{}
-(\ref{typeOfAFunction}).%
+  If no return type is specified, the return type of the setter is \VOID{}
+  (\ref{typeOfAFunction}).%
 }
 
 \LMHash{}%
@@ -3761,8 +3779,8 @@ The name of a setter is obtained by appending the string `=' to
 the identifier given in its signature.
 
 \commentary{%
-Hence, a setter name can never conflict with, override or be overridden by
-a getter or method.%
+  Hence, a setter name can never conflict with, override or be overridden by
+  a getter or method.%
 }
 
 \LMHash{}%
@@ -3778,8 +3796,8 @@ either implicitly or explicitly.
 It is a compile-time error if a setter's formal parameter list
 does not consist of exactly one required formal parameter $p$.
 \rationale{%
-We could enforce this via the grammar,
-but we'd have to specify the evaluation rules in that case.%
+  We could enforce this via the grammar,
+  but we'd have to specify the evaluation rules in that case.%
 }
 
 \LMHash{}%
@@ -3790,11 +3808,11 @@ a getter named $v$ with return type $S$,
 and $S$ may not be assigned to $T$.
 
 \commentary{%
-The rules for when a setter correctly overrides another member
-are given elsewhere
-(\ref{correctMemberOverrides}).
-A setter declaration may conflict with other declarations as well
-(\ref{classMemberConflicts}).%
+  The rules for when a setter correctly overrides another member
+  are given elsewhere
+  (\ref{correctMemberOverrides}).
+  A setter declaration may conflict with other declarations as well
+  (\ref{classMemberConflicts}).%
 }
 
 
@@ -3815,40 +3833,41 @@ A \IndexCustom{concrete method}{method!concrete}
 is an instance method, getter or setter that is not abstract.
 
 \rationale{%
-Abstract instance members are useful because of their interplay with classes.
-Every Dart class induces an implicit interface,
-and Dart does not support specifying interfaces explicitly.
-Using an abstract class instead of a traditional interface
-has important advantages.
-An abstract class can provide default implementations.
-It can also provide static methods,
-obviating the need for service classes
-such as \code{Collections} or \code{Lists},
-whose entire purpose is to group utilities related to a given type.%
+  Abstract instance members are useful because of their interplay with classes.
+  Every Dart class induces an implicit interface,
+  and Dart does not support specifying interfaces explicitly.
+  Using an abstract class instead of a traditional interface
+  has important advantages.
+  An abstract class can provide default implementations.
+  It can also provide static methods,
+  obviating the need for service classes
+  such as \code{Collections} or \code{Lists},
+  whose entire purpose is to group utilities related to a given type.%
 }
 
 \commentary{%
-Invocation of an abstract method, getter, or setter cannot occur,
-because lookup (\ref{lookup}) will never yield an abstract member as its result.
-One way to think about this is that
-an abstract member declaration in a subclass
-does not override or shadow an inherited member implementation.
-It only serves to specify the signature of the given member that
-every concrete subtype must have an implementation of;
-that is, it contributes to the interface of the class,
-not to the class itself.%
+  Invocation of an abstract method, getter, or setter cannot occur,
+  because lookup (\ref{lookup}) will never yield
+  an abstract member as its result.
+  One way to think about this is that
+  an abstract member declaration in a subclass
+  does not override or shadow an inherited member implementation.
+  It only serves to specify the signature of the given member that
+  every concrete subtype must have an implementation of;
+  that is, it contributes to the interface of the class,
+  not to the class itself.%
 }
 
 \rationale{%
-The purpose of an abstract method is to provide a declaration
-for purposes such as type checking and reflection.
-In mixins, it is often useful to introduce such declarations for methods that
-the mixin expects will be provided by the superclass the mixin is applied to.%
+  The purpose of an abstract method is to provide a declaration
+  for purposes such as type checking and reflection.
+  In mixins, it is often useful to introduce such declarations for methods that
+  the mixin expects will be provided by the superclass the mixin is applied to.%
 }
 
 \rationale{%
-We wish to detect if one declares a concrete class with abstract members.
-However, code like the following should work:%
+  We wish to detect if one declares a concrete class with abstract members.
+  However, code like the following should work:%
 }
 
 \begin{dartCode}
@@ -3865,11 +3884,11 @@ class Base \{
 \end{dartCode}
 
 \rationale{%
-At run time, the concrete method \code{one} declared in \code{Base}
-will be executed,
-and no problem should arise.
-Therefore no error should be raised
-if a corresponding concrete member exists in the hierarchy.%
+  At run time, the concrete method \code{one} declared in \code{Base}
+  will be executed,
+  and no problem should arise.
+  Therefore no error should be raised
+  if a corresponding concrete member exists in the hierarchy.%
 }
 
 
@@ -3889,21 +3908,21 @@ and the instance variables inherited by $C$ from its superclass.
 It is a compile-time error if an instance variable is declared to be constant.
 
 \rationale{%
-The notion of a constant instance variable
-is subtle and confusing to programmers.
-An instance variable is intended to vary per instance.
-A constant instance variable would have the same value for all instances,
-and as such is already a dubious idea.
+  The notion of a constant instance variable
+  is subtle and confusing to programmers.
+  An instance variable is intended to vary per instance.
+  A constant instance variable would have the same value for all instances,
+  and as such is already a dubious idea.
 
-The language could interpret const instance variable declarations as
-instance getters that return a constant.
-However, a constant instance variable could not be treated as
-a true compile-time constant,
-as its getter would be subject to overriding.
+  The language could interpret const instance variable declarations as
+  instance getters that return a constant.
+  However, a constant instance variable could not be treated as
+  a true compile-time constant,
+  as its getter would be subject to overriding.
 
-Given that the value does not depend on the instance,
-it is better to use a static variable.
-An instance getter for it can always be defined manually if desired.%
+  Given that the value does not depend on the instance,
+  it is better to use a static variable.
+  An instance getter for it can always be defined manually if desired.%
 }
 
 \LMHash{}%
@@ -3916,11 +3935,11 @@ is considered to be covariant-by-declaration
 (\ref{covariantParameters}).
 
 \commentary{%
-The modifier \COVARIANT{} on an instance variable has no other effects.
-In particular, the return type of the implicitly induced getter
-can already be overridden covariantly without \COVARIANT,
-and it can never be overridden to a supertype or an unrelated type,
-regardless of whether the modifier \COVARIANT{} is present.%
+  The modifier \COVARIANT{} on an instance variable has no other effects.
+  In particular, the return type of the implicitly induced getter
+  can already be overridden covariantly without \COVARIANT,
+  and it can never be overridden to a supertype or an unrelated type,
+  regardless of whether the modifier \COVARIANT{} is present.%
 }
 
 
@@ -3950,35 +3969,35 @@ and whose formal parameter types, optionality, and names of named parameters
 correspond to the declaration of $k$.
 
 \commentary{%
-Note that the function type $F$ of a constructor $k$ may contain
-type variables declared by the enclosing class $C$.
-In that case we can apply a substitution to $F$, as in
-$[T_1/X_1, \ldots, T_m/X_m]F$,
-where $X_j, j \in 1 .. m$ are the formal type parameters of $C$
-and $T_j, j \in 1 .. m$ are specified in the given context.
-We may also omit such a substitution when the given context is
-the body scope of $C$, where $X_1, \ldots, X_m$ are in scope.%
+  Note that the function type $F$ of a constructor $k$ may contain
+  type variables declared by the enclosing class $C$.
+  In that case we can apply a substitution to $F$, as in
+  $[T_1/X_1, \ldots, T_m/X_m]F$,
+  where $X_j, j \in 1 .. m$ are the formal type parameters of $C$
+  and $T_j, j \in 1 .. m$ are specified in the given context.
+  We may also omit such a substitution when the given context is
+  the body scope of $C$, where $X_1, \ldots, X_m$ are in scope.%
 }
 
 \commentary{%
-A constructor declaration may conflict with static member declarations
-(\ref{classMemberConflicts}).%
+  A constructor declaration may conflict with static member declarations
+  (\ref{classMemberConflicts}).%
 }
 
 \commentary{%
-A constructor declaration does not introduce a name into a scope.
-If a function expression invocation
-(\ref{functionExpressionInvocation})
-or an instance creation
-(\ref{instanceCreation})
-denotes a constructor as
-$C$, \code{$prefix$.$C$}, \code{$C$.\id}, or \code{\metavar{prefix}.$C$.\id},
-resolution relies on the library scope to determine the class
-(possibly via an import prefix).
-The class declaration is then directly checked for
-whether it has a constructor named $C$ respectively \code{$C$.\id}.
-It is not possible for an identifier to directly refer to a constructor,
-since the constructor is not in any scope used for resolving identifiers.%
+  A constructor declaration does not introduce a name into a scope.
+  If a function expression invocation
+  (\ref{functionExpressionInvocation})
+  or an instance creation
+  (\ref{instanceCreation})
+  denotes a constructor as
+  $C$, \code{$prefix$.$C$}, \code{$C$.\id}, or \code{\metavar{prefix}.$C$.\id},
+  resolution relies on the library scope to determine the class
+  (possibly via an import prefix).
+  The class declaration is then directly checked for
+  whether it has a constructor named $C$ respectively \code{$C$.\id}.
+  It is not possible for an identifier to directly refer to a constructor,
+  since the constructor is not in any scope used for resolving identifiers.%
 }
 
 \LMHash{}%
@@ -4004,8 +4023,8 @@ and either a redirect clause or an initializer list and an optional body.
 \end{grammar}
 
 \commentary{%
-See \synt{declaration} and \synt{methodSignature} for grammar rules
-introducing a redirection or an initializer list and a body.%
+  See \synt{declaration} and \synt{methodSignature} for grammar rules
+  introducing a redirection or an initializer list and a body.%
 }
 
 %% TODO(eernst): Add `\Error{...}` below when that command is added.
@@ -4014,9 +4033,9 @@ A compile-time error occurs if a generative constructor declaration
 has a body of the form `\code{=>\,\,$e$;}'.
 
 \commentary{%
-In other function declarations,
-this kind of body is taken to imply that the value of $e$ is returned,
-but generative constructors do not return anything.%
+  In other function declarations,
+  this kind of body is taken to imply that the value of $e$ is returned,
+  but generative constructors do not return anything.%
 }
 
 \LMHash{}%
@@ -4061,14 +4080,14 @@ every other formal parameter introduces a local variable into
 both the formal parameter scope and the formal parameter initializer scope.
 
 \commentary{%
-This means that formal parameters, including initializing formals,
-must have distinct names, and that initializing formals
-are in scope for the initializer list,
-but they are not in scope for the body of the constructor.
-When a formal parameter introduces a local variable into two scopes,
-it is still one variable and hence one storage location.
-The type of the constructor is defined in terms of its formal parameters,
-including the initializing formals.%
+  This means that formal parameters, including initializing formals,
+  must have distinct names, and that initializing formals
+  are in scope for the initializer list,
+  but they are not in scope for the body of the constructor.
+  When a formal parameter introduces a local variable into two scopes,
+  it is still one variable and hence one storage location.
+  The type of the constructor is defined in terms of its formal parameters,
+  including the initializing formals.%
 }
 
 \LMHash{}%
@@ -4083,7 +4102,7 @@ which is not a subtype of the declared type of the instance variable \id,
 in which case a dynamic error occurs.
 
 \commentary{%
-The above rule allows initializing formals to be used as optional parameters:%
+  The above rule allows initializing formals to be used as optional parameters:%
 }
 
 \begin{dartCode}
@@ -4094,7 +4113,7 @@ class A \{
 \end{dartCode}
 
 \commentary{%
-is legal, and has the same effect as%
+  is legal, and has the same effect as%
 }
 
 \begin{dartCode}
@@ -4111,10 +4130,10 @@ A generative constructor always operates on a fresh instance of
 its immediately enclosing class.
 
 \commentary{%
-The above holds if the constructor is actually run, as it is by \NEW.
-If a constructor $c$ is referenced by \CONST, $c$ may not be run;
-instead, a canonical object may be looked up.
-See the section on instance creation (\ref{instanceCreation}).%
+  The above holds if the constructor is actually run, as it is by \NEW.
+  If a constructor $c$ is referenced by \CONST, $c$ may not be run;
+  instead, a canonical object may be looked up.
+  See the section on instance creation (\ref{instanceCreation}).%
 }
 
 \LMHash{}%
@@ -4179,24 +4198,24 @@ of \code{($e_1 \ldots,\ e_p,\ x_1$:\ $e_{p+1}, \ldots,\ x_q$:\ $e_{p+q}$)}
 is not an assignable match for the formal parameter list of the redirectee.
 
 \commentary{%
-Note that the case where no named parameters are passed
-is covered by letting $q$ be zero,
-and the case where $C$ is a non-generic class
-is covered by letting $m$ be zero,
-in which case the formal type parameter list and actual type argument lists
-are omitted
-(\ref{generics}).%
+  Note that the case where no named parameters are passed
+  is covered by letting $q$ be zero,
+  and the case where $C$ is a non-generic class
+  is covered by letting $m$ be zero,
+  in which case the formal type parameter list and actual type argument lists
+  are omitted
+  (\ref{generics}).%
 }
 
 \rationale{%
-We require an assignable match rather than the stricter subtype match
-because a generative redirecting constructor $k$ invokes its redirectee $k'$
-in a manner which resembles function invocation in general.
-For instance, $k$ could accept an argument \code{x}
-and pass on an expression $e_j$ using \code{x} such as \code{x.f(42)} to $k'$,
-and it would be surprising
-if $e_j$ were subject to more strict constraints than the ones applied to
-actual arguments to function invocations in general.%
+  We require an assignable match rather than the stricter subtype match
+  because a generative redirecting constructor $k$ invokes its redirectee $k'$
+  in a manner which resembles function invocation in general.
+  For instance, $k$ could accept an argument \code{x}
+  and pass on an expression $e_j$ using \code{x} such as \code{x.f(42)} to $k'$,
+  and it would be surprising
+  if $e_j$ were subject to more strict constraints than the ones applied to
+  actual arguments to function invocations in general.%
 }
 
 \LMHash{}%
@@ -4237,18 +4256,18 @@ An initializer list begins with a colon,
 and consists of a comma-separated list of individual \Index{initializers}.
 
 \commentary{%
-There are three kinds of initializers.
+  There are three kinds of initializers.
 
-\begin{itemize}
-\item[$\bullet$] A \emph{superinitializer} identifies a
-  \emph{superconstructor}\,---\,that is,
-  a specific constructor of the superclass.
-  Execution of the superinitializer causes
-  the initializer list of the superconstructor to be executed.
-\item[$\bullet$] An \emph{instance variable initializer}
-  assigns an object to an individual instance variable.
-\item[$\bullet$] An assertion.
-\end{itemize}%
+  \begin{itemize}
+  \item[$\bullet$] A \emph{superinitializer} identifies a
+    \emph{superconstructor}\,---\,that is,
+    a specific constructor of the superclass.
+    Execution of the superinitializer causes
+    the initializer list of the superconstructor to be executed.
+  \item[$\bullet$] An \emph{instance variable initializer}
+    assigns an object to an individual instance variable.
+  \item[$\bullet$] An assertion.
+  \end{itemize}%
 }
 
 \begin{grammar}
@@ -4278,21 +4297,21 @@ As a special disambiguation rule,
 an \synt{initializerExpression} can not derive a \synt{functionExpression}.
 
 \rationale{%
-This resolves a near-ambiguity:
-In \code{A()\,:\,\,x\,\,=\,\,()\,\,\{\,\ldots\,\}},
-\code{x} could be initialized to the empty record,
-and the block could be the body of the constructor.
-Alternatively, \code{x} could be initialized to a function object,
-and the constructor would then not have a body.
-It would only be known which case we have when we encounter
-(or do not encounter)
-a semicolon at the very end.
-That was considered unreadable.
-Hence, parsers can commit to not parsing a function expression
-in this situation.
-Note that it is still possible for \synt{initializerExpression} to derive
-a term that contains a function expression as a subterm, e.g.,
-\code{A()\,:\,\,x\,\,=\,\,(()\,\,\{\,\ldots\,\});}.%
+  This resolves a near-ambiguity:
+  In \code{A()\,:\,\,x\,\,=\,\,()\,\,\{\,\ldots\,\}},
+  \code{x} could be initialized to the empty record,
+  and the block could be the body of the constructor.
+  Alternatively, \code{x} could be initialized to a function object,
+  and the constructor would then not have a body.
+  It would only be known which case we have when we encounter
+  (or do not encounter)
+  a semicolon at the very end.
+  That was considered unreadable.
+  Hence, parsers can commit to not parsing a function expression
+  in this situation.
+  Note that it is still possible for \synt{initializerExpression} to derive
+  a term that contains a function expression as a subterm, e.g.,
+  \code{A()\,:\,\,x\,\,=\,\,(()\,\,\{\,\ldots\,\});}.%
 }
 
 \LMHash{}%
@@ -4370,9 +4389,9 @@ an initializer for a variable that is not
 an instance variable declared in the immediately surrounding class.
 
 \commentary{%
-The initializer list may of course contain an initializer for
-any instance variable declared by the immediately surrounding class,
-even if it is not final.%
+  The initializer list may of course contain an initializer for
+  any instance variable declared by the immediately surrounding class,
+  even if it is not final.%
 }
 
 \LMHash{}%
@@ -4392,9 +4411,9 @@ and the type parameters of the immediately enclosing class or enum bound to
 a set of actual type arguments of $T$, \DefineSymbol{\List{t}{1}{m}}.
 
 \commentary{%
-These bindings are usually determined by the instance creation expression
-that invoked the constructor (directly or indirectly).
-However, they may also be determined by a reflective call.%
+  These bindings are usually determined by the instance creation expression
+  that invoked the constructor (directly or indirectly).
+  However, they may also be determined by a reflective call.%
 }
 
 \LMHash{}%
@@ -4445,8 +4464,8 @@ in the order they appear in the program, as described below
 (p.\,\pageref{executionOfInitializerLists}).
 
 \rationale{%
-We could observe the order by side effecting external routines called.
-So we need to specify the order.%
+  We could observe the order by side effecting external routines called.
+  So we need to specify the order.%
 }
 
 \LMHash{}%
@@ -4465,13 +4484,14 @@ After the superinitializer has completed, the body of $k$ is executed
 in a scope where \THIS{} is bound to $i$.
 
 \rationale{%
-This process ensures that no uninitialized final instance variable
-is ever seen by code.
-Note that \THIS{} is not in scope on the right hand side of an initializer
-(see \ref{this})
-so no instance method can execute during initialization:
-an instance method cannot be directly invoked,
-nor can \THIS{} be passed into any other code being invoked in the initializer.%
+  This process ensures that no uninitialized final instance variable
+  is ever seen by code.
+  Note that \THIS{} is not in scope on the right hand side of an initializer
+  (see \ref{this})
+  so no instance method can execute during initialization:
+  an instance method cannot be directly invoked,
+  nor can \THIS{} be passed into any other code being invoked
+  in the initializer.%
 }
 
 
@@ -4566,16 +4586,16 @@ whose type is not a subtype of its actual
 return type.
 
 \rationale{%
-It seems useless to allow a factory to return the null object (\ref{null}).
-But it is more uniform to allow it, as the rules currently do.%
+  It seems useless to allow a factory to return the null object (\ref{null}).
+  But it is more uniform to allow it, as the rules currently do.%
 }
 
 \rationale{%
-Factories address classic weaknesses associated with constructors
-in other languages.
-Factories can produce instances that are not freshly allocated:
-they can come from a cache.
-Likewise, factories can return instances of different classes.%
+  Factories address classic weaknesses associated with constructors
+  in other languages.
+  Factories can produce instances that are not freshly allocated:
+  they can come from a cache.
+  Likewise, factories can return instances of different classes.%
 }
 
 
@@ -4656,26 +4676,26 @@ It is a compile-time error if $\argumentList{T}$
 is not a subtype match for the formal parameter list of the redirectee.
 
 \rationale{%
-We require a subtype match
-(rather than the more forgiving assignable match
-which is used with a generative redirecting constructor),
-because a factory redirecting constructor $k$ always invokes
-its redirectee $k'$ with
-exactly the same actual arguments that $k$ received.
-This means that a downcast on an actual argument
-``between'' $k$ and $k'$
-would either be unused because the actual argument has
-the type required by $k'$,
-or it would amount to a dynamic error which is simply delayed a single step.%
+  We require a subtype match
+  (rather than the more forgiving assignable match
+  which is used with a generative redirecting constructor),
+  because a factory redirecting constructor $k$ always invokes
+  its redirectee $k'$ with
+  exactly the same actual arguments that $k$ received.
+  This means that a downcast on an actual argument
+  ``between'' $k$ and $k'$
+  would either be unused because the actual argument has
+  the type required by $k'$,
+  or it would amount to a dynamic error which is simply delayed a single step.%
 }
 
 \commentary{%
-Note that the non-generic case is covered by
-letting $m$ or $p$ or both be zero,
-in which case the formal type parameter list of the class $C$
-and/or the actual type argument list of
-the redirectee constructor is omitted
-(\ref{generics}).%
+  Note that the non-generic case is covered by
+  letting $m$ or $p$ or both be zero,
+  in which case the formal type parameter list of the class $C$
+  and/or the actual type argument list of
+  the redirectee constructor is omitted
+  (\ref{generics}).%
 }
 
 \LMHash{}%
@@ -4683,9 +4703,9 @@ It is a compile-time error if $k$ explicitly specifies
 a default value for an optional parameter.
 
 \rationale{%
-Default values specified in $k$ would be ignored,
-since it is the \emph{actual} parameters that are passed to $k'$.
-Hence, default values are disallowed.%
+  Default values specified in $k$ would be ignored,
+  since it is the \emph{actual} parameters that are passed to $k'$.
+  Hence, default values are disallowed.%
 }
 
 \LMHash{}%
@@ -4694,24 +4714,24 @@ whose type is not a subtype of the type annotation
 on the corresponding formal parameter in $k$.
 
 \commentary{%
-Note that it is not possible to modify the arguments being passed to $k'$.%
+  Note that it is not possible to modify the arguments being passed to $k'$.%
 }
 
 \rationale{%
-At first glance, one might think that
-ordinary factory constructors could simply create
-instances of other classes and return them,
-and that redirecting factories are unnecessary.
-However, redirecting factories have several advantages:
+  At first glance, one might think that
+  ordinary factory constructors could simply create
+  instances of other classes and return them,
+  and that redirecting factories are unnecessary.
+  However, redirecting factories have several advantages:
 
-\begin{itemize}
-\item
-  An abstract class may provide a constant constructor
-  that utilizes the constant constructor of another class.
-\item
-  A redirecting factory constructor avoids the need for forwarders
-  to repeat the formal parameters and their default values.
-\end{itemize}%
+  \begin{itemize}
+  \item
+    An abstract class may provide a constant constructor
+    that utilizes the constant constructor of another class.
+  \item
+    A redirecting factory constructor avoids the need for forwarders
+    to repeat the formal parameters and their default values.
+  \end{itemize}%
 }
 
 \LMHash{}%
@@ -4728,11 +4748,11 @@ It is a compile-time error if $[T_1/X_1, \ldots, T_m/X_m]F'$
 is not a subtype of the function type of $k$.
 
 \commentary{%
-In the case where the two classes are non-generic
-this is just a subtype check on the function types of the two constructors.
-In general, this implies that the resulting object conforms to
-%% TODO(eernst): Come Dart 3.0, add 'mixin'.
-the interface of the class or enum that immediately encloses $k$.%
+  In the case where the two classes are non-generic
+  this is just a subtype check on the function types of the two constructors.
+  In general, this implies that the resulting object conforms to
+  %% TODO(eernst): Come Dart 3.0, add 'mixin'.
+  the interface of the class or enum that immediately encloses $k$.%
 }
 
 \LMHash{}%
@@ -4779,13 +4799,14 @@ A constant constructor is prefixed by the reserved word \CONST.
 \end{grammar}
 
 \commentary{%
-Constant constructors have stronger constraints than other constructors.
-For instance, all the work of a non-redirecting generative constant constructor
-must be done in its initializers
-and in the initializing expressions of
-the instance variables of the enclosing class
-(and the latter may already have happened earlier,
-because those initializing expressions must be constant).%
+  Constant constructors have stronger constraints than other constructors.
+  For instance, all the work of
+  a non-redirecting generative constant constructor
+  must be done in its initializers
+  and in the initializing expressions of
+  the instance variables of the enclosing class
+  (and the latter may already have happened earlier,
+  because those initializing expressions must be constant).%
 }
 
 \LMHash{}%
@@ -4800,7 +4821,7 @@ It is a compile-time error if a non-redirecting generative constant constructor
 is declared by a class that has a instance variable which is not final.
 
 \commentary{%
-The above refers to both locally declared and inherited instance variables.%
+  The above refers to both locally declared and inherited instance variables.%
 }
 
 \LMHash{}%
@@ -4811,11 +4832,11 @@ for an instance variable declared in $C$
 to have an initializing expression that is not a constant expression.
 
 \commentary{%
-A superclass of $C$ cannot have such an initializing expression $e$ either.
-If it has a non-redirecting generative constant constructor
-then $e$ is an error,
-and if it does not have such a constructor
-then the (implicit or explicit) superinitializer in $k$ is an error.%
+  A superclass of $C$ cannot have such an initializing expression $e$ either.
+  If it has a non-redirecting generative constant constructor
+  then $e$ is an error,
+  and if it does not have such a constructor
+  then the (implicit or explicit) superinitializer in $k$ is an error.%
 }
 
 \LMHash{}%
@@ -4843,13 +4864,13 @@ yields an initializing expression $e$ in the initializer list of $k$
 which is not a constant expression.
 
 \commentary{%
-For instance, if $e$ is \code{a.length}
-where \code{a} is a formal argument of $k$ with type \DYNAMIC,
-$e$ is potentially constant and can be used in the initializer list of $k$.
-It is an error to invoke $k$ with an argument of type \code{C}
-if \code{C} is a class different from \code{String},
-even if \code{C} has a \code{length} getter,
-and that same expression would evaluate without errors at run time.%
+  For instance, if $e$ is \code{a.length}
+  where \code{a} is a formal argument of $k$ with type \DYNAMIC,
+  $e$ is potentially constant and can be used in the initializer list of $k$.
+  It is an error to invoke $k$ with an argument of type \code{C}
+  if \code{C} is a class different from \code{String},
+  even if \code{C} has a \code{length} getter,
+  and that same expression would evaluate without errors at run time.%
 }
 
 
@@ -4864,21 +4885,21 @@ and that are declared \STATIC.
 The static methods of a class $C$ are those static methods declared by $C$.
 
 \rationale{%
-Inheritance of static methods has little utility in Dart.
-Static methods cannot be overridden.
-Any required static method can be obtained from its declaring library,
-and there is no need to bring it into scope via inheritance.
-Experience shows that developers are confused by
-the idea of inherited methods that are not instance methods.
+  Inheritance of static methods has little utility in Dart.
+  Static methods cannot be overridden.
+  Any required static method can be obtained from its declaring library,
+  and there is no need to bring it into scope via inheritance.
+  Experience shows that developers are confused by
+  the idea of inherited methods that are not instance methods.
 
-Of course, the entire notion of static methods is debatable,
-but it is retained here because so many programmers are familiar with it.
-Dart static methods may be seen as functions of the enclosing library.%
+  Of course, the entire notion of static methods is debatable,
+  but it is retained here because so many programmers are familiar with it.
+  Dart static methods may be seen as functions of the enclosing library.%
 }
 
 \commentary{%
-Static method declarations may conflict with other declarations
-(\ref{classMemberConflicts}).%
+  Static method declarations may conflict with other declarations
+  (\ref{classMemberConflicts}).%
 }
 
 
@@ -4937,19 +4958,19 @@ a deferred type (\ref{staticTypes}), type \DYNAMIC{} (\ref{typeDynamic}),
 or type \code{FutureOr<$T$>} for any $T$ (\ref{typeFutureOr}).
 
 \commentary{%
-Note that \VOID{} is a reserved word,
-which implies that the same restrictions apply for the type \VOID,
-and similar restrictions are specified for other types like
-\code{Null} (\ref{null}) and
-\code{String} (\ref{strings}).%
+  Note that \VOID{} is a reserved word,
+  which implies that the same restrictions apply for the type \VOID,
+  and similar restrictions are specified for other types like
+  \code{Null} (\ref{null}) and
+  \code{String} (\ref{strings}).%
 }
 
 \commentary{%
-The type parameters of a generic class are available in
-the lexical scope of the superclass clause,
-potentially shadowing classes in the surrounding scope.
-The following code is therefore illegal
-and should cause a compile-time error:%
+  The type parameters of a generic class are available in
+  the lexical scope of the superclass clause,
+  potentially shadowing classes in the surrounding scope.
+  The following code is therefore illegal
+  and should cause a compile-time error:%
 }
 
 \begin{dartCode}
@@ -4985,13 +5006,13 @@ that have not been overridden by a concrete declaration in $C$
 or in at least one of $S_1, \ldots, S_k$.
 
 \rationale{%
-It would be more attractive to give a purely local definition of inheritance,
-that depended only on the members of the direct superclass $S$.
-However, a class $C$ can inherit a member $m$ that
-is not a member of its superclass $S$.
-This can occur when the member $m$ is private to the library $L_1$ of $C$,
-whereas $S$ comes from a different library $L_2$,
-but the superclass chain of $S$ includes a class declared in $L_1$.%
+  It would be more attractive to give a purely local definition of inheritance,
+  that depended only on the members of the direct superclass $S$.
+  However, a class $C$ can inherit a member $m$ that
+  is not a member of its superclass $S$.
+  This can occur when the member $m$ is private to the library $L_1$ of $C$,
+  whereas $S$ comes from a different library $L_2$,
+  but the superclass chain of $S$ includes a class declared in $L_1$.%
 }
 
 \LMHash{}%
@@ -5013,108 +5034,107 @@ at least one of $S_1, \ldots, S_{j-1}$
 and neither $m$ nor $m'$ are instance variables.
 
 \commentary{%
-Instance variables never override each other.
-The getters and setters induced by instance variables do.%
+  Instance variables never override each other.
+  The getters and setters induced by instance variables do.%
 }
 
 \rationale{%
-Again, a local definition of overriding would be preferable,
-but fails to account for library privacy.%
+  Again, a local definition of overriding would be preferable,
+  but fails to account for library privacy.%
 }
 
 \commentary{%
-Whether an override is legal or not is specified relative to
-all direct superinterfaces, not just the interface of the superclass,
-and that is described elsewhere
-(\ref{instanceMethods}).
-Static members never override anything,
-but they may participate in some conflicts
-involving declarations in superinterfaces
-(\ref{classMemberConflicts}).%
+  Whether an override is legal or not is specified relative to
+  all direct superinterfaces, not just the interface of the superclass,
+  and that is described elsewhere
+  (\ref{instanceMethods}).
+  Static members never override anything,
+  but they may participate in some conflicts
+  involving declarations in superinterfaces
+  (\ref{classMemberConflicts}).%
 }
 
 \commentary{%
-For convenience, here is a summary of the relevant rules,
-using `error' to denote compile-time errors.
-Remember that this is not normative.
-The controlling language is in the relevant sections of the specification.
+  For convenience, here is a summary of the relevant rules,
+  using `error' to denote compile-time errors.
+  Remember that this is not normative.
+  The controlling language is in the relevant sections of the specification.
 
-\begin{enumerate}
-
-\item There is only one namespace
-  for getters, setters, methods and constructors (\ref{scoping}).
-  A non-local variable $f$ introduces a getter $f$,
-  and a non-local variable $f$
-  also introduces a setter
-  if it is not final and not constant,
-  or it is late and final and has no initializing expression
-  \code{$f$=} (\ref{instanceVariables}, \ref{variables}).
-  When we speak of members here, we mean
-  accessible instance, static, or library variables,
-  getters, setters, and methods
-  (\ref{classes}).
-\item You cannot have two members with the same name in the same class---be
-  they declared or inherited (\ref{scoping}, \ref{classes}).
-\item Static members are never inherited.
-\item It is an error if you have a static member named $m$ in your class
-  and an instance member of the same basename
-  (\ref{classMemberConflicts}).
-\item It is an error if you have a static setter \code{$v$=},
-  and an instance member $v$ (\ref{setters}).
-\item It is an error if you have a static getter $v$
-  and an instance setter \code{$v$=} (\ref{getters}).
-\item If you define an instance member named $m$,
-  and your superclass has an instance member of the same name,
-  they override each other.
-  This may or may not be legal.
-\item \label{typeSigAssignable}
-  If two members override each other,
-  it is an error unless it is a correct override
-  (\ref{correctMemberOverrides}).
-\item Setters, getters and operators never have
-  optional parameters of any kind;
-  it's an error (\ref{operators}, \ref{getters}, \ref{setters}).
-\item
-  It is an error if a member has the same name as its enclosing class
-  (\ref{classes}).
-\item A class has an implicit interface (\ref{classes}).
-\item Superinterface members are not inherited by a class,
-  but are inherited by its implicit interface.
-  Interfaces have their own inheritance rules
-  (\ref{interfaceInheritanceAndOverriding}).
-\item A member is abstract if
-  it has no body and is not labeled \EXTERNAL{}
-  (\ref{abstractInstanceMembers}, \ref{externalFunctions}).
-\item A class is abstract if{}f it is explicitly labeled \ABSTRACT.
-\item It is an error if a concrete class does not implement some member
-  of its interface, and there is no non-trivial \code{noSuchMethod}
-  (\ref{classes}).
-\item It is an error to call a non-factory constructor of an abstract class
-  using an instance creation expression (\ref{instanceCreation}),
-  such a constructor may only be invoked from another constructor
-  using a superinvocation (\ref{superInvocations}).
-\item If a class defines an instance member named $m$,
-  and any of its superinterfaces have a member signature named $m$,
-  the interface of the class contains the $m$ from the class itself.
-\item An interface inherits all members of its superinterfaces
-  that are not overridden and not members of multiple superinterfaces.
-\item If multiple superinterfaces of an interface
-  define a member with the same name as $m$,
-  then at most one member is inherited.
-  That member (if it exists) is the one whose type is a subtype
-  of all the others.
-  If there is no such member, an error occurs
-  (\ref{interfaceInheritanceAndOverriding}).
-\item Rule \ref{typeSigAssignable} applies to interfaces as well as classes
-  (\ref{interfaceInheritanceAndOverriding}).
-\item It is an error if a concrete class does not have an implementation
-  for a method in its interface
-  unless it has a non-trivial \code{noSuchMethod}
-  (\ref{theMethodNoSuchMethod}).
-\item The identifier of a named constructor cannot be the same as
-  the basename of a static member declared in the same class
-  (\ref{classMemberConflicts}).
-\end{enumerate}%
+  \begin{enumerate}
+  \item There is only one namespace
+    for getters, setters, methods and constructors (\ref{scoping}).
+    A non-local variable $f$ introduces a getter $f$,
+    and a non-local variable $f$
+    also introduces a setter
+    if it is not final and not constant,
+    or it is late and final and has no initializing expression
+    \code{$f$=} (\ref{instanceVariables}, \ref{variables}).
+    When we speak of members here, we mean
+    accessible instance, static, or library variables,
+    getters, setters, and methods
+    (\ref{classes}).
+  \item You cannot have two members with the same name in the same class---be
+    they declared or inherited (\ref{scoping}, \ref{classes}).
+  \item Static members are never inherited.
+  \item It is an error if you have a static member named $m$ in your class
+    and an instance member of the same basename
+    (\ref{classMemberConflicts}).
+  \item It is an error if you have a static setter \code{$v$=},
+    and an instance member $v$ (\ref{setters}).
+  \item It is an error if you have a static getter $v$
+    and an instance setter \code{$v$=} (\ref{getters}).
+  \item If you define an instance member named $m$,
+    and your superclass has an instance member of the same name,
+    they override each other.
+    This may or may not be legal.
+  \item \label{typeSigAssignable}
+    If two members override each other,
+    it is an error unless it is a correct override
+    (\ref{correctMemberOverrides}).
+  \item Setters, getters and operators never have
+    optional parameters of any kind;
+    it's an error (\ref{operators}, \ref{getters}, \ref{setters}).
+  \item
+    It is an error if a member has the same name as its enclosing class
+    (\ref{classes}).
+  \item A class has an implicit interface (\ref{classes}).
+  \item Superinterface members are not inherited by a class,
+    but are inherited by its implicit interface.
+    Interfaces have their own inheritance rules
+    (\ref{interfaceInheritanceAndOverriding}).
+  \item A member is abstract if
+    it has no body and is not labeled \EXTERNAL{}
+    (\ref{abstractInstanceMembers}, \ref{externalFunctions}).
+  \item A class is abstract if{}f it is explicitly labeled \ABSTRACT.
+  \item It is an error if a concrete class does not implement some member
+    of its interface, and there is no non-trivial \code{noSuchMethod}
+    (\ref{classes}).
+  \item It is an error to call a non-factory constructor of an abstract class
+    using an instance creation expression (\ref{instanceCreation}),
+    such a constructor may only be invoked from another constructor
+    using a superinvocation (\ref{superInvocations}).
+  \item If a class defines an instance member named $m$,
+    and any of its superinterfaces have a member signature named $m$,
+    the interface of the class contains the $m$ from the class itself.
+  \item An interface inherits all members of its superinterfaces
+    that are not overridden and not members of multiple superinterfaces.
+  \item If multiple superinterfaces of an interface
+    define a member with the same name as $m$,
+    then at most one member is inherited.
+    That member (if it exists) is the one whose type is a subtype
+    of all the others.
+    If there is no such member, an error occurs
+    (\ref{interfaceInheritanceAndOverriding}).
+  \item Rule \ref{typeSigAssignable} applies to interfaces as well as classes
+    (\ref{interfaceInheritanceAndOverriding}).
+  \item It is an error if a concrete class does not have an implementation
+    for a method in its interface
+    unless it has a non-trivial \code{noSuchMethod}
+    (\ref{theMethodNoSuchMethod}).
+  \item The identifier of a named constructor cannot be the same as
+    the basename of a static member declared in the same class
+    (\ref{classMemberConflicts}).
+  \end{enumerate}%
 }
 
 
@@ -5150,22 +5170,23 @@ It is a compile-time error if the superclass of a class $C$ is
 one of the elements of the type list of the \IMPLEMENTS{} clause of $C$.
 
 \rationale{%
-One might argue that it is harmless to repeat a type in the superinterface list,
-so why make it an error?
-The issue is not so much that the situation is erroneous,
-but that it is pointless.
-As such, it is an indication that the programmer may very well have meant
-to say something else---and that is a mistake that should be
-called to her or his attention.%
+  One might argue that it is harmless
+  to repeat a type in the superinterface list,
+  so why make it an error?
+  The issue is not so much that the situation is erroneous,
+  but that it is pointless.
+  As such, it is an indication that the programmer may very well have meant
+  to say something else---and that is a mistake that should be
+  called to her or his attention.%
 }
 
 \LMHash{}%
 It is a compile-time error if a class $C$ has two superinterfaces
 that are different instantiations of the same generic class.
 \commentary{%
-For example, a class can not have
-both \code{List<\VOID>} and \code{List<\DYNAMIC>} as superinterfaces,
-directly or indirectly.%
+  For example, a class can not have
+  both \code{List<\VOID>} and \code{List<\DYNAMIC>} as superinterfaces,
+  directly or indirectly.%
 }
 
 \LMHash{}%
@@ -5176,9 +5197,9 @@ it is a compile-time error if $X$ occurs in a non-covariant position
 % for indirect ones as well.
 in a type which specifies a superinterface of $C$.
 \commentary{%
-For example, the class can not have
-\code{List<\VOID{} \FUNCTION($X$)>}
-in its \EXTENDS{} or \IMPLEMENTS{} clause.%
+  For example, the class can not have
+  \code{List<\VOID{} \FUNCTION($X$)>}
+  in its \EXTENDS{} or \IMPLEMENTS{} clause.%
 }
 
 \LMHash{}%
@@ -5186,8 +5207,8 @@ It is a compile-time error if the interface of a class $C$ is
 a superinterface of itself.
 
 \commentary{%
-A class does not inherit members from its superinterfaces.
-However, its implicit interface does.%
+  A class does not inherit members from its superinterfaces.
+  However, its implicit interface does.%
 }
 
 
@@ -5223,10 +5244,10 @@ and a static setter with basename $n$.
 When \DefineSymbol{C} is a mixin or an extension,
 the compile-time errors occur according to the same rules.
 \commentary{%
-This is redundant in some cases.
-For instance, it is already an error for a mixin to declare a constructor.
-But useful cases exist as well, e.g., a conflict between a static member
-and an instance member.%
+  This is redundant in some cases.
+  For instance, it is already an error for a mixin to declare a constructor.
+  But useful cases exist as well, e.g., a conflict between a static member
+  and an instance member.%
 }
 
 \LMHash{}%
@@ -5234,16 +5255,16 @@ These errors occur when the getters or setters are defined explicitly
 as well as when they are induced by variable declarations.
 
 \commentary{%
-Note that other errors which are similar in nature are covered elsewhere.
-For instance, if $C$ is a class that has two superinterfaces $I_1$ and $I_2$,
-where $I_1$ has a method named $m$
-and $I_2$ has a getter named $m$,
-then it is an error because the computation of the interface of $C$
-includes a computation of the combined member signature
-(\ref{combinedMemberSignatures})
-of that getter and that method,
-and it is an error for a combined member signature
-to include a getter and a non-getter.%
+  Note that other errors which are similar in nature are covered elsewhere.
+  For instance, if $C$ is a class that has two superinterfaces $I_1$ and $I_2$,
+  where $I_1$ has a method named $m$
+  and $I_2$ has a getter named $m$,
+  then it is an error because the computation of the interface of $C$
+  includes a computation of the combined member signature
+  (\ref{combinedMemberSignatures})
+  of that getter and that method,
+  and it is an error for a combined member signature
+  to include a getter and a non-getter.%
 }
 
 
@@ -5298,20 +5319,20 @@ The difference is that the names of positional parameters are omitted.
 This syntax is only used for the purposes of specification.
 
 \rationale{%
-Member signatures are synthetic entities, that is,
-they are not supported as concrete syntax in a Dart program,
-they are computed entities used during static analysis.
-However, it is useful to be able to indicate the
-properties of a member signature in this specification
-via a syntactic representation.
-A member signature makes it explicit
-whether a parameter is covariant-by-declaration,
-but it remains implicit whether it is covariant-by-class
-(\ref{covariantParameters}).
-The reason for this is that the rule for determining whether
-a given override relation is correct
-(\ref{correctMemberOverrides})
-depends on the former and not on the latter.%
+  Member signatures are synthetic entities, that is,
+  they are not supported as concrete syntax in a Dart program,
+  they are computed entities used during static analysis.
+  However, it is useful to be able to indicate the
+  properties of a member signature in this specification
+  via a syntactic representation.
+  A member signature makes it explicit
+  whether a parameter is covariant-by-declaration,
+  but it remains implicit whether it is covariant-by-class
+  (\ref{covariantParameters}).
+  The reason for this is that the rule for determining whether
+  a given override relation is correct
+  (\ref{correctMemberOverrides})
+  depends on the former and not on the latter.%
 }
 
 \LMHash{}%
@@ -5362,8 +5383,8 @@ The function type of a member signature remains unchanged if
 some or all default values are omitted.
 
 \commentary{%
-We do not specify the function type of a getter signature.
-For such signatures we will instead directly refer to the return type.%
+  We do not specify the function type of a getter signature.
+  For such signatures we will instead directly refer to the return type.%
 }
 
 \LMHash{}%
@@ -5388,18 +5409,18 @@ The \Index{direct superinterfaces} of $I$ are the direct superinterfaces of $C$
 (\ref{superinterfaces}).
 
 \commentary{%
-We say that the class interface `declares' these member signatures,
-such that we can say that an interface `declares' or `has' a member,
-just like we do for classes.
-Note that a member signature $s$ of the interface of class $C$
-may have a parameter $p$ with modifier \COVARIANT,
-even though $s$ was derived from a declaration $D$ in $C$
-and the parameter corresponding to $p$ in $D$ does not
-have that modifier.
-This is because $p$ may have ``inherited''
-the property of being covariant-by-declaration
-from one of its superinterfaces
-(\ref{covariantParameters}).%
+  We say that the class interface `declares' these member signatures,
+  such that we can say that an interface `declares' or `has' a member,
+  just like we do for classes.
+  Note that a member signature $s$ of the interface of class $C$
+  may have a parameter $p$ with modifier \COVARIANT,
+  even though $s$ was derived from a declaration $D$ in $C$
+  and the parameter corresponding to $p$ in $D$ does not
+  have that modifier.
+  This is because $p$ may have ``inherited''
+  the property of being covariant-by-declaration
+  from one of its superinterfaces
+  (\ref{covariantParameters}).%
 }
 
 \LMHash{}%
@@ -5437,50 +5458,50 @@ Let $M_0$ be the set of all member signatures declared by \List{I}{1}{k}.
 \end{itemize}
 
 \rationale{%
-Interfaces must be able to contain inaccessible member signatures,
-because they may be accessible from the interfaces associated with
-declarations of subtypes.%
+  Interfaces must be able to contain inaccessible member signatures,
+  because they may be accessible from the interfaces associated with
+  declarations of subtypes.%
 }
 
 \commentary{%
-For instance, class $C$ in library $L$ may declare a private member named
-\code{\_foo},
-a class $D$ in a different library $L_2$ may extend $C$,
-and a class $E$ in library $L$ may extend $D$;
-$E$ may then declare a member that overrides \code{\_foo} from $C$,
-and that override relation must be checked based on the interface of $D$.
-So we cannot allow the interface of $D$
-to ``forget'' inaccessible members like \code{\_foo}.
+  For instance, class $C$ in library $L$ may declare a private member named
+  \code{\_foo},
+  a class $D$ in a different library $L_2$ may extend $C$,
+  and a class $E$ in library $L$ may extend $D$;
+  $E$ may then declare a member that overrides \code{\_foo} from $C$,
+  and that override relation must be checked based on the interface of $D$.
+  So we cannot allow the interface of $D$
+  to ``forget'' inaccessible members like \code{\_foo}.
 
-For conflicts the situation is even more demanding:
-Classes $C_1$ and $C_2$ in library $L$ may declare private members
-\code{String \_foo(int i)} and \code{int get \_foo},
-and a subtype $D_{12}$ in a different library $L_2$ may have
-an \IMPLEMENTS{} clause listing both $C_1$ and $C_2$.
-In that case we must report a conflict even though the conflicting
-declarations are not accessible to $L_2$,
-because those member signatures are then noSuchMethod forwarded
-(\ref{theMethodNoSuchMethod}),
-and an invocation of \code{\_foo} on an instance of $D$ in $L$
-must return an `int` according to the first member signature,
-and it must return a function object according to the second one,
-and an invocation of \code{\_foo(42)}
-must return a \code{String} with the first member signature, and it must fail
-(at compile time or, for a dynamic invocation, run time) with the second.%
+  For conflicts the situation is even more demanding:
+  Classes $C_1$ and $C_2$ in library $L$ may declare private members
+  \code{String \_foo(int i)} and \code{int get \_foo},
+  and a subtype $D_{12}$ in a different library $L_2$ may have
+  an \IMPLEMENTS{} clause listing both $C_1$ and $C_2$.
+  In that case we must report a conflict even though the conflicting
+  declarations are not accessible to $L_2$,
+  because those member signatures are then noSuchMethod forwarded
+  (\ref{theMethodNoSuchMethod}),
+  and an invocation of \code{\_foo} on an instance of $D$ in $L$
+  must return an `int` according to the first member signature,
+  and it must return a function object according to the second one,
+  and an invocation of \code{\_foo(42)}
+  must return a \code{String} with the first member signature, and it must fail
+  (at compile time or, for a dynamic invocation, run time) with the second.%
 }
 
 \rationale{%
-It may not be possible to satisfy such constraints simultaneously,
-and it will inevitably be a complex semantics,
-so we have chosen to make it an error.
-It is unfortunate that the addition of a private declaration
-in one library may break existing code in a different library.
-But it should be noted that the conflicts can be detected locally
-in the library where the private declarations exist,
-because they only arise for private members with
-the same name and incompatible signatures.
-Renaming that private member to anything not used in that library
-will eliminate the conflict and will not break any clients.%
+  It may not be possible to satisfy such constraints simultaneously,
+  and it will inevitably be a complex semantics,
+  so we have chosen to make it an error.
+  It is unfortunate that the addition of a private declaration
+  in one library may break existing code in a different library.
+  But it should be noted that the conflicts can be detected locally
+  in the library where the private declarations exist,
+  because they only arise for private members with
+  the same name and incompatible signatures.
+  Renaming that private member to anything not used in that library
+  will eliminate the conflict and will not break any clients.%
 }
 
 
@@ -5493,20 +5514,20 @@ appropriately stand for a prioritized set of several member signatures,
 taken from a given list of interfaces.
 
 \commentary{%
-In general, a combined member signature has a type which is
-a subtype of all the types given for that member.
-This is needed in order to ensure that the type of
-a member \id{} of a class $C$ is well-defined,
-even in the case where $C$ inherits
-several different declarations of \id{}
-and does not override \id.
-In case of failure, it serves to specify the situations
-where a developer must add a declaration in order to resolve an ambiguity.
-The member signatures are prioritized in the sense that we will select
-a member signature from the interface with the lowest possible index
-in the case where several member signatures are equally suitable
-to be chosen as the combined member signature.
-That is, ``the first interface wins''.%
+  In general, a combined member signature has a type which is
+  a subtype of all the types given for that member.
+  This is needed in order to ensure that the type of
+  a member \id{} of a class $C$ is well-defined,
+  even in the case where $C$ inherits
+  several different declarations of \id{}
+  and does not override \id.
+  In case of failure, it serves to specify the situations
+  where a developer must add a declaration in order to resolve an ambiguity.
+  The member signatures are prioritized in the sense that we will select
+  a member signature from the interface with the lowest possible index
+  in the case where several member signatures are equally suitable
+  to be chosen as the combined member signature.
+  That is, ``the first interface wins''.%
 }
 
 \LMHash{}%
@@ -5522,13 +5543,13 @@ or the same function type and the same occurrences of \COVARIANT{}
 (for methods and setters).
 
 \commentary{%
-In particular, private methods from different libraries are never equal.
-Top types differ as well.
-For instance,
-\FunctionTypeSimple{\DYNAMIC}{} and \FunctionTypeSimple{\code{Object}}{}
-are not equal, even though they are subtypes of each other.
-We need this distinction because management of top type discrepancies is
-one of the purposes of computing a combined interface.%
+  In particular, private methods from different libraries are never equal.
+  Top types differ as well.
+  For instance,
+  \FunctionTypeSimple{\DYNAMIC}{} and \FunctionTypeSimple{\code{Object}}{}
+  are not equal, even though they are subtypes of each other.
+  We need this distinction because management of top type discrepancies is
+  one of the purposes of computing a combined interface.%
 }
 
 \LMHash{}%
@@ -5588,11 +5609,11 @@ the function type of $m_j$ for each $j \in 1 .. q$.
 %
 If no such set exists, the computation of the combined member signature failed.
 \commentary{%
-A useful intuition about this situation is that
-the given member signatures do not agree on
-which type is suitable for the member named \id.
-Otherwise we have a set of member signatures which are ``most specific''
-in the sense that their function types are subtypes of them all.%
+  A useful intuition about this situation is that
+  the given member signatures do not agree on
+  which type is suitable for the member named \id.
+  Otherwise we have a set of member signatures which are ``most specific''
+  in the sense that their function types are subtypes of them all.%
 }
 
 { % Scope for N_min, M_min, N_firstMin.
@@ -5607,16 +5628,16 @@ let \Nall{} be the greatest set satisfying the requirement on $N$,
 \BlindDefineSymbol{\Mall}%
 and let $\Mall{} = \{ m_i\;|\;i \in \Nall\}$.
 \commentary{%
-That is, \Mall{} contains all member signatures named \id{}
-with the most specific type.
-Dart subtyping is a partial pre-order,
-which ensures that such a greatest set of least elements exists,
-if any non-empty set of least elements exist.
-We can have several such signatures because member signatures
-can be such that they are not equal,
-and yet their function types are subtypes of each other.
-We need to compute one member signature from \Mall,
-and we do that by using the ordering of the given interfaces.%
+  That is, \Mall{} contains all member signatures named \id{}
+  with the most specific type.
+  Dart subtyping is a partial pre-order,
+  which ensures that such a greatest set of least elements exists,
+  if any non-empty set of least elements exist.
+  We can have several such signatures because member signatures
+  can be such that they are not equal,
+  and yet their function types are subtypes of each other.
+  We need to compute one member signature from \Mall,
+  and we do that by using the ordering of the given interfaces.%
 }
 
 \LMHash{}%
@@ -5625,11 +5646,11 @@ Let $j \in 1 .. k$ be the smallest number such that
 $\MallFirst{} = \Mall{} \cap I_j$ is non-empty.
 Let $m_i$ be the single element that \MallFirst{} contains.
 \commentary{%
-This set contains exactly one element because it is non-empty
-and no interface contains more than one member signature named \id.
-In other words, we choose $m_i$ as the member signature from
-the first possible interface
-among the most specific member signatures \Mall.%
+  This set contains exactly one element because it is non-empty
+  and no interface contains more than one member signature named \id.
+  In other words, we choose $m_i$ as the member signature from
+  the first possible interface
+  among the most specific member signatures \Mall.%
 }
 }
 
@@ -5642,12 +5663,12 @@ such that the parameter corresponding to $p$
 (\ref{covariantParameters})
 has the modifier \COVARIANT.
 \commentary{%
-In other words,
-each parameter in the combined member signature is marked covariant
-if any of the corresponding parameters are marked covariant,
-not just among the most specific signatures,
-but among \emph{all} signatures named \id{} (which are accessible to $L$)
-in the given list of interfaces.%
+  In other words,
+  each parameter in the combined member signature is marked covariant
+  if any of the corresponding parameters are marked covariant,
+  not just among the most specific signatures,
+  but among \emph{all} signatures named \id{} (which are accessible to $L$)
+  in the given list of interfaces.%
 }
 \EndCase
 
@@ -5680,13 +5701,13 @@ this means that there exist types \List{U}{1}{s}
 such that $S$ implements \code{$G$<\List{U}{1}{s}>}.
 
 \commentary{%
-Note that this is not the same as being a subtype.
-For instance, \code{List<int>} implements \code{Iterable<int>},
-but it does not implement \code{Iterable<num>}.
-Similarly, \code{List<int>} implements \code{Iterable}.
-Also, note that when $S$ implements $T$
-where $T$ is not a subtype of \code{Null},
-$S$ cannot be a subtype of \code{Null}.%
+  Note that this is not the same as being a subtype.
+  For instance, \code{List<int>} implements \code{Iterable<int>},
+  but it does not implement \code{Iterable<num>}.
+  Similarly, \code{List<int>} implements \code{Iterable}.
+  Also, note that when $S$ implements $T$
+  where $T$ is not a subtype of \code{Null},
+  $S$ cannot be a subtype of \code{Null}.%
 }
 
 \LMHash{}%
@@ -5702,13 +5723,13 @@ and we say that $U_j$ is the
 for any $j \in 1 .. s$.
 
 \commentary{%
-For instance, the type argument of \code{List<int>} at \code{Iterable}
-is \code{int}.
-This concept is particularly useful when
-the chain of direct superinterfaces from $S$ to $G$
-does not just pass all type arguments on unchanged, e.g.,
-with a declaration like
-\code{\CLASS\,\,C<X,\,Y>\,\,\EXTENDS\,\,B<List<Y>,\,Y,\,X> \{\}}.%
+  For instance, the type argument of \code{List<int>} at \code{Iterable}
+  is \code{int}.
+  This concept is particularly useful when
+  the chain of direct superinterfaces from $S$ to $G$
+  does not just pass all type arguments on unchanged, e.g.,
+  with a declaration like
+  \code{\CLASS\,\,C<X,\,Y>\,\,\EXTENDS\,\,B<List<Y>,\,Y,\,X> \{\}}.%
 }
 
 
@@ -5815,14 +5836,14 @@ if{}f the following criteria are all satisfied:
 \end{itemize}
 
 \commentary{%
-Note that a parameter which is covariant-by-declaration
-must have a type which satisfies one more requirement,
-relative to the corresponding parameters in all superinterfaces,
-both direct and indirect
-(\ref{instanceMethods}).
-We cannot make that requirement a part of the notion of correct overrides,
-because correct overrides are only concerned with
-the relation to a single superinterface.%
+  Note that a parameter which is covariant-by-declaration
+  must have a type which satisfies one more requirement,
+  relative to the corresponding parameters in all superinterfaces,
+  both direct and indirect
+  (\ref{instanceMethods}).
+  We cannot make that requirement a part of the notion of correct overrides,
+  because correct overrides are only concerned with
+  the relation to a single superinterface.%
 }
 
 
@@ -5919,10 +5940,10 @@ a compile-time error.
 % to be compile-time errors.
 
 \commentary{%
-It is an error, for example, if $M$ contains a member declaration $d$
-which overrides a member signature $m$ in the interface of $S$,
-but which is not a correct override of $m$
-(\ref{correctMemberOverrides}).%
+  It is an error, for example, if $M$ contains a member declaration $d$
+  which overrides a member signature $m$ in the interface of $S$,
+  but which is not a correct override of $m$
+  (\ref{correctMemberOverrides}).%
 }
 
 \subsection{Mixin Declaration}
@@ -6004,16 +6025,16 @@ where $M_{super}$ is a fresh name.
 It is a compile-time error for the mixin declaration if the $M_S$
 class declaration would cause a compile-time error,
 \commentary{%
-that is, if any member is declared by more than one declared superinterface,
-and there is not a most specific signature for that member among the super
-interfaces%
+  that is, if any member is declared by more than one declared superinterface,
+  and there is not a most specific signature for that member among the super
+  interfaces%
 }.
 The interface $M_S$ is called the
 \Index{superinvocation interface} of the mixin declaration $M$.
 \commentary{%
-If the mixin declaration $M$ has only one declared superinterface, $T_1$,
-then the superinvocation interface $M_{super}$ has exactly the same members
-as the interface $T_1$.%
+  If the mixin declaration $M$ has only one declared superinterface, $T_1$,
+  then the superinvocation interface $M_{super}$ has exactly the same members
+  as the interface $T_1$.%
 }
 
 \LMHash{}%
@@ -6032,11 +6053,11 @@ as if \SUPER{} was a valid expression with static type $M_S$.
 It is a compile-time error for the mixin $M$ if this $N$ class
 declaration would cause a compile-time error,
 \commentary{%
-that is, if the required superinterfaces, the implemented interfaces
-and the declarations do not define a consistent interface,
-if any member declaration contains a compile-time error
-other than a super-invocation,
-or if a super-invocation is not valid against the interface $M_S$.%
+  that is, if the required superinterfaces, the implemented interfaces
+  and the declarations do not define a consistent interface,
+  if any member declaration contains a compile-time error
+  other than a super-invocation,
+  or if a super-invocation is not valid against the interface $M_S$.%
 }
 The interface introduced by the mixin declaration $M$ has the same member
 signatures and superinterfaces as $M_I$.
@@ -6076,11 +6097,11 @@ and $S$ does not have a concrete
 implementation of $m$ which is a valid override of the member $m$ in
 the interface $M_S$.
 \rationale{%
-We treat super-invocations in mixins as
-interface invocations on the combined superinterface,
-so we require the superclass of a mixin application to have
-valid implementations of those interface members
-that are actually super-invoked.%
+  We treat super-invocations in mixins as
+  interface invocations on the combined superinterface,
+  so we require the superclass of a mixin application to have
+  valid implementations of those interface members
+  that are actually super-invoked.%
 }
 
 \LMHash{}%
@@ -6200,38 +6221,39 @@ and the latter is known as the
 of the extension.
 
 \commentary{%
-A fresh name is also introduced into
-the library namespace of the current library
-for each imported extension,
-even when it is imported with a prefix
-(\ref{theImportedNamespace}).
-%
-The declared name of an extension $E$ is
-introduced into the library scope of the current library
-following the same rules as the names of
-other locally declared or imported declarations like classes.
-%
-A fresh name of $E$ is introduced in these cases,
-but also in one additional case:
-when there is a name clash on the declared name of $E$.%
+  A fresh name is also introduced into
+  the library namespace of the current library
+  for each imported extension,
+  even when it is imported with a prefix
+  (\ref{theImportedNamespace}).
+  %
+  The declared name of an extension $E$ is
+  introduced into the library scope of the current library
+  following the same rules as the names of
+  other locally declared or imported declarations like classes.
+  %
+  A fresh name of $E$ is introduced in these cases,
+  but also in one additional case:
+  when there is a name clash on the declared name of $E$.%
 }
 
 \commentary{%
-The fresh name makes it possible for an extension to be used
-in an implicit invocation
-(\ref{implicitExtensionInvocations}),
-even in the case where the declared name
-or an import prefix that provides access to the declared name
-is shadowed by a declaration in an intermediate scope,
-or conflicted by a name clash.%
+  The fresh name makes it possible for an extension to be used
+  in an implicit invocation
+  (\ref{implicitExtensionInvocations}),
+  even in the case where the declared name
+  or an import prefix that provides access to the declared name
+  is shadowed by a declaration in an intermediate scope,
+  or conflicted by a name clash.%
 }
 
 \rationale{%
-The fact that an extension can be used implicitly even in the case where
-it does not have a declared name or the declared name is shadowed or conflicted
-reflects the fact that the primary intended usage is implicit invocation.
-Even though a developer cannot know (and hence cannot use) the fresh name
-of a given extension, an implicit invocation can use it.%
+  The fact that an extension can be used implicitly even in the case where
+  it does not have a declared name
+  or the declared name is shadowed or conflicted
+  reflects the fact that the primary intended usage is implicit invocation.
+  Even though a developer cannot know (and hence cannot use) the fresh name
+  of a given extension, an implicit invocation can use it.%
 }
 
 \LMHash{}%
@@ -6241,15 +6263,15 @@ such that the imported namespace from $L'$ contains
 a name denoting an extension.
 
 \commentary{%
-This implies that the import must use \HIDE{} or \SHOW{} to eliminate
-the names of extensions from the deferred import.%
+  This implies that the import must use \HIDE{} or \SHOW{} to eliminate
+  the names of extensions from the deferred import.%
 }
 
 \rationale{%
-This restriction ensures that no extensions are introduced
-using deferred imports,
-which allows us to introduce a semantics for such extensions in the future
-without affecting existing code.%
+  This restriction ensures that no extensions are introduced
+  using deferred imports,
+  which allows us to introduce a semantics for such extensions in the future
+  without affecting existing code.%
 }
 
 \LMHash{}%
@@ -6259,17 +6281,17 @@ is known as the extension's
 The \ON{} type can be any valid type, including a type variable.
 
 \commentary{%
-The basic intuition is that an extension \code{E} may have
-an \ON{} type $T$ (specifying the type of receiver) and a set of members.
-If $e$ is an expression whose static type is $T$
-and \code{foo()} is a member declared by \code{E},
-\code{$e$.foo()} may invoke said member with the value of $e$ bound to \THIS.
-An explicitly resolved form \code{E($e$).foo()} is available,
-such that \code{E.foo} can be invoked even in the case
-where \code{$e$.foo()} would invoke some other function
-because some other extension is more specific.
-Details of these concepts, rules, and mechanisms are given
-in this section and its subsections.%
+  The basic intuition is that an extension \code{E} may have
+  an \ON{} type $T$ (specifying the type of receiver) and a set of members.
+  If $e$ is an expression whose static type is $T$
+  and \code{foo()} is a member declared by \code{E},
+  \code{$e$.foo()} may invoke said member with the value of $e$ bound to \THIS.
+  An explicitly resolved form \code{E($e$).foo()} is available,
+  such that \code{E.foo} can be invoked even in the case
+  where \code{$e$.foo()} would invoke some other function
+  because some other extension is more specific.
+  Details of these concepts, rules, and mechanisms are given
+  in this section and its subsections.%
 }
 
 \LMHash{}%
@@ -6335,21 +6357,21 @@ Moreover, a compile-time error occurs in the following situations:
 \end{itemize}
 
 \rationale{%
-Abstract members are not allowed because there is
-no support for providing an implementation.
-%
-Constructors are not allowed since the extension
-does not introduce any type that can be constructed.
-%
-Instance variables are not allowed because no memory is allocated
-for each object accessed as \THIS{} in the members.
-Developers can emulate per-\THIS{} state if needed,
-e.g., using an \code{Expando}.
-%
-Members with the same basename as members of \code{Object}
-are not allowed because they could only be invoked using explicit resolution,
-as in \code{E(e).toString(14)},
-which would be confusing and error-prone.%
+  Abstract members are not allowed because there is
+  no support for providing an implementation.
+  %
+  Constructors are not allowed since the extension
+  does not introduce any type that can be constructed.
+  %
+  Instance variables are not allowed because no memory is allocated
+  for each object accessed as \THIS{} in the members.
+  Developers can emulate per-\THIS{} state if needed,
+  e.g., using an \code{Expando}.
+  %
+  Members with the same basename as members of \code{Object}
+  are not allowed because they could only be invoked using explicit resolution,
+  as in \code{E(e).toString(14)},
+  which would be confusing and error-prone.%
 }
 
 
@@ -6369,15 +6391,15 @@ by performing a member invocation
 where the receiver is an extension application.
 
 \commentary{%
-Type inference is not yet specified in this document,
-and is assumed to have taken place already
-(\ref{overview}),
-but the following describes the intended treatment.
-This section and its subsections have similar commentary about type inference
-below, marked 'With type inference: \ldots'.
+  Type inference is not yet specified in this document,
+  and is assumed to have taken place already
+  (\ref{overview}),
+  but the following describes the intended treatment.
+  This section and its subsections have similar commentary about type inference
+  below, marked 'With type inference: \ldots'.
 
-Let $E$ be a simple or qualified identifier denoting
-an extension named \code{E} and declared as follows:%
+  Let $E$ be a simple or qualified identifier denoting
+  an extension named \code{E} and declared as follows:%
 }
 
 \begin{dartCode}
@@ -6386,12 +6408,12 @@ an extension named \code{E} and declared as follows:%
 
 \noindent
 \commentary{%
-Type inference for an extension application
-of the form \code{$E$($e$)}
-is done exactly the same as it would be for
-the same syntax considered as a constructor invocation
-where $E$ is assumed to denote the following class,
-and the context type is empty (implying no requirements):%
+  Type inference for an extension application
+  of the form \code{$E$($e$)}
+  is done exactly the same as it would be for
+  the same syntax considered as a constructor invocation
+  where $E$ is assumed to denote the following class,
+  and the context type is empty (implying no requirements):%
 }
 
 \begin{dartCode}
@@ -6401,14 +6423,13 @@ and the context type is empty (implying no requirements):%
 \}
 \end{dartCode}
 
-\noindent
 \commentary{%
-This will infer type arguments for \code{$E$($e$)}, and it will
-introduce a context type for the expression $e$.
-For example, if $E$ is declared as
-\code{\EXTENSION{} E<T> on Set<T> \{\,\ldots\,\}}
-then \code{E(\{\})} will provide the expression \code{\{\}} with
-a context type that makes it a set literal.%
+  This will infer type arguments for \code{$E$($e$)}, and it will
+  introduce a context type for the expression $e$.
+  For example, if $E$ is declared as
+  \code{\EXTENSION{} E<T> on Set<T> \{\,\ldots\,\}}
+  then \code{E(\{\})} will provide the expression \code{\{\}} with
+  a context type that makes it a set literal.%
 }
 
 \LMHash{}%
@@ -6441,9 +6462,9 @@ $j \in 1 .. s$
 A compile-time error occurs unless the static type of $e$ is assignable to
 the instantiated \ON{} type of $a$.
 \commentary{%
-Note that a compile-time error occurs as well
-if the static type of $e$ is \VOID{}
-(\ref{typeVoid}).%
+  Note that a compile-time error occurs as well
+  if the static type of $e$ is \VOID{}
+  (\ref{typeVoid}).%
 }
 
 \LMHash{}%
@@ -6453,21 +6474,21 @@ a simple or composite member invocation
 (\ref{memberInvocations}).
 
 \commentary{%
-That is, the only valid use of an extension application is
-to invoke or tear off members on it.
-This is similar to how prefix names can also only be used as
-member invocation targets,
-except that extensions can also declare operators.
-For instance, \code{$E$($e$) + 1} can be a valid invocation of
-an operator \lit{+} declared in an extension $E$.%
+  That is, the only valid use of an extension application is
+  to invoke or tear off members on it.
+  This is similar to how prefix names can also only be used as
+  member invocation targets,
+  except that extensions can also declare operators.
+  For instance, \code{$E$($e$) + 1} can be a valid invocation of
+  an operator \lit{+} declared in an extension $E$.%
 }
 
 \LMHash{}%
 An extension application does not have a type.
 
 \commentary{%
-This is consistent with the fact that any use of an extension application
-where a type is needed is a compile-time error.%
+  This is consistent with the fact that any use of an extension application
+  where a type is needed is a compile-time error.%
 }
 
 \LMHash{}%
@@ -6477,7 +6498,7 @@ Let $i$ be a simple member invocation
 whose receiver $r$ is an extension application of the form
 \BlindDefineSymbol{E, T_j, k, e}%
 \code{$E$<\List{T}{1}{k}>($e$)}
-\commentary({which is \code{$E$($e$)} when $k$ is zero)}
+\commentary{(which is \code{$E$($e$)} when $k$ is zero)}
 whose corresponding member name is \DefineSymbol{n},
 and assume that $r$ has no compile-time errors.
 A compile-time error occurs unless the extension denoted by $E$
@@ -6526,11 +6547,11 @@ the invocation member signature of $i$.
 \end{dartCode}
 
 \commentary{%
-With type inference:
-In the case where the invocation member signature $s_1$ is generic,
-type inference occurs on $i$ in the same way as it
-would occur for an invocation of a function whose type is the
-function type of $s_1$.%
+  With type inference:
+  In the case where the invocation member signature $s_1$ is generic,
+  type inference occurs on $i$ in the same way as it
+  would occur for an invocation of a function whose type is the
+  function type of $s_1$.%
 }
 
 \LMHash{}%
@@ -6563,12 +6584,12 @@ member invocation desugaring
 (\ref{memberInvocations}).
 
 \rationale{%
-Note that a cascade (\ref{cascades})
-whose receiver is an extension application $a$ is a compile-time error.
-This is so because it implies that $a$ denotes an object, which is not true,
-and also because it would force each \synt{cascadeSection}
-to invoke a member of the same extension,
-which is unlikely to be desirable.%
+  Note that a cascade (\ref{cascades})
+  whose receiver is an extension application $a$ is a compile-time error.
+  This is so because it implies that $a$ denotes an object, which is not true,
+  and also because it would force each \synt{cascadeSection}
+  to invoke a member of the same extension,
+  which is unlikely to be desirable.%
 }
 
 
@@ -6582,23 +6603,23 @@ as if they were instance members of the receiver of
 the given member invocation.
 
 \commentary{%
-For instance, if \code{E<$T_1, T_2$>($e_1$).m<$T_3$>($e_2$)} is
-a correct explicit invocation of the instance member \code{m} of
-an extension \code{E},
-then \code{$e_1$.m<$T_3$>($e_2$)} may be
-a correct implicit invocation with the same meaning.
-In other words,
-the receiver $r$ of a member invocation can be implicitly replaced by
-an extension application with receiver $r$,
-if a number of requirements that are detailed below are satisfied.%
+  For instance, if \code{E<$T_1, T_2$>($e_1$).m<$T_3$>($e_2$)} is
+  a correct explicit invocation of the instance member \code{m} of
+  an extension \code{E},
+  then \code{$e_1$.m<$T_3$>($e_2$)} may be
+  a correct implicit invocation with the same meaning.
+  In other words,
+  the receiver $r$ of a member invocation can be implicitly replaced by
+  an extension application with receiver $r$,
+  if a number of requirements that are detailed below are satisfied.%
 }
 
 \rationale{%
-Implicit invocation is intended as the primary way to use extensions,
-with explicit invocation as a fallback
-in case the implicit invocation is an error, or
-the implicit invocation resolves to an instance member of
-a different extension than the intended one.%
+  Implicit invocation is intended as the primary way to use extensions,
+  with explicit invocation as a fallback
+  in case the implicit invocation is an error, or
+  the implicit invocation resolves to an instance member of
+  a different extension than the intended one.%
 }
 
 \LMHash{}%
@@ -6624,19 +6645,19 @@ $i$ is treated as $i'$, which is obtained from $i$ by
 replacing the leading $r$ by \code{$E$($r$)}.
 
 \commentary{%
-With type inference:
-When $E$ is generic,
-type inference applied to \code{$E$($r$)} may provide actual type arguments,
-yielding an $i'$ of the form \code{$E$<\List{T}{1}{k}>($r$)}.
-If this type inference step fails then $E$ is not applicable
-(\ref{extensionApplicability}).%
+  With type inference:
+  When $E$ is generic,
+  type inference applied to \code{$E$($r$)} may provide actual type arguments,
+  yielding an $i'$ of the form \code{$E$<\List{T}{1}{k}>($r$)}.
+  If this type inference step fails then $E$ is not applicable
+  (\ref{extensionApplicability}).%
 }
 
 \commentary{%
-Implicit invocation of an instance member of an extension
-in a cascade is also possible,
-because a cascade is desugared to an expression that contains
-one or more member invocations.%
+  Implicit invocation of an instance member of an extension
+  in a cascade is also possible,
+  because a cascade is desugared to an expression that contains
+  one or more member invocations.%
 }
 
 
@@ -6652,18 +6673,18 @@ if there exists a name $n$ such that a lexical lookup for $n$ from $S$
 yields $E$.
 
 \commentary{%
-The name $n$ can be the declared name of $E$ or the fresh name of $E$,
-but since the fresh name is always in scope
-whenever the declared name is in scope,
-it is sufficient to consider the fresh name.
-%
-When the fresh name of $E$ is in the library scope,
-it is available in \emph{any} scope,
-because the name is fresh and hence it cannot be shadowed
-by any declaration in any intermediate scope.
-%
-This implies that if $E$ is accessible anywhere in a given library $L$
-then it is accessible everywhere in $L$.%
+  The name $n$ can be the declared name of $E$ or the fresh name of $E$,
+  but since the fresh name is always in scope
+  whenever the declared name is in scope,
+  it is sufficient to consider the fresh name.
+  %
+  When the fresh name of $E$ is in the library scope,
+  it is available in \emph{any} scope,
+  because the name is fresh and hence it cannot be shadowed
+  by any declaration in any intermediate scope.
+  %
+  This implies that if $E$ is accessible anywhere in a given library $L$
+  then it is accessible everywhere in $L$.%
 }
 
 
@@ -6738,13 +6759,13 @@ to $e$ if the following conditions are all satisfied:
 \end{itemize}
 
 \commentary{%
-With type inference:
-The context type of the invocation does not affect
-whether the extension is applicable,
-and neither the context type nor the method invocation affects
-the type inference of $r$,
-but if the extension method itself is generic,
-the context type may affect the member invocation.%
+  With type inference:
+  The context type of the invocation does not affect
+  whether the extension is applicable,
+  and neither the context type nor the method invocation affects
+  the type inference of $r$,
+  but if the extension method itself is generic,
+  the context type may affect the member invocation.%
 }
 
 
@@ -6761,8 +6782,8 @@ we define the notion of
 which is a partial order on \List{E}{1}{k}.
 
 \commentary{%
-Specificity is used to determine which extension method to execute
-in the situation where more than one choice is possible.%
+  Specificity is used to determine which extension method to execute
+  in the situation where more than one choice is possible.%
 }
 
 \LMHash{}%
@@ -6802,8 +6823,8 @@ if at least one of the following conditions is satisfied:
 \end{itemize}
 
 \commentary{%
-The following examples illustrate implicit extension resolution
-when multiple applicable extensions are available.%
+  The following examples illustrate implicit extension resolution
+  when multiple applicable extensions are available.%
 }
 
 \begin{dartCode}
@@ -6825,9 +6846,9 @@ when multiple applicable extensions are available.%
 \end{dartCode}
 
 \commentary{%
-Here both of the extensions apply,
-but \code{ExtendList} is more specific than \code{ExtendIterable} because
-\SubtypeNE{\code{List<int>}}{\code{Iterable<int>}}.%
+  Here both of the extensions apply,
+  but \code{ExtendList} is more specific than \code{ExtendIterable} because
+  \SubtypeNE{\code{List<int>}}{\code{Iterable<int>}}.%
 }
 
 \begin{dartCode}
@@ -6844,34 +6865,34 @@ but \code{ExtendList} is more specific than \code{ExtendIterable} because
 \end{dartCode}
 
 \commentary{%
-Here all three extensions apply to both invocations.
-For \code{x.best()}, \code{BestList} is most specific,
-because \code{List<int>} is a proper subtype of both
-\code{Iterable<int>} and \code{List<num>}.
-Hence, the type of \code{x.best()} is \code{int}.
+  Here all three extensions apply to both invocations.
+  For \code{x.best()}, \code{BestList} is most specific,
+  because \code{List<int>} is a proper subtype of both
+  \code{Iterable<int>} and \code{List<num>}.
+  Hence, the type of \code{x.best()} is \code{int}.
 
-For \code{y.best()}, \code{BestSpec} is most specific.
-The instantiated \ON{} types that are compared are
-\code{Iterable<num>} for \code{BestCom} and
-\code{List<num>} for the two other extensions.
-Using the instantiation-to-bound \ON{} types as a tie breaker,
-we find that \code{List<Object>} is less precise than \code{List<num>},
-so \code{BestSpec} is selected.
-Hence, the type of \code{y.best()} is \code{num}.%
+  For \code{y.best()}, \code{BestSpec} is most specific.
+  The instantiated \ON{} types that are compared are
+  \code{Iterable<num>} for \code{BestCom} and
+  \code{List<num>} for the two other extensions.
+  Using the instantiation-to-bound \ON{} types as a tie breaker,
+  we find that \code{List<Object>} is less precise than \code{List<num>},
+  so \code{BestSpec} is selected.
+  Hence, the type of \code{y.best()} is \code{num}.%
 }
 
 \rationale{%
-In general, the definition of specificity aims to select
-the extension which has more precise type information available.
-This does not necessarily yield the most precise type of the result
-(for instance, \code{BestSpec.best} could have returned \code{Object}),
-but it is also important that the rule is simple.
+  In general, the definition of specificity aims to select
+  the extension which has more precise type information available.
+  This does not necessarily yield the most precise type of the result
+  (for instance, \code{BestSpec.best} could have returned \code{Object}),
+  but it is also important that the rule is simple.
 
-In practice, we expect unintended extension member name conflicts to be rare.
-If the same author is providing more specialized versions of
-an extension for subtypes,
-the choice of an extension which has the most precise types available
-is likely to be a rather unsurprising and useful behavior.%
+  In practice, we expect unintended extension member name conflicts to be rare.
+  If the same author is providing more specialized versions of
+  an extension for subtypes,
+  the choice of an extension which has the most precise types available
+  is likely to be a rather unsurprising and useful behavior.%
 }
 
 
@@ -6894,26 +6915,26 @@ A compile-time error occurs if the body of an extension member
 contains \SUPER.
 
 \commentary{%
-A lexical lookup in an extension $E$ may yield
-a declaration of an instance method declared in $E$.
-As specified elsewhere
-(\ref{lexicalLookup}),
-this implies that extension instance members
-will shadow class instance members
-when called from another instance member inside the same extension
-using an unqualified function invocation
-(that is, invoking it as \code{m()} and not \code{\THIS.m()},
-\ref{unqualifiedInvocation}).
-%
-This is the only situation where implicit invocation of
-an extension member with basename \id{}
-can succeed even if the interface of the receiver has
-a member with basename \id.
-%
-On the other hand, it is consistent with the general property of Dart that
-lexically enclosing declarations shadow other declarations, e.g.,
-an inherited declaration can be shadowed by a global declaration.
-Here is an example:%
+  A lexical lookup in an extension $E$ may yield
+  a declaration of an instance method declared in $E$.
+  As specified elsewhere
+  (\ref{lexicalLookup}),
+  this implies that extension instance members
+  will shadow class instance members
+  when called from another instance member inside the same extension
+  using an unqualified function invocation
+  (that is, invoking it as \code{m()} and not \code{\THIS.m()},
+  \ref{unqualifiedInvocation}).
+  %
+  This is the only situation where implicit invocation of
+  an extension member with basename \id{}
+  can succeed even if the interface of the receiver has
+  a member with basename \id.
+  %
+  On the other hand, it is consistent with the general property of Dart that
+  lexically enclosing declarations shadow other declarations, e.g.,
+  an inherited declaration can be shadowed by a global declaration.
+  Here is an example:%
 }
 
 \begin{dartCode}
@@ -6927,42 +6948,42 @@ Here is an example:%
 \end{dartCode}
 
 \commentary{%
-With \code{list.isEven},
-\code{isEven} resolves to the declaration in \code{MyUnaryNumber},
-given that \code{List} does not have a member with basename \code{isEven},
-and unless there are any other extensions creating a conflict.
+  With \code{list.isEven},
+  \code{isEven} resolves to the declaration in \code{MyUnaryNumber},
+  given that \code{List} does not have a member with basename \code{isEven},
+  and unless there are any other extensions creating a conflict.
 
-The use of \code{length} in the declaration of \code{isEven}
-is not defined in the current lexical scope,
-so it is treated as \code{\THIS.length},
-because the interface of the \ON{} type \code{List<Object>} has
-a \code{length} getter.
+  The use of \code{length} in the declaration of \code{isEven}
+  is not defined in the current lexical scope,
+  so it is treated as \code{\THIS.length},
+  because the interface of the \ON{} type \code{List<Object>} has
+  a \code{length} getter.
 
-The use of \code{isEven} in \code{isOdd} resolves lexically to
-the \code{isEven} getter above it,
-so it is treated as \code{MyUnaryNumber(this).isEven},
-even if there are other extensions in scope
-which define an \code{isEven} on \code{List<Object>}.
+  The use of \code{isEven} in \code{isOdd} resolves lexically to
+  the \code{isEven} getter above it,
+  so it is treated as \code{MyUnaryNumber(this).isEven},
+  even if there are other extensions in scope
+  which define an \code{isEven} on \code{List<Object>}.
 
-The use of \code{first} in \code{smallest} resolves lexically to
-the \code{first} getter above it,
-even though there is a member with the same basename in
-the interface of \THIS.
-The getter \code{first} cannot be called
-in an implicit invocation from anywhere outside of \code{MyUnaryNumber}.
-This is the exceptional case mentioned above,
-where a member of an extension shadows
-a regular instance member on \THIS.
-In practice, extensions will very rarely introduce members
-with the same basename as a member of its \ON{} type's interface.
+  The use of \code{first} in \code{smallest} resolves lexically to
+  the \code{first} getter above it,
+  even though there is a member with the same basename in
+  the interface of \THIS.
+  The getter \code{first} cannot be called
+  in an implicit invocation from anywhere outside of \code{MyUnaryNumber}.
+  This is the exceptional case mentioned above,
+  where a member of an extension shadows
+  a regular instance member on \THIS.
+  In practice, extensions will very rarely introduce members
+  with the same basename as a member of its \ON{} type's interface.
 
-An unqualified identifier \code{id} which is not in scope
-is treated as \code{\THIS.id} inside instance members as usual
-(\ref{lexicalLookup}).
-If \code{id} is not declared by the static type of \THIS{}
-(the \ON{} type)
-then it may be an error,
-or it may be resolved using a different extension.%
+  An unqualified identifier \code{id} which is not in scope
+  is treated as \code{\THIS.id} inside instance members as usual
+  (\ref{lexicalLookup}).
+  If \code{id} is not declared by the static type of \THIS{}
+  (the \ON{} type)
+  then it may be an error,
+  or it may be resolved using a different extension.%
 }
 
 
@@ -6994,9 +7015,9 @@ $e$ has the static type $[S_1/Y_1, \ldots, S_m/Y_m]F$,
 where $F$ is the function type of said method declaration.
 
 \commentary{%
-If \id{} is a getter then $e$ is a getter invocation,
-which is specified elsewhere
-(\ref{explicitExtensionInvocations}).%
+  If \id{} is a getter then $e$ is a getter invocation,
+  which is specified elsewhere
+  (\ref{explicitExtensionInvocations}).%
 }
 
 \LMHash{}%
@@ -7051,36 +7072,36 @@ so $X_j$ must be renamed if \List{S}{1}{m} contains any occurrences of $X_j$,
 for all $j \in 1 .. s$.
 
 \commentary{%
-In other words, the closurization is the value of
-a function literal whose signature is the same as that of \id,
-except that the actual type arguments are substituted for
-the formal type parameters of $E$,
-and then it simply forwards the invocation
-to \id{} with the captured object $u$ as the receiver.%
+  In other words, the closurization is the value of
+  a function literal whose signature is the same as that of \id,
+  except that the actual type arguments are substituted for
+  the formal type parameters of $E$,
+  and then it simply forwards the invocation
+  to \id{} with the captured object $u$ as the receiver.%
 }
 
 \commentary{%
-Two extension instance method closurizations are never equal
-unless they are identical.
-Note that this differs from closurizations of class instance methods,
-which are equal when they tear off the same method of the same receiver.%
+  Two extension instance method closurizations are never equal
+  unless they are identical.
+  Note that this differs from closurizations of class instance methods,
+  which are equal when they tear off the same method of the same receiver.%
 }
 
 \rationale{%
-The reason for this difference is that even if $o_1$ and $o_2$
-are instance method closurizations of the same extension $E$
-applied to the same receiver $o$,
-they may have different actual type arguments passed to $E$,
-because those type arguments are determined by the call site
-(and with inference: by the static type of the expression yielding $o$),
-and not just by the properties of $o$ and the torn-off method.%
+  The reason for this difference is that even if $o_1$ and $o_2$
+  are instance method closurizations of the same extension $E$
+  applied to the same receiver $o$,
+  they may have different actual type arguments passed to $E$,
+  because those type arguments are determined by the call site
+  (and with inference: by the static type of the expression yielding $o$),
+  and not just by the properties of $o$ and the torn-off method.%
 }
 
 \commentary{%
-Note that an instance method closurization on an extension is not
-a constant expression,
-even in the case where the receiver is a constant expression.
-This is because it creates a new function object each time it is evaluated.%
+  Note that an instance method closurization on an extension is not
+  a constant expression,
+  even in the case where the receiver is a constant expression.
+  This is because it creates a new function object each time it is evaluated.%
 }
 
 \LMHash{}%
@@ -7088,13 +7109,13 @@ Extension method closurization can occur for an implicit invocation
 of an extension instance member.
 
 \commentary{%
-This is a consequence of the fact that the implicit invocation is
-treated as the corresponding explicit invocation
-(\ref{implicitExtensionInvocations}).
-For instance,
-\code{$e$.\id} may be implicitly transformed into
-\code{$E$<$T_1, T_2$>($e$).\id},
-which is then handled as specified above.%
+  This is a consequence of the fact that the implicit invocation is
+  treated as the corresponding explicit invocation
+  (\ref{implicitExtensionInvocations}).
+  For instance,
+  \code{$e$.\id} may be implicitly transformed into
+  \code{$E$<$T_1, T_2$>($e$).\id},
+  which is then handled as specified above.%
 }
 
 \LMHash{}%
@@ -7114,11 +7135,11 @@ Extension method closurizations are subject to generic function instantiation
 \end{dartCode}
 
 \commentary{%
-In this example \code{\{\}} is printed,
-because the function object obtained by extension method closurization
-was subject to a generic function instantiation
-which gave \code{T} the value \code{double},
-which makes `\code{\THIS\,\,\IS\,\,T}' evaluate to false.%
+  In this example \code{\{\}} is printed,
+  because the function object obtained by extension method closurization
+  was subject to a generic function instantiation
+  which gave \code{T} the value \code{double},
+  which makes `\code{\THIS\,\,\IS\,\,T}' evaluate to false.%
 }
 
 
@@ -7131,9 +7152,9 @@ similarly to a function expression invocation
 (\ref{functionExpressionInvocation}).
 
 \commentary{%
-E.g., \code{$e$()} is treated as \code{$e$.call()}
-when the static type of $e$ is a non-function that has a method named \CALL.
-Here is an example where the \CALL{} method comes from an extension:%
+  E.g., \code{$e$()} is treated as \code{$e$.call()}
+  when the static type of $e$ is a non-function that has a method named \CALL.
+  Here is an example where the \CALL{} method comes from an extension:%
 }
 
 \begin{dartCode}
@@ -7149,10 +7170,10 @@ Here is an example where the \CALL{} method comes from an extension:%
 \end{dartCode}
 
 \rationale{%
-This may look somewhat surprising,
-though similar to an approach using \code{\OPERATOR []}:
-\code{\FOR{} (\VAR{} i \IN{} 1[3])\,\,\{\,...\,\}}.
-We expect developers to use this power responsibly.%
+  This may look somewhat surprising,
+  though similar to an approach using \code{\OPERATOR []}:
+  \code{\FOR{} (\VAR{} i \IN{} 1[3])\,\,\{\,...\,\}}.
+  We expect developers to use this power responsibly.%
 }
 
 \LMHash{}%
@@ -7173,8 +7194,8 @@ $i$ is then treated as
 \code{$a$.\CALL<$A_1, \ldots,\ A_r$>($a_1, \ldots,\ a_n,\ x_{n+1}$:\ $a_{n+1}, \ldots,\ x_{n+k}$:\ $a_{n+k}$)}.
 
 \commentary{%
-In other words, an invocation of an extension application
-is immediately treated as an invocation of an extension method named \CALL.%
+  In other words, an invocation of an extension application
+  is immediately treated as an invocation of an extension method named \CALL.%
 }
 
 \LMHash{}%
@@ -7201,11 +7222,11 @@ Otherwise, $i$ is treated as the expression $i'$ which is
 \code{$e$.\CALL<$A_1, \ldots,\ A_r$>($a_1, \ldots,\ a_n,\ x_{n+1}$:\ $a_{n+1}, \ldots,\ x_{n+k}$:\ $a_{n+k}$)}.
 
 \commentary{%
-Note that $i'$ can be an implicit invocation of
-an extension method named \CALL,
-and it can be an error.
-In the latter case, error messages should be worded in terms of $i$,
-not $i'$.%
+  Note that $i'$ can be an implicit invocation of
+  an extension method named \CALL,
+  and it can be an error.
+  In the latter case, error messages should be worded in terms of $i$,
+  not $i'$.%
 }
 
 \LMHash{}%
@@ -7213,14 +7234,14 @@ It is a compile-time error unless $i'$ is an implicit invocation of
 an extension instance method named \CALL.
 
 \commentary{%
-In particular, $i'$ cannot be an invocation of an extension getter
-whose return type is a function type, \FUNCTION, or \DYNAMIC.%
+  In particular, $i'$ cannot be an invocation of an extension getter
+  whose return type is a function type, \FUNCTION, or \DYNAMIC.%
 }
 
 \commentary{%
-Note that there is no support for an implicit property extraction
-which tears off an extension method named \CALL.
-For instance, assuming the extension $E$ declared in the previous example:%
+  Note that there is no support for an implicit property extraction
+  which tears off an extension method named \CALL.
+  For instance, assuming the extension $E$ declared in the previous example:%
 }
 
 \begin{dartCode}
@@ -7228,18 +7249,18 @@ Iterable<int> \FUNCTION(int) from2 = 2; // \comment{Error.}
 \end{dartCode}
 
 \rationale{%
-The implicit property extraction could be allowed,
-but it would come at a readability cost.
-A type like \code{int} is well known as being non-callable,
-and an implicit \code{.call} tear-off would have no visible syntax.
-In an implicit \CALL{} invocation, the arguments are visible to a reader,
-but for an implicit tear-off of a \CALL{} function,
-there is no visible syntax at all.%
+  The implicit property extraction could be allowed,
+  but it would come at a readability cost.
+  A type like \code{int} is well known as being non-callable,
+  and an implicit \code{.call} tear-off would have no visible syntax.
+  In an implicit \CALL{} invocation, the arguments are visible to a reader,
+  but for an implicit tear-off of a \CALL{} function,
+  there is no visible syntax at all.%
 }
 
 \commentary{%
-If desired, the property extraction can be expressed explicitly
-using \code{2.\CALL}.%
+  If desired, the property extraction can be expressed explicitly
+  using \code{2.\CALL}.%
 }
 
 
@@ -7275,11 +7296,11 @@ $m$ \CLASS{} $E$ \{
 \end{normativeDartCode}
 
 \commentary{%
-It is also a compile-time error to subclass, mix-in or implement an enum
-or to explicitly instantiate an enum.
-These restrictions are given in normative form
-in sections \ref{superclasses}, \ref{superinterfaces}, \ref{mixinApplication}
-and \ref{instanceCreation} as appropriate.%
+  It is also a compile-time error to subclass, mix-in or implement an enum
+  or to explicitly instantiate an enum.
+  These restrictions are given in normative form
+  in sections \ref{superclasses}, \ref{superinterfaces}, \ref{mixinApplication}
+  and \ref{instanceCreation} as appropriate.%
 }
 
 
@@ -7300,13 +7321,14 @@ and the special case is considered where the number of type arguments is zero,
 the type argument list should be omitted.
 
 \commentary{%
-This allows non-generic cases to be included implicitly as special cases.
-For example,
-an invocation of a non-generic function arises as the special case
-where the function takes zero type arguments,
-and zero type arguments are passed.
-In this situation some operations are also omitted (have no effect), e.g.,
-operations where formal type parameters are replaced by actual type arguments.%
+  This allows non-generic cases to be included implicitly as special cases.
+  For example,
+  an invocation of a non-generic function arises as the special case
+  where the function takes zero type arguments,
+  and zero type arguments are passed.
+  In this situation some operations are also omitted (have no effect), e.g.,
+  operations where formal type parameters are replaced by
+  actual type arguments.%
 }
 
 \LMHash{}%
@@ -7334,14 +7356,14 @@ a class declaration which is obtained from the declaration $G$ by replacing
 each occurrence of $X_j$ by $T_j$.
 
 \commentary{%
-Other properties of $C'$ such as the subtype relationships
-are specified elsewhere
-(\ref{subtypes}).%
+  Other properties of $C'$ such as the subtype relationships
+  are specified elsewhere
+  (\ref{subtypes}).%
 }
 
 \commentary{%
-Generic type aliases are specified elsewhere
-(\ref{typedef}).%
+  Generic type aliases are specified elsewhere
+  (\ref{typedef}).%
 }
 
 \LMHash{}%
@@ -7364,11 +7386,11 @@ It is a compile-time error if there exists a $j$
 such that $T_j$ is not a subtype of $[T_1/X_1, \ldots, T_m/X_m]B_j$.
 
 \commentary{%
-That is, if the number of type arguments is wrong,
-or if the $j$th actual type argument is not a subtype of
-the corresponding bound,
-where each formal type parameter has been replaced by
-the corresponding actual type argument.%
+  That is, if the number of type arguments is wrong,
+  or if the $j$th actual type argument is not a subtype of
+  the corresponding bound,
+  where each formal type parameter has been replaced by
+  the corresponding actual type argument.%
 }
 
 \begin{grammar}
@@ -7385,10 +7407,10 @@ It is a compile-time error if a type parameter is a supertype of its upper bound
 when that upper bound is itself a type variable.
 
 \commentary{%
-This prevents circular declarations like
-\code{X \EXTENDS{} X}
-and
-\code{X \EXTENDS{} Y, Y \EXTENDS{} X}.%
+  This prevents circular declarations like
+  \code{X \EXTENDS{} X}
+  and
+  \code{X \EXTENDS{} Y, Y \EXTENDS{} X}.%
 }
 
 \LMHash{}%
@@ -7400,26 +7422,27 @@ the \EXTENDS{} and \IMPLEMENTS{} clauses of $G$ (if these exist)
 and in the body of $G$.
 
 \commentary{%
-However, a type parameter of a generic class
-is considered to be a malformed type
-when referenced by a static member
-(\ref{staticTypes}).
-The scopes associated with the type parameters of a generic function
-are described in (\ref{formalParameters}).%
+  However, a type parameter of a generic class
+  is considered to be a malformed type
+  when referenced by a static member
+  (\ref{staticTypes}).
+  The scopes associated with the type parameters of a generic function
+  are described in (\ref{formalParameters}).%
 }
 
 \rationale{%
-The restriction on static members is necessary since
-a type variable has no meaning in the context of a static member,
-because statics are shared among all generic instantiations of a generic class.
-However, a type variable may be referenced from an instance initializer,
-even though \THIS{} is not available.%
+  The restriction on static members is necessary since
+  a type variable has no meaning in the context of a static member,
+  because statics are shared among
+  all generic instantiations of a generic class.
+  However, a type variable may be referenced from an instance initializer,
+  even though \THIS{} is not available.%
 }
 
 \commentary{%
-Because type parameters are in scope in their bounds,
-we support F-bounded quantification.
-This enables typechecking code such as:%
+  Because type parameters are in scope in their bounds,
+  we support F-bounded quantification.
+  This enables typechecking code such as:%
 }
 
 \begin{dartCode}
@@ -7434,23 +7457,23 @@ This enables typechecking code such as:%
 \end{dartCode}
 
 \commentary{%
-Even where type parameters are in scope
-there are numerous restrictions at this time:
+  Even where type parameters are in scope
+  there are numerous restrictions at this time:
 
-\begin{itemize}
-\item[$\bullet$]
-  A type parameter cannot be used to name a constructor in
-  an instance creation expression (\ref{instanceCreation}).
-\item[$\bullet$]
-  A type parameter cannot be used as a superclass or superinterface
-  (\ref{superclasses}, \ref{superinterfaces}, \ref{interfaceSuperinterfaces}).
-\item[$\bullet$]
-  A type parameter cannot be used as a generic type.
-\end{itemize}
+  \begin{itemize}
+  \item[$\bullet$]
+    A type parameter cannot be used to name a constructor in
+    an instance creation expression (\ref{instanceCreation}).
+  \item[$\bullet$]
+    A type parameter cannot be used as a superclass or superinterface
+    (\ref{superclasses}, \ref{superinterfaces}, \ref{interfaceSuperinterfaces}).
+  \item[$\bullet$]
+    A type parameter cannot be used as a generic type.
+  \end{itemize}
 
-The normative versions of these are given
-in the appropriate sections of this specification.
-Some of these restrictions may be lifted in the future.%
+  The normative versions of these are given
+  in the appropriate sections of this specification.
+  Some of these restrictions may be lifted in the future.%
 }
 
 
@@ -7626,20 +7649,20 @@ if{}f $X_j$ occurs covariantly in $T$, and $X_j$
 if{}f $X_j$ occurs contravariantly in $T$.
 
 \rationale{%
-Variance gives a characterization of the way a type varies
-as the value of a subterm varies, e.g., a type variable:
-Assume that $T$ is a type where a type variable $X$ occurs,
-and $L$ and $U$ are types such that $L$ is a subtype of $U$.
-If $X$ occurs covariantly in $T$
-then $[L/X]T$ is a subtype of $[U/X]T$.
-Similarly, if $X$ occurs contravariantly in $T$
-then $[U/X]T$ is a subtype of $[L/X]T$.
-If $X$ occurs invariantly
-then $[L/X]T$ and $[U/X]T$ are not guaranteed
-to be subtypes of each other in any direction.
-In short: with covariance, the type covaries;
-with contravariance, the type contravaries;
-with invariance, all bets are off.%
+  Variance gives a characterization of the way a type varies
+  as the value of a subterm varies, e.g., a type variable:
+  Assume that $T$ is a type where a type variable $X$ occurs,
+  and $L$ and $U$ are types such that $L$ is a subtype of $U$.
+  If $X$ occurs covariantly in $T$
+  then $[L/X]T$ is a subtype of $[U/X]T$.
+  Similarly, if $X$ occurs contravariantly in $T$
+  then $[U/X]T$ is a subtype of $[L/X]T$.
+  If $X$ occurs invariantly
+  then $[L/X]T$ and $[U/X]T$ are not guaranteed
+  to be subtypes of each other in any direction.
+  In short: with covariance, the type covaries;
+  with contravariance, the type contravaries;
+  with invariance, all bets are off.%
 }
 
 
@@ -7654,8 +7677,8 @@ including some cases where a limited form of violation is allowed.
 \LMHash{}%
 A \Index{top type} is a type $T$ such that \code{Object} is a subtype of $T$.
 \commentary{%
-For instance, \code{Object}, \DYNAMIC, and \VOID{} are top types,
-and so are \code{FutureOr<\VOID>} and \code{FutureOr<FutureOr<\DYNAMIC>{}>}.%
+  For instance, \code{Object}, \DYNAMIC, and \VOID{} are top types,
+  and so are \code{FutureOr<\VOID>} and \code{FutureOr<FutureOr<\DYNAMIC>{}>}.%
 }
 
 % We define the property of being regular-bounded for all types,
@@ -7669,8 +7692,8 @@ and so are \code{FutureOr<\VOID>} and \code{FutureOr<FutureOr<\DYNAMIC>{}>}.%
 Every type which is not a parameterized type is \Index{regular-bounded}.
 
 \commentary{%
-In particular, every non-generic class and every function type
-is a regular-bounded type.%
+  In particular, every non-generic class and every function type
+  is a regular-bounded type.%
 }
 
 \LMHash{}%
@@ -7686,8 +7709,8 @@ $[S_1/X_1, \ldots,\ S_n/X_n]B_j$,
 for all $j \in 1 .. n$.
 
 \commentary{%
-This means that regular-bounded types are those types
-that do not violate their type parameter bounds.%
+  This means that regular-bounded types are those types
+  that do not violate their type parameter bounds.%
 }
 
 \LMHash{}%
@@ -7713,9 +7736,9 @@ $T$ is \Index{super-bounded} if{}f the following conditions are both true:
 \end{itemize}
 
 \commentary{%
-In short, at least one type argument violates its bound, but the type is
-regular-bounded after replacing all occurrences of an extreme type by an
-opposite extreme type, depending on their variance.%
+  In short, at least one type argument violates its bound, but the type is
+  regular-bounded after replacing all occurrences of an extreme type by an
+  opposite extreme type, depending on their variance.%
 }
 
 \LMHash{}%
@@ -7749,17 +7772,17 @@ when it is used in any of the following ways:
 \end{itemize}
 
 \commentary{%
-It is \emph{not} an error if a super-bounded type occurs
-as an immediate subterm of an \EXTENDS{} clause
-that specifies the bound of a type variable
-(\ref{generics}).%
+  It is \emph{not} an error if a super-bounded type occurs
+  as an immediate subterm of an \EXTENDS{} clause
+  that specifies the bound of a type variable
+  (\ref{generics}).%
 }
 
 \commentary{%
-Types of members from super-bounded class types are computed using the same
-rules as types of members from other types. Types of function applications
-involving super-bounded types are computed using the same rules as types of
-function applications involving other types. Here is an example:%
+  Types of members from super-bounded class types are computed using the same
+  rules as types of members from other types. Types of function applications
+  involving super-bounded types are computed using the same rules as types of
+  function applications involving other types. Here is an example:%
 }
 
 \begin{dartCode}
@@ -7771,18 +7794,18 @@ A<Object> a;
 \end{dartCode}
 
 \commentary{%
-With this, \code{a.x} has static type \code{Object},
-even though the upper bound on the type variable \code{X} is \code{num}.%
+  With this, \code{a.x} has static type \code{Object},
+  even though the upper bound on the type variable \code{X} is \code{num}.%
 }
 
 \rationale{%
-Super-bounded types enable the expression of informative common supertypes
-of some sets of types whose common supertypes
-would otherwise be much less informative.%
+  Super-bounded types enable the expression of informative common supertypes
+  of some sets of types whose common supertypes
+  would otherwise be much less informative.%
 }
 
 \commentary{%
-For example, consider the following class:%
+  For example, consider the following class:%
 }
 
 \begin{dartCode}
@@ -7792,49 +7815,51 @@ For example, consider the following class:%
 \end{dartCode}
 
 \commentary{%
-Without super-bounded types,
-there is no type $T$ which makes \code{C<$T$>} a common supertype of
-all types of the form \code{C<$S$>}
-(noting that all types must be regular-bounded
-when we do not have the notion of super-bounded types).
-So if we wish to allow a variable to hold any instance ``of type \code{C}''
-then that variable must use \code{Object} or another top type
-as its type annotation,
-which means that a member like \code{next} is not known to exist
-(which is what we mean by saying that the type is `less informative').%
+  Without super-bounded types,
+  there is no type $T$ which makes \code{C<$T$>} a common supertype of
+  all types of the form \code{C<$S$>}
+  (noting that all types must be regular-bounded
+  when we do not have the notion of super-bounded types).
+  So if we wish to allow a variable to hold any instance ``of type \code{C}''
+  then that variable must use \code{Object} or another top type
+  as its type annotation,
+  which means that a member like \code{next} is not known to exist
+  (which is what we mean by saying that the type is `less informative').%
 }
 
 \rationale{%
-We could introduce a notion of recursive (infinite) types, and express
-the least upper bound of all types of the form \code{C<$S$>} as
-some syntax whose meaning could be approximated by
-\code{C<C<C<C<$\ldots$>$\!$>$\!$>$\!$>}.
-%
-However, we expect that any such concept in Dart would incur a significant cost
-on developers and implementations in terms of added complexity and subtlety,
-so we have chosen not to do that.
-Super-bounded types are finite,
-but they offer a useful developer-controlled approximation
-to such infinite types.%
+  We could introduce a notion of recursive (infinite) types, and express
+  the least upper bound of all types of the form \code{C<$S$>} as
+  some syntax whose meaning could be approximated by
+  \code{C<C<C<C<$\ldots$>$\!$>$\!$>$\!$>}.
+  %
+  However, we expect that any such concept in Dart
+  would incur a significant cost
+  on developers and implementations
+  in terms of added complexity and subtlety,
+  so we have chosen not to do that.
+  Super-bounded types are finite,
+  but they offer a useful developer-controlled approximation
+  to such infinite types.%
 }
 
 \commentary{%
-For example,
-\code{C<Object>} and
-\code{C<C<C<\VOID>{}>{}>}
-are types that a developer may choose to use as a type annotation.
-This choice serves as a commitment to
-a finite level of unfolding of the infinite type,
-and it allows for a certain amount of control
-at the point where the unfolding ends:
-%
-If \code{c} has type \code{C<C<\DYNAMIC>{}>}
-then \code{c.next.next} has type \DYNAMIC{}
-and \code{c.next.next.whatever} has no compile-time error,
-but if \code{c} has type \code{C<C<\VOID>{}>} then already
-\code{Object x = c.next.next;} is a compile-time error.
-It is thus possible for developers to get a more or less strict treatment
-of expressions whose type proceeds beyond the given finite unfolding.%
+  For example,
+  \code{C<Object>} and
+  \code{C<C<C<\VOID>{}>{}>}
+  are types that a developer may choose to use as a type annotation.
+  This choice serves as a commitment to
+  a finite level of unfolding of the infinite type,
+  and it allows for a certain amount of control
+  at the point where the unfolding ends:
+  %
+  If \code{c} has type \code{C<C<\DYNAMIC>{}>}
+  then \code{c.next.next} has type \DYNAMIC{}
+  and \code{c.next.next.whatever} has no compile-time error,
+  but if \code{c} has type \code{C<C<\VOID>{}>} then already
+  \code{Object x = c.next.next;} is a compile-time error.
+  It is thus possible for developers to get a more or less strict treatment
+  of expressions whose type proceeds beyond the given finite unfolding.%
 }
 
 
@@ -7847,19 +7872,19 @@ that are omitted from a type,
 or from an invocation of a generic function.
 
 \commentary{%
-%% TODO(eernst): When we add a specification of type inference, we will adjust
-%% the specification of i2b such that it allows for taking initial values for
-%% the actual type arguments (that is, $U_{j,0}$ is given "from the caller" for
-%% some $j$; probably "the caller" will always be type inference), and all other
-%% parts of the algorithm remain unchanged.
-%% I think it will be more confusing than helpful to start writing this now,
-%% and it will be a small adjustment when we add a spec of type inference. So
-%% at this point we just specify i2b as a stand-alone algorithm.
-Note that type inference is assumed to have taken place already
-(\ref{overview}),
-so type arguments are not considered to be omitted if they are inferred.
-This means that instantiation to bound is a backup mechanism,
-which will be used when no information is available for inference.%
+  %% TODO(eernst): When we add a specification of type inference, we will adjust
+  %% the specification of i2b such that it allows for taking initial values for
+  %% the actual type arguments (that is, $U_{j,0}$ is given "from the caller"
+  %% for some $j$; probably "the caller" will always be type inference), and
+  %% all other parts of the algorithm remain unchanged.
+  %% I think it will be more confusing than helpful to start writing this now,
+  %% and it will be a small adjustment when we add a spec of type inference. So
+  %% at this point we just specify i2b as a stand-alone algorithm.
+  Note that type inference is assumed to have taken place already
+  (\ref{overview}),
+  so type arguments are not considered to be omitted if they are inferred.
+  This means that instantiation to bound is a backup mechanism,
+  which will be used when no information is available for inference.%
 }
 
 \LMHash{}%
@@ -7867,7 +7892,7 @@ Consider the situation where a term $t$ of the form \synt{typeName}
 denotes a generic type declaration,
 and it is used as a type or as an expression in the enclosing program.
 \commentary{%
-This implies that type arguments are accepted, but not provided.%
+  This implies that type arguments are accepted, but not provided.%
 }
 We use the phrase
 \Index{raw type} respectively \Index{raw type expression}
@@ -7877,63 +7902,63 @@ but everything said about raw types
 applies to raw type expressions in the obvious manner.
 
 \commentary{%
-For instance, with the declaration \code{Type listType() => List;},
-evaluation of the raw type expression \code{List} in the body yields
-an instance of class \code{Type} reifying \code{List<dynamic>},
-because \code{List} is subject to instantiation to bound.
-Note that \code{List<dynamic>} is not syntactically an expression,
-but it is still possible to get access to
-a \code{Type} instance reifying \code{List<dynamic>}
-without instantiation to bound,
-because it can be the value of a type variable.%
+  For instance, with the declaration \code{Type listType() => List;},
+  evaluation of the raw type expression \code{List} in the body yields
+  an instance of class \code{Type} reifying \code{List<dynamic>},
+  because \code{List} is subject to instantiation to bound.
+  Note that \code{List<dynamic>} is not syntactically an expression,
+  but it is still possible to get access to
+  a \code{Type} instance reifying \code{List<dynamic>}
+  without instantiation to bound,
+  because it can be the value of a type variable.%
 }
 
 \rationale{%
-We can unambiguously define raw types to denote
-the result of applying the generic type
-to a list of implicitly provided actual type arguments,
-and instantiation to bound is a mechanism which does just that.
-This is because Dart does not, and will not, support higher-kinded types;
-for example, the value of a type variable $X$ will be a type,
-it cannot be the generic class \code{List} as such,
-and it cannot be applied to type arguments, e.g., \code{$X$<int>}.%
+  We can unambiguously define raw types to denote
+  the result of applying the generic type
+  to a list of implicitly provided actual type arguments,
+  and instantiation to bound is a mechanism which does just that.
+  This is because Dart does not, and will not, support higher-kinded types;
+  for example, the value of a type variable $X$ will be a type,
+  it cannot be the generic class \code{List} as such,
+  and it cannot be applied to type arguments, e.g., \code{$X$<int>}.%
 }
 
 \rationale{%
-In the typical case where only covariance is encountered,
-instantiation to bound will yield a \emph{supertype} of
-all the regular-bounded types that can be expressed.
-This allows developers to consider a raw type as a type
-which is used to specify that
-``the actual type arguments do not matter''$\!$.%
+  In the typical case where only covariance is encountered,
+  instantiation to bound will yield a \emph{supertype} of
+  all the regular-bounded types that can be expressed.
+  This allows developers to consider a raw type as a type
+  which is used to specify that
+  ``the actual type arguments do not matter''$\!$.%
 }
 \commentary{%
-For example, assuming the declaration
-\code{\CLASS{} C<X extends num> \{\ldots\}},
-instantiation to bound on \code{C} yields \code{C<num>},
-and this means that \code{C x;} can be used to declare a variable \code{x}
-whose value can be a \code{C<$T$>} for \emph{all possible} values of $T$.%
+  For example, assuming the declaration
+  \code{\CLASS{} C<X extends num> \{\ldots\}},
+  instantiation to bound on \code{C} yields \code{C<num>},
+  and this means that \code{C x;} can be used to declare a variable \code{x}
+  whose value can be a \code{C<$T$>} for \emph{all possible} values of $T$.%
 }
 
 \rationale{%
-Conversely, consider the situation where
-a generic type alias denotes a function type,
-and it has one type parameter which is contravariant.
-Instantiation to bound on that type alias will then yield a \emph{subtype} of
-all the regular-bounded types that can be expressed
-by varying that type argument.
-This allows developers to consider such a type alias used as a raw type
-as a function type which allows the function to be passed to clients
-``where it does not matter which values
-for the type argument the client expects''$\!$.%
+  Conversely, consider the situation where
+  a generic type alias denotes a function type,
+  and it has one type parameter which is contravariant.
+  Instantiation to bound on that type alias will then yield a \emph{subtype} of
+  all the regular-bounded types that can be expressed
+  by varying that type argument.
+  This allows developers to consider such a type alias used as a raw type
+  as a function type which allows the function to be passed to clients
+  ``where it does not matter which values
+  for the type argument the client expects''$\!$.%
 }
 \commentary{%
-E.g., with
-\code{\TYPEDEF{} F<X> = \FUNCTION(X);}
-instantiation to bound on \code{F} yields \code{F<dynamic>},
-and this means that \code{F f;} can be used to declare a variable \code{f}
-whose value will be a function that can be passed to clients expecting
-an \code{F<$T$>} for \emph{all possible} values of $T$.%
+  E.g., with
+  \code{\TYPEDEF{} F<X> = \FUNCTION(X);}
+  instantiation to bound on \code{F} yields \code{F<dynamic>},
+  and this means that \code{F f;} can be used to declare a variable \code{f}
+  whose value will be a function that can be passed to clients expecting
+  an \code{F<$T$>} for \emph{all possible} values of $T$.%
 }
 
 
@@ -7952,15 +7977,15 @@ $T$ if one or more of the following conditions hold:
 \item
   $S$ is of the form \synt{typeName}, and $S$ is $T$.
   \commentary{%
-  Note that this case is not applicable
-  if $S$ is a subterm of a term of the form
-  \syntax{$S$ <typeArguments>},
-  that is,
-  if $S$ receives any type arguments.
-  Also note that $S$ cannot be a type variable,
-  because then `$S$ is $T$' cannot hold.
-  See the discussion below and the reference to~\ref{subtypeRules}
-  for more details about why this is so.%
+    Note that this case is not applicable
+    if $S$ is a subterm of a term of the form
+    \syntax{$S$ <typeArguments>},
+    that is,
+    if $S$ receives any type arguments.
+    Also note that $S$ cannot be a type variable,
+    because then `$S$ is $T$' cannot hold.
+    See the discussion below and the reference to~\ref{subtypeRules}
+    for more details about why this is so.%
   }
 \item
   $S$ is of the form \syntax{<typeName> <typeArguments>},
@@ -7978,33 +8003,33 @@ $T$ if one or more of the following conditions hold:
 \end{itemize}
 
 \commentary{%
-Meta-variables
-(\ref{metaVariables})
-like $S$ and $T$ are understood to denote types,
-and they are considered to be equal (as in `$S$ is $T$')
-in the same sense as in the section about subtype rules
-(\ref{subtypeRules}).
-%
-In particular,
-even though two identical pieces of syntax may denote two distinct types,
-and two different pieces of syntax may denote the same type,
-the property of interest here is whether they denote the same type
-and not whether they are spelled identically.
+  Meta-variables
+  (\ref{metaVariables})
+  like $S$ and $T$ are understood to denote types,
+  and they are considered to be equal (as in `$S$ is $T$')
+  in the same sense as in the section about subtype rules
+  (\ref{subtypeRules}).
+  %
+  In particular,
+  even though two identical pieces of syntax may denote two distinct types,
+  and two different pieces of syntax may denote the same type,
+  the property of interest here is whether they denote the same type
+  and not whether they are spelled identically.
 
-The intuition behind the situation where a type raw-depends on another type is
-that we need to compute any missing type arguments for the latter
-in order to be able to tell what the former means.
+  The intuition behind the situation where a type raw-depends on another type is
+  that we need to compute any missing type arguments for the latter
+  in order to be able to tell what the former means.
 
-In the rule about type aliases, $F$ may or may not be generic,
-and type arguments may or may not be present.
-However, there is no need to consider the result of substituting
-actual type arguments for formal type parameters in the body of $F$
-(or even the correctness of passing those type arguments to $F$),
-because we only need to inspect
-all types of the form \synt{typeName} in its body,
-and they are not affected by such a substitution.
-In other words, raw-dependency is a relation
-which is simple and cheap to compute.%
+  In the rule about type aliases, $F$ may or may not be generic,
+  and type arguments may or may not be present.
+  However, there is no need to consider the result of substituting
+  actual type arguments for formal type parameters in the body of $F$
+  (or even the correctness of passing those type arguments to $F$),
+  because we only need to inspect
+  all types of the form \synt{typeName} in its body,
+  and they are not affected by such a substitution.
+  In other words, raw-dependency is a relation
+  which is simple and cheap to compute.%
 }
 
 \LMHash{}%
@@ -8030,15 +8055,15 @@ generic type alias $G$ is reached during an investigation of whether
 $B_j$ is a simple bound, the answer is no.
 
 \commentary{%
-For example, with
-\code{\CLASS{} C<X \EXTENDS{} C> \{\}},
-the type parameter \code{X} does not have a simple bound:
-A raw \code{C} is used as a bound for \code{X},
-so \code{C} must have simple bounds,
-but one of the bounds of \code{C} is the bound of \code{X},
-and that bound is \code{C}, so \code{C} must have simple bounds:
-That was a cycle, so the answer is ``no'',
-\code{C} does not have simple bounds.%
+  For example, with
+  \code{\CLASS{} C<X \EXTENDS{} C> \{\}},
+  the type parameter \code{X} does not have a simple bound:
+  A raw \code{C} is used as a bound for \code{X},
+  so \code{C} must have simple bounds,
+  but one of the bounds of \code{C} is the bound of \code{X},
+  and that bound is \code{C}, so \code{C} must have simple bounds:
+  That was a cycle, so the answer is ``no'',
+  \code{C} does not have simple bounds.%
 }
 
 \LMHash{}%
@@ -8048,10 +8073,10 @@ We say that $G$
 if{}f every type parameter of $G$ has simple bounds.
 
 \commentary{%
-We can now specify in which sense instantiation to bound requires
-the involved types to be "simple enough".
-We impose the following constraint on all type parameter bounds,
-because all type parameters may be subject to instantiation to bound.%
+  We can now specify in which sense instantiation to bound requires
+  the involved types to be "simple enough".
+  We impose the following constraint on all type parameter bounds,
+  because all type parameters may be subject to instantiation to bound.%
 }
 
 \LMHash{}%
@@ -8060,15 +8085,15 @@ if a formal type parameter bound $B$ contains a raw type $T$,
 unless $T$ has simple bounds.
 
 \commentary{%
-So type arguments on bounds can only be omitted
-if they themselves have simple bounds.
-In particular,
-\code{\CLASS{} C<X \EXTENDS{} C> \{\}}
-is a compile-time error,
-because the bound \code{C} is raw,
-and the formal type parameter \code{X}
-that corresponds to the omitted type argument
-does not have a simple bound.%
+  So type arguments on bounds can only be omitted
+  if they themselves have simple bounds.
+  In particular,
+  \code{\CLASS{} C<X \EXTENDS{} C> \{\}}
+  is a compile-time error,
+  because the bound \code{C} is raw,
+  and the formal type parameter \code{X}
+  that corresponds to the omitted type argument
+  does not have a simple bound.%
 }
 
 \LMHash{}%
@@ -8080,12 +8105,12 @@ the result obtained by applying instantiation to bound to $T$.
 It is a compile-time error if the instantiation to bound fails.
 
 \commentary{%
-This rule is applicable for all occurrences of raw types,
-e.g., when it occurs as a type annotation of a variable or a parameter,
-as a return type of a function,
-as a type which is tested in a type test,
-as the type in an \synt{onPart},
-etc.%
+  This rule is applicable for all occurrences of raw types,
+  e.g., when it occurs as a type annotation of a variable or a parameter,
+  as a return type of a function,
+  as a type which is tested in a type test,
+  as the type in an \synt{onPart},
+  etc.%
 }
 
 
@@ -8104,20 +8129,20 @@ let $S_i$ denote the result of instantiation to bound on $B_i$;
 in the case where the $i$th bound is omitted, let $S_i$ be \DYNAMIC.
 
 \commentary{%
-If $B_i$ for some $i$ is raw (in general: if it raw-depends on some type $U$)
-then all its (respectively $U$'s) omitted type arguments have simple bounds.
-This limits the complexity of instantiation to bound for $B_i$,
-and in particular it cannot involve a dependency cycle
-where we need the result from instantiation to bound for $G$
-in order to compute the instantiation to bound for $G$.%
+  If $B_i$ for some $i$ is raw (in general: if it raw-depends on some type $U$)
+  then all its (respectively $U$'s) omitted type arguments have simple bounds.
+  This limits the complexity of instantiation to bound for $B_i$,
+  and in particular it cannot involve a dependency cycle
+  where we need the result from instantiation to bound for $G$
+  in order to compute the instantiation to bound for $G$.%
 }
 
 \LMHash{}%
 Let $U_{i,0}$ be $S_i$, for all $i \in 1 .. k$.
 \commentary{%
-This is the "current value" of the bound for type variable $i$, at step 0;
-in general we will consider the current step, $m$, and use data for that step,
-e.g., the bound $U_{i,m}$, to compute the data for step $m + 1$.%
+  This is the "current value" of the bound for type variable $i$, at step 0;
+  in general we will consider the current step, $m$, and use data for that step,
+  e.g., the bound $U_{i,m}$, to compute the data for step $m + 1$.%
 }
 
 { %% Scope for definitions of relations used during i2b
@@ -8130,8 +8155,8 @@ Let \Depends{} be a relation among the type variables
 \List{X}{1}{k} such that
 $X_p \Depends X_q$ iff $X_q$ occurs in $U_{p,m}$.
 \commentary{%
-So each type variable is related to, that is, depends on,
-every type variable in its bound, which might include itself.%
+  So each type variable is related to, that is, depends on,
+  every type variable in its bound, which might include itself.%
 }
 Let \TransitivelyDepends{} be the transitive
 \commentary{(but not reflexive)}
@@ -8148,12 +8173,12 @@ be determined by the following iterative process, where $V_m$ denotes
   let \List{M}{1}{p} be the strongly connected components (SCCs)
   with respect to \Depends.
   \commentary{%
-  That is, the maximal subsets of \List{X}{1}{k}
-  where every pair of variables in each subset
-  are related in both directions by \TransitivelyDepends;
-  note that the SCCs are pairwise disjoint;
-  also, they are uniquely defined up to reordering,
-  and the order does not matter for this algorithm.%
+    That is, the maximal subsets of \List{X}{1}{k}
+    where every pair of variables in each subset
+    are related in both directions by \TransitivelyDepends;
+    note that the SCCs are pairwise disjoint;
+    also, they are uniquely defined up to reordering,
+    and the order does not matter for this algorithm.%
   }
   Let $M$ be the union of \List{M}{1}{p}
   \commentary{(that is, all variables that participate in a dependency cycle)}.
@@ -8178,7 +8203,7 @@ be determined by the following iterative process, where $V_m$ denotes
   Then, for all $i \in 1 .. k$,
   $U_{i,m+1}$ is obtained from $U_{i,m}$
   by substituting $U_{j,m}$ for every occurrence of $X_j$
-  that is in a position in $V_m$ which  is not contravariant,
+  that is in a position in $V_m$ which is not contravariant,
   and substituting \code{Null} for every occurrence of $X_j$
   which is in a contravariant position in $V_m$.
 
@@ -8189,23 +8214,24 @@ be determined by the following iterative process, where $V_m$ denotes
 \end{itemize}
 
 \commentary{%
-This process will always terminate, because the total number of
-occurrences of type variables from $\{\,\List{X}{1}{k}\,\}$ in
-the current bounds is strictly decreasing with each step, and we terminate
-when that number reaches zero.%
+  This process will always terminate, because the total number of
+  occurrences of type variables from $\{\,\List{X}{1}{k}\,\}$ in
+  the current bounds is strictly decreasing with each step, and we terminate
+  when that number reaches zero.%
 }
 
 \rationale{%
-It may seem somewhat arbitrary to treat unused and invariant parameters
-in the same way as covariant parameters,
-in particular because invariant parameters fail to satisfy the expectation that
-a raw type denotes a supertype of all the expressible regular-bounded types.
+  It may seem somewhat arbitrary to treat unused and invariant parameters
+  in the same way as covariant parameters,
+  in particular because invariant parameters fail
+  to satisfy the expectation that
+  a raw type denotes a supertype of all the expressible regular-bounded types.
 
-We could easily have made every instantiation to bound an error
-when applied to a type where invariance occurs anywhere
-during the run of the algorithm.
-However, there are a number of cases where this choice produces a usable type,
-and we decided that it is not helpful to outlaw such cases.%
+  We could easily have made every instantiation to bound an error
+  when applied to a type where invariance occurs anywhere
+  during the run of the algorithm.
+  However, there are a number of cases where this choice produces a usable type,
+  and we decided that it is not helpful to outlaw such cases.%
 }
 
 \begin{dartCode}
@@ -8216,13 +8242,13 @@ B b; // \comment{The raw B means} B<num, Inv<num>{}>.
 \end{dartCode}
 
 \commentary{%
-For example, the value of \code{b} can have dynamic type
-\code{B<int,\,int\,\FUNCTION(num)>}.
-However, the type arguments have to be chosen carefully,
-or the result will not be a subtype of \code{B}.
-For instance, \code{b} cannot have dynamic type
-\code{B<int, Inv<int>{}>},
-because \code{Inv<int>} is not a subtype of \code{Inv<num>}.%
+  For example, the value of \code{b} can have dynamic type
+  \code{B<int,\,int\,\FUNCTION(num)>}.
+  However, the type arguments have to be chosen carefully,
+  or the result will not be a subtype of \code{B}.
+  For instance, \code{b} cannot have dynamic type
+  \code{B<int, Inv<int>{}>},
+  because \code{Inv<int>} is not a subtype of \code{Inv<num>}.%
 }
 
 \LMHash{}%
@@ -8231,7 +8257,7 @@ yields a type which is not well-bounded
 (\ref{superBoundedTypes}).
 
 \commentary{%
-This kind of error can occur, as demonstrated by the following example:%
+  This kind of error can occur, as demonstrated by the following example:%
 }
 
 \begin{dartCode}
@@ -8242,30 +8268,30 @@ F f; // \comment{Compile-time error.}
 \end{dartCode}
 
 \commentary{%
-With these declarations,
-the raw \code{F} which is used as a type annotation is a compile-time error:
-The algorithm yields \code{F<C<\DYNAMIC{}>{}>},
-and that is neither a regular-bounded nor a super-bounded type.
-%
-The resulting type can be specified explicitly as
-\code{C<\DYNAMIC{}> \FUNCTION(C<\DYNAMIC{}>)}.
-That type exists,
-we just cannot express it by passing a type argument to \code{F},
-so we make it an error rather than allowing it implicitly.%
+  With these declarations,
+  the raw \code{F} which is used as a type annotation is a compile-time error:
+  The algorithm yields \code{F<C<\DYNAMIC{}>{}>},
+  and that is neither a regular-bounded nor a super-bounded type.
+  %
+  The resulting type can be specified explicitly as
+  \code{C<\DYNAMIC{}> \FUNCTION(C<\DYNAMIC{}>)}.
+  That type exists,
+  we just cannot express it by passing a type argument to \code{F},
+  so we make it an error rather than allowing it implicitly.%
 }
 
 \rationale{%
-The core reason why it makes sense to make such a raw type an error
-is that there is no subtype relationship
-between the relevant parameterized types.%
+  The core reason why it makes sense to make such a raw type an error
+  is that there is no subtype relationship
+  between the relevant parameterized types.%
 }
 \commentary{%
-For instance, \code{F<T1>} and \code{F<T2>} are unrelated,
-even when \SubtypeNE{\code{T1}}{\code{T2}} or vice versa.
-In fact, there is no type \code{T} whatsoever
-such that a variable with declared type \code{F<T>}
-could be assigned to a variable of type
-\code{C<\DYNAMIC{}> \FUNCTION(C<\DYNAMIC{}>)}.
+  For instance, \code{F<T1>} and \code{F<T2>} are unrelated,
+  even when \SubtypeNE{\code{T1}}{\code{T2}} or vice versa.
+  In fact, there is no type \code{T} whatsoever
+  such that a variable with declared type \code{F<T>}
+  could be assigned to a variable of type
+  \code{C<\DYNAMIC{}> \FUNCTION(C<\DYNAMIC{}>)}.
 %
 So the raw \code{F}, if permitted,
 would not be ``a supertype of \code{F<T>} for all possible \code{T}'',
@@ -8287,10 +8313,10 @@ and a function type
 it is applied to \List{T}{0}{n+k}.
 
 \commentary{%
-This means that instantiation to bound has no effect on
-a type that does not contain any raw types.
-Conversely, instantiation to bound acts on types which are syntactic subterms,
-also when they are deeply nested.%
+  This means that instantiation to bound has no effect on
+  a type that does not contain any raw types.
+  Conversely, instantiation to bound acts on types which are syntactic subterms,
+  also when they are deeply nested.%
 }
 
 \LMHash{}%
@@ -8343,9 +8369,9 @@ It is a compile-time error if $e$ is not one of the following:
 \end{itemize}
 
 \commentary{%
-The expression $e$ occurs in a constant context
-(\ref{constantContexts}),
-which means that \CONST{} modifiers need not be specified explicitly.%
+  The expression $e$ occurs in a constant context
+  (\ref{constantContexts}),
+  which means that \CONST{} modifiers need not be specified explicitly.%
 }
 
 \LMHash{}%
@@ -8359,18 +8385,18 @@ of the program construct $p$ that immediately follows the metadata
 in the grammar rule.
 
 \rationale{%
-These rules are intended to ensure a minimal level of consistency
-in the association that binds each metadatum to a program construct.
-The structure of the abstract syntax tree is implementation specific,
-and it is not even guaranteed that a tool will use anything
-which is known as an abstract syntax tree.
-In that case the phrase `abstract syntax tree' should be interpreted as
-the program representation entities which are actually used.
+  These rules are intended to ensure a minimal level of consistency
+  in the association that binds each metadatum to a program construct.
+  The structure of the abstract syntax tree is implementation specific,
+  and it is not even guaranteed that a tool will use anything
+  which is known as an abstract syntax tree.
+  In that case the phrase `abstract syntax tree' should be interpreted as
+  the program representation entities which are actually used.
 
-This implies that the fine details of the association between metadata
-and an abstract syntax tree node is also implementation specific.
-In particular, an implementation can choose to associate a given metadatum
-with more than one abstract syntax tree node.%
+  This implies that the fine details of the association between metadata
+  and an abstract syntax tree node is also implementation specific.
+  In particular, an implementation can choose to associate a given metadatum
+  with more than one abstract syntax tree node.%
 }
 
 \LMHash{}%
@@ -8378,34 +8404,35 @@ Metadata can be retrieved at run time via a reflective call,
 provided the annotated program construct $p$ is accessible via reflection.
 
 \commentary{%
-Obviously, metadata can also be retrieved statically by
-parsing the program and evaluating the constants via a suitable interpreter.
-In fact, many if not most uses of metadata are entirely static.
-In this case the binding of each metadatum to an abstract syntax tree node
-is determined by the given static analysis tool,
-which is of course not subject to any constraints in this document.
-Surely it will still be useful to strive for consistency among all tools
-with respect to the binding from metadata to abstract syntax tree nodes.%
+  Obviously, metadata can also be retrieved statically by
+  parsing the program and evaluating the constants via a suitable interpreter.
+  In fact, many if not most uses of metadata are entirely static.
+  In this case the binding of each metadatum to an abstract syntax tree node
+  is determined by the given static analysis tool,
+  which is of course not subject to any constraints in this document.
+  Surely it will still be useful to strive for consistency among all tools
+  with respect to the binding from metadata to abstract syntax tree nodes.%
 }
 
 \rationale{%
-It is important that no run-time overhead be incurred by
-the introduction of metadata that is not actually used.
-Because metadata only involves constants,
-the time at which it is computed is irrelevant.
-So implementations may skip the metadata during ordinary parsing and execution,
-and evaluate it lazily.%
+  It is important that no run-time overhead be incurred by
+  the introduction of metadata that is not actually used.
+  Because metadata only involves constants,
+  the time at which it is computed is irrelevant.
+  So implementations may skip the metadata
+  during ordinary parsing and execution,
+  and evaluate it lazily.%
 }
 
 \commentary{%
-It is possible to associate metadata with constructs
-that may not be accessible via reflection,
-such as local variables
-(though it is conceivable that in the future,
-richer reflective libraries might provide access to these as well).
-This is not as useless as it might seem.
-As noted above, the data can be retrieved statically
-if source code is available.%
+  It is possible to associate metadata with constructs
+  that may not be accessible via reflection,
+  such as local variables
+  (though it is conceivable that in the future,
+  richer reflective libraries might provide access to these as well).
+  This is not as useless as it might seem.
+  As noted above, the data can be retrieved statically
+  if source code is available.%
 }
 
 \LMHash{}%
@@ -8477,26 +8504,26 @@ An expression $e$ may always be enclosed in parentheses,
 but this never has any semantic effect on $e$.
 
 \commentary{%
-However, it may have an effect on the surrounding expression.
-For instance, given a class \code{C} with a static method
-\code{m() => 42}, \code{C.m()} returns 42,
-but \code{(C).m()} is a compile-time error.
-%
-The point is that the meaning of \code{C.m()}
-is specified in terms of several parts,
-rather than being specified in a strictly compositional manner.
-Concretely, the meaning of \code{C} and \code{(C)} as expressions is the same,
-but the meaning of \code{C.m()} is not defined in terms of
-the meaning of \code{C} as an expression,
-and it differs from the meaning of \code{(C).m()}.%
-% A strictly compositional evaluation would always evaluate every subexpression
-% using the same rules (`evaluation` is always the same thing), and then it
-% would combine the evaluation results into the result of the whole expression.
-% We won't expand on that here, and in particular we won't discuss whether
-% compositional evaluation is even meaningful in the context of side-effects.
-% But it's still useful to keep in mind that we have these "highly
-% non-compositional" elements in the semantics, such as static method
-% lookups.
+  However, it may have an effect on the surrounding expression.
+  For instance, given a class \code{C} with a static method
+  \code{m() => 42}, \code{C.m()} returns 42,
+  but \code{(C).m()} is a compile-time error.
+  %
+  The point is that the meaning of \code{C.m()}
+  is specified in terms of several parts,
+  rather than being specified in a strictly compositional manner.
+  Concretely, the meaning of \code{C} and \code{(C)} as expressions is the same,
+  but the meaning of \code{C.m()} is not defined in terms of
+  the meaning of \code{C} as an expression,
+  and it differs from the meaning of \code{(C).m()}.%
+  % A strictly compositional evaluation would always evaluate every
+  % subexpression using the same rules (`evaluation` is always the same thing),
+  % and then it would combine the evaluation results into the result of the
+  % whole expression. We won't expand on that here, and in particular we won't
+  % discuss whether compositional evaluation is even meaningful in the context
+  % of side-effects. But it's still useful to keep in mind that we have these
+  % "highly non-compositional" elements in the semantics, such as static
+  % method lookups.
 }
 
 
@@ -8555,22 +8582,22 @@ is defined such that \code{identical($c_1$, $c_2$)} if{}f:
 \end{itemize}
 
 \commentary{%
-The definition of \code{identity} for doubles differs from that of equality
-in that a NaN is identical to itself,
-and that negative and positive zero are distinct.%
+  The definition of \code{identity} for doubles differs from that of equality
+  in that a NaN is identical to itself,
+  and that negative and positive zero are distinct.%
 }
 
 \rationale{%
-The definition of equality for doubles is dictated by the IEEE 754 standard,
-which posits that NaNs do not obey the law of reflexivity.
-Given that hardware implements these rules,
-it is necessary to support them for reasons of efficiency.
+  The definition of equality for doubles is dictated by the IEEE 754 standard,
+  which posits that NaNs do not obey the law of reflexivity.
+  Given that hardware implements these rules,
+  it is necessary to support them for reasons of efficiency.
 
-The definition of identity is not constrained in the same way.
-Instead, it assumes that bit-identical doubles are identical.
+  The definition of identity is not constrained in the same way.
+  Instead, it assumes that bit-identical doubles are identical.
 
-The rules for identity make it impossible for a Dart programmer
-to observe whether a boolean or numerical value is boxed or unboxed.%
+  The rules for identity make it impossible for a Dart programmer
+  to observe whether a boolean or numerical value is boxed or unboxed.%
 }
 
 
@@ -8578,22 +8605,22 @@ to observe whether a boolean or numerical value is boxed or unboxed.%
 \LMLabel{constants}
 
 \commentary{%
-All usages of 'constant' in Dart are associated with compile time.
-A potentially constant expression is an expression that will generally yield
-a constant value when the values of certain parameters are given.
-The constant expressions is a subset of the potentially constant expressions
-that \emph{can} be evaluated at compile time.%
+  All usages of 'constant' in Dart are associated with compile time.
+  A potentially constant expression is an expression that will generally yield
+  a constant value when the values of certain parameters are given.
+  The constant expressions is a subset of the potentially constant expressions
+  that \emph{can} be evaluated at compile time.%
 }
 
 \rationale{%
-The constant expressions are restricted to expressions that
-perform only simple arithmetic operations, boolean conditions,
-and string and instance creation.
-No user-written function body is executed
-during constant expression evaluation,
-only members of the system classes
-\code{Object}, \code{bool}, \code{int}, \code{double},
-\code{String}, \code{Type}, \code{Symbol}, or \code{Null}.%
+  The constant expressions are restricted to expressions that
+  perform only simple arithmetic operations, boolean conditions,
+  and string and instance creation.
+  No user-written function body is executed
+  during constant expression evaluation,
+  only members of the system classes
+  \code{Object}, \code{bool}, \code{int}, \code{double},
+  \code{String}, \code{Type}, \code{Symbol}, or \code{Null}.%
 }
 
 \LMHash{}%
@@ -8691,48 +8718,20 @@ are the following:
   is a potentially constant expression.
 
 \item
-  A constant object expression (\ref{const}),
-  \code{\CONST{} $C$<$T_1,\ \ldots,\ T_k$>(\metavar{arguments})} or
-  \code{\CONST{} $C$<$T_1,\ \ldots,\ T_k$>.\id(\metavar{arguments})},
-  or either expression without the leading \CONST{} that occurs in
-  a constant context,
-  is a potentially constant expression.
-  It is further a constant expression if the invocation evaluates to an object.
-  % \ref{const} requires each actual argument to be a constant expression,
-  % but here we also catch errors during evaluation, e.g., `C(1, 0)` where
-  % `C(double x, double y): z = x / y;`.
-  It is a compile-time error if a constant object expression is
-  not a constant expression (\ref{const}).
+  A constant object expression (\ref{const})
+  is a potentially constant and constant expression.
 
 \item
-  A constant list literal (\ref{lists}),
-  \code{\CONST{} <$T$>[$e_1$, \ldots, $e_n$]}, or
-  \code{<$T$>[$e_1$, \ldots, $e_n$]}
-  that occurs in a constant context,
-  is a potentially constant expression if $T$ is a constant type expression,
-  and $e_1$, \ldots{} , $e_n$ are constant expressions.
-  It is further a constant expression
-  if the list literal evaluates to an object.
+  A constant list literal (\ref{lists})
+  is a potentially constant and constant expression.
 
 \item
-  A constant set literal (\ref{sets}),
-  \code{\CONST{} <$T$>\{$e_1$, \ldots, $e_n$\}}, or
-  \code{<$T$>\{$e_1$, \ldots, $e_n$\}}
-  that occurs in a constant context,
-  is a potentially constant expression
-  if $T$ is a constant type expression,
-  and $e_1$, \ldots{} , $e_n$ are constant expressions.
-  It is further a constant expression
-  if the set literal evaluates to an object.
+  A constant set literal (\ref{sets})
+  is a potentially constant and constant expression.
 
 \item
-  A constant map literal (\ref{maps}),
-  \code{\CONST{} <$K$, $V$>\{$k_1$: $v_1$, \ldots, $k_n$: $v_n$\}}, or
-  \code{<$K$, $V$>\{$k_1$: $v_1$, \ldots, $k_n$: $v_n$\}}
-  that occurs in a constant context,
-  is a potentially constant expression.
-  It is further a constant expression
-  if the map literal evaluates to an object.
+  A constant map literal (\ref{maps})
+  is a potentially constant and constant expression.
 
 \item
   A parenthesized expression \code{($e$)} is
@@ -8851,7 +8850,7 @@ are the following:
 \item An expression of the form \code{$e_1$\,?\,$e_2$\,:\,$e_3$}
   is potentially constant if $e_1$, $e_2$, and $e_3$
   are all potentially constant expressions.
-  It is constant if $e_1$ is a constant expression and either
+  It is further constant if $e_1$ is a constant expression and either
   \begin{enumerate}
   \item $e_1$ evaluates to \TRUE{} and $e_2$ is a constant expression, or
   \item $e_1$ evaluates to \FALSE{} and $e_3$ is a constant expression.
@@ -8950,7 +8949,7 @@ It is a compile-time error if the value of a constant expression
 depends on itself.
 
 \commentary{%
-As an example, consider:%
+  As an example, consider:%
 }
 
 \begin{dartCode}
@@ -8966,26 +8965,26 @@ As an example, consider:%
 \LMLabel{furtherCommentsOnConstantsAndPotentiallyConstants}
 
 \rationale{%
-There is no requirement that
-every constant expression evaluate correctly.
-Only when a constant expression is required
-(e.g., to initialize a constant variable,
-or as a default value of a formal parameter,
-or as metadata)
-do we insist that a constant expression actually
-be evaluated successfully at compile time.%
+  There is no requirement that
+  every constant expression evaluate correctly.
+  Only when a constant expression is required
+  (e.g., to initialize a constant variable,
+  or as a default value of a formal parameter,
+  or as metadata)
+  do we insist that a constant expression actually
+  be evaluated successfully at compile time.%
 }
 
 \commentary{%
-The above is not dependent on program control-flow.
-The mere presence of a required compile-time constant
-whose evaluation would fail within a program is an error.
-This also holds recursively:
-since compound constants are composed out of constants,
-if any subpart of a constant would throw an exception when evaluated,
-that is an error.
-On the other hand, since implementations are free to compile code late,
-some compile-time errors may manifest quite late:%
+  The above is not dependent on program control-flow.
+  The mere presence of a required compile-time constant
+  whose evaluation would fail within a program is an error.
+  This also holds recursively:
+  since compound constants are composed out of constants,
+  if any subpart of a constant would throw an exception when evaluated,
+  that is an error.
+  On the other hand, since implementations are free to compile code late,
+  some compile-time errors may manifest quite late:%
 }
 
 \begin{dartCode}
@@ -9007,75 +9006,76 @@ some compile-time errors may manifest quite late:%
 \end{dartCode}
 
 \commentary{%
-An implementation is free to immediately issue a compilation error for \code{x},
-but it is not required to do so.
-It could defer errors if it does not immediately compile
-the declarations that reference \code{x}.
-For example, it could delay giving a compilation error
-about the method \code{m1} until the first invocation of \code{m1}.
-However, it could not choose to execute \code{m1},
-see that the branch that refers to \code{x} is not taken,
-and return 2 successfully.
+  An implementation is free to immediately issue
+  a compilation error for \code{x},
+  but it is not required to do so.
+  It could defer errors if it does not immediately compile
+  the declarations that reference \code{x}.
+  For example, it could delay giving a compilation error
+  about the method \code{m1} until the first invocation of \code{m1}.
+  However, it could not choose to execute \code{m1},
+  see that the branch that refers to \code{x} is not taken,
+  and return 2 successfully.
 
-The situation with respect to an invocation of \code{m2} is different.
-Because \code{y} is not a compile-time constant (even though its value is),
-one need not give a compile-time error upon compiling \code{m2}.
-An implementation may run the code,
-which will cause the getter for \code{y} to be invoked.
-At that point, the initialization of \code{y} must take place,
-which requires the initializer to be compiled,
-which will cause a compilation error.%
+  The situation with respect to an invocation of \code{m2} is different.
+  Because \code{y} is not a compile-time constant (even though its value is),
+  one need not give a compile-time error upon compiling \code{m2}.
+  An implementation may run the code,
+  which will cause the getter for \code{y} to be invoked.
+  At that point, the initialization of \code{y} must take place,
+  which requires the initializer to be compiled,
+  which will cause a compilation error.%
 }
 
 \rationale{%
-The treatment of \code{\NULL} merits some discussion.
-Consider \code{\NULL{} + 2}.
-This expression always causes an error.
-We could have chosen not to treat it as a constant expression
-(and in general, not to allow \code{\NULL} as
-a subexpression of numeric or boolean constant expressions).
-There are two arguments for including it:
-First, it is constant so we \emph{can} evaluate it at compile time.
-Second, it seems more useful to give
-the error stemming from the evaluation explicitly.%
+  The treatment of \code{\NULL} merits some discussion.
+  Consider \code{\NULL{} + 2}.
+  This expression always causes an error.
+  We could have chosen not to treat it as a constant expression
+  (and in general, not to allow \code{\NULL} as
+  a subexpression of numeric or boolean constant expressions).
+  There are two arguments for including it:
+  First, it is constant so we \emph{can} evaluate it at compile time.
+  Second, it seems more useful to give
+  the error stemming from the evaluation explicitly.%
 }
 
 \rationale{%
-One might reasonably ask why
-$e_1$\,?\,\,$e_2$\,:\,$e_3$ and $e_1$\,??\,\,$e_2$
-have constant forms.
-If $e_1$ is known statically, why do we need to test it?
-The answer is that there are contexts where $e_1$ is a variable,
-e.g., in constant constructor initializers such as
-\code{\CONST{} C(foo):\ \THIS.foo = foo ??\ someDefaultValue;}%
+  One might reasonably ask why
+  $e_1$\,?\,\,$e_2$\,:\,$e_3$ and $e_1$\,??\,\,$e_2$
+  have constant forms.
+  If $e_1$ is known statically, why do we need to test it?
+  The answer is that there are contexts where $e_1$ is a variable,
+  e.g., in constant constructor initializers such as
+  \code{\CONST{} C(foo):\ \THIS.foo = foo ??\ someDefaultValue;}%
 }
 
 \commentary{%
-The difference between
-a potentially constant expression and a constant expression
-deserves some explanation.
-The key issue is how one treats the formal parameters of a constructor.
+  The difference between
+  a potentially constant expression and a constant expression
+  deserves some explanation.
+  The key issue is how one treats the formal parameters of a constructor.
 
-If a constant constructor is invoked from a constant object expression,
-the actual arguments will be required to be constant expressions.
-Therefore, if we were assured that
-constant constructors were always invoked from constant object expressions,
-we could assume that the formal parameters of a constructor were
-compile-time constants.
+  If a constant constructor is invoked from a constant object expression,
+  the actual arguments will be required to be constant expressions.
+  Therefore, if we were assured that
+  constant constructors were always invoked from constant object expressions,
+  we could assume that the formal parameters of a constructor were
+  compile-time constants.
 
-However, constant constructors can also be invoked from
-ordinary instance creation expressions (\ref{new}),
-and so the above assumption is not generally valid.
+  However, constant constructors can also be invoked from
+  ordinary instance creation expressions (\ref{new}),
+  and so the above assumption is not generally valid.
 
-Nevertheless, the use of the formal parameters of a constant constructor
-is of considerable utility.
-The concept of potentially constant expressions is introduced to facilitate
-limited use of such formal parameters.
-Specifically, we allow the usage of
-the formal parameters of a constant constructor
-for expressions that involve built-in operators,
-but not for constant objects, lists and maps.
-For instance:%
+  Nevertheless, the use of the formal parameters of a constant constructor
+  is of considerable utility.
+  The concept of potentially constant expressions is introduced to facilitate
+  limited use of such formal parameters.
+  Specifically, we allow the usage of
+  the formal parameters of a constant constructor
+  for expressions that involve built-in operators,
+  but not for constant objects, lists and maps.
+  For instance:%
 }
 
 \begin{dartCode}
@@ -9086,20 +9086,20 @@ For instance:%
 \end{dartCode}
 
 \commentary{%
-The assignment to \code{x} is allowed under the assumption
-that \code{q} is constant
-(even though \code{q} is not, in general a compile-time constant).
-The assignment to \code{y} is similar, but raises additional questions.
-In this case, the superexpression of \code{p} is \code{p + 100},
-and it requires that \code{p} be a numeric constant expression
-for the entire expression to be considered constant.
-The wording of the specification allows us to assume
-that \code{p} evaluates to an integer,
-for an invocation of this constructor in a constant expression.
-A similar argument holds for \code{p} and \code{q}
-in the assignment to \code{z}.
+  The assignment to \code{x} is allowed under the assumption
+  that \code{q} is constant
+  (even though \code{q} is not, in general a compile-time constant).
+  The assignment to \code{y} is similar, but raises additional questions.
+  In this case, the superexpression of \code{p} is \code{p + 100},
+  and it requires that \code{p} be a numeric constant expression
+  for the entire expression to be considered constant.
+  The wording of the specification allows us to assume
+  that \code{p} evaluates to an integer,
+  for an invocation of this constructor in a constant expression.
+  A similar argument holds for \code{p} and \code{q}
+  in the assignment to \code{z}.
 
-However, the following constructors are disallowed:%
+  However, the following constructors are disallowed:%
 }
 
 \begin{dartCode}
@@ -9112,27 +9112,27 @@ However, the following constructors are disallowed:%
 \end{dartCode}
 
 \commentary{%
-The problem is that all these run afoul of the rules for
-constant lists (\ref{lists}),
-maps (\ref{maps}),
-and objects (\ref{const}),
-all of which independently require their subexpressions to be
-constant expressions.%
+  The problem is that all these run afoul of the rules for
+  constant lists (\ref{lists}),
+  maps (\ref{maps}),
+  and objects (\ref{const}),
+  all of which independently require their subexpressions to be
+  constant expressions.%
 }
 
 \rationale{%
-All of the illegal constructors of \code{D} above
-could not be sensibly invoked via \NEW,
-because an expression that must be constant cannot depend on
-a formal parameter, which may or may not be constant.
-In contrast, the legal examples make sense regardless of
-whether the constructor is invoked via \CONST{} or via \NEW.
+  All of the illegal constructors of \code{D} above
+  could not be sensibly invoked via \NEW,
+  because an expression that must be constant cannot depend on
+  a formal parameter, which may or may not be constant.
+  In contrast, the legal examples make sense regardless of
+  whether the constructor is invoked via \CONST{} or via \NEW.
 
-Careful readers will of course worry about cases where
-the actual arguments to \code{C()} are constants, but are not numeric.
-This is precluded by the rules on constant constructors
-(\ref{constantConstructors}),
-combined with the rules for evaluating constant objects (\ref{const}).%
+  Careful readers will of course worry about cases where
+  the actual arguments to \code{C()} are constants, but are not numeric.
+  This is precluded by the rules on constant constructors
+  (\ref{constantConstructors}),
+  combined with the rules for evaluating constant objects (\ref{const}).%
 }
 
 
@@ -9171,10 +9171,10 @@ if{}f one of the following applies:
 \end{itemize}
 
 \rationale{%
-A constant context is introduced in situations where
-an expression is required to be constant.
-This is used to allow the \CONST{} modifier to be omitted
-in cases where it does not contribute any new information.%
+  A constant context is introduced in situations where
+  an expression is required to be constant.
+  This is used to allow the \CONST{} modifier to be omitted
+  in cases where it does not contribute any new information.%
 }
 
 
@@ -9199,8 +9199,8 @@ The \code{Null} class extends the \code{Object} class
 and declares no methods except those also declared by \code{Object}.
 
 \commentary{%
-The null object has primitive equality
-(\ref{theOperatorEqualsEquals}).%
+  The null object has primitive equality
+  (\ref{theOperatorEqualsEquals}).%
 }
 
 \LMHash{}%
@@ -9256,16 +9256,16 @@ then the static type of $l$ is \code{double};
 otherwise the static type of $l$ is \code{int}.
 
 \commentary{%
-This means that an integer literal denotes a \code{double}
-when it would satisfy the type requirement, and an \code{int} would not.
-Otherwise it is an \code{int}, even in situations where that is an error.%
+  This means that an integer literal denotes a \code{double}
+  when it would satisfy the type requirement, and an \code{int} would not.
+  Otherwise it is an \code{int}, even in situations where that is an error.%
 }
 
 \LMHash{}%
 A numeric literal that is not an integer literal is a
 \IndexCustom{double literal}{literal!double}.
 \commentary{%
-A double literal always contains either a decimal point or an exponent part.%
+  A double literal always contains either a decimal point or an exponent part.%
 }
 The static type of a double literal is \code{double}.
 
@@ -9287,13 +9287,13 @@ then evaluation of $l$ proceeds as follows:
 \end{itemize}
 
 \commentary{%
-Integers in Dart are designed to be implemented as
-64-bit two's complement integer representations.
-In practice, implementations may be limited by other considerations.
-For example, Dart compiled to JavaScript may use the JavaScript number type,
-equivalent to Dart \code{double}, to represent integers, and if so,
-integer literals with more than 53 bits of precision cannot be represented
-exactly.%
+  Integers in Dart are designed to be implemented as
+  64-bit two's complement integer representations.
+  In practice, implementations may be limited by other considerations.
+  For example, Dart compiled to JavaScript may use the JavaScript number type,
+  equivalent to Dart \code{double}, to represent integers, and if so,
+  integer literals with more than 53 bits of precision cannot be represented
+  exactly.%
 }
 
 \LMHash{}%
@@ -9308,13 +9308,13 @@ It is a compile-time error if the value $i$
 cannot be represented \emph{precisely} by an instance of \code{double}.
 
 \commentary{%
-A 64 bit double precision floating point number
-is usually taken to represent a range of real numbers
-around the precise value denoted by the number's
-sign, mantissa and exponent.
-For integer literals evaluating to \code{double}
-values we insist that the integer literal's numeric value
-is the precise value of the \code{double} instance.%
+  A 64 bit double precision floating point number
+  is usually taken to represent a range of real numbers
+  around the precise value denoted by the number's
+  sign, mantissa and exponent.
+  For integer literals evaluating to \code{double}
+  values we insist that the integer literal's numeric value
+  is the precise value of the \code{double} instance.%
 }
 
 \LMHash{}%
@@ -9354,8 +9354,8 @@ It is a compile-time error for a class to
 extend, mix in or implement \code{bool}.
 
 \commentary{%
-The \TRUE{} and \FALSE{} objects have primitive equality
-(\ref{theOperatorEqualsEquals}).%
+  The \TRUE{} and \FALSE{} objects have primitive equality
+  (\ref{theOperatorEqualsEquals}).%
 }
 
 \LMHash{}%
@@ -9371,10 +9371,10 @@ The static type of a boolean literal is \code{bool}.
 A \Index{string} is a sequence of UTF-16 code units.
 
 \rationale{%
-This decision was made for compatibility with web browsers and Javascript.
-Earlier versions of the specification required a string to be
-a sequence of valid Unicode code points.
-Programmers should not depend on this distinction.%
+  This decision was made for compatibility with web browsers and Javascript.
+  Earlier versions of the specification required a string to be
+  a sequence of valid Unicode code points.
+  Programmers should not depend on this distinction.%
 }
 
 \begin{grammar}
@@ -9438,23 +9438,23 @@ A single line string is delimited by
 either matching single quotes or matching double quotes.
 
 \commentary{%
-Hence, \code{'abc'} and \code{"abc"} are both legal strings,
-as are \code{'He said "To be or not to be" did he not?'} and
-\code{"He said 'To be or not to be' didn't he?"}.
-However, \code{"This'} is not a valid string, nor is \code{'this"}.%
+  Hence, \code{'abc'} and \code{"abc"} are both legal strings,
+  as are \code{'He said "To be or not to be" did he not?'} and
+  \code{"He said 'To be or not to be' didn't he?"}.
+  However, \code{"This'} is not a valid string, nor is \code{'this"}.%
 }
 
 \commentary{%
-The grammar ensures that a single line string cannot span more than
-one line of source code,
-unless it includes an interpolated expression that spans multiple lines.%
+  The grammar ensures that a single line string cannot span more than
+  one line of source code,
+  unless it includes an interpolated expression that spans multiple lines.%
 }
 
 \LMHash{}%
 Adjacent strings are implicitly concatenated to form a single string literal.
 
 \commentary{%
-Here is an example:%
+  Here is an example:%
 }
 
 \begin{dartCode}
@@ -9462,11 +9462,11 @@ print("A string" "and then another"); // \comment{A stringand then another}
 \end{dartCode}
 
 \rationale{%
-Dart also supports the operator + for string concatenation.
+  Dart also supports the operator + for string concatenation.
 
-The + operator on Strings requires a String argument.
-It does not coerce its argument into a string.
-This helps avoid puzzlers such as%
+  The + operator on Strings requires a String argument.
+  It does not coerce its argument into a string.
+  This helps avoid puzzlers such as%
 }
 
 \begin{dartCode}
@@ -9475,10 +9475,10 @@ print("A simple sum: 2 + 2 = " +
 \end{dartCode}
 
 \rationale{%
-which would print `\code{A simple sum: 2 + 2 = 22}' rather than
-`\code{A simple sum: 2 + 2 = 4}'.
-However, for efficiency reasons,
-the recommended Dart idiom is to use string interpolation.%
+  which would print `\code{A simple sum: 2 + 2 = 22}' rather than
+  `\code{A simple sum: 2 + 2 = 4}'.
+  However, for efficiency reasons,
+  the recommended Dart idiom is to use string interpolation.%
 }
 
 \begin{dartCode}
@@ -9486,13 +9486,13 @@ print("A simple sum: 2 + 2 = \$\{2+2\}");
 \end{dartCode}
 
 \rationale{%
-String interpolation works well for most cases.
-The main situation where it is not fully satisfactory
-is for string literals that are too large to fit on a line.
-Multiline strings can be useful, but in some cases,
-we want to visually align the code.
-This can be expressed by writing
-smaller strings separated by whitespace, as shown here:%
+  String interpolation works well for most cases.
+  The main situation where it is not fully satisfactory
+  is for string literals that are too large to fit on a line.
+  Multiline strings can be useful, but in some cases,
+  we want to visually align the code.
+  This can be expressed by writing
+  smaller strings separated by whitespace, as shown here:%
 }
 
 \begin{dartCode}
@@ -9509,9 +9509,9 @@ is maintained outside the parser,
 in order to ensure that string interpolations are matched up correctly.
 
 \commentary{%
-This is necessary because the expression of a non-simple string interpolation
-may itself contain string literals
-with their own non-simple string interpolations.%
+  This is necessary because the expression of a non-simple string interpolation
+  may itself contain string literals
+  with their own non-simple string interpolations.%
 }
 
 \LMHash{}%
@@ -9595,12 +9595,12 @@ then that line is ignored,
 including the line break at its end.
 
 \rationale{%
-The idea is to ignore a whitespace-only first line of a multiline string,
-where whitespace is defined as tabs, spaces and the final line break.
-These can be represented directly,
-but since for most characters prefixing by backslash is
-an identity in a non-raw string,
-we allow those forms as well.%
+  The idea is to ignore a whitespace-only first line of a multiline string,
+  where whitespace is defined as tabs, spaces and the final line break.
+  These can be represented directly,
+  but since for most characters prefixing by backslash is
+  an identity in a non-raw string,
+  we allow those forms as well.%
 }
 
 \LMHash{}%
@@ -9611,9 +9611,9 @@ It terminates as soon as the lookahead is the specified next token
 \commentary{(that is, \lit{\sqsqsq} or \lit{"""})}.
 
 \commentary{%
-Note that multi-line string interpolation relies on
-the auxiliary string interpolation state stack,
-just like single-line string interpolation.%
+  Note that multi-line string interpolation relies on
+  the auxiliary string interpolation state stack,
+  just like single-line string interpolation.%
 }
 
 \LMHash{}%
@@ -9717,9 +9717,9 @@ This process is known as \Index{string interpolation}.
 \end{grammar}
 
 \commentary{%
-The reader will note that the expression inside the interpolation
-could itself include strings,
-which could again be interpolated recursively.%
+  The reader will note that the expression inside the interpolation
+  could itself include strings,
+  which could again be interpolated recursively.%
 }
 
 \LMHash{}%
@@ -9783,10 +9783,10 @@ where \List{\id}{1}{n} are identifiers
 evaluates to an instance of \code{Symbol}
 representing that particular sequence of identifiers.
 \commentary{%
-This kind of symbol literal denotes the name of a library declaration,
-as specified in a \synt{libraryName}.
-Library names are not subject to library privacy, even
-if some of its identifiers begin with an underscore.%
+  This kind of symbol literal denotes the name of a library declaration,
+  as specified in a \synt{libraryName}.
+  Library names are not subject to library privacy, even
+  if some of its identifiers begin with an underscore.%
 }
 
 \LMHash{}%
@@ -9807,9 +9807,9 @@ as specified in the previous paragraphs, we say that $o$ is a
 the string whose contents is the characters of that term, without whitespace.
 
 \commentary{%
-Note that this does not apply for private symbols,
-which are discussed below.
-A private symbol is not based on any string.%
+  Note that this does not apply for private symbols,
+  which are discussed below.
+  A private symbol is not based on any string.%
 }
 
 \LMHash{}%
@@ -9823,8 +9823,8 @@ that evaluates to a string $s$,
 we say that $o$ is a \NoIndex{non-private symbol based on} $s$.
 
 \commentary{%
-Note that \code{Symbol('\_foo')} is a non-private symbol,
-and it is distinct from \code{\#\_foo}, as described below.%
+  Note that \code{Symbol('\_foo')} is a non-private symbol,
+  and it is distinct from \code{\#\_foo}, as described below.%
 }
 
 \LMHash{}%
@@ -9854,31 +9854,31 @@ nor to a \code{Symbol} instance that is equal to that object
 according to the \lit{==} operator.
 
 \rationale{%
-One may well ask what is the motivation for introducing literal symbols?
-In some languages, symbols are canonicalized whereas strings are not.
-However literal strings are already canonicalized in Dart.
-Symbols are slightly easier to type compared to strings
-and their use can become strangely addictive,
-but this is not nearly sufficient justification for adding
-a literal form to the language.
-The primary motivation is related to the use of reflection
-and a web specific practice known as minification.
+  One may well ask what is the motivation for introducing literal symbols?
+  In some languages, symbols are canonicalized whereas strings are not.
+  However literal strings are already canonicalized in Dart.
+  Symbols are slightly easier to type compared to strings
+  and their use can become strangely addictive,
+  but this is not nearly sufficient justification for adding
+  a literal form to the language.
+  The primary motivation is related to the use of reflection
+  and a web specific practice known as minification.
 
-Minification compresses identifiers consistently throughout a program
-in order to reduce download size.
-This practice poses difficulties for reflective programs
-that refer to program declarations via strings.
-A string will refer to an identifier in the source,
-but the identifier will no longer be used in the minified code,
-and reflective code using these would fail.
-Therefore, Dart reflection uses objects of type \code{Symbol}
-rather than strings.
-Instances of \code{Symbol} are guaranteed to be stable
-with respect to minification.
-Providing a literal form for symbols makes
-reflective code easier to read and write.
-The fact that symbols are easy to type and can often act as
-convenient substitutes for enums are secondary benefits.%
+  Minification compresses identifiers consistently throughout a program
+  in order to reduce download size.
+  This practice poses difficulties for reflective programs
+  that refer to program declarations via strings.
+  A string will refer to an identifier in the source,
+  but the identifier will no longer be used in the minified code,
+  and reflective code using these would fail.
+  Therefore, Dart reflection uses objects of type \code{Symbol}
+  rather than strings.
+  Instances of \code{Symbol} are guaranteed to be stable
+  with respect to minification.
+  Providing a literal form for symbols makes
+  reflective code easier to read and write.
+  The fact that symbols are easy to type and can often act as
+  convenient substitutes for enums are secondary benefits.%
 }
 
 
@@ -9946,10 +9946,10 @@ how to obtain zero or more entities,
 of the form \synt{ifElement} or \synt{forElement}.
 
 \commentary{%
-Terms derived from \synt{element},
-and the ability to build collections from them,
-is also known as
-\Index{UI-as-code}.%
+  Terms derived from \synt{element},
+  and the ability to build collections from them,
+  is also known as
+  \Index{UI-as-code}.%
 }
 
 \LMHash{}%
@@ -9966,8 +9966,8 @@ is the union of the leaf elements of $\ell_1$ and $\ell_2$.
 The leaf elements of a \synt{spreadElement} is the empty set.
 
 \commentary{%
-The leaf elements of a collection literal is always
-a set of expression elements and/or map elements.%
+  The leaf elements of a collection literal is always
+  a set of expression elements and/or map elements.%
 }
 
 \LMHash{}%
@@ -10041,7 +10041,7 @@ or
 \end{itemize}
 
 \commentary{%
-A \synt{forElement} can never occur in a constant collection literal.%
+  A \synt{forElement} can never occur in a constant collection literal.%
 }
 
 %% TODO(eernst): We may change this text to commentary or delete it,
@@ -10144,10 +10144,10 @@ unless any of the following are true:
 
 %% TODO(eernst): Come nnbd, update this.
 \commentary{%
-Type promotion will likely get more sophisticated in a future version of Dart.
-When that happens,
-\synt{ifElement}s will continue to match \IF{} statements
-(\ref{if}).%
+  Type promotion will likely get more sophisticated in a future version of Dart.
+  When that happens,
+  \synt{ifElement}s will continue to match \IF{} statements
+  (\ref{if}).%
 }
 
 
@@ -10177,30 +10177,30 @@ and hence no notion of dynamic errors arising from
 a type mismatch during concatenation.
 
 \commentary{%
-Object sequences can safely be treated as a low-level mechanism
-which may omit otherwise required actions like dynamic type checks
-because every access to an object sequence occurs
-in code created by language defined desugaring
-on statically checked constructs.
-It is left unspecified how an object sequence is implemented,
-it is only required that it contains the indicated objects or pairs
-in the given order.
-For each kind of collection,
-the sequence is used in the given order to populate the collection,
-in a manner which is specific to the kind,
-and which is specified separately
-(\ref{lists}, \ref{sets}, \ref{maps}).%
+  Object sequences can safely be treated as a low-level mechanism
+  which may omit otherwise required actions like dynamic type checks
+  because every access to an object sequence occurs
+  in code created by language defined desugaring
+  on statically checked constructs.
+  It is left unspecified how an object sequence is implemented,
+  it is only required that it contains the indicated objects or pairs
+  in the given order.
+  For each kind of collection,
+  the sequence is used in the given order to populate the collection,
+  in a manner which is specific to the kind,
+  and which is specified separately
+  (\ref{lists}, \ref{sets}, \ref{maps}).%
 
-There may be an actual data structure
-representing the object sequence at run time,
-but the object sequence could also be eliminated, e.g.,
-because each element is inserted directly into the target collection
-as soon as it has been computed.
-Note that each object sequence will exclusively contain objects,
-or it will exclusively contain pairs,
-because any attempt to create a mixed sequence would cause
-an error at compile time or at run time
-(the latter may occur for a spread element with static type \DYNAMIC{}).%
+  There may be an actual data structure
+  representing the object sequence at run time,
+  but the object sequence could also be eliminated, e.g.,
+  because each element is inserted directly into the target collection
+  as soon as it has been computed.
+  Note that each object sequence will exclusively contain objects,
+  or it will exclusively contain pairs,
+  because any attempt to create a mixed sequence would cause
+  an error at compile time or at run time
+  (the latter may occur for a spread element with static type \DYNAMIC{}).%
 }
 
 \LMHash{}%
@@ -10210,18 +10210,18 @@ to populate \metavar{target}.
 Let $T_{\metavar{target}}$ denote the dynamic type of \metavar{target}.
 
 \commentary{%
-Access to the type of \metavar{target} is needed below
-in order to raise dynamic errors at specific points during
-the evaluation of an object sequence.
-Note that the dynamic type of \metavar{target} is statically known,
-except for the binding of any type variables in its \synt{typeArguments}.
-This implies that some questions can be answered at compile-time, e.g.,
-whether or not \code{Iterable} occurs as a superinterface of
-$T_{\metavar{target}}$.
-In any case, $T_{\metavar{target}}$ is guaranteed to implement
-\code{Iterable} (when \metavar{target} is a list or a set)
-or \code{Map} (when \metavar{target} is a map),
-but never both.%
+  Access to the type of \metavar{target} is needed below
+  in order to raise dynamic errors at specific points during
+  the evaluation of an object sequence.
+  Note that the dynamic type of \metavar{target} is statically known,
+  except for the binding of any type variables in its \synt{typeArguments}.
+  This implies that some questions can be answered at compile-time, e.g.,
+  whether or not \code{Iterable} occurs as a superinterface of
+  $T_{\metavar{target}}$.
+  In any case, $T_{\metavar{target}}$ is guaranteed to implement
+  \code{Iterable} (when \metavar{target} is a list or a set)
+  or \code{Map} (when \metavar{target} is a map),
+  but never both.%
 }
 
 \LMHash{}%
@@ -10387,11 +10387,11 @@ $\EvaluateElement{\ell} := s$;
 \end{enumerate}
 
 \rationale{%
-This may not be the most efficient way to traverse the items in a collection,
-and implementations may of course use any other approach
-with the same observable behavior.
-However, in order to give implementations more room to optimize
-we also allow the following.%
+  This may not be the most efficient way to traverse the items in a collection,
+  and implementations may of course use any other approach
+  with the same observable behavior.
+  However, in order to give implementations more room to optimize
+  we also allow the following.%
 }
 
 \LMHash{}%
@@ -10407,14 +10407,14 @@ If it does so, it will only pass indices
 that are non-negative and less than the value returned by \code{length}.
 
 \rationale{%
-This may allow for more efficient code for
-allocating the collection and accessing its parts.
-The given classes are expected to have
-an efficient and side-effect free implementation
-of \code{length} and operator \lit{[]}.
-A Dart implementation may detect whether these options apply
-at compile time based on the static type of $e$,
-or at runtime based on the actual value.%
+  This may allow for more efficient code for
+  allocating the collection and accessing its parts.
+  The given classes are expected to have
+  an efficient and side-effect free implementation
+  of \code{length} and operator \lit{[]}.
+  A Dart implementation may detect whether these options apply
+  at compile time based on the static type of $e$,
+  or at runtime based on the actual value.%
 }
 \EndCase
 
@@ -10501,10 +10501,10 @@ the inferred type of $e$ in context $P$.
 % So we _must_ specify the error in \ref{lists}, and this location should
 % then be a commentary, because we already have the error elsewhere.
 \commentary{%
-This cannot occur:
-it is a compile-time error
-when a leaf element of a list literal is a map element
-(\ref{lists}).%
+  This cannot occur:
+  it is a compile-time error
+  when a leaf element of a list literal is a map element
+  (\ref{lists}).%
 }
 \EndCase
 
@@ -10574,9 +10574,9 @@ located in the same scope as $\ell$.
 Moreover, the errors and type analysis of $\ell$ is performed
 as if it occurred in the body scope of said \FOR{} statement.
 \commentary{%
-For instance, if $P$ is of the form
-\code{\VAR\,\,v\,\,\IN\,\,$e_1$}
-then the variable \code{v} is in scope for $\ell$.%
+  For instance, if $P$ is of the form
+  \code{\VAR\,\,v\,\,\IN\,\,$e_1$}
+  then the variable \code{v} is in scope for $\ell$.%
 }
 
 Inference for the parts
@@ -10590,7 +10590,7 @@ Then, if the inferred element type of $\ell_1$ is $S$,
 the inferred element type of $\ell$ is $S$.
 
 \commentary{%
-In other words, inference flows upwards from the body element.%
+  In other words, inference flows upwards from the body element.%
 }
 \vspace{3mm}
 \EndCase
@@ -10640,9 +10640,9 @@ and $e$ is henceforth treated as
 \code{<$T$>$e$}.
 
 \commentary{%
-The static type of a list literal of the form \code{<$T$>$e$}
-is \code{List<$T$>}
-(\ref{listLiteralInference}).%
+  The static type of a list literal of the form \code{<$T$>$e$}
+  is \code{List<$T$>}
+  (\ref{listLiteralInference}).%
 }
 
 \LMHash{}%
@@ -10665,9 +10665,9 @@ It is a dynamic error to attempt to access a list
 using an index that is not a member of its set of indices.
 
 \rationale{%
-The system libraries define many members for the type \code{List},
-but we specify only the minimal set of requirements
-which are used by the language itself.%
+  The system libraries define many members for the type \code{List},
+  but we specify only the minimal set of requirements
+  which are used by the language itself.%
 }
 
 \LMHash{}%
@@ -10688,13 +10688,13 @@ after they are created.
 Attempting to mutate a constant list literal will result in a dynamic error.
 
 \commentary{%
-% The following is true either directly or indirectly: There is a \CONST{}
-% modifier on the list literal, or the list literal as a whole occurs
-% in a constant context.
-Note that the collection literal elements of a constant list literal
-occur in a constant context
-(\ref{constantContexts}),
-which means that \CONST{} modifiers need not be specified explicitly.%
+  % The following is true either directly or indirectly: There is a \CONST{}
+  % modifier on the list literal, or the list literal as a whole occurs
+  % in a constant context.
+  Note that the collection literal elements of a constant list literal
+  occur in a constant context
+  (\ref{constantContexts}),
+  which means that \CONST{} modifiers need not be specified explicitly.%
 }
 
 \LMHash{}%
@@ -10706,9 +10706,9 @@ is not a constant type expression
 (\ref{constants}).
 
 \rationale{%
-The binding of a formal type parameter of an enclosing class or function
-is not known at compile time,
-so we cannot use such type parameters inside constant expressions.%
+  The binding of a formal type parameter of an enclosing class or function
+  is not known at compile time,
+  so we cannot use such type parameters inside constant expressions.%
 }
 
 \LMHash{}%
@@ -10736,11 +10736,11 @@ Then \code{identical($o_1$, $o_2$)} evaluates to \TRUE{} if{}f
 evaluates to \TRUE{} for all $i \in 1 .. n$.
 
 \commentary{%
-In other words, constant list literals are canonicalized.
-There is no need to consider canonicalization
-for other instances of type \code{List},
-because such instances cannot be
-the result of evaluating a constant expression.%
+  In other words, constant list literals are canonicalized.
+  There is no need to consider canonicalization
+  for other instances of type \code{List},
+  because such instances cannot be
+  the result of evaluating a constant expression.%
 }
 
 \LMHash{}%
@@ -10772,13 +10772,13 @@ The objects created by list literals do not override
 the \lit{==} operator inherited from the \code{Object} class.
 
 \commentary{%
-Note that this document does not specify an order
-in which the elements are set.
-This allows for parallel assignments into the list
-if an implementation so desires.
-The order can only be observed as follows (and may not be relied upon):
-if element $i$ is not a subtype of the element type of the list,
-a dynamic type error will occur when $a[i]$ is assigned $o_{i-1}$.%
+  Note that this document does not specify an order
+  in which the elements are set.
+  This allows for parallel assignments into the list
+  if an implementation so desires.
+  The order can only be observed as follows (and may not be relied upon):
+  if element $i$ is not a subtype of the element type of the list,
+  a dynamic type error will occur when $a[i]$ is assigned $o_{i-1}$.%
 }
 
 
@@ -10807,26 +10807,26 @@ Otherwise let $S$ be the greatest closure of \futureOrBase{C}
 
 %% TODO(eernst): Delete when `context type', `greatest closure' are defined.
 \commentary{%
-A future version of this document will specify context types.
-The basic intuition is that a
-\Index{context type}
-is the type declared for a
-receiving entity such as
-a formal parameter $p$ or a declared variable $v$.
-That type will be the context type for
-an actual argument passed to $p$,
-respectively an initializing expression for $v$.
-In some situations the context has no constraints,
-e.g., when a variable is declared with \VAR{} rather than a type annotation.
-This gives rise to an
-\IndexCustom{unconstrained context type}{context type!unconstrained},
-\IndexCustom{\rm\FreeContext}{[]@\FreeContext},
-which may also occur in a composite term, e.g., \code{List<\FreeContext>}.
-%% TODO(eernst): Clarify why we do not just use i2b, rather than
-%% introducing the notion of a greatest (and least) closure.
-The greatest closure of a context type $C$ is
-approximately the least common supertype of all types
-obtainable by replacing \FreeContext{} by a type.%
+  A future version of this document will specify context types.
+  The basic intuition is that a
+  \Index{context type}
+  is the type declared for a
+  receiving entity such as
+  a formal parameter $p$ or a declared variable $v$.
+  That type will be the context type for
+  an actual argument passed to $p$,
+  respectively an initializing expression for $v$.
+  In some situations the context has no constraints,
+  e.g., when a variable is declared with \VAR{} rather than a type annotation.
+  This gives rise to an
+  \IndexCustom{unconstrained context type}{context type!unconstrained},
+  \IndexCustom{\rm\FreeContext}{[]@\FreeContext},
+  which may also occur in a composite term, e.g., \code{List<\FreeContext>}.
+  %% TODO(eernst): Clarify why we do not just use i2b, rather than
+  %% introducing the notion of a greatest (and least) closure.
+  The greatest closure of a context type $C$ is
+  approximately the least common supertype of all types
+  obtainable by replacing \FreeContext{} by a type.%
 }
 
 \LMHash{}%
@@ -10876,9 +10876,9 @@ the first applicable entry in the following list:
 \end{itemize}
 
 \commentary{%
-When this step does not determine a static type,
-it will be determined by type inference
-(\ref{setAndMapLiteralInference}).%
+  When this step does not determine a static type,
+  it will be determined by type inference
+  (\ref{setAndMapLiteralInference}).%
 }
 
 \LMHash{}%
@@ -10903,24 +10903,24 @@ and/or an associated
 is determined.
 
 \commentary{%
-If $e$ has an element type then it may be a set,
-and if it has a key and value type pair then it may be a map.
-%
-However, if the literal $e$ contains a spread element of type \DYNAMIC,
-that element cannot be used to determine whether $e$ is a set or a map.
-The ambiguity is represented as having \emph{both}
-an element type and a key and value type pair.
+  If $e$ has an element type then it may be a set,
+  and if it has a key and value type pair then it may be a map.
+  %
+  However, if the literal $e$ contains a spread element of type \DYNAMIC,
+  that element cannot be used to determine whether $e$ is a set or a map.
+  The ambiguity is represented as having \emph{both}
+  an element type and a key and value type pair.
 
-It is an error if the ambiguity is not resolved by some other elements,
-but if it is resolved then the dynamic spread element is required
-to evaluate to a suitable instance
-(implementing \code{Iterable} when $e$ is a set,
-and implementing \code{Map} when $e$ is a map),
-which means that it is a dynamic error if there is a mismatch.
-In other situations it is a compile-time error to have both
-an element type and a key and value type pair,
-because $e$ must be both a set and a map.
-Here is an example:%
+  It is an error if the ambiguity is not resolved by some other elements,
+  but if it is resolved then the dynamic spread element is required
+  to evaluate to a suitable instance
+  (implementing \code{Iterable} when $e$ is a set,
+  and implementing \code{Map} when $e$ is a map),
+  which means that it is a dynamic error if there is a mismatch.
+  In other situations it is a compile-time error to have both
+  an element type and a key and value type pair,
+  because $e$ must be both a set and a map.
+  Here is an example:%
 }
 
 \begin{dartCode}
@@ -11172,9 +11172,9 @@ It is a compile error if $\ell_1$ must be a set and $\ell_2$ must be a map,
 or vice versa.
 
 \commentary{%
-This means that one cannot spread a map on one branch and a set on the other.
-Since \DYNAMIC{} provides both an element type and a key and value type pair,
-a \DYNAMIC{} spread in either branch does not cause the error to occur.%
+  This means that one cannot spread a map on one branch and a set on the other.
+  Since \DYNAMIC{} provides both an element type and a key and value type pair,
+  a \DYNAMIC{} spread in either branch does not cause the error to occur.%
 }
 
 Then:
@@ -11213,9 +11213,9 @@ Moreover, the errors and type analysis of $\ell$ is performed
 as if it occurred in the body scope of said \FOR{} statement.
 
 \commentary{%
-For instance, if $P$ is of the form
-\code{\VAR\,\,v\,\,\IN\,\,$e_1$}
-then the variable \code{v} is in scope for $\ell$.%
+  For instance, if $P$ is of the form
+  \code{\VAR\,\,v\,\,\IN\,\,$e_1$}
+  then the variable \code{v} is in scope for $\ell$.%
 }
 
 Inference for the parts
@@ -11236,7 +11236,7 @@ including \AWAIT{} if and only if the element includes \AWAIT.
 \end{itemize}
 
 \commentary{%
-In other words, inference flows upwards from the body element.%
+  In other words, inference flows upwards from the body element.%
 }
 \vspace{3mm}
 \EndCase
@@ -11322,8 +11322,8 @@ and the context type for \metavar{collection} is $P$.
 \end{itemize}
 
 \commentary{%
-This last error can occur if the literal \emph{must} be both a set and a map.
-Here is an example:%
+  This last error can occur if the literal \emph{must} be both a set and a map.
+  Here is an example:%
 }
 
 \begin{dartCode}
@@ -11332,9 +11332,9 @@ Here is an example:%
 \VAR{} ambiguous = \{...iterable, ...map\}; // \comment{Compile-time error}
 \end{dartCode}
 
-\commentary{%
 \noindent
-Or, if there is nothing indicates that it is \emph{either} a set or a map:%
+\commentary{%
+  Or, if there is nothing indicates that it is \emph{either} a set or a map:%
 }
 
 \begin{dartCode}
@@ -11368,9 +11368,9 @@ and $e$ is henceforth treated as
 \code{<$T$>$e$}.
 
 \commentary{%
-The static type of a set literal of the form \code{<$T$>$e$}
-is \code{Set<$T$>}
-(\ref{setAndMapLiteralInference}).%
+  The static type of a set literal of the form \code{<$T$>$e$}
+  is \code{Set<$T$>}
+  (\ref{setAndMapLiteralInference}).%
 }
 
 \LMHash{}%
@@ -11399,16 +11399,16 @@ A set is ordered: iteration over the elements of a set
 occurs in the order the elements were added to the set.
 
 \commentary{%
-The system libraries define many members for the type \code{Set},
-but we specify only the minimal set of requirements
-which are used by the language itself.%
+  The system libraries define many members for the type \code{Set},
+  but we specify only the minimal set of requirements
+  which are used by the language itself.%
 
-Note that an implementation may require
-consistent definitions of several members
-of a class implementing \code{Set} in order to work correctly.
-For instance, there may be a getter \code{hashCode} which is required
-to have a behavior which is in some sense consistent with operator \lit{==}.
-Such constraints are documented in the system libraries.%
+  Note that an implementation may require
+  consistent definitions of several members
+  of a class implementing \code{Set} in order to work correctly.
+  For instance, there may be a getter \code{hashCode} which is required
+  to have a behavior which is in some sense consistent with operator \lit{==}.
+  Such constraints are documented in the system libraries.%
 }
 
 \LMHash{}%
@@ -11428,13 +11428,13 @@ Only run-time set literals can be mutated after they are created.
 Attempting to mutate a constant set literal will result in a dynamic error.
 
 \commentary{%
-% The following is true either directly or indirectly: There is a \CONST{}
-% modifier on the literal set, or we use the "immediate subexpression" rule
-% about constant contexts.
-Note that the element expressions of a constant set literal
-occur in a constant context
-(\ref{constantContexts}),
-which means that \CONST{} modifiers need not be specified explicitly.%
+  % The following is true either directly or indirectly: There is a \CONST{}
+  % modifier on the literal set, or we use the "immediate subexpression" rule
+  % about constant contexts.
+  Note that the element expressions of a constant set literal
+  occur in a constant context
+  (\ref{constantContexts}),
+  which means that \CONST{} modifiers need not be specified explicitly.%
 }
 
 \LMHash{}%
@@ -11454,9 +11454,9 @@ is not a constant type expression
 (\ref{constants}).
 
 \rationale{%
-The binding of a formal type parameter of an enclosing class or function
-is not known at compile time,
-so we cannot use such type parameters inside constant expressions.%
+  The binding of a formal type parameter of an enclosing class or function
+  is not known at compile time,
+  so we cannot use such type parameters inside constant expressions.%
 }
 
 \LMHash{}%
@@ -11488,14 +11488,14 @@ Then \code{identical($o_1$, $o_2$)} evaluates to \TRUE{} if{}f
 evaluates to \TRUE{} for all $i \in 1 .. n$.
 
 \commentary{%
-In other words, constant set literals are canonicalized if they have
-the same type argument and the same values in the same order.
-Two constant set literals are never identical
-if they have a different number of elements.
-There is no need to consider canonicalization
-for other instances of type \code{Set},
-because such instances cannot be
-the result of evaluating a constant expression.%
+  In other words, constant set literals are canonicalized if they have
+  the same type argument and the same values in the same order.
+  Two constant set literals are never identical
+  if they have a different number of elements.
+  There is no need to consider canonicalization
+  for other instances of type \code{Set},
+  because such instances cannot be
+  the result of evaluating a constant expression.%
 }
 
 \LMHash{}%
@@ -11554,9 +11554,9 @@ and $e$ is henceforth treated as
 \code{<$K$,\,$V$>$e$}.
 
 \commentary{%
-The static type of a map literal of the form \code{<$K$,\,$V$>$e$}
-is \code{Map<$K$,\,$V$>}
-(\ref{setAndMapLiteralInference}).%
+  The static type of a map literal of the form \code{<$K$,\,$V$>$e$}
+  is \code{Map<$K$,\,$V$>}
+  (\ref{setAndMapLiteralInference}).%
 }
 
 \LMHash{}%
@@ -11596,17 +11596,17 @@ A map is ordered: iteration over the keys, values, or key/value pairs
 occurs in the order in which the keys were added to the set.
 
 \commentary{%
-The system libraries support many operations on an instance
-whose type implements \code{Map},
-but we specify only the minimal set of requirements
-which are used by the language itself.
+  The system libraries support many operations on an instance
+  whose type implements \code{Map},
+  but we specify only the minimal set of requirements
+  which are used by the language itself.
 
-Note that an implementation may require
-consistent definitions of several members
-of a class implementing \code{Map} in order to work correctly.
-For instance, there may be a getter \code{hashCode} which is required
-to have a behavior which is in some sense consistent with operator \lit{==}.
-Such constraints are documented in the system libraries.%
+  Note that an implementation may require
+  consistent definitions of several members
+  of a class implementing \code{Map} in order to work correctly.
+  For instance, there may be a getter \code{hashCode} which is required
+  to have a behavior which is in some sense consistent with operator \lit{==}.
+  Such constraints are documented in the system libraries.%
 }
 
 \LMHash{}%
@@ -11626,13 +11626,13 @@ Only run-time map literals can be mutated after they are created.
 Attempting to mutate a constant map literal will result in a dynamic error.
 
 \commentary{%
-% The following is true either directly or indirectly: There is a \CONST{}
-% modifier on the literal map, or we use the "immediate subexpression" rule
-% about constant contexts.
-Note that the key and value expressions of a constant map literal
-occur in a constant context
-(\ref{constantContexts}),
-which means that \CONST{} modifiers need not be specified explicitly.%
+  % The following is true either directly or indirectly: There is a \CONST{}
+  % modifier on the literal map, or we use the "immediate subexpression" rule
+  % about constant contexts.
+  Note that the key and value expressions of a constant map literal
+  occur in a constant context
+  (\ref{constantContexts}),
+  which means that \CONST{} modifiers need not be specified explicitly.%
 }
 
 \LMHash{}%
@@ -11651,9 +11651,9 @@ is not a constant type expression
 (\ref{constants}).
 
 \rationale{%
-The binding of a formal type parameter of an enclosing class or function
-is not known at compile time,
-so we cannot use such type parameters inside constant expressions.%
+  The binding of a formal type parameter of an enclosing class or function
+  is not known at compile time,
+  so we cannot use such type parameters inside constant expressions.%
 }
 
 \LMHash{}%
@@ -11686,11 +11686,11 @@ Then \code{identical($o_1$, $o_2$)} evaluates to \TRUE{} if{}f
 for all $i \in 1 .. n$.
 
 \commentary{%
-In other words, constant map literals are canonicalized.
-There is no need to consider canonicalization
-for other instances of type \code{Map},
-because such instances cannot be
-the result of evaluating a constant expression.%
+  In other words, constant map literals are canonicalized.
+  There is no need to consider canonicalization
+  for other instances of type \code{Map},
+  because such instances cannot be
+  the result of evaluating a constant expression.%
 }
 
 \LMHash{}%
@@ -11744,8 +11744,8 @@ The expression $e$ is evaluated to an object $v$
 (\ref{expressionEvaluation}).
 
 \commentary{%
-There is no requirement that the expression $e$ must evaluate to
-any special kind of object.%
+  There is no requirement that the expression $e$ must evaluate to
+  any special kind of object.%
 }
 
 \LMHash{}%
@@ -11761,9 +11761,9 @@ the stack trace $t$ is stored on $v$ so that it will be returned
 by the \code{stackTrace} getter inherited from \code{Error}.
 
 \commentary{%
-If the same \code{Error} object is thrown more than once,
-its \code{stackTrace} getter will return the stack trace from
-the \emph{first} time it was thrown.%
+  If the same \code{Error} object is thrown more than once,
+  its \code{stackTrace} getter will return the stack trace from
+  the \emph{first} time it was thrown.%
 }
 
 \LMHash{}%
@@ -11802,10 +11802,10 @@ Such a return type is included
 when we refer to the declared return type of a function.
 
 \commentary{%
-Type inference will be specified in a future version of this document.
-Currently we consider type inference to be a phase that has completed,
-and this document specifies the meaning of Dart programs
-where inferred types have already been added.%
+  Type inference will be specified in a future version of this document.
+  Currently we consider type inference to be a phase that has completed,
+  and this document specifies the meaning of Dart programs
+  where inferred types have already been added.%
 }
 
 \LMHash{}%
@@ -11848,48 +11848,50 @@ When none of these cases are applicable,
 we say that $T$ does not derive a future type.
 
 \commentary{%
-Note that if $T$ derives a future type $F$ then \SubtypeNE{T}{F},
-and $F$ is always of the form \code{$G$<...>} or \code{$G$<...>?},
-where $G$ is \code{Future} or \code{FutureOr}. The proof is by induction on the
-structure of $T$:
+  Note that if $T$ derives a future type $F$ then \SubtypeNE{T}{F},
+  and $F$ is always of the form \code{$G$<...>} or \code{$G$<...>?},
+  where $G$ is \code{Future} or \code{FutureOr}. The proof is
+  by induction on the structure of $T$:
 
-\begin{itemize}
-\item
-  %% TODO(eernst): Come mixin classes and extension types: add them.
-  If $T$ is a type which is introduced by
-  a class, mixin, or enum declaration,
-  and if $T$ or a direct or indirect superinterface
-  (\ref{interfaceSuperinterfaces})
-  of $T$ is \code{Future<$U$>} for some $U$, then, letting
-  \code{$G =$ Future} and \code{$F = G$<$U$>}, $T <: F$.
-\item
-  If $T$ is the type \code{FutureOr<$U$>} for some $U$, then by reflexivity,
-  \code{$T <:$ FutureOr<$U$>}. Letting \code{$G =$ FutureOr} and
-  \code{$F = G$<$U$>}, it follows that $T <: F$.
-\item
-  If $T$ is \code{$S$?} for some $S$, and
-  $S$ derives the future type $F'$,
-  then by the induction hypothesis, \code{$S <: F'$}, where $F'$ is of the form
-  \code{$G'$<$U$>} or \code{$G'$<$U$>?} and $G'$ is \code{Future} or
-  \code{FutureOr}. Therefore, \code{$S$? $<: F'$?}, and by substitution,
-  \code{$T <: F'$?}. Since \code{$T$?? $= T$?} for all $T$, it follows that
-  \code{$T <: G'$<$U$>?}. So, letting $G = G'$ and \code{$F = G$<$U$>?},
-  it follows that $T <: F$.
-\item
-  If $T$ is a type variable with bound $B$, and
-  $B$ derives the future type $F$,
-  then by the induction hypothesis, \code{$B <: F'$}, where $F'$ is of the form
-  \code{$G'$<$U$>} or \code{$G'$<$U$>?} and $G'$ is \code{Future} or
-  \code{FutureOr}. Also, since $B$ is the bound of $T$, $T <: B$, so by
-  transitivity, $T <: F'$. Therefore, letting $G = G'$ and $F = F'$, it
-  follows that $T <: F$.
-\end{itemize}
+  \begin{itemize}
+  \item
+    %% TODO(eernst): Come mixin classes and extension types: add them.
+    If $T$ is a type which is introduced by
+    a class, mixin, or enum declaration,
+    and if $T$ or a direct or indirect superinterface
+    (\ref{interfaceSuperinterfaces})
+    of $T$ is \code{Future<$U$>} for some $U$, then, letting
+    \code{$G =$ Future} and \code{$F = G$<$U$>}, $T <: F$.
+  \item
+    If $T$ is the type \code{FutureOr<$U$>} for some $U$, then by reflexivity,
+    \code{$T <:$ FutureOr<$U$>}. Letting \code{$G =$ FutureOr} and
+    \code{$F = G$<$U$>}, it follows that $T <: F$.
+  \item
+    If $T$ is \code{$S$?} for some $S$, and
+    $S$ derives the future type $F'$,
+    then by the induction hypothesis, \code{$S <: F'$},
+    where $F'$ is of the form
+    \code{$G'$<$U$>} or \code{$G'$<$U$>?} and $G'$ is \code{Future} or
+    \code{FutureOr}. Therefore, \code{$S$? $<: F'$?}, and by substitution,
+    \code{$T <: F'$?}. Since \code{$T$?? $= T$?} for all $T$, it follows that
+    \code{$T <: G'$<$U$>?}. So, letting $G = G'$ and \code{$F = G$<$U$>?},
+    it follows that $T <: F$.
+  \item
+    If $T$ is a type variable with bound $B$, and
+    $B$ derives the future type $F$,
+    then by the induction hypothesis, \code{$B <: F'$},
+    where $F'$ is of the form
+    \code{$G'$<$U$>} or \code{$G'$<$U$>?} and $G'$ is \code{Future} or
+    \code{FutureOr}. Also, since $B$ is the bound of $T$, $T <: B$, so by
+    transitivity, $T <: F'$. Therefore, letting $G = G'$ and $F = F'$, it
+    follows that $T <: F$.
+  \end{itemize}
 
-Also note that 'derives' in this context refers to the computation
-where a type $T$ is given, the supertypes of $T$ are searched,
-and a type $F$ of one of those forms is selected.
-There is no connection to the notion of a 'derived class' meaning 'subclass'
-that some programming language communities use.%
+  Also note that 'derives' in this context refers to the computation
+  where a type $T$ is given, the supertypes of $T$ are searched,
+  and a type $F$ of one of those forms is selected.
+  There is no connection to the notion of a 'derived class' meaning 'subclass'
+  that some programming language communities use.%
 }
 
 \LMHash{}%
@@ -11919,46 +11921,46 @@ as follows, using the first applicable case:
 \end{itemize}
 
 \rationale{%
-This definition guarantees that for any type $T$,
-\code{$T <:$ FutureOr<$\flatten{T}$>}. The proof is by induction on the
-structure of $T$:
-
-\begin{itemize}
-\item If $T$ is \code{$X$\,\&\,$S$} then
+  This definition guarantees that for any type $T$,
+  \code{$T <:$ FutureOr<$\flatten{T}$>}. The proof is by induction on the
+  structure of $T$:
 
   \begin{itemize}
-  \item if $S$ derives a future type $U$,
-    then \code{$T <: S$} and \code{$S <: U$}, so \code{$T <: U$}.
-    By the induction hypothesis, \code{$U <:$ FutureOr<$\flatten{U}$>}.
-    Since \code{$\flatten{T} = \flatten{U}$} in this case, it follows that
-    \code{$U <:$ FutureOr<$\flatten{T}$>}, and so
-    \code{$T <:$ FutureOr<$\flatten{T}$>}.
-  \item otherwise, \code{$T <: X$}.
-    By the induction hypothesis, \code{$X <:$ FutureOr<$\flatten{X}$>}.
-    Since \code{$\flatten{T} = \flatten{X}$} in this case, it follows that
-    \code{$U <:$ FutureOr<$\flatten{T}$>}, and so
+  \item If $T$ is \code{$X$\,\&\,$S$} then
+
+    \begin{itemize}
+    \item if $S$ derives a future type $U$,
+      then \code{$T <: S$} and \code{$S <: U$}, so \code{$T <: U$}.
+      By the induction hypothesis, \code{$U <:$ FutureOr<$\flatten{U}$>}.
+      Since \code{$\flatten{T} = \flatten{U}$} in this case, it follows that
+      \code{$U <:$ FutureOr<$\flatten{T}$>}, and so
+      \code{$T <:$ FutureOr<$\flatten{T}$>}.
+    \item otherwise, \code{$T <: X$}.
+      By the induction hypothesis, \code{$X <:$ FutureOr<$\flatten{X}$>}.
+      Since \code{$\flatten{T} = \flatten{X}$} in this case, it follows that
+      \code{$U <:$ FutureOr<$\flatten{T}$>}, and so
+      \code{$T <:$ FutureOr<$\flatten{T}$>}.
+    \end{itemize}
+
+  \item If $T$ derives a future type \code{Future<$S$>}
+    or \code{FutureOr<$S$>}, then, since \code{Future<$S$> $<:$ FutureOr<$S$>},
+    it follows that \code{$T <:$ FutureOr<$S$>}. Since \code{$\flatten{T} = S$}
+    in this case, it follows that \code{$T <:$ FutureOr<$\flatten{T}$>}.
+
+  \item If $T$ derives a future type \code{Future<$S$>?} or
+    \code{FutureOr<$S$>?}, then, since \code{Future<$S$>? $<:$ FutureOr<$S$>?},
+    it follows that \code{$T <:$ FutureOr<$S$>?}.
+    \code{FutureOr<$S$>? $<:$ FutureOr<$S$?>} for any type $S$
+    (this can be shown using the union type subtype rules and from
+    \code{Future<$S$> $<:$ Future<$S$?>} by covariance), so by transivitity,
+    \code{$T <:$ FutureOr<$S$?>}. Since \code{$\flatten{T} = S$?} in this case,
+    it follows that \code{$T <:$ FutureOr<$\flatten{T}$>}.
+
+  \item Otherwise, \code{$\flatten{T} = T$}, so
+    \code{FutureOr<$\flatten{T}$> $=$ FutureOr<$T$>}. Since
+    \code{$T <:$ FutureOr<$T$>}, it follows that
     \code{$T <:$ FutureOr<$\flatten{T}$>}.
   \end{itemize}
-
-\item If $T$ derives a future type \code{Future<$S$>}
-  or \code{FutureOr<$S$>}, then, since \code{Future<$S$> $<:$ FutureOr<$S$>},
-  it follows that \code{$T <:$ FutureOr<$S$>}. Since \code{$\flatten{T} = S$}
-  in this case, it follows that \code{$T <:$ FutureOr<$\flatten{T}$>}.
-
-\item If $T$ derives a future type \code{Future<$S$>?} or
-  \code{FutureOr<$S$>?}, then, since \code{Future<$S$>? $<:$ FutureOr<$S$>?},
-  it follows that \code{$T <:$ FutureOr<$S$>?}.
-  \code{FutureOr<$S$>? $<:$ FutureOr<$S$?>} for any type $S$ (this can be shown
-  using the union type subtype rules and from
-  \code{Future<$S$> $<:$ Future<$S$?>} by covariance), so by transivitity,
-  \code{$T <:$ FutureOr<$S$?>}. Since \code{$\flatten{T} = S$?} in this case,
-  it follows that \code{$T <:$ FutureOr<$\flatten{T}$>}.
-
-\item Otherwise, \code{$\flatten{T} = T$}, so
-  \code{FutureOr<$\flatten{T}$> $=$ FutureOr<$T$>}. Since
-  \code{$T <:$ FutureOr<$T$>}, it follows that
-  \code{$T <:$ FutureOr<$\flatten{T}$>}.
-\end{itemize}
 }
 
 \LMHash{}%
@@ -12171,11 +12173,11 @@ it is considered to have been specified as \DYNAMIC.
 Evaluation of a function literal yields a function object $o$.
 
 \commentary{%
-The run-time type of $o$ is specified based on
-the static type $T$ of the function literal
-and the binding of type variables occurring in $T$
-at the occasion where the evaluation occurred
-(\ref{typeOfAFunction}).%
+  The run-time type of $o$ is specified based on
+  the static type $T$ of the function literal
+  and the binding of type variables occurring in $T$
+  at the occasion where the evaluation occurred
+  (\ref{typeOfAFunction}).%
 }
 
 
@@ -12198,9 +12200,9 @@ the \ON{} type of the enclosing extension, if any
 (\ref{extensions}).
 
 \commentary{%
-If none of those declarations exist,
-an occurrence of \THIS{} is a compile-time error
-(\ref{classes}).%
+  If none of those declarations exist,
+  an occurrence of \THIS{} is a compile-time error
+  (\ref{classes}).%
 }
 
 \LMHash{}%
@@ -12218,12 +12220,12 @@ Instance creation expressions generally produce instances
 and invoke constructors to initialize them.
 
 \commentary{%
-The exception is that
-a factory constructor invocation works like a regular function call.
-It may of course evaluate an instance creation expression and thus
-produce a fresh instance,
-but no fresh instances are created as a direct consequence of
-the factory constructor invocation.%
+  The exception is that
+  a factory constructor invocation works like a regular function call.
+  It may of course evaluate an instance creation expression and thus
+  produce a fresh instance,
+  but no fresh instances are created as a direct consequence of
+  the factory constructor invocation.%
 }
 
 \LMHash{}%
@@ -12271,8 +12273,8 @@ It is a compile-time error if $T$ is not
 a class or a parameterized type accessible in the current scope,
 or if $T$ is a parameterized type which is not a class.
 \commentary{%
-For instance, \code{\NEW{} F<int>()} is an error if \code{F} is a type alias
-that does not denote a class.%
+  For instance, \code{\NEW{} F<int>()} is an error if \code{F} is a type alias
+  that does not denote a class.%
 }
 
 \LMHash{}%
@@ -12322,12 +12324,12 @@ If $q$ is a redirecting factory constructor,
 it is a compile-time error if $q$ in some number of
 redirecting factory redirections redirects to itself.
 \commentary{%
-It is possible and allowed for a redirecting factory $q'$
-to enter an infinite loop, e.g.,
-because $q'$ redirects to a non-redirecting factory constructor
-$q''$ whose body uses $q'$ in an instance creation expression.
-Only loops that consist exclusively of redirecting factory redirections
-are detected at compile time.%
+  It is possible and allowed for a redirecting factory $q'$
+  to enter an infinite loop, e.g.,
+  because $q'$ redirects to a non-redirecting factory constructor
+  $q''$ whose body uses $q'$ in an instance creation expression.
+  Only loops that consist exclusively of redirecting factory redirections
+  are detected at compile time.%
 }
 
 \LMHash{}%
@@ -12338,7 +12340,7 @@ It is a compile-time error if the static type of
 $a_i, i \in 1 .. n + k$
 is not assignable to $[U_1/X_1, \ldots, U_m/X_m]S_i$.
 \commentary{%
-The non-generic case is covered with $m = 0$.%
+  The non-generic case is covered with $m = 0$.%
 }
 
 \LMHash{}%
@@ -12414,7 +12416,7 @@ in an environment where
 $v_j$ is a fresh variable bound to $o_j$ for $j \in 1 .. n + k$, and
 $X_j$ is bound to $u_j$ for $j \in 1 .. m$.
 \commentary{%
-We need access to the type variables because $c$ may contain them.%
+  We need access to the type variables because $c$ may contain them.%
 }
 \EndCase
 
@@ -12435,8 +12437,8 @@ and then evaluation of $e$ also throws $x$ and $t$
 (\ref{expressionEvaluation}).
 
 \rationale{%
-A factory constructor can be declared in an abstract class and used safely,
-as it will either produce a valid instance or throw.%
+  A factory constructor can be declared in an abstract class and used safely,
+  as it will either produce a valid instance or throw.%
 }
 \EndCase
 
@@ -12468,9 +12470,7 @@ a class or a parameterized type accessible in the current scope,
 or if $T$ is a parameterized type which is not a class.
 It is a compile-time error if $T$ is a deferred type
 (\ref{staticTypes}).
-\commentary{%
-In particular, $T$ must not be a type variable.%
-}
+\commentary{In particular, $T$ must not be a type variable.}
 
 \LMHash{}%
 It is a compile-time error if $a_i$ is not a constant expression
@@ -12534,9 +12534,7 @@ corresponding to the actual argument $a_i$, $i \in 1 .. n+k$.
 It is a compile-time error if the static type of
 $a_i, i \in 1 .. n + k$
 is not assignable to $[U_1/X_1, \ldots, U_m/X_m]S_i$.
-\commentary{%
-The non-generic case is covered with $m = 0$.%
-}
+\commentary{The non-generic case is covered with $m = 0$.}
 
 \LMHash{}%
 The static type of $e$ is $T$.
@@ -12553,14 +12551,14 @@ let $i$ be the value of the expression $e'$:
 \code{\NEW{} $T$.\id($a_1, \ldots,\ a_n,\ x_{n+1}$: $a_{n+1}, \ldots,\ x_{n+k}$: $a_{n+k}$)}.
 
 \commentary{%
-Let $o$ be the result of an evaluation of $e'$,
-at some point in time of some execution of the program
-in the library $L$ where $e$ occurs.
-The result of an evaluation of $e'$ in $L$
-at some other time and/or in some other execution will
-yield a result $o'$, such that $o'$ would be replaced by $o$
-by canonicalization as described below.
-This means that the value is well-defined.%
+  Let $o$ be the result of an evaluation of $e'$,
+  at some point in time of some execution of the program
+  in the library $L$ where $e$ occurs.
+  The result of an evaluation of $e'$ in $L$
+  at some other time and/or in some other execution will
+  yield a result $o'$, such that $o'$ would be replaced by $o$
+  by canonicalization as described below.
+  This means that the value is well-defined.%
 }
 
 \LMHash{}%
@@ -12568,9 +12566,7 @@ If $e$ is of the form
 \code{\CONST{} $T$($a_1, \ldots,\ a_n,\ x_{n+1}$: $a_{n+1}, \ldots,\ x_{n+k}$: $a_{n+k}$)},
 let $i$ be the value of
 \code{\NEW{} $T$($a_1, \ldots,\ a_n,\ x_{n+1}$: $a_{n+1}, \ldots,\ x_{n+k}$: $a_{n+k}$)}.
-\commentary{%
-Which is well-defined for the same reason.%
-}
+\commentary{Which is well-defined for the same reason.}
 
 \begin{itemize}
 \item If during execution of the program,
@@ -12590,16 +12586,16 @@ Which is well-defined for the same reason.%
 \end{itemize}
 
 \commentary{%
-In other words, constant objects are canonicalized.
-In order to determine if an object is actually new, one has to compute it;
-then it can be compared to any cached instances.
-If an equivalent object exists in the cache,
-we throw away the newly created object and use the cached one.
-Objects are equivalent if
-they have identical type arguments and identical instance variables.
-Since the constructor cannot induce any side effects,
-the execution of the constructor is unobservable.
-The constructor need only be executed once per call site, at compile time.%
+  In other words, constant objects are canonicalized.
+  In order to determine if an object is actually new, one has to compute it;
+  then it can be compared to any cached instances.
+  If an equivalent object exists in the cache,
+  we throw away the newly created object and use the cached one.
+  Objects are equivalent if
+  they have identical type arguments and identical instance variables.
+  Since the constructor cannot induce any side effects,
+  the execution of the constructor is unobservable.
+  The constructor need only be executed once per call site, at compile time.%
 }
 
 \LMHash{}%
@@ -12607,7 +12603,7 @@ It is a compile-time error if evaluation of a constant object
 results in an uncaught exception being thrown.
 
 \commentary{%
-To see how such situations might arise, consider the following examples:%
+  To see how such situations might arise, consider the following examples:%
 }
 
 %% TODO(eernst): Delete some \CONST{} when integrating implicit-creation.md
@@ -12630,14 +12626,14 @@ To see how such situations might arise, consider the following examples:%
 \end{dartCode}
 
 \commentary{%
-Due to the rules governing constant constructors,
-evaluating the constructor \code{A()}
-with the argument \code{"x"} or the argument \code{\CONST{} IntPair(1, 2)}
-would cause it to throw an exception, resulting in a compile-time error.
-In the latter case, the error is caused by the fact that
-\code{\OPERATOR{} *} can only be used with a few ``well-known'' types,
-which is required in order to avoid running arbitrary code during
-the evaluation of constant expressions.%
+  Due to the rules governing constant constructors,
+  evaluating the constructor \code{A()}
+  with the argument \code{"x"} or the argument \code{\CONST{} IntPair(1, 2)}
+  would cause it to throw an exception, resulting in a compile-time error.
+  In the latter case, the error is caused by the fact that
+  \code{\OPERATOR{} *} can only be used with a few ``well-known'' types,
+  which is required in order to avoid running arbitrary code during
+  the evaluation of constant expressions.%
 }
 
 
@@ -12661,8 +12657,8 @@ resulting in a dynamic error that cannot be effectively caught,
 which will force the isolate to be suspended.
 
 \commentary{%
-As discussed in section \ref{errorsAndWarnings},
-the handling of a suspended isolate is the responsibility of the runtime.%
+  As discussed in section \ref{errorsAndWarnings},
+  the handling of a suspended isolate is the responsibility of the runtime.%
 }
 
 
@@ -12710,17 +12706,17 @@ the invocation throws the same exception object and stack trace
 (\ref{expressionEvaluation}).
 
 \commentary{%
-A complete function body can never break or continue
-(\ref{statementCompletion})
-because a \BREAK{} or \CONTINUE{} statement must always occur inside
-the statement that is the target of the \BREAK{} or \CONTINUE.
-This means that a function body can only
-either complete normally, throw, or return.
-Completing normally or returning without an object is treated
-the same as returning with the null object (\ref{null}),
-so the result of executing a function body can always be used as
-the result of evaluating an expression,
-either by evaluating to an object, or by the evaluation throwing.%
+  A complete function body can never break or continue
+  (\ref{statementCompletion})
+  because a \BREAK{} or \CONTINUE{} statement must always occur inside
+  the statement that is the target of the \BREAK{} or \CONTINUE.
+  This means that a function body can only
+  either complete normally, throw, or return.
+  Completing normally or returning without an object is treated
+  the same as returning with the null object (\ref{null}),
+  so the result of executing a function body can always be used as
+  the result of evaluating an expression,
+  either by evaluating to an object, or by the evaluation throwing.%
 }
 
 \LMHash{}%
@@ -12733,13 +12729,13 @@ corresponding to the element type of $f$
 (\ref{functions}).
 
 \commentary{%
-A Dart implementation will need to provide
-a specific implementation of \code{Iterable}
-that will be returned by \code{\SYNC*} methods.
-A typical strategy would be to produce an instance of
-a subclass of class \code{IterableBase} defined in \code{dart:core}.
-The only method that needs to be added
-by the Dart implementation in that case is \code{iterator}.%
+  A Dart implementation will need to provide
+  a specific implementation of \code{Iterable}
+  that will be returned by \code{\SYNC*} methods.
+  A typical strategy would be to produce an instance of
+  a subclass of class \code{IterableBase} defined in \code{dart:core}.
+  The only method that needs to be added
+  by the Dart implementation in that case is \code{iterator}.%
 }
 
 \LMHash{}%
@@ -12748,14 +12744,14 @@ the contract of \code{Iterable} and should not
 take any steps identified as exceptionally efficient in that contract.
 
 \commentary{%
-The contract explicitly mentions a number of situations
-where certain iterables could be more efficient than normal.
-For example, by precomputing their length.
-Normal iterables must iterate over their elements to determine their length.
-This is certainly true in the case of a synchronous generator,
-where each element is computed by a function.
-It would not be acceptable to pre-compute the results of the generator
-and cache them, for example.%
+  The contract explicitly mentions a number of situations
+  where certain iterables could be more efficient than normal.
+  For example, by precomputing their length.
+  Normal iterables must iterate over their elements to determine their length.
+  This is certainly true in the case of a synchronous generator,
+  where each element is computed by a function.
+  It would not be acceptable to pre-compute the results of the generator
+  and cache them, for example.%
 }
 
 \LMHash{}%
@@ -12785,17 +12781,17 @@ If the \code{\SYNC*} function is impure,
 the sequence of objects yielded by each iterator may differ.
 
 \commentary{%
-One can derive more than one iterator from a given iterable.
-Note that operations on the iterable itself can create distinct iterators.
-An example would be \code{length}.
-It is conceivable that different iterators might yield
-sequences of different length.
-The same care needs to be taken when writing \code{\SYNC*} functions as when
-writing an \code{Iterator} class.
-In particular, it should handle multiple simultaneous iterators gracefully.
-If the iterator depends on external state that might change,
-it should check that the state is still valid after every yield
-(and maybe throw a \code{ConcurrentModificationError} if it isn't).%
+  One can derive more than one iterator from a given iterable.
+  Note that operations on the iterable itself can create distinct iterators.
+  An example would be \code{length}.
+  It is conceivable that different iterators might yield
+  sequences of different length.
+  The same care needs to be taken when writing \code{\SYNC*} functions as when
+  writing an \code{Iterator} class.
+  In particular, it should handle multiple simultaneous iterators gracefully.
+  If the iterator depends on external state that might change,
+  it should check that the state is still valid after every yield
+  (and maybe throw a \code{ConcurrentModificationError} if it isn't).%
 }
 
 \LMHash{}%
@@ -12803,7 +12799,7 @@ Each iterator runs with its own shallow copies of all local variables;
 in particular, each iterator has the same initial arguments,
 even if their bindings are modified by the function.
 \commentary{%
-Two executions of an iterator interact only via state outside the function.%
+  Two executions of an iterator interact only via state outside the function.%
 }
 % The alternative would be to cache the results of an iterator in the iterable,
 % and check the cache at each \YIELD. This would have strange issues as well.
@@ -12821,8 +12817,8 @@ corresponding to the future value type of $f$.
 Then the body of $f$ is executed until it either suspends or completes,
 at which point $o$ is returned.
 \commentary{%
-The body of $f$ may suspend during the evaluation of an \AWAIT{} expression
-or execution of an asynchronous \FOR{} loop.%
+  The body of $f$ may suspend during the evaluation of an \AWAIT{} expression
+  or execution of an asynchronous \FOR{} loop.%
 }
 The future $o$ is completed when execution of the body of $f$ completes
 (\ref{statementCompletion}).
@@ -12834,9 +12830,9 @@ $o$ is completed with the error $e$ and stack trace $t$.
 If execution of the body throws before the body suspends the first time,
 completion of $o$ happens at some future time after the invocation has returned.
 \rationale{%
-The caller needs time to set up error handling for the returned future,
-so the future is not completed with an error
-\emph{before} it has been returned.%
+  The caller needs time to set up error handling for the returned future,
+  so the future is not completed with an error
+  \emph{before} it has been returned.%
 }
 
 \LMHash{}%
@@ -12864,21 +12860,22 @@ When execution of the body of $f$ completes:
   \end{itemize}
 \item $s$ is closed.
 \end{itemize}
+
 \commentary{%
-The body of an asynchronous generator function
-cannot break, continue or return with an object
-(\ref{statementCompletion}).
-The first two are only allowed in contexts that
-will handle the break or continue,
-and return statements with an expression are not allowed
-in generator functions.%
+  The body of an asynchronous generator function
+  cannot break, continue or return with an object
+  (\ref{statementCompletion}).
+  The first two are only allowed in contexts that
+  will handle the break or continue,
+  and return statements with an expression are not allowed
+  in generator functions.%
 }
 
 \rationale{%
-When an asynchronous generator's stream has been canceled,
-cleanup will occur in the \FINALLY{} clauses (\ref{try}) inside the generator.
-We choose to direct any exceptions that occur at this time
-to the cancellation future rather than have them be lost.%
+  When an asynchronous generator's stream has been canceled,
+  cleanup will occur in the \FINALLY{} clauses (\ref{try}) inside the generator.
+  We choose to direct any exceptions that occur at this time
+  to the cancellation future rather than have them be lost.%
 }
 
 
@@ -12974,8 +12971,8 @@ $j \in n + 1 .. n + k$, for all
 $i \in m + 1 .. m + p$.
 
 \commentary{%
-In short, an actual argument list is a match for a formal parameter list
-whenever the former can safely be passed to the latter.%
+  In short, an actual argument list is a match for a formal parameter list
+  whenever the former can safely be passed to the latter.%
 }
 
 
@@ -13001,25 +12998,25 @@ as a generic function invocation.
 %   argumentPart in the grammar.
 
 \commentary{%
-An example is \code{f(a<B, C>($d$))},
-which may be an invocation of \code{f} passing
-two actual arguments of type \code{bool}, or
-an invocation of \code{f} passing the result returned by
-an invocation of the generic function \code{a}.
-Note that the ambiguity can be eliminated by omitting
-the parentheses around the expression $d$,
-or adding parentheses around one of the relational expressions.%
+  An example is \code{f(a<B, C>($d$))},
+  which may be an invocation of \code{f} passing
+  two actual arguments of type \code{bool}, or
+  an invocation of \code{f} passing the result returned by
+  an invocation of the generic function \code{a}.
+  Note that the ambiguity can be eliminated by omitting
+  the parentheses around the expression $d$,
+  or adding parentheses around one of the relational expressions.%
 }
 
 \rationale{%
-When the intention is to pass
-several relational or shift expressions as actual arguments
-and there is an ambiguity, the source code can easily be adjusted
-to a form which is unambiguous.
-Also, we expect that it will be more common to have
-generic function invocations as actual arguments
-than having relational or shift expressions that happen to match up
-and have parentheses at the end, such that the ambiguity arises.%
+  When the intention is to pass
+  several relational or shift expressions as actual arguments
+  and there is an ambiguity, the source code can easily be adjusted
+  to a form which is unambiguous.
+  Also, we expect that it will be more common to have
+  generic function invocations as actual arguments
+  than having relational or shift expressions that happen to match up
+  and have parentheses at the end, such that the ambiguity arises.%
 }
 
 \LMHash{}%
@@ -13038,11 +13035,11 @@ in the order they appear in the program,
 producing objects $o_1, \ldots, o_{m+l}$.
 
 \commentary{%
-Simply stated, an argument part consisting of $s$ type arguments,
-$m$ positional arguments, and $l$ named arguments is
-evaluated from left to right.
-Note that the type argument list is omitted when $r = 0$
-(\ref{generics}).%
+  Simply stated, an argument part consisting of $s$ type arguments,
+  $m$ positional arguments, and $l$ named arguments is
+  evaluated from left to right.
+  Note that the type argument list is omitted when $r = 0$
+  (\ref{generics}).%
 }
 
 
@@ -13050,10 +13047,10 @@ Note that the type argument list is omitted when $r = 0$
 \LMLabel{bindingActualsToFormals}
 
 \commentary{%
-In the following, the non-generic case is covered implicitly:
-When the number of actual type arguments is zero
-the entire type argument list \code{<\ldots{}>} is omitted,
-and similarly for empty type parameter lists (\ref{generics}).%
+  In the following, the non-generic case is covered implicitly:
+  When the number of actual type arguments is zero
+  the entire type argument list \code{<\ldots{}>} is omitted,
+  and similarly for empty type parameter lists (\ref{generics}).%
 }
 
 \LMHash{}%
@@ -13062,35 +13059,35 @@ an actual argument part of the form
 \code{<$A_1, \ldots,\ A_r$>($a_1, \ldots,\ a_m,\ q_1$: $a_{m+1}, \ldots,\ q_l$: $a_{m+l}$)}.
 
 \commentary{%
-Note that $f$ denotes a function in a semantic sense,
-rather than a syntactic construct.
-A reference to this section is used in other sections
-when the static analysis of an invocation is specified,
-and the static type of $f$ has been determined.
-The function itself may have been obtained from a function declaration,
-from an instance bound to \THIS{} and an instance method declaration,
-or as a function object obtained by evaluation of an expression.
-Because of that, we cannot indicate here which syntactic construct
-corresponds to $f$.
-%
-A reference to this section is also used in other sections
-when actual arguments are to be bound to the corresponding formal parameters,
-and $f$ is about to be invoked, to specify the dynamic semantics.%
+  Note that $f$ denotes a function in a semantic sense,
+  rather than a syntactic construct.
+  A reference to this section is used in other sections
+  when the static analysis of an invocation is specified,
+  and the static type of $f$ has been determined.
+  The function itself may have been obtained from a function declaration,
+  from an instance bound to \THIS{} and an instance method declaration,
+  or as a function object obtained by evaluation of an expression.
+  Because of that, we cannot indicate here which syntactic construct
+  corresponds to $f$.
+  %
+  A reference to this section is also used in other sections
+  when actual arguments are to be bound to the corresponding formal parameters,
+  and $f$ is about to be invoked, to specify the dynamic semantics.%
 }
 
 \commentary{%
-We do not call $f$ a `function object' here, because we do not wish to imply
-that every function invocation must involve a separate evaluation
-of an expression that yields a function object,
-followed by an invocation of that function object.
-For instance, an implementation should be allowed to compile the invocation
-of a top-level function as a series of steps whereby a stack frame is
-created, followed by a low-level jump to the generated code for the body.
-So, in this section,
-the word `function' is more low-level than `function object',
-but `function' still denotes a semantic entity
-which is associated with a function declaration,
-even though there may not be a corresponding entity in the heap at run time.%
+  We do not call $f$ a `function object' here, because we do not wish to imply
+  that every function invocation must involve a separate evaluation
+  of an expression that yields a function object,
+  followed by an invocation of that function object.
+  For instance, an implementation should be allowed to compile the invocation
+  of a top-level function as a series of steps whereby a stack frame is
+  created, followed by a low-level jump to the generated code for the body.
+  So, in this section,
+  the word `function' is more low-level than `function object',
+  but `function' still denotes a semantic entity
+  which is associated with a function declaration,
+  even though there may not be a corresponding entity in the heap at run time.%
 }
 
 \LMHash{}%
@@ -13151,11 +13148,11 @@ in the given parameter type annotation.
 Finally, let $T_i$ be the static type of $a_i$.
 
 \commentary{%
-We have an actual argument list consisting of $r$ type arguments,
-$m$ positional arguments, and $l$ named arguments.
-We have a function with $s$ type parameters,
-$h$ required parameters, and $k$ optional parameters.
-Figure~\ref{fig:argumentsAndParameters} shows how this situation arises.%
+  We have an actual argument list consisting of $r$ type arguments,
+  $m$ positional arguments, and $l$ named arguments.
+  We have a function with $s$ type parameters,
+  $h$ required parameters, and $k$ optional parameters.
+  Figure~\ref{fig:argumentsAndParameters} shows how this situation arises.%
 }
 
 % View on declaration:
@@ -13229,11 +13226,12 @@ it is a compile-time error unless $F$ has named parameters and
 $q_j \in \{p_{h+1}, \ldots, p_{h+k}\}, j \in 1 .. l$.
 
 \commentary{%
-That is, the number of type arguments must match the number of type parameters,
-and the bounds must be respected.
-We must receive at least the required number of positional arguments,
-and not more than the total number of positional parameters.
-For each named argument there must be a named parameter with the same name.%
+  That is, the number of type arguments must match
+  the number of type parameters,
+  and the bounds must be respected.
+  We must receive at least the required number of positional arguments,
+  and not more than the total number of positional parameters.
+  For each named argument there must be a named parameter with the same name.%
 }
 
 \LMHash{}%
@@ -13246,29 +13244,29 @@ It is a compile-time error if $T_{m+j}$ may not be assigned to
 $S_{q_j}, j \in 1 .. l$.
 
 \commentary{%
-Consider the case where the function invocation in focus here is
-an instance method invocation.
-In that case, for each actual argument,
-the corresponding parameter may be covariant.
-However, the above assignability requirements apply equally
-both when the parameter is covariant and when it is not.%
+  Consider the case where the function invocation in focus here is
+  an instance method invocation.
+  In that case, for each actual argument,
+  the corresponding parameter may be covariant.
+  However, the above assignability requirements apply equally
+  both when the parameter is covariant and when it is not.%
 }
 
 \rationale{%
-Parameter covariance in an instance method invocation can be introduced by
-a subtype of the statically known receiver type,
-which means that any attempt to flag a given actual argument as dangerous
-due to the dynamic type check that it will be subjected to
-will be incomplete:
-some actual arguments can be subjected to such a dynamic type check
-even though this is not known statically at the call site.
-This is not surprising for a mechanism like parameter covariance which is
-designed for the very purpose of allowing developers to explicitly request
-that this specific kind of compile-time safety is violated.
-The point is that this mechanism postpones the enforcement of
-the underlying invariant to run time,
-and in return allows some useful program designs
-that would otherwise be rejected at compile-time.%
+  Parameter covariance in an instance method invocation can be introduced by
+  a subtype of the statically known receiver type,
+  which means that any attempt to flag a given actual argument as dangerous
+  due to the dynamic type check that it will be subjected to
+  will be incomplete:
+  some actual arguments can be subjected to such a dynamic type check
+  even though this is not known statically at the call site.
+  This is not surprising for a mechanism like parameter covariance which is
+  designed for the very purpose of allowing developers to explicitly request
+  that this specific kind of compile-time safety is violated.
+  The point is that this mechanism postpones the enforcement of
+  the underlying invariant to run time,
+  and in return allows some useful program designs
+  that would otherwise be rejected at compile-time.%
 }
 
 \LMHash{}%
@@ -13325,8 +13323,8 @@ and $q_j$ is bound to $o_{m+j}, j \in 1 .. l$.
 All remaining formal parameters of $f$ are bound to their default values.
 
 \commentary{%
-All of these remaining parameters are necessarily optional
-and thus have default values.%
+  All of these remaining parameters are necessarily optional
+  and thus have default values.%
 }
 
 \LMHash{}%
@@ -13362,7 +13360,7 @@ An unqualified function invocation $i$ has the form
 where \id{} is an identifier.
 
 \commentary{%
-Note that the type argument list is omitted when $r = 0$ (\ref{generics}).%
+  Note that the type argument list is omitted when $r = 0$ (\ref{generics}).%
 }
 
 \LMHash{}%
@@ -13446,22 +13444,22 @@ the ordinary method invocation
 (\ref{ordinaryInvocation}).
 
 \commentary{%
-This occurs when the lexical lookup has determined that
-$i$ must invoke an instance member of a class or an extension,
-and the location of $i$ can access \THIS,
-and the interface of the enclosing class has a member named \id,
-or there is an applicable extension with such a member.
-Both the static analysis and evaluation proceeds with
-\code{\THIS.$i$},
-so there is no need to further specify the treatment of $i$.%
+  This occurs when the lexical lookup has determined that
+  $i$ must invoke an instance member of a class or an extension,
+  and the location of $i$ can access \THIS,
+  and the interface of the enclosing class has a member named \id,
+  or there is an applicable extension with such a member.
+  Both the static analysis and evaluation proceeds with
+  \code{\THIS.$i$},
+  so there is no need to further specify the treatment of $i$.%
 }
 \EndCase
 
 \commentary{%
-Note that an unqualified invocation does not specify an evaluation semantics.
-This is because every case which is not an error ends in the conclusion that
-the unqualified invocation should be treated as some other construct,
-which is specified elsewhere.%
+  Note that an unqualified invocation does not specify an evaluation semantics.
+  This is because every case which is not an error ends in the conclusion that
+  the unqualified invocation should be treated as some other construct,
+  which is specified elsewhere.%
 }
 
 
@@ -13478,8 +13476,8 @@ A function expression invocation $i$ has the form
 where $e_f$ is an expression.
 
 \commentary{%
-Note that the type argument list is omitted when $r = 0$
-(\ref{generics}).%
+  Note that the type argument list is omitted when $r = 0$
+  (\ref{generics}).%
 }
 
 \LMHash{}%
@@ -13495,20 +13493,20 @@ and if $i$ does not occur in a constant context
 then $i$ is treated as \code{\NEW\,\,$i$}.
 
 \commentary{%
-When $i$ is treated as another construct $i'$,
-both the static analysis and the dynamic semantics
-is specified in the section about $i'$
-(\ref{notation}).%
+  When $i$ is treated as another construct $i'$,
+  both the static analysis and the dynamic semantics
+  is specified in the section about $i'$
+  (\ref{notation}).%
 }
 
 \LMHash{}%
 Otherwise, it is a compile-time error if $e_f$ is a type literal.
 
 \commentary{%
-This error was already specified elsewhere
-(\ref{unqualifiedInvocation})
-for the case where $e_f$ is an identifier,
-but $e_f$ may also have other forms, e.g., \code{p.C}.%
+  This error was already specified elsewhere
+  (\ref{unqualifiedInvocation})
+  for the case where $e_f$ is an identifier,
+  but $e_f$ may also have other forms, e.g., \code{p.C}.%
 }
 
 \LMHash{}%
@@ -13524,16 +13522,16 @@ then $i$ treated as an ordinary method invocation
 (\ref{ordinaryInvocation}).
 
 \commentary{%
-\code{$a.b(x)$} is treated as a method invocation of method
-\code{$b()$} on object \code{$a$},
-not as an invocation of getter \code{$b$} on \code{$a$}
-followed by a function call \code{$(a.b)(x)$}.
-If a method or getter \code{$b$} exists, the two will be equivalent.
-However, if \code{$b$} is not defined on \code{$a$},
-the resulting invocation of \code{noSuchMethod()} would differ.
-The \code{Invocation} passed to \code{noSuchMethod()} would describe
-a call to a method \code{$b$} with argument \code{$x$} in the former case,
-and a call to a getter \code{$b$} (with no arguments) in the latter.%
+  \code{$a.b(x)$} is treated as a method invocation of method
+  \code{$b()$} on object \code{$a$},
+  not as an invocation of getter \code{$b$} on \code{$a$}
+  followed by a function call \code{$(a.b)(x)$}.
+  If a method or getter \code{$b$} exists, the two will be equivalent.
+  However, if \code{$b$} is not defined on \code{$a$},
+  the resulting invocation of \code{noSuchMethod()} would differ.
+  The \code{Invocation} passed to \code{noSuchMethod()} would describe
+  a call to a method \code{$b$} with argument \code{$x$} in the former case,
+  and a call to a getter \code{$b$} (with no arguments) in the latter.%
 }
 
 \LMHash{}%
@@ -13610,14 +13608,14 @@ Then the method invocation \code{f.noSuchMethod($im$)} is evaluated,
 and its result is then the result of evaluating $i$.
 
 \commentary{%
-The situation where \code{noSuchMethod} is invoked can only arise
-when the static type of $e_f$ is \DYNAMIC.
-The run-time semantics ensures that
-a function invocation may amount to an invocation of
-the instance method \CALL.
-However, an interface type with a method named \CALL{}
-is not itself a subtype of any function type
-(\ref{subtypeRules}).%
+  The situation where \code{noSuchMethod} is invoked can only arise
+  when the static type of $e_f$ is \DYNAMIC.
+  The run-time semantics ensures that
+  a function invocation may amount to an invocation of
+  the instance method \CALL.
+  However, an interface type with a method named \CALL{}
+  is not itself a subtype of any function type
+  (\ref{subtypeRules}).%
 }
 
 
@@ -13657,17 +13655,17 @@ There does not exist a function type $F'$ which is a proper subtype of $F$
 such that $C$ is a subtype of $F'$.
 
 \commentary{%
-If $f$ is a static method or a top-level function
-then $o$ has primitive equality
-(\ref{theOperatorEqualsEquals}).%
+  If $f$ is a static method or a top-level function
+  then $o$ has primitive equality
+  (\ref{theOperatorEqualsEquals}).%
 }
 
 \commentary{%
-In other words, $C$ has the freedom to be a proper subtype of
-the function type that we can read off of the declaration of $f$
-because it may need to be a specific internal platform defined class,
-but $C$ does not have the freedom to be a subtype of
-a different and more special function type, and it cannot be \code{Null}.%
+  In other words, $C$ has the freedom to be a proper subtype of
+  the function type that we can read off of the declaration of $f$
+  because it may need to be a specific internal platform defined class,
+  but $C$ does not have the freedom to be a subtype of
+  a different and more special function type, and it cannot be \code{Null}.%
 }
 
 \LMHash{}%
@@ -13687,8 +13685,8 @@ of the same function declaration.
 In this case \code{identical($e_1$, $e_2$)} shall evaluate to true.
 
 \commentary{%
-That is, constant expressions whose evaluation is a function closurization
-are canonicalized.%
+  That is, constant expressions whose evaluation is a function closurization
+  are canonicalized.%
 }
 
 
@@ -13708,15 +13706,15 @@ Generic function instantiation is a mechanism that yields
 a non-generic function object based on a given generic function.
 
 \rationale{%
-The essence of generic function instantiation
-is to allow for ``curried'' invocations,
-in the sense that a generic function can receive its actual
-type arguments separately
-(it must then receive \emph{all} type arguments, not just some of them),
-and that yields a non-generic function object.
-The type arguments are passed implicitly, based on type inference;
-%% TODO(eernst): Come constructor-tearoffs, revise this.
-a future version of Dart may allow for passing them explicitly.%
+  The essence of generic function instantiation
+  is to allow for ``curried'' invocations,
+  in the sense that a generic function can receive its actual
+  type arguments separately
+  (it must then receive \emph{all} type arguments, not just some of them),
+  and that yields a non-generic function object.
+  The type arguments are passed implicitly, based on type inference;
+  %% TODO(eernst): Come constructor-tearoffs, revise this.
+  a future version of Dart may allow for passing them explicitly.%
 }
 \commentary{Here is an example:}
 
@@ -13733,13 +13731,13 @@ X fg<X \EXTENDS{} num>(X x) => x;
 \}
 \end{dartCode}
 
-\commentary{%
 \noindent
-Each function object stored in \code{functions}
-has dynamic type \code{int\,\,\FUNCTION(int)},
-and it is obtained by implicitly
-``passing the actual type argument \code{int}''
-to the corresponding generic function.%
+\commentary{%
+  Each function object stored in \code{functions}
+  has dynamic type \code{int\,\,\FUNCTION(int)},
+  and it is obtained by implicitly
+  ``passing the actual type argument \code{int}''
+  to the corresponding generic function.%
 }
 
 \LMHash{}%
@@ -13776,12 +13774,12 @@ and it yields the actual type argument list
 \List{T}{1}{s}.
 
 \commentary{%
-The generic function type instantiation fails
-in the case where type inference fails,
-in which case the above mentioned compile-time error occurs.
-It will be specified in a future version of this document
-how type inference computes \List{T}{1}{s}
-(\ref{overview}).%
+  The generic function type instantiation fails
+  in the case where type inference fails,
+  in which case the above mentioned compile-time error occurs.
+  It will be specified in a future version of this document
+  how type inference computes \List{T}{1}{s}
+  (\ref{overview}).%
 }
 
 \LMHash{}%
@@ -13789,8 +13787,8 @@ Assume that the generic function type instantiation succeeded.
 Let \DefineSymbol{F'} denote the type
 $[T_1/X_1, \ldots, T_s/X_s](\FunctionTypeSimple{T_0}{$p$})$.
 \commentary{%
-Note that it is guaranteed that $F'$ is assignable to $F$,
-or inference would have failed.%
+  Note that it is guaranteed that $F'$ is assignable to $F$,
+  or inference would have failed.%
 }
 Henceforth in the static analysis,
 this occurrence of $f$ is considered to have static type $F'$.
@@ -13821,10 +13819,10 @@ yielding the non-generic function objects $o'_1$ respectively $o'_2$.
 In this case \code{identical($o'_1$, $o'_2$)} shall evaluate to true.
 
 \commentary{%
-That is, constant expressions whose evaluation is
-a generic function instantiation are canonicalized,
-based on the underlying function and on the actual type arguments.
-As a consequence, they are also equal according to operator \lit{==}.%
+  That is, constant expressions whose evaluation is
+  a generic function instantiation are canonicalized,
+  based on the underlying function and on the actual type arguments.
+  As a consequence, they are also equal according to operator \lit{==}.%
 }
 
 \LMHash{}%
@@ -13840,20 +13838,20 @@ yielding the non-generic function objects $o'_1$ respectively $o'_2$.
 In this case \code{$o'_1$ == $o'_2$} shall evaluate to true.
 
 \commentary{%
-When one or both of the expressions is not constant,
-it is unspecified whether
-\code{identical($o_1$,\,\,$o_2$)} evaluates to \TRUE{} or \FALSE,
-but operator \lit{==} yields true for equal function objects
-instantiated with the same actual type arguments.%
+  When one or both of the expressions is not constant,
+  it is unspecified whether
+  \code{identical($o_1$,\,\,$o_2$)} evaluates to \TRUE{} or \FALSE,
+  but operator \lit{==} yields true for equal function objects
+  instantiated with the same actual type arguments.%
 }
 
 \rationale{%
-No notion of equality is appropriate when the type arguments differ,
-even if the resulting function objects
-turn out to have exactly the same type at run time,
-because execution of two function objects that differ in these ways
-can have different side-effects and return different results
-when executed starting from exactly the same state.%
+  No notion of equality is appropriate when the type arguments differ,
+  even if the resulting function objects
+  turn out to have exactly the same type at run time,
+  because execution of two function objects that differ in these ways
+  can have different side-effects and return different results
+  when executed starting from exactly the same state.%
 }
 
 
@@ -13869,14 +13867,14 @@ A lookup may be part of the static analysis, and it may be performed
 at run time. It may succeed or fail.
 
 \commentary{%
-We define several kinds of lookup with a very similar structure.
-We spell out each of them in spite of the redundancy,
-in order to avoid introducing meta-level abstraction mechanisms
-just for this purpose.
-The point is that we must indicate for each lookup
-which kind of member it is looking for,
-because, e.g., a `method lookup' and a `getter lookup' are used
-in different situations.%
+  We define several kinds of lookup with a very similar structure.
+  We spell out each of them in spite of the redundancy,
+  in order to avoid introducing meta-level abstraction mechanisms
+  just for this purpose.
+  The point is that we must indicate for each lookup
+  which kind of member it is looking for,
+  because, e.g., a `method lookup' and a `getter lookup' are used
+  in different situations.%
 }
 
 { % Scope for `lookup' definition.
@@ -13923,20 +13921,20 @@ Let $m$ be an identifier, $o$ an object, and $L$ a library.
 } % End of scope for lookup definitions.
 
 \commentary{%
-Note that for getter (setter) lookup, the result may be
-a getter (setter) which has been induced by an instance variable
-declaration.%
+  Note that for getter (setter) lookup, the result may be
+  a getter (setter) which has been induced by an instance variable
+  declaration.%
 }
 
 \commentary{%
-Note that we sometimes use phrases like `looking up method $m$'
-to indicate that a method lookup is performed,
-and similarly for setter lookups and getter lookups.%
+  Note that we sometimes use phrases like `looking up method $m$'
+  to indicate that a method lookup is performed,
+  and similarly for setter lookups and getter lookups.%
 }
 
 \rationale{%
-The motivation for ignoring abstract members during lookup
-is largely to allow smoother mixin composition.%
+  The motivation for ignoring abstract members during lookup
+  is largely to allow smoother mixin composition.%
 }
 
 
@@ -13952,10 +13950,10 @@ proceeds as follows:
 The getter function $m$ is invoked.
 The value of $i$ is the result returned by the call to the getter function.
 \commentary{%
-Note that the invocation is always defined.
-Per the rules for identifier references,
-an identifier will not be treated as a top-level getter invocation
-unless the getter $i$ is defined.%
+  Note that the invocation is always defined.
+  Per the rules for identifier references,
+  an identifier will not be treated as a top-level getter invocation
+  unless the getter $i$ is defined.%
 }
 
 \LMHash{}%
@@ -14043,8 +14041,8 @@ this section is only concerned with
 the syntactic classification and terminology.
 
 \commentary{%
-For example, one kind of member invocation is an ordinary method invocation
-(\ref{ordinaryInvocation}).%
+  For example, one kind of member invocation is an ordinary method invocation
+  (\ref{ordinaryInvocation}).%
 }
 
 \LMHash{}%
@@ -14070,23 +14068,23 @@ An
 is a member invocation which is not conditional.
 
 \commentary{%
-For a simple member invocation the corresponding member name is
-the name of the member which is invoked
-in the case where the member invocation invokes an instance member.
-For a composite member invocation it is the name of the getter
-and the basename of both the getter and the setter.%
+  For a simple member invocation the corresponding member name is
+  the name of the member which is invoked
+  in the case where the member invocation invokes an instance member.
+  For a composite member invocation it is the name of the getter
+  and the basename of both the getter and the setter.%
 }
 
 \rationale{%
-Note that $r$ cannot be \SUPER{}
-even though \code{\SUPER.m()} invokes an instance method.
-This is because the semantics of a superinvocation is different from
-that of other invocations.
-Among the binary operators, \lit{==} is not included.
-This is because evaluation of \code{$e_1$ == $e_2$}
-involves more steps than an instance member invocation.
-Similarly, \lit{\&\&}, and \lit{||} are not included
-because their evaluation does not involve method invocation.%
+  Note that $r$ cannot be \SUPER{}
+  even though \code{\SUPER.m()} invokes an instance method.
+  This is because the semantics of a superinvocation is different from
+  that of other invocations.
+  Among the binary operators, \lit{==} is not included.
+  This is because evaluation of \code{$e_1$ == $e_2$}
+  involves more steps than an instance member invocation.
+  Similarly, \lit{\&\&}, and \lit{||} are not included
+  because their evaluation does not involve method invocation.%
 }
 
 \begin{figure}[t]
@@ -14209,12 +14207,12 @@ $r'$ is a fresh variable bound to the value of $r$,
 with the same static type as $r$.
 
 \commentary{%
-This corresponds to an extra outermost \LET{} in each rule
-in Fig.~\ref{fig:desugarCompositeMemberInvocations}
-where $r'$ occurs,
-and an explicit distinction between the two forms of $r$,
-but the figure would be considerably more verbose if it had been
-specified in that manner.%
+  This corresponds to an extra outermost \LET{} in each rule
+  in Fig.~\ref{fig:desugarCompositeMemberInvocations}
+  where $r'$ occurs,
+  and an explicit distinction between the two forms of $r$,
+  but the figure would be considerably more verbose if it had been
+  specified in that manner.%
 }
 
 
@@ -14240,10 +14238,10 @@ $i$ of the form
 \code{$e$?.$m$<$A_1, \ldots,\ A_r$>($a_1, \ldots,\ a_n,\ x_{n+1}$: $a_{n+1}, \ldots,\ x_{n+k}$: $a_{n+k}$)}.
 
 \commentary{%
-Note that non-generic invocations arise as the special case where
-the number of type arguments is zero,
-in which case the type argument list is omitted,
-and similarly for formal type parameter lists (\ref{generics}).%
+  Note that non-generic invocations arise as the special case where
+  the number of type arguments is zero,
+  in which case the type argument list is omitted,
+  and similarly for formal type parameter lists (\ref{generics}).%
 }
 
 \LMHash{}%
@@ -14287,8 +14285,8 @@ $i$ is an invocation of the form
 where $C$ is a type literal, or $C$ denotes an extension.
 
 \commentary{%
-Non-generic invocations arise as the special case
-where the number of type arguments is zero (\ref{generics}).%
+  Non-generic invocations arise as the special case
+  where the number of type arguments is zero (\ref{generics}).%
 }
 
 \LMHash{}%
@@ -14344,8 +14342,8 @@ where $e$ is an expression that is not a type literal,
 and does not denote an extension.
 
 \commentary{%
-Non-generic invocations arise as the special case
-where the number of type arguments is zero (\ref{generics}).%
+  Non-generic invocations arise as the special case
+  where the number of type arguments is zero (\ref{generics}).%
 }
 
 \LMHash{}%
@@ -14381,14 +14379,14 @@ instance member named $m$, unless either:
   \commentary{(apart from separate static checks on subterms like arguments)}
   and the static type of $i$ is \DYNAMIC.
 \rationale{%
-This means that for invocations of an instance method named \CALL,
-a receiver of type \FUNCTION{} is treated like a receiver of type \DYNAMIC.
-The expectation is that any concrete subclass of \FUNCTION{}
-will implement \CALL,
-but there is no method signature
-which can be assumed for \CALL{} in \FUNCTION{}
-because every signature will conflict with
-some potential overriding declarations.%
+  This means that for invocations of an instance method named \CALL,
+  a receiver of type \FUNCTION{} is treated like a receiver of type \DYNAMIC.
+  The expectation is that any concrete subclass of \FUNCTION{}
+  will implement \CALL,
+  but there is no method signature
+  which can be assumed for \CALL{} in \FUNCTION{}
+  because every signature will conflict with
+  some potential overriding declarations.%
 }
 \end{itemize}
 
@@ -14411,8 +14409,8 @@ if $m$ is \code{noSuchMethod} or \code{toString}
 then let $F$ be the type of said method.
 
 \commentary{%
-Note that it is always a compile-time error if $m$
-is \code{hashCode} or \code{runtimeType}.%
+  Note that it is always a compile-time error if $m$
+  is \code{hashCode} or \code{runtimeType}.%
 }
 
 \LMHash{}%
@@ -14426,7 +14424,7 @@ Otherwise, let $d$ be the result of getter lookup
 for $m$ in $T$ with respect to $L$,
 and let $F$ be the return type of $d$.
 \commentary{%
-Since \code{$T$.$m$} exists we cannot have a failure in both lookups.%
+  Since \code{$T$.$m$} exists we cannot have a failure in both lookups.%
 }
 If the getter return type $F$ is an interface type
 that has a method named \CALL,
@@ -14515,37 +14513,35 @@ of $e_3$.
 \LMHash{}%
 It is a compile-time error to invoke an instance method on a type literal
 that is immediately followed by the token `.' (a period).
-\commentary{%
-For instance, \code{int.toString()} is an error.%
-}
+\commentary{For instance, \code{int.toString()} is an error.}
 
 \rationale{%
-The reason for this rule is that member access on a type literal
-is reserved for invocation of static members.
-Invocation of a static member of a class, mixin, enum, or extension
-uses said entity as a \emph{namespace},
-not as an actual class, mixin, enum, or extension.
-In particular, the syntactic receiver is not evaluated
-to an object---that would not even be possible for an extension.%
+  The reason for this rule is that member access on a type literal
+  is reserved for invocation of static members.
+  Invocation of a static member of a class, mixin, enum, or extension
+  uses said entity as a \emph{namespace},
+  not as an actual class, mixin, enum, or extension.
+  In particular, the syntactic receiver is not evaluated
+  to an object---that would not even be possible for an extension.%
 }
 
 \commentary{%
-A member access on a type literal
-(e.g., \code{C.id()}, \code{C.id}, or \code{C?.id()}),
-always treats the declaration denoted by the literal as
-a namespace for accessing static members or constructors.
-For instance, \code{int.toString()} is an error
-because \code{int} does not declare a static member named \code{toString}.
-It will not evaluate \code{int} to a \code{Type} object
-and then call its \code{toString} instance method.
-To do that, you can use \code{(int).toString()}.
-Note that cascades are different:
-they \emph{always} evaluate their receiver to an object first.
+  A member access on a type literal
+  (e.g., \code{C.id()}, \code{C.id}, or \code{C?.id()}),
+  always treats the declaration denoted by the literal as
+  a namespace for accessing static members or constructors.
+  For instance, \code{int.toString()} is an error
+  because \code{int} does not declare a static member named \code{toString}.
+  It will not evaluate \code{int} to a \code{Type} object
+  and then call its \code{toString} instance method.
+  To do that, you can use \code{(int).toString()}.
+  Note that cascades are different:
+  they \emph{always} evaluate their receiver to an object first.
 
-As a natural consequence,
-a type literal cannot be the receiver in
-an implicit invocation of an extension method
-(\ref{implicitExtensionInvocations}).%
+  As a natural consequence,
+  a type literal cannot be the receiver in
+  an implicit invocation of an extension method
+  (\ref{implicitExtensionInvocations}).%
 }
 
 \LMHash{}%
@@ -14611,10 +14607,10 @@ invoked with argument $im$,
 and the result of this invocation is the result of evaluating $i$.
 
 \commentary{%
-The situation where \code{noSuchMethod} is invoked can only arise
-when the static type of $e$ is \DYNAMIC.
-Notice that the wording avoids re-evaluating the receiver $o$ and
-the arguments $a_i$.%
+  The situation where \code{noSuchMethod} is invoked can only arise
+  when the static type of $e$ is \DYNAMIC.
+  Notice that the wording avoids re-evaluating the receiver $o$ and
+  the arguments $a_i$.%
 }
 \EndCase
 
@@ -14649,26 +14645,26 @@ A \IndexCustom{cascaded member access}{cascaded member access}
 is an expression derived from \synt{cascade}.
 
 \rationale{%
-A \synt{cascadeSection} allows for accessing members, including setters.
-The motivation for having a cascaded member access is that it allows for
-performing a chain of operations based on an object
-while preserving a reference to that object for further processing.%
+  A \synt{cascadeSection} allows for accessing members, including setters.
+  The motivation for having a cascaded member access is that it allows for
+  performing a chain of operations based on an object
+  while preserving a reference to that object for further processing.%
 }
 
 \commentary{%
-Let $e_0$ be an extension application
-(\ref{extensions}).
-Note that it is then a compile-time error
-to have a \synt{cascade} of the form
-\code{$e_0$..$c$} or \code{$e_0$?..$c$},
-where $c$ is a \synt{cascadeSection}.%
+  Let $e_0$ be an extension application
+  (\ref{extensions}).
+  Note that it is then a compile-time error
+  to have a \synt{cascade} of the form
+  \code{$e_0$..$c$} or \code{$e_0$?..$c$},
+  where $c$ is a \synt{cascadeSection}.%
 }
 
 \commentary{%
-For example, \code{C()..foo.bar = 2} allows us to obtain a reference to
-the object $o$ which is the result of evaluating \code{C()},
-and at the same time use $o$ to invoke the getter \code{foo} and
-the setter \code{bar=} on the value returned by that getter.%
+  For example, \code{C()..foo.bar = 2} allows us to obtain a reference to
+  the object $o$ which is the result of evaluating \code{C()},
+  and at the same time use $o$ to invoke the getter \code{foo} and
+  the setter \code{bar=} on the value returned by that getter.%
 }
 
 \LMHash{}%
@@ -14683,11 +14679,11 @@ $s$ is derived from \synt{cascadeSection} then
 \code{$e_0$..$s$} is also initially conditional.
 
 \commentary{%
-In short, a cascade is initially conditional if
-the ``innermost dots'' are \lit{?..} rather than \lit{..}.
-Note that only the innermost dots can have the \lit{?}.
-All the non-innermost ones are implicitly skipped if the receiver is null,
-so any \lit{?} on a non-innermost \lit{..} would be useless.%
+  In short, a cascade is initially conditional if
+  the ``innermost dots'' are \lit{?..} rather than \lit{..}.
+  Note that only the innermost dots can have the \lit{?}.
+  All the non-innermost ones are implicitly skipped if the receiver is null,
+  so any \lit{?} on a non-innermost \lit{..} would be useless.%
 }
 
 \LMHash{}%
@@ -14720,8 +14716,8 @@ In this case, $e$ is desugared to
 $v$\,==\,\NULL\ ?\ \NULL\ :\ \LetMany{$v_1$}{$v$.$c_1$}{$v_k$}{$v$.$c_k$}{$v$}}.
 
 \commentary{%
-Note that the grammar is such that \code{$v$.$c_j$} is
-a syntactically correct expression for all $j$.%
+  Note that the grammar is such that \code{$v$.$c_j$} is
+  a syntactically correct expression for all $j$.%
 }
 
 
@@ -14738,10 +14734,10 @@ A \Index{method superinvocation} $i$ has the form
 \code{\SUPER.$m$<$A_1, \ldots,\ A_r$>($a_1, \ldots,\ a_n,\ x_{n+1}$: $a_{n+1}, \ldots,\ x_{n+k}$: $a_{n+k}$)}.
 
 \commentary{%
-Note that non-generic invocations arise as
-the special case where the number of type arguments is zero,
-in which case the type argument list is omitted,
-and similarly for formal type parameter lists (\ref{generics}).%
+  Note that non-generic invocations arise as
+  the special case where the number of type arguments is zero,
+  in which case the type argument list is omitted,
+  and similarly for formal type parameter lists (\ref{generics}).%
 }
 
 \LMHash{}%
@@ -14782,10 +14778,10 @@ considering the function to have static type $F$,
 and the static type of $i$ is as specified there.
 
 \commentary{%
-Note that member lookups ignore abstract declarations,
-which means that there will be a compile-time error
-if the targeted member $m$ is abstract,
-as well as when it does not exist at all.%
+  Note that member lookups ignore abstract declarations,
+  which means that there will be a compile-time error
+  if the targeted member $m$ is abstract,
+  as well as when it does not exist at all.%
 }
 
 \LMHash{}%
@@ -14803,9 +14799,7 @@ and it is treated as
 \noindent
 \code{\SUPER.\CALL<$A_1, \ldots,\ A_r$>($a_1, \ldots,\ a_n,\ x_{n+1}$: $a_{n+1}, \ldots,\ x_{n+k}$: $a_{n+k}$)}.
 
-\commentary{%
-The type argument list is again omitted when $r = 0$.%
-}
+\commentary{The type argument list is again omitted when $r = 0$.}
 
 \LMHash{}%
 \BlindDefineSymbol{o, C, \SuperClass}%
@@ -14831,9 +14825,9 @@ invoke said getter with \THIS{} bound to $o$,
 and let $f$ denote the returned object.
 
 \commentary{%
-It cannot occur that both lookups fail,
-because the corresponding lookups would then have failed at compile-time,
-in which case the program has a compile-time error.%
+  It cannot occur that both lookups fail,
+  because the corresponding lookups would then have failed at compile-time,
+  in which case the program has a compile-time error.%
 }
 
 \LMHash{}%
@@ -14855,9 +14849,9 @@ Messages are the sole means of communication among isolates.
 Messages are sent by invoking specific methods in the Dart libraries; there is no specific syntax for sending a message.
 
 \commentary{%
-In other words, the methods supporting sending messages
-embody primitives of Dart that are not accessible to ordinary code,
-much like the methods that spawn isolates.%
+  In other words, the methods supporting sending messages
+  embody primitives of Dart that are not accessible to ordinary code,
+  much like the methods that spawn isolates.%
 }
 
 
@@ -14880,8 +14874,8 @@ A property extraction can be either:
 \end{enumerate}
 
 \commentary{%
-Function objects derived from members via closurization
-are colloquially known as tear-offs.%
+  Function objects derived from members via closurization
+  are colloquially known as tear-offs.%
 }
 
 \LMHash{}%
@@ -14976,12 +14970,12 @@ or the type \FUNCTION,
 $e$ is treated as \code{$e$.\CALL}.
 
 \commentary{%
-This means that a ``callable object'' may be treated as a function
-that supports a mechanism similar to function closurization
-(\ref{functionClosurization})
-by desugaring it to a method closurization on \CALL.
-This only occurs when it is statically known that it is a callable object,
-and when the context type requires a function.%
+  This means that a ``callable object'' may be treated as a function
+  that supports a mechanism similar to function closurization
+  (\ref{functionClosurization})
+  by desugaring it to a method closurization on \CALL.
+  This only occurs when it is statically known that it is a callable object,
+  and when the context type requires a function.%
 }
 \EndCase
 
@@ -14998,20 +14992,20 @@ an instance member of the built-in class \code{Object}
 and $e$ is a type literal.
 
 \commentary{%
-This means that we cannot use \code{int.toString}
-to obtain a function object for the \code{toString} method of the
-\code{Type} object for \code{int}.
-But we can use \code{(int).toString}:
-$e$ is then not a type literal, but a parenthesized expression.%
+  This means that we cannot use \code{int.toString}
+  to obtain a function object for the \code{toString} method of the
+  \code{Type} object for \code{int}.
+  But we can use \code{(int).toString}:
+  $e$ is then not a type literal, but a parenthesized expression.%
 }
 
 \rationale{%
-This is a pragmatic trade-off.
-The ability to tear off instance methods on instances of \code{Type}
-was considered less useful,
-and it was considered more useful to insist on the simple rule that
-a method tear-off on a type literal is \emph{always} a tear-off
-of a static method on the denoted class.%
+  This is a pragmatic trade-off.
+  The ability to tear off instance methods on instances of \code{Type}
+  was considered less useful,
+  and it was considered more useful to insist on the simple rule that
+  a method tear-off on a type literal is \emph{always} a tear-off
+  of a static method on the denoted class.%
 }
 
 \LMHash{}%
@@ -15053,10 +15047,10 @@ The static type of $i$ is:
 \end{itemize}
 
 \commentary{%
-Note that the type of a method tear-off ignores
-whether any given parameter is covariant.
-However, the dynamic type of a function object
-thus obtained does take parameter covariance into account.%
+  Note that the type of a method tear-off ignores
+  whether any given parameter is covariant.
+  However, the dynamic type of a function object
+  thus obtained does take parameter covariance into account.%
 }
 
 \LMHash{}%
@@ -15073,16 +15067,16 @@ the closurization of method $f$ on object $o$
 (\ref{instanceMethodClosurization}).
 
 \commentary{%
-Note that $f$ is never an abstract method,
-because method lookup skips abstract methods.
-If the method lookup failed, e.g.,
-because there is an abstract declaration of \id, but no concrete declaration,
-we will continue to the next step.
-However, since methods and getters never override each other,
-getter lookup will necessarily fail as well,
-and \code{noSuchMethod()} will ultimately be invoked.
-The regrettable implication is that the error will refer to a missing getter
-rather than an attempt to closurize an abstract method.%
+  Note that $f$ is never an abstract method,
+  because method lookup skips abstract methods.
+  If the method lookup failed, e.g.,
+  because there is an abstract declaration of \id, but no concrete declaration,
+  we will continue to the next step.
+  However, since methods and getters never override each other,
+  getter lookup will necessarily fail as well,
+  and \code{noSuchMethod()} will ultimately be invoked.
+  The regrettable implication is that the error will refer to a missing getter
+  rather than an attempt to closurize an abstract method.%
 }
 
 \LMHash{}%
@@ -15118,8 +15112,8 @@ in $o$ and invoked with argument $im$,
 and the result of this invocation is the result of evaluating $i$.
 
 \commentary{%
-The situation where \code{noSuchMethod} is invoked can only arise
-when the static type of $e$ is \DYNAMIC.%
+  The situation where \code{noSuchMethod} is invoked can only arise
+  when the static type of $e$ is \DYNAMIC.%
 }
 
 
@@ -15145,10 +15139,10 @@ The static type of $i$ is:
 \end{itemize}
 
 \commentary{%
-Note that the type of a method tear-off ignores
-whether any given parameter is covariant.
-However, the dynamic type of a function object
-thus obtained does take parameter covariance into account.%
+  Note that the type of a method tear-off ignores
+  whether any given parameter is covariant.
+  However, the dynamic type of a function object
+  thus obtained does take parameter covariance into account.%
 }
 
 \LMHash{}%
@@ -15174,9 +15168,9 @@ The body of $f$ is executed with \THIS{} bound to the current value of \THIS.
 The value of $i$ is the result returned by the call to the getter function.
 
 \commentary{%
-The getter lookup will not fail, because it is a compile-time error to have
-a super property extraction of a member \id{} when the superclass $S$
-does not have a concrete member named \id.%
+  The getter lookup will not fail, because it is a compile-time error to have
+  a super property extraction of a member \id{} when the superclass $S$
+  does not have a concrete member named \id.%
 }
 
 
@@ -15187,10 +15181,10 @@ does not have a concrete member named \id.%
 This section specifies the dynamic semantics of instance method closurizations.
 
 \commentary{%
-Note that the non-generic case is covered implicitly using $s = 0$,
-in which case the type parameter declaration lists
-and the actual type argument lists passed in invocations
-are omitted (\ref{generics}).%
+  Note that the non-generic case is covered implicitly using $s = 0$,
+  in which case the type parameter declaration lists
+  and the actual type argument lists passed in invocations
+  are omitted (\ref{generics}).%
 }
 
 \LMHash{}%
@@ -15248,9 +15242,9 @@ and $t'_1, \ldots, t'_{s'}$ be the actual type arguments.
 Then $B'_j = [t'_1/X'_1, \ldots, t'_{s'}/X'_{s'}]B_j, j \in 1 .. s$.
 
 \commentary{%
-That is, we replace the formal type parameters of the enclosing class,
-if any,
-by the corresponding actual type arguments.%
+  That is, we replace the formal type parameters of the enclosing class,
+  if any,
+  by the corresponding actual type arguments.%
 }
 
 \LMHash{}%
@@ -15260,7 +15254,7 @@ which is invoked by the expression in the body.
 Let $T$ be the class that contains $D$.
 
 \commentary{%
-Note that $T$ is the dynamic type of $o$, or a superclass thereof.%
+  Note that $T$ is the dynamic type of $o$, or a superclass thereof.%
 }
 
 \LMHash{}%
@@ -15269,13 +15263,13 @@ For each parameter $p_j$, $j \in 1 .. n+k$, if $p_j$ is covariant
 then $T_j$ is the built-in class \code{Object}.
 
 \commentary{%
-This is concerned with the dynamic type of the function object obtained by
-the member closurization.
-The static type of the expression that gives rise to the member closurization
-is specified elsewhere
-(\ref{propertyExtraction},
-\ref{getterAccessAndMethodExtraction}).
-Note that for the static type it is ignored whether a parameter is covariant.%
+  This is concerned with the dynamic type of the function object obtained by
+  the member closurization.
+  The static type of the expression that gives rise to the member closurization
+  is specified elsewhere
+  (\ref{propertyExtraction},
+  \ref{getterAccessAndMethodExtraction}).
+  Note that for the static type it is ignored whether a parameter is covariant.%
 }
 
 \LMHash{}%
@@ -15307,25 +15301,27 @@ Then \code{$c_1$ == $c_2$} evaluates to true
 if and only if $o_1$ and $o_2$ is the same object.
 
 \commentary{%
-% Spell out the consequences for `==` and for `identical`, for the receivers
-% and for the closurizations.
-In particular, two closurizations of a method $m$
-from the same object are equal,
-and two closurizations of a method $m$
-from non-identical objects are not equal.
-Assuming that $v_i$ is a fresh variable bound to an object, $i \in 1 .. 2$,
-it also follows that \code{identical($v_1.m, v_2.m$)} must be false
-when $v_1$ and $v_2$ are not bound to the same object.
-However, Dart implementations are not required to canonicalize function objects,
-which means that \code{identical($v_1.m, v_2.m$)} is not guaranteed to be true,
-even when it is known that $v_1$ and $v_2$ are bound to the same object.%
+  % Spell out the consequences for `==` and for `identical`, for the receivers
+  % and for the closurizations.
+  In particular, two closurizations of a method $m$
+  from the same object are equal,
+  and two closurizations of a method $m$
+  from non-identical objects are not equal.
+  Assuming that $v_i$ is a fresh variable bound to an object, $i \in 1 .. 2$,
+  it also follows that \code{identical($v_1.m, v_2.m$)} must be false
+  when $v_1$ and $v_2$ are not bound to the same object.
+  However, Dart implementations are not required
+  to canonicalize function objects,
+  which means that \code{identical($v_1.m, v_2.m$)}
+  is not guaranteed to be true,
+  even when it is known that $v_1$ and $v_2$ are bound to the same object.%
 }
 
 \rationale{%
-The special treatment of equality in this case facilitates
-the use of extracted property functions in APIs where callbacks
-such as event listeners must often be registered and later unregistered.
-A common example is the DOM API in web browsers.%
+  The special treatment of equality in this case facilitates
+  the use of extracted property functions in APIs where callbacks
+  such as event listeners must often be registered and later unregistered.
+  A common example is the DOM API in web browsers.%
 }
 
 
@@ -15337,8 +15333,8 @@ This section specifies the dynamic semantics of
 super closurizations.
 
 \commentary{%
-Note that the non-generic case is covered implicitly using $s = 0$,
-in which case the type parameter declarations are omitted (\ref{generics}).%
+  Note that the non-generic case is covered implicitly using $s = 0$,
+  in which case the type parameter declarations are omitted (\ref{generics}).%
 }
 
 \LMHash{}%
@@ -15349,8 +15345,8 @@ and there is no class $U$ which is
 a subclass of $S$ and a superclass of $T$ which implements $f$.
 
 \commentary{%
-In short, consider a situation where
-a superinvocation of $f$ will execute $f$ as declared in $S$.%
+  In short, consider a situation where
+  a superinvocation of $f$ will execute $f$ as declared in $S$.%
 }
 
 \LMHash{}%
@@ -15394,8 +15390,8 @@ and optional positional parameters
 \end{itemize}
 
 \commentary{%
-Note that a super closurization is an instance method closurization,
-as defined in (\ref{instanceMethodClosurization}).%
+  Note that a super closurization is an instance method closurization,
+  as defined in (\ref{instanceMethodClosurization}).%
 }
 
 \LMHash{}%
@@ -15406,11 +15402,12 @@ and $t'_1, \ldots, t'_{s'}$ be the actual type arguments of \THIS{} at $S$.
 Then $B'_j = [t'_1/X'_1, \ldots, t'_{s'}/X'_{s'}]B_j, j \in 1 .. s$.
 
 \commentary{%
-That is, we replace the formal type parameters of the enclosing class, if any,
-by the corresponding actual type arguments.
-We need to consider the type arguments with respect to a specific class because
-it is possible for a class to pass different type arguments to its superclass
-than the ones it receives itself.%
+  That is, we replace the formal type parameters of the enclosing class, if any,
+  by the corresponding actual type arguments.
+  We need to consider the type arguments with respect to a specific class
+  because it is possible for a class to pass different type arguments
+  to its superclass
+  than the ones it receives itself.%
 }
 
 \LMHash{}%
@@ -15423,13 +15420,13 @@ For each parameter $p_j$, $j \in 1 .. n+k$, if $p_j$ is covariant
 then $T_j$ is the built-in class \code{Object}.
 
 \commentary{%
-This is concerned with the dynamic type of the function object obtained by
-the super closurization.
-The static type of the expression that gives rise to the super closurization
-is specified elsewhere
-(\ref{propertyExtraction},
-\ref{superGetterAccessAndMethodClosurization}).
-Note that for the static type it is ignored whether a parameter is covariant.%
+  This is concerned with the dynamic type of the function object obtained by
+  the super closurization.
+  The static type of the expression that gives rise to the super closurization
+  is specified elsewhere
+  (\ref{propertyExtraction},
+  \ref{superGetterAccessAndMethodClosurization}).
+  Note that for the static type it is ignored whether a parameter is covariant.%
 }
 
 \LMHash{}%
@@ -15476,20 +15473,20 @@ based on a property extraction which denotes an instance method closurization
 (\ref{instanceMethodClosurization}, \ref{superClosurization}).
 
 \commentary{%
-It is a mechanism which is very similar to instance method closurization,
-but it only occurs in situations where
-a compile-time error would otherwise occur.%
+  It is a mechanism which is very similar to instance method closurization,
+  but it only occurs in situations where
+  a compile-time error would otherwise occur.%
 }
 
 \rationale{%
-The essence of generic method instantiation
-is to allow for ``curried'' invocations,
-in the sense that a generic instance method can receive its actual
-type arguments separately during closurization
-(it must then receive \emph{all} type arguments, not just some of them),
-and that yields a non-generic function object.
-The type arguments are passed implicitly, based on type inference;
-a future version of Dart may allow for passing them explicitly.%
+  The essence of generic method instantiation
+  is to allow for ``curried'' invocations,
+  in the sense that a generic instance method can receive its actual
+  type arguments separately during closurization
+  (it must then receive \emph{all} type arguments, not just some of them),
+  and that yields a non-generic function object.
+  The type arguments are passed implicitly, based on type inference;
+  a future version of Dart may allow for passing them explicitly.%
 }
 \commentary{Here is an example:}
 
@@ -15508,34 +15505,34 @@ a future version of Dart may allow for passing them explicitly.%
 \}
 \end{dartCode}
 
-\commentary{%
 \noindent
-The function object which is stored in \code{f} at the end of \code{main}
-has dynamic type \code{int\,\,\FUNCTION(int,\,[List<int>])},
-and it is obtained by implicitly
-``passing the actual type argument \code{int}''
-to the denoted generic instance method,
-thus obtaining a non-generic function object of the specified type.
-%
-Note that this function object accepts an optional positional argument,
-even though this is not part of
-the statically known type of the corresponding instance method,
-nor of the context type.%
+\commentary{%
+  The function object which is stored in \code{f} at the end of \code{main}
+  has dynamic type \code{int\,\,\FUNCTION(int,\,[List<int>])},
+  and it is obtained by implicitly
+  ``passing the actual type argument \code{int}''
+  to the denoted generic instance method,
+  thus obtaining a non-generic function object of the specified type.
+  %
+  Note that this function object accepts an optional positional argument,
+  even though this is not part of
+  the statically known type of the corresponding instance method,
+  nor of the context type.%
 }
 
 \rationale{%
-In other words, generic method instantiation yields a function
-whose signature matches the context type as far as possible,
-but with respect to its parameter list shape
-(that is, the number of positional parameters and their optionality,
-or the set of names of named parameters),
-it will be determined by the method signature of the actual instance method
-of the given receiver.
-Of course, the difference can only be such that the actual type is
-% This is about the dynamic type, so there is no exception for \COVARIANT.
-a subtype of the given context type,
-otherwise the declaration of that instance method
-would have been a compile-time error.%
+  In other words, generic method instantiation yields a function
+  whose signature matches the context type as far as possible,
+  but with respect to its parameter list shape
+  (that is, the number of positional parameters and their optionality,
+  or the set of names of named parameters),
+  it will be determined by the method signature of the actual instance method
+  of the given receiver.
+  Of course, the difference can only be such that the actual type is
+  % This is about the dynamic type, so there is no exception for \COVARIANT.
+  a subtype of the given context type,
+  otherwise the declaration of that instance method
+  would have been a compile-time error.%
 }
 
 \LMHash{}%
@@ -15621,9 +15618,9 @@ Consider the situation where generic function type instantiation succeeded.
 Let \gmiName{} be a fresh name which is associated with \id,
 which is private if and only if \id{} is private.
 \commentary{%
-An implementation could use, say, \code{foo_*} when \id{} is \code{foo},
-which is known to be fresh because
-user-written identifiers cannot contain `\code{*}'.%
+  An implementation could use, say, \code{foo_*} when \id{} is \code{foo},
+  which is known to be fresh because
+  user-written identifiers cannot contain `\code{*}'.%
 }
 The program is then modified as follows:
 
@@ -15652,26 +15649,27 @@ formal type parameters \TypeParametersStd,
 and formal parameter declarations \metavar{parameters}.
 Let \metavar{arguments} denote the corresponding actual argument list,
 passing these parameters.
+
 \commentary{%
-For instance, \metavar{parameters} could be
+  For instance, \metavar{parameters} could be
 
-\noindent
-\code{$\PairList{T}{p}{1}{n},\ $\{$T_{n+1}\ p_{n+1} = d_1, \ldots,\ T_{n+k}\ p_{n+k} = d_k$\}}
+  \noindent
+  \code{$\PairList{T}{p}{1}{n},\ $\{$T_{n+1}\ p_{n+1} = d_1, \ldots,\ T_{n+k}\ p_{n+k} = d_k$\}}
 
-\noindent
-in which case \metavar{arguments} would be
-\code{\List{p}{1}{n},\ $p_{n+1}$:\ $p_{n+1}$,\ $p_{n+k}$:\ $p_{n+k}$}.%
+  \noindent
+  in which case \metavar{arguments} would be
+  \code{\List{p}{1}{n},\ $p_{n+1}$:\ $p_{n+1}$,\ $p_{n+k}$:\ $p_{n+k}$}.%
 }
 
 \LMHash{}%
 Let $G'$ be the same function type as $G$,
 except that it omits the formal type parameter declarations.
 \commentary{%
-For instance, if $G$ is
-\FunctionTypeSimpleGeneric{\VOID}{$X$, $Y$ \EXTENDS\ num}{X x, List<Y> ys}
-then $G'$ is
-\FunctionTypeSimple{\VOID}{X x, List<Y> ys}.
-Note that $G'$ will typically contain free type variables.%
+  For instance, if $G$ is
+  \FunctionTypeSimpleGeneric{\VOID}{$X$, $Y$ \EXTENDS\ num}{X x, List<Y> ys}
+  then $G'$ is
+  \FunctionTypeSimple{\VOID}{X x, List<Y> ys}.
+  Note that $G'$ will typically contain free type variables.%
 }
 
 \LMHash{}%
@@ -15709,11 +15707,11 @@ evaluates to \TRUE{} or \FALSE.
 } % End of scope for \gmiName.
 
 \rationale{%
-No notion of equality is appropriate with different receivers,
-nor when different type arguments are provided,
-because execution of two function objects that differ in these ways
-can have different side-effects and return different results
-when executed starting from exactly the same state.%
+  No notion of equality is appropriate with different receivers,
+  nor when different type arguments are provided,
+  because execution of two function objects that differ in these ways
+  can have different side-effects and return different results
+  when executed starting from exactly the same state.%
 }
 
 
@@ -15937,8 +15935,8 @@ Then the method \code{noSuchMethod()} is looked up in $o_1$
 and invoked with argument $im$.
 
 \commentary{%
-The situation where \code{noSuchMethod} is invoked can only arise
-when the static type of $e_1$ is \DYNAMIC.%
+  The situation where \code{noSuchMethod} is invoked can only arise
+  when the static type of $e_1$ is \DYNAMIC.%
 }
 
 \LMHash{}%
@@ -15969,8 +15967,8 @@ The body of \code{$v$=} is executed with its formal parameter bound to $o$
 and \THIS{} bound to the current value of \THIS.
 
 \commentary{%
-The setter lookup will not fail, because it is a compile-time error
-when no concrete setter named \code{$v$=} exists in $S_{static}$.%
+  The setter lookup will not fail, because it is a compile-time error
+  when no concrete setter named \code{$v$=} exists in $S_{static}$.%
 }
 
 \LMHash{}%
@@ -16465,16 +16463,16 @@ Otherwise,
 \end{itemize}
 
 \commentary{%
-As a result of the above definition,
-user defined \lit{==} methods can assume that their argument is non-null,
-and avoid the standard boiler-plate prelude:
+  As a result of the above definition,
+  user defined \lit{==} methods can assume that their argument is non-null,
+  and avoid the standard boiler-plate prelude:
 
-\code{if (identical(\NULL, arg)) return \FALSE;}
+  \code{if (identical(\NULL, arg)) return \FALSE;}
 
-Another implication is that there is never a need
-to use \code{identical()} to test against \NULL,
-nor should anyone ever worry about whether to write
-\NULL{} == $e$ or $e$ == \NULL.%
+  Another implication is that there is never a need
+  to use \code{identical()} to test against \NULL,
+  nor should anyone ever worry about whether to write
+  \NULL{} == $e$ or $e$ == \NULL.%
 }
 
 \LMHash{}%
@@ -16558,11 +16556,11 @@ A bitwise expression of the form \code{\SUPER{} $op$ $e_2$} is equivalent to
 the method invocation \code{\SUPER.$op$($e_2$)}.
 
 \commentary{%
-It should be obvious that the static type rules for these expressions
-are defined by the equivalence above---ergo,
-by the type rules for method invocation and
-the signatures of the operators on the type $e_1$.
-The same holds in similar situations throughout this specification.%
+  It should be obvious that the static type rules for these expressions
+  are defined by the equivalence above---ergo,
+  by the type rules for method invocation and
+  the signatures of the operators on the type $e_1$.
+  The same holds in similar situations throughout this specification.%
 }
 
 
@@ -16596,13 +16594,13 @@ A shift expression of the form \SUPER{} $op$ $e_2$ is equivalent to
 the method invocation \code{\SUPER.$op$($e_2$)}.
 
 \commentary{%
-Note that this definition implies left-to-right evaluation order
-among shift expressions:
-\code{$e_1$\,<\mbox<\,$e_2$\,<\mbox<\,$e_3$}
-is evaluated as
-\code{($e_1$\,<\mbox<\,$e_2$).<\mbox< ($e_3$)} which is equivalent to
-\code{($e_1$\,<\mbox<\,$e_2$)\,<\mbox<\,$e_3$}.
-The same holds for additive and multiplicative expressions.%
+  Note that this definition implies left-to-right evaluation order
+  among shift expressions:
+  \code{$e_1$\,<\mbox<\,$e_2$\,<\mbox<\,$e_3$}
+  is evaluated as
+  \code{($e_1$\,<\mbox<\,$e_2$).<\mbox< ($e_3$)} which is equivalent to
+  \code{($e_1$\,<\mbox<\,$e_2$)\,<\mbox<\,$e_3$}.
+  The same holds for additive and multiplicative expressions.%
 }
 
 
@@ -16818,10 +16816,10 @@ If $i$ is zero, the resulting instance instead represents the
 It is a compile-time error if the integer $-i$ cannot be represented
 exactly by an instance of \code{double}.
 \commentary{%
-We treat \code{-$l$} \emph{as if} it is a single integer literal
-with a negative numeric value.
-We do not evaluate $l$ individually as an expression,
-or concern ourselves with its static type.%
+  We treat \code{-$l$} \emph{as if} it is a single integer literal
+  with a negative numeric value.
+  We do not evaluate $l$ individually as an expression,
+  or concern ourselves with its static type.%
 }
 
 \LMHash{}%
@@ -16875,53 +16873,54 @@ $a$ throws $x$ and $t$
 If $f$ completes with an object $v$, $a$ evaluates to $v$.
 
 \rationale{%
-The use of \flattenName{} to find $T$ and hence determine the dynamic type test
-implies that we await a future in every case where this choice is sound.%
+  The use of \flattenName{} to find $T$
+  and hence determine the dynamic type test
+  implies that we await a future in every case where this choice is sound.%
 }
 
 \commentary{%
-An interesting case on the edge of this trade-off is when $e$
-has the static type \code{FutureOr<Object>?}.
-You could say that the intention behind this type is that
-the value of $e$ is a \code{Future<Object>},
-or it is an \code{Object} which is not a future,
-or it is \NULL.
-So, presumably, we should await the first kind,
-and we should pass on the second and third kind unchanged.
-However, the second kind could be a \code{Future<Object?>}.
-This object isn't a \code{Future<Object>}, and it isn't \NULL,
-so it \emph{must} be considered to be in the second group.
-Nevertheless, \flatten{\code{FutureOr<Object>?}} is \code{Object?},
-so we \emph{will} await a \code{Future<Object?>}.
-We have chosen this semantics because it was the smallest breaking change
-relative to the semantics in earlier versions of Dart,
-and also because it allows for a simple rule:
-The type of \code{\AWAIT\,\,$e$} is used to decide whether or not
-the future (if any) is awaited, and there are no exceptions---even
-in cases like this example, where the type seems to imply that
-a \code{Future<Object?>} should not be awaited.
-In summary, we await every future that we can soundly await.%
+  An interesting case on the edge of this trade-off is when $e$
+  has the static type \code{FutureOr<Object>?}.
+  You could say that the intention behind this type is that
+  the value of $e$ is a \code{Future<Object>},
+  or it is an \code{Object} which is not a future,
+  or it is \NULL.
+  So, presumably, we should await the first kind,
+  and we should pass on the second and third kind unchanged.
+  However, the second kind could be a \code{Future<Object?>}.
+  This object isn't a \code{Future<Object>}, and it isn't \NULL,
+  so it \emph{must} be considered to be in the second group.
+  Nevertheless, \flatten{\code{FutureOr<Object>?}} is \code{Object?},
+  so we \emph{will} await a \code{Future<Object?>}.
+  We have chosen this semantics because it was the smallest breaking change
+  relative to the semantics in earlier versions of Dart,
+  and also because it allows for a simple rule:
+  The type of \code{\AWAIT\,\,$e$} is used to decide whether or not
+  the future (if any) is awaited, and there are no exceptions---even
+  in cases like this example, where the type seems to imply that
+  a \code{Future<Object?>} should not be awaited.
+  In summary, we await every future that we can soundly await.%
 }
 
 \commentary{%
-An await expression can only occur in a function which is declared
-asynchronous. The \AWAIT{} identifier has has no special meaning
-in the context of a normal function, so occurrences of \AWAIT{}
-in those functions does not introduce an await expression.
-However, \code{\AWAIT ($e$)} can be a valid function invocation in
-non-asynchronous functions.%
+  An await expression can only occur in a function which is declared
+  asynchronous. The \AWAIT{} identifier has has no special meaning
+  in the context of a normal function, so occurrences of \AWAIT{}
+  in those functions does not introduce an await expression.
+  However, \code{\AWAIT ($e$)} can be a valid function invocation in
+  non-asynchronous functions.%
 }
 
 \rationale{%
-An await expression could not meaningfully occur in a synchronous function.
-If such a function were to suspend waiting for a future,
-it would no longer be synchronous.%
+  An await expression could not meaningfully occur in a synchronous function.
+  If such a function were to suspend waiting for a future,
+  it would no longer be synchronous.%
 }
 
 \commentary{%
-It is not a compile-time error if the type of $e$ is not
-a supertype or subtype of \code{Future}.
-Tools may choose to give a hint in such cases.%
+  It is not a compile-time error if the type of $e$ is not
+  a supertype or subtype of \code{Future}.
+  Tools may choose to give a hint in such cases.%
 }
 
 
@@ -16976,11 +16975,11 @@ then $e$ is treated as \code{\NEW\,\,$e$}.
 % We might add support for passing type arguments to static methods,
 % but that is not a feature which is coming any time soon.
 \commentary{%
-Note that $e$ cannot be anything other than an instance creation
-(constant or not)
-because $e$ provides actual type arguments to $n$,
-which is not supported if $n$ denotes a library prefix,
-nor if $e$ is a static method invocation.%
+  Note that $e$ cannot be anything other than an instance creation
+  (constant or not)
+  because $e$ provides actual type arguments to $n$,
+  which is not supported if $n$ denotes a library prefix,
+  nor if $e$ is a static method invocation.%
 }
 \EndCase
 
@@ -17012,9 +17011,9 @@ Evaluate \code{$v$ = $y$ + 1} respectively \code{$v$ = $y$ - 1}.
 Then $e$ evaluates to $r$.
 
 \rationale{%
-The above ensures that if the evaluation involves a getter,
-it gets called exactly once.
-Likewise in the cases below.%
+  The above ensures that if the evaluation involves a getter,
+  it gets called exactly once.
+  Likewise in the cases below.%
 }
 \EndCase
 
@@ -17142,20 +17141,20 @@ The semantics of an assignment as a whole is described elsewhere
 (\ref{assignment}).
 
 \commentary{%
-The grammar of assignable expressions includes very general forms
-like an identifier \id{} or a qualified identifier \code{$\id_1$.$\id_2$}.
-Hence, an assignable expression can have many different meanings,
-depending on the binding of those identifiers in the context.
+  The grammar of assignable expressions includes very general forms
+  like an identifier \id{} or a qualified identifier \code{$\id_1$.$\id_2$}.
+  Hence, an assignable expression can have many different meanings,
+  depending on the binding of those identifiers in the context.
 
-For example, the term \code{x.y.z} is an assignable expression.
-\code{x.y} may refer to a getter \code{y} on
-an object referenced by a variable \code{x},
-in which case \code{x.y} will be evaluated to an object
-before accessing the \code{z} member of that object.
-The term \code{x.y} could also denote a class \code{y} referenced through
-an import prefix \code{x},
-with \code{z} denoting a static variable of that class.
-In this case \code{x.y} will not be evaluated to a value.%
+  For example, the term \code{x.y.z} is an assignable expression.
+  \code{x.y} may refer to a getter \code{y} on
+  an object referenced by a variable \code{x},
+  in which case \code{x.y} will be evaluated to an object
+  before accessing the \code{z} member of that object.
+  The term \code{x.y} could also denote a class \code{y} referenced through
+  an import prefix \code{x},
+  with \code{z} denoting a static variable of that class.
+  In this case \code{x.y} will not be evaluated to a value.%
 }
 
 \begin{grammar}
@@ -17194,11 +17193,11 @@ that is, they are only used if no other case matches
 }.
 
 \commentary{%
-Syntactically, these expressions are not derived from \synt{expression},
-but they are derivable from \synt{expression}, e.g., because
-an \synt{assignableExpression} may contain a \synt{primary}
-which is derivable from \synt{expression}.
-We use the following rule to find such expressions:%
+  Syntactically, these expressions are not derived from \synt{expression},
+  but they are derivable from \synt{expression}, e.g., because
+  an \synt{assignableExpression} may contain a \synt{primary}
+  which is derivable from \synt{expression}.
+  We use the following rule to find such expressions:%
 }
 
 \LMHash{}%
@@ -17214,12 +17213,11 @@ When $t$ is an expression, we say that $t$ is the
 of $e$.
 
 \commentary{%
-In short, we obtain $t$ by cutting off an assignable selector
-from the end of $e$.
-It is easy to see that only some \synt{assignableExpression}s
-have a receiver term.
-For instance, a plain \synt{identifier} does not.
-%
+  In short, we obtain $t$ by cutting off an assignable selector
+  from the end of $e$.
+  It is easy to see that only some \synt{assignableExpression}s
+  have a receiver term.
+  For instance, a plain \synt{identifier} does not.%
 }
 
 \LMHash{}%
@@ -17244,11 +17242,11 @@ A lexical lookup can yield a declaration or an import prefix,
 and it can yield nothing.
 
 \commentary{%
-It is not a compile-time error when the lexical lookup yields nothing.
-In this situation the given name $n$ will be transformed into
-\code{\THIS.$n$},
-and the static analysis of the resulting expression
-may or may not have any compile-time errors.%
+  It is not a compile-time error when the lexical lookup yields nothing.
+  In this situation the given name $n$ will be transformed into
+  \code{\THIS.$n$},
+  and the static analysis of the resulting expression
+  may or may not have any compile-time errors.%
 }
 
 \LMHash{}%
@@ -17258,24 +17256,24 @@ However, that is different from a result yielded by the lexical lookup,
 because this specification never specifies the propagation of errors.
 
 \commentary{%
-In other words, when other parts of this specification indicate that
-a lexical lookup is performed,
-they need to consider the further steps taken
-when the lookup yields a declaration,
-when it yields an import prefix,
-and when it yields nothing.
-But they do not mention that, e.g., \code{\id.m} is an error
-because the lexical lookup for \id{} incurred an error.%
+  In other words, when other parts of this specification indicate that
+  a lexical lookup is performed,
+  they need to consider the further steps taken
+  when the lookup yields a declaration,
+  when it yields an import prefix,
+  and when it yields nothing.
+  But they do not mention that, e.g., \code{\id.m} is an error
+  because the lexical lookup for \id{} incurred an error.%
 }
 
 \commentary{%
-A lexical lookup differs from a lookup of an instance member
-(\ref{lookup})
-because that operation searches through a sequence of superclasses,
-whereas a lexical lookup searches through a sequence of enclosing scopes.
-A lexical lookup differs from a straightforward lookup in the enclosing scopes
-because the lexical lookup ``bundles'' getters and setters,
-as detailed below.%
+  A lexical lookup differs from a lookup of an instance member
+  (\ref{lookup})
+  because that operation searches through a sequence of superclasses,
+  whereas a lexical lookup searches through a sequence of enclosing scopes.
+  A lexical lookup differs from a straightforward lookup in the enclosing scopes
+  because the lexical lookup ``bundles'' getters and setters,
+  as detailed below.%
 }
 
 \LMHash{}%
@@ -17288,13 +17286,13 @@ and a lexical lookup of $n$ is performed from a given location
 \DefineSymbol{\ell}.
 
 \commentary{%
-We specify a name and a location from where a lexical lookup is performed.
-The location is not always redundant:
-In some situations we perform a lookup for a setter named \code{\id=},
-but the token \code{\id=} does not occur in the program.
-To handle such situations we must specify both
-the name which is being looked up,
-and the location that determines which scopes are the enclosing ones.%
+  We specify a name and a location from where a lexical lookup is performed.
+  The location is not always redundant:
+  In some situations we perform a lookup for a setter named \code{\id=},
+  but the token \code{\id=} does not occur in the program.
+  To handle such situations we must specify both
+  the name which is being looked up,
+  and the location that determines which scopes are the enclosing ones.%
 }
 
 \LMHash{}%
@@ -17313,22 +17311,22 @@ exactly one declaration with basename \id,
 let $D$ be that declaration.
 
 \commentary{%
-A non-local variable declaration named \id{} will implicitly induce
-a getter \id{} and possibly a setter \code{\id=} into the current scope.
-This means that $D$ may denote an implicitly induced getter or setter
-rather than the underlying variable declaration.
-That is significant in the case where an error must arise
-because the lookup was for one kind, but only the other kind exists.%
+  A non-local variable declaration named \id{} will implicitly induce
+  a getter \id{} and possibly a setter \code{\id=} into the current scope.
+  This means that $D$ may denote an implicitly induced getter or setter
+  rather than the underlying variable declaration.
+  That is significant in the case where an error must arise
+  because the lookup was for one kind, but only the other kind exists.%
 }
 
 \commentary{%
-If we are looking up a name $n$ with basename \id,
-we stop searching if we find any declaration named \id{} or \code{\id=}.
-If, in that scope, there are declarations for both \id{} and \code{\id=},
-we return the one which has the requested name $n$.
-In the case where only one declaration is present, we return it,
-even though it may have the name \id{} when $n$ is \code{\id=}, or vice versa.
-That situation may cause an error, as specified below.%
+  If we are looking up a name $n$ with basename \id,
+  we stop searching if we find any declaration named \id{} or \code{\id=}.
+  If, in that scope, there are declarations for both \id{} and \code{\id=},
+  we return the one which has the requested name $n$.
+  In the case where only one declaration is present, we return it,
+  even though it may have the name \id{} when $n$ is \code{\id=}, or vice versa.
+  That situation may cause an error, as specified below.%
 }
 
 \LMHash{}%
@@ -17344,14 +17342,14 @@ unless $D$ is an instance member or a local variable
 \commentary{(which may be a formal parameter)}.
 
 \commentary{%
-That is, it is an error if we look for a setter and find a getter,
-or vice versa,
-but not an error if we look for a setter and find a local variable.
-If we look for a setter and find an instance getter, or vice versa,
-it is not an error,
-because the setter could be inherited.
-That is checked after yielding nothing
-(which implies that \THIS{} will be prepended).%
+  That is, it is an error if we look for a setter and find a getter,
+  or vice versa,
+  but not an error if we look for a setter and find a local variable.
+  If we look for a setter and find an instance getter, or vice versa,
+  it is not an error,
+  because the setter could be inherited.
+  That is checked after yielding nothing
+  (which implies that \THIS{} will be prepended).%
 }
 
 \LMHash{}%
@@ -17366,26 +17364,26 @@ It is a compile-time error if $\ell$ does not have access to \THIS{}
 \EndCase
 
 \rationale{%
-We are always looking up \emph{both} \id{} and \code{\id=},
-no matter whether $n$ is \id{} or \code{\id=}.
-This approach creates a tighter connection between a pair of declarations
-where one is a getter named \id{}
-and the other is a setter named \code{\id=}.
-This allows developers to think about
-a getter and setter that are declared together as a single entity,
-rather than two independent declarations.%
+  We are always looking up \emph{both} \id{} and \code{\id=},
+  no matter whether $n$ is \id{} or \code{\id=}.
+  This approach creates a tighter connection between a pair of declarations
+  where one is a getter named \id{}
+  and the other is a setter named \code{\id=}.
+  This allows developers to think about
+  a getter and setter that are declared together as a single entity,
+  rather than two independent declarations.%
 }
 
 \commentary{%
-For example, if a term refers to \id{} and needs a setter,
-and the innermost declaration named \id{} or \code{\id=} is a getter $g$
-and there is no corresponding setter,
-it is a compile-time error.
-This error occurs even in the case where a more remote enclosing scope has
-a declaration of a setter $s$ named \code{\id=},
-because we already committed to using $g$
-(so that's actually ``a setter/getter pair where the setter is missing''),
-and we could say that this ``pair'' shadows $s$:%
+  For example, if a term refers to \id{} and needs a setter,
+  and the innermost declaration named \id{} or \code{\id=} is a getter $g$
+  and there is no corresponding setter,
+  it is a compile-time error.
+  This error occurs even in the case where a more remote enclosing scope has
+  a declaration of a setter $s$ named \code{\id=},
+  because we already committed to using $g$
+  (so that's actually ``a setter/getter pair where the setter is missing''),
+  and we could say that this ``pair'' shadows $s$:%
 }
 
 \begin{dartCode}
@@ -17444,18 +17442,18 @@ proceed as described in the first applicable case from the following list:
 \end{itemize}
 
 \rationale{%
-Note that a lexical lookup will never yield a declaration of
-an instance member.
-In each case where it is determined that there is no error,
-and an instance member is the result of the lookup,
-the lexical lookup yields nothing.
+  Note that a lexical lookup will never yield a declaration of
+  an instance member.
+  In each case where it is determined that there is no error,
+  and an instance member is the result of the lookup,
+  the lexical lookup yields nothing.
 
-The reason for this is that there may not be a declaration in scope,
-but the interface of the class could have the required member,
-or an extension method could be applicable.
-So, for uniformity,
-in these situations we always report that nothing was found,
-which implies that \THIS{} should be added.%
+  The reason for this is that there may not be a declaration in scope,
+  but the interface of the class could have the required member,
+  or an extension method could be applicable.
+  So, for uniformity,
+  in these situations we always report that nothing was found,
+  which implies that \THIS{} should be added.%
 }
 
 
@@ -17538,22 +17536,22 @@ A \Index{built-in identifier} is one of
 the identifiers produced by the production \synt{BUILT\_IN\_IDENTIFIER}.
 
 \commentary{%
-Note that it is a syntax error if a built-in identifier
-is used as the declared name of
-%% TODO(eernst): Come extension types, add them.
-a prefix, class, mixin, enum, type parameter, type alias, or extension.
-Similarly, it is a syntax error to use a built-in identifier
-other than \DYNAMIC{} or \FUNCTION{}
-as an identifier in a type annotation or a type parameter bound.%
+  Note that it is a syntax error if a built-in identifier
+  is used as the declared name of
+  %% TODO(eernst): Come extension types, add them.
+  a prefix, class, mixin, enum, type parameter, type alias, or extension.
+  Similarly, it is a syntax error to use a built-in identifier
+  other than \DYNAMIC{} or \FUNCTION{}
+  as an identifier in a type annotation or a type parameter bound.%
 }
 
 \rationale{%
-Built-in identifiers are identifiers that are used as keywords in Dart,
-but are not reserved words.
-A built-in identifier may not be used to name a class or type.
-In other words, they are treated as reserved words when used as types.
-This eliminates many confusing situations,
-both for human readers and during parsing.%
+  Built-in identifiers are identifiers that are used as keywords in Dart,
+  but are not reserved words.
+  A built-in identifier may not be used to name a class or type.
+  In other words, they are treated as reserved words when used as types.
+  This eliminates many confusing situations,
+  both for human readers and during parsing.%
 }
 
 \LMHash{}%
@@ -17562,11 +17560,11 @@ is used as an \synt{identifier} in a function body
 marked with either \ASYNC, \code{\ASYNC*}, or \code{\SYNC*}.
 
 \rationale{%
-This makes the identifiers \AWAIT{} and \YIELD{} behave like reserved words
-in a limited context.
-This approach was chosen because it was less breaking than it would have been
-to make \AWAIT{} and \YIELD{} reserved words or built-in identifiers,
-at the time where these features were added to the language.%
+  This makes the identifiers \AWAIT{} and \YIELD{} behave like reserved words
+  in a limited context.
+  This approach was chosen because it was less breaking than it would have been
+  to make \AWAIT{} and \YIELD{} reserved words or built-in identifiers,
+  at the time where these features were added to the language.%
 }
 
 \LMHash{}%
@@ -17654,9 +17652,9 @@ No static type is associated with $e$ in this case.
 % of every construct of the form $p$.something is specified without referring
 % to the static type of $p$. So we do not mention that type here.
 \commentary{%
-No such type is needed, because every construct where
-an import prefix $p$ is used and followed by \lit{.} is specified
-in such a way that the type of $p$ is not used.%
+  No such type is needed, because every construct where
+  an import prefix $p$ is used and followed by \lit{.} is specified
+  in such a way that the type of $p$ is not used.%
 }
 \EndCase
 
@@ -17670,11 +17668,11 @@ $e$ is treated as
 \code{\THIS.\id}.
 
 \commentary{%
-In this case it is known that $e$ has access to \THIS{}
-(\ref{classes}).
-Both the static analysis and evaluation proceeds with
-\code{\THIS.\id},
-so there is no need to further specify the treatment of $e$.%
+  In this case it is known that $e$ has access to \THIS{}
+  (\ref{classes}).
+  Both the static analysis and evaluation proceeds with
+  \code{\THIS.\id},
+  so there is no need to further specify the treatment of $e$.%
 }
 \EndCase
 
@@ -17736,14 +17734,14 @@ The evaluation of $e$ proceeds as follows:
 \end{itemize}
 
 \commentary{%
-Note that $D$ cannot be the declaration of
-a static variable, static getter or static setter declared in a class $C$,
-because in that case $e$ is treated as
-(\ref{notation})
-the property extraction
-(\ref{propertyExtraction})
-\code{$C$.\id},
-which also determines the evaluation of $e$.%
+  Note that $D$ cannot be the declaration of
+  a static variable, static getter or static setter declared in a class $C$,
+  because in that case $e$ is treated as
+  (\ref{notation})
+  the property extraction
+  (\ref{propertyExtraction})
+  \code{$C$.\id},
+  which also determines the evaluation of $e$.%
 }
 \EndCase
 
@@ -17789,15 +17787,15 @@ the is-expression evaluates to \TRUE.
 Otherwise it evaluates to \FALSE.
 
 \commentary{%
-It follows that \code{$e$ \IS{} Object} is always true.
-This makes sense in a language where everything is an object.
+  It follows that \code{$e$ \IS{} Object} is always true.
+  This makes sense in a language where everything is an object.
 
-Also note that \code{\NULL{} \IS{} $T$} is false
-unless $T = \code{Object}$, $T = \code{\DYNAMIC}$ or $T = \code{Null}$.
-The former two are useless, as is anything
-of the form \code{$e$ \IS{} Object} or \code{$e$ \IS{} \DYNAMIC}.
-Users should test for the null object (\ref{null}) directly
-rather than via type tests.%
+  Also note that \code{\NULL{} \IS{} $T$} is false
+  unless $T = \code{Object}$, $T = \code{\DYNAMIC}$ or $T = \code{Null}$.
+  The former two are useless, as is anything
+  of the form \code{$e$ \IS{} Object} or \code{$e$ \IS{} \DYNAMIC}.
+  Users should test for the null object (\ref{null}) directly
+  rather than via type tests.%
 }
 
 \LMHash{}%
@@ -17820,28 +17818,28 @@ then $e$ shows that $v$ has type $X \& T$.
 Otherwise $e$ does not show that $v$ has type $T$ for any $T$.
 
 \rationale{%
-The motivation for the ``shows that v has type T" relation is
-to reduce spurious errors thereby enabling a more natural coding style.
-The rules in the current specification are deliberately kept simple.
-It would be upwardly compatible to refine these rules in the future;
-such a refinement would accept more code without errors,
-but not reject any code now error-free.
+  The motivation for the ``shows that v has type T'' relation is
+  to reduce spurious errors thereby enabling a more natural coding style.
+  The rules in the current specification are deliberately kept simple.
+  It would be upwardly compatible to refine these rules in the future;
+  such a refinement would accept more code without errors,
+  but not reject any code now error-free.
 
-The rule only applies to locals and parameters,
-as non-local variables could be modified
-via side-effecting functions or methods that are not accessible
-to a local analysis.
+  The rule only applies to locals and parameters,
+  as non-local variables could be modified
+  via side-effecting functions or methods that are not accessible
+  to a local analysis.
 
-It is pointless to deduce a weaker type than what is already known.
-Furthermore, this would lead to a situation where multiple types are
-associated with a variable at a given point,
-which complicates the specification.
-Hence the requirement that the promoted type is a subtype of the current type.
+  It is pointless to deduce a weaker type than what is already known.
+  Furthermore, this would lead to a situation where multiple types are
+  associated with a variable at a given point,
+  which complicates the specification.
+  Hence the requirement that the promoted type is a subtype of the current type.
 
-In any case, it is not an error when a type test does not show
-that a given variable does not have a ``better'' type than previously known,
-but tools may choose to give a hint in such cases,
-if suitable heuristics indicate that a promotion is likely to be intended.%
+  In any case, it is not an error when a type test does not show
+  that a given variable does not have a ``better'' type than previously known,
+  but tools may choose to give a hint in such cases,
+  if suitable heuristics indicate that a promotion is likely to be intended.%
 }
 
 \LMHash{}%
@@ -17933,8 +17931,8 @@ and the execution of that other statement does not complete normally,
 then, unless otherwise stated, the execution of $s$ stops
 at that point and completes in the same way.
 \commentary{%
-For example, if execution of the body of a \DO{} loop returns an object,
-so does execution of the \DO{} loop statement itself.%
+  For example, if execution of the body of a \DO{} loop returns an object,
+  so does execution of the \DO{} loop statement itself.%
 }
 
 \LMHash{}%
@@ -17943,11 +17941,11 @@ and the evaluation of that expression throws,
 then, unless otherwise stated, the execution of the statement stops
 at that point and throws the same exception object and stack trace.
 \commentary{%
-For example,
-if evaluation of the condition expression of an \IF{} statement throws,
-then so does execution of the \IF{} statement.
-Likewise, if evaluation of the expression of a \RETURN{} statement throws,
-so does execution of the \RETURN{} statement.%
+  For example,
+  if evaluation of the condition expression of an \IF{} statement throws,
+  then so does execution of the \IF{} statement.
+  Likewise, if evaluation of the expression of a \RETURN{} statement throws,
+  so does execution of the \RETURN{} statement.%
 }
 
 %% TODO(eernst): Use proposal from Lasse to add a definition of the concept of
@@ -17988,17 +17986,18 @@ begin with a \lit{\{} character.
 The expression of an expression statement is not allowed
 to begin with a \lit{\{}.
 \commentary{%
-This means that if some source text could otherwise be parsed as an expression
-followed by a \lit{;}, then this grammar production does not apply
-when the expression starts with a \lit{\{}.%
+  This means that if some source text could otherwise be
+  parsed as an expression followed by a \lit{;},
+  then this grammar production does not apply
+  when the expression starts with a \lit{\{}.%
 }
 \rationale{%
-The restriction resolves an ambiguity while parsing where a
-\lit{\{} can start either a block (\ref{blocks}) or
-a map literal (\ref{maps}).
-By disallowing the latter from starting an expression statement,
-the parser does not need to look further ahead
-before deciding that it is parsing a block statement.%
+  The restriction resolves an ambiguity while parsing where a
+  \lit{\{} can start either a block (\ref{blocks}) or
+  a map literal (\ref{maps}).
+  By disallowing the latter from starting an expression statement,
+  the parser does not need to look further ahead
+  before deciding that it is parsing a block statement.%
 }
 
 \LMHash{}%
@@ -18025,10 +18024,10 @@ a \IndexCustom{local variable}{variable!local}
 into the current scope.
 
 \commentary{%
-Local variables do not induce getters and setters.
-Note that a formal parameter declaration also introduces
-a local variable into the associated formal parameter scope
-(\ref{formalParameters}).%
+  Local variables do not induce getters and setters.
+  Note that a formal parameter declaration also introduces
+  a local variable into the associated formal parameter scope
+  (\ref{formalParameters}).%
 }
 
 \LMHash{}%
@@ -18054,12 +18053,12 @@ is equivalent to \code{$T$ $v$ = \NULL;}.
 
 %% TODO(eernst): Revise when flow analysis is added.
 \commentary{%
-If $T$ is a potentially non-nullable type
-then a local variable declaration of the form \code{$T$ $v$;} is allowed,
-but an expression that gives rise to evaluation of $v$
-is a compile-time error unless flow analysis
-(\ref{flowAnalysis})
-shows that the variable is guaranteed to have been initialized.%
+  If $T$ is a potentially non-nullable type
+  then a local variable declaration of the form \code{$T$ $v$;} is allowed,
+  but an expression that gives rise to evaluation of $v$
+  is a compile-time error unless flow analysis
+  (\ref{flowAnalysis})
+  shows that the variable is guaranteed to have been initialized.%
 }
 
 \LMHash{}%
@@ -18113,20 +18112,20 @@ the declared type of $v$.
 
 %% TODO(eernst): Revise when flow analysis is added.
 \commentary{%
-If a local variable $v$ is \FINAL{} and not \LATE,
-it is not a compile-time error if the declaration of $v$ is
-not an initializing variable declaration,
-but an expression that gives rise to evaluation of $v$
-is a compile-time error unless flow analysis shows that
-the variable is guaranteed to have been initialized.
-Similarly, an expression that gives rise to an assignment to $v$
-is a compile-time error unless flow analysis shows that
-it is guaranteed that the variable has \emph{not} been initialized.%
+  If a local variable $v$ is \FINAL{} and not \LATE,
+  it is not a compile-time error if the declaration of $v$ is
+  not an initializing variable declaration,
+  but an expression that gives rise to evaluation of $v$
+  is a compile-time error unless flow analysis shows that
+  the variable is guaranteed to have been initialized.
+  Similarly, an expression that gives rise to an assignment to $v$
+  is a compile-time error unless flow analysis shows that
+  it is guaranteed that the variable has \emph{not} been initialized.%
 
-In every situation which is not covered by the previous paragraph,
-it is a compile-time error to assign to a local variable
-which is \FINAL{} and not \LATE{}
-(\ref{assignment}).%
+  In every situation which is not covered by the previous paragraph,
+  it is a compile-time error to assign to a local variable
+  which is \FINAL{} and not \LATE{}
+  (\ref{assignment}).%
 }
 
 \LMHash{}%
@@ -18140,10 +18139,10 @@ the immediately enclosing function for $a$,
 and $f$ is not the immediately enclosing function for $D$.
 
 \commentary{%
-In other words,
-the initializing expression cannot await an expression directly,
-any await expressions must be syntactically nested inside some other function,
-that is, a function literal.%
+  In other words,
+  the initializing expression cannot await an expression directly,
+  any await expressions must be syntactically nested inside some other function,
+  that is, a function literal.%
 }
 
 \LMHash{}%
@@ -18154,9 +18153,9 @@ and otherwise before the declaring occurrence of
 the identifier which names the variable.
 
 \commentary{%
-The example below illustrates the expected behavior.
-A variable `\code{x}' is declared at the library level,
-and another `\code{x}' is declared inside the function `\code{f}'.%
+  The example below illustrates the expected behavior.
+  A variable `\code{x}' is declared at the library level,
+  and another `\code{x}' is declared inside the function `\code{f}'.%
 }
 
 \begin{dartCode}
@@ -18174,36 +18173,36 @@ f(y) \{
 \end{dartCode}
 
 \commentary{%
-The declaration inside `\code{f}' hides the enclosing one.
-So all references to `\code{x}' inside `\code{f}'
-refer to the inner declaration of `\code{x}'.
-However, many of these references are illegal,
-because they appear before the declaration.
-The assignment to `\code{z}' is one such case.
-The assignment to `\code{x}' in the \IF{} statement
-suffers from multiple problems.
-The right hand side reads `\code{x}' before its declaration,
-and the left hand side assigns to `\code{x}' before its declaration.
-Each of these are, independently, compile-time errors.
-The print statement inside the \IF{} is also illegal.
+  The declaration inside `\code{f}' hides the enclosing one.
+  So all references to `\code{x}' inside `\code{f}'
+  refer to the inner declaration of `\code{x}'.
+  However, many of these references are illegal,
+  because they appear before the declaration.
+  The assignment to `\code{z}' is one such case.
+  The assignment to `\code{x}' in the \IF{} statement
+  suffers from multiple problems.
+  The right hand side reads `\code{x}' before its declaration,
+  and the left hand side assigns to `\code{x}' before its declaration.
+  Each of these are, independently, compile-time errors.
+  The print statement inside the \IF{} is also illegal.
 
-The inner declaration of `\code{x}' is itself erroneous
-because its right hand side attempts to
-read `\code{x}' before the declaration has terminated.
-The occurrence of `\code{x}' that declares and names the variable
-(that is, the one to the left of `\code{=}' in the inner declaration)
-is not a reference, and so is legal.
-The last print statement is perfectly legal as well.%
+  The inner declaration of `\code{x}' is itself erroneous
+  because its right hand side attempts to
+  read `\code{x}' before the declaration has terminated.
+  The occurrence of `\code{x}' that declares and names the variable
+  (that is, the one to the left of `\code{=}' in the inner declaration)
+  is not a reference, and so is legal.
+  The last print statement is perfectly legal as well.%
 }
 
 \commentary{%
-As another example \code{\VAR{} x = 3, y = x;} is legal,
-because \code{x} is referenced after its initializer.
+  As another example \code{\VAR{} x = 3, y = x;} is legal,
+  because \code{x} is referenced after its initializer.
 
-A particularly perverse example involves
-a local variable name shadowing a type.
-This is possible because Dart has a
-single namespace for types, functions and variables.%
+  A particularly perverse example involves
+  a local variable name shadowing a type.
+  This is possible because Dart has a
+  single namespace for types, functions and variables.%
 }
 
 \begin{dartCode}
@@ -18216,11 +18215,11 @@ perverse() \{
 \end{dartCode}
 
 \commentary{%
-Inside \code{perverse()}, `\code{C}' denotes a local variable.
-The type `\code{C}' is hidden by the variable of the same name.
-The attempt to instantiate `\code{C}' causes a compile-time error
-because it references a local variable prior to its declaration.
-Similarly, for the declaration of `\code{aC}'.%
+  Inside \code{perverse()}, `\code{C}' denotes a local variable.
+  The type `\code{C}' is hidden by the variable of the same name.
+  The attempt to instantiate `\code{C}' causes a compile-time error
+  because it references a local variable prior to its declaration.
+  Similarly, for the declaration of `\code{aC}'.%
 }
 
 \LMHash{}%
@@ -18243,12 +18242,12 @@ of $v$.
 Otherwise, the variable $v$ is bound to $o$.
 
 \commentary{%
-Note that $e$ could have been transformed due to implicit coercions.
-For example, \code{myFunction} could be transformed into
-\code{myFunction<int>} due to generic function instantiation
-(\ref{genericFunctionInstantiation}).
-Such transformations are assumed to have taken place already
-in the declarations above.%
+  Note that $e$ could have been transformed due to implicit coercions.
+  For example, \code{myFunction} could be transformed into
+  \code{myFunction<int>} due to generic function instantiation
+  (\ref{genericFunctionInstantiation}).
+  Such transformations are assumed to have taken place already
+  in the declarations above.%
 }
 
 \LMHash{}%
@@ -18283,9 +18282,9 @@ causes a new function named \id{} to be added to the current scope.
 It is a compile-time error to reference a local function before its declaration.
 
 \commentary{%
-This implies that local functions can be directly recursive,
-but not mutually recursive.
-Consider these examples:%
+  This implies that local functions can be directly recursive,
+  but not mutually recursive.
+  Consider these examples:%
 }
 
 \begin{dartCode}
@@ -18307,11 +18306,11 @@ top() \{ // \comment{another top level function}
 \end{dartCode}
 
 \commentary{%
-There is no way to write a pair of mutually recursive local functions,
-because one always has to come before the other is declared.
-These cases are quite rare,
-and can always be managed by defining a pair of variables first,
-then assigning them appropriate function literals:%
+  There is no way to write a pair of mutually recursive local functions,
+  because one always has to come before the other is declared.
+  These cases are quite rare,
+  and can always be managed by defining a pair of variables first,
+  then assigning them appropriate function literals:%
 }
 
 \begin{dartCode}
@@ -18323,14 +18322,14 @@ top2() \{ // \comment{a top level function}
 \end{dartCode}
 
 \rationale{%
-The rules for local functions differ slightly from those for local variables
-in that a function can be accessed within its declaration
-but a variable can only be accessed after its declaration.
-This is because recursive functions are useful
-whereas recursively defined variables are almost always errors.
-It therefore makes sense to harmonize the rules for local functions
-with those for functions in general rather than
-with the rules for local variables.%
+  The rules for local functions differ slightly from those for local variables
+  in that a function can be accessed within its declaration
+  but a variable can only be accessed after its declaration.
+  This is because recursive functions are useful
+  whereas recursively defined variables are almost always errors.
+  It therefore makes sense to harmonize the rules for local functions
+  with those for functions in general rather than
+  with the rules for local variables.%
 }
 
 
@@ -18355,7 +18354,7 @@ where $s_2$ is not a block statement is equivalent to the statement
 \code{\IF{} ($e$) $s_1$ \ELSE{} \{$s_2$\}}.
 
 \rationale{%
-The reason for this equivalence is to catch errors such as%
+  The reason for this equivalence is to catch errors such as%
 }
 
 \begin{dartCode}
@@ -18367,23 +18366,23 @@ The reason for this equivalence is to catch errors such as%
 \end{dartCode}
 
 \rationale{%
-Under reasonable scope rules such code is problematic.
-If we assume that \code{v} is declared
-in the scope of the method \code{main()},
-then when \code{somePredicate} is false,
-\code{v} will be uninitialized when accessed.
-The cleanest approach would be to require a block following the test,
-rather than an arbitrary statement.
-However, this goes against long standing custom,
-undermining Dart's goal of familiarity.
-Instead, we choose to insert a block, introducing a scope,
-around the statement following the predicate
-(and similarly for \ELSE{} and loops).
-This will cause a compile-time error in the case above.
-Of course, if there is a declaration of \code{v} in the surrounding scope,
-programmers might still be surprised.
-We expect tools to highlight cases of shadowing
-to help avoid such situations.%
+  Under reasonable scope rules such code is problematic.
+  If we assume that \code{v} is declared
+  in the scope of the method \code{main()},
+  then when \code{somePredicate} is false,
+  \code{v} will be uninitialized when accessed.
+  The cleanest approach would be to require a block following the test,
+  rather than an arbitrary statement.
+  However, this goes against long standing custom,
+  undermining Dart's goal of familiarity.
+  Instead, we choose to insert a block, introducing a scope,
+  around the statement following the predicate
+  (and similarly for \ELSE{} and loops).
+  This will cause a compile-time error in the case above.
+  Of course, if there is a declaration of \code{v} in the surrounding scope,
+  programmers might still be surprised.
+  We expect tools to highlight cases of shadowing
+  to help avoid such situations.%
 }
 
 \LMHash{}%
@@ -18489,19 +18488,19 @@ Then:
 \end{enumerate}
 
 \rationale{%
-The definition above is intended to prevent the common error
-where users create a function object inside a for loop,
-intending to close over the current binding of the loop variable, and find
-(usually after a painful process of debugging and learning)
-that all the created function objects have captured
-the same value---the one current in the last iteration executed.
+  The definition above is intended to prevent the common error
+  where users create a function object inside a for loop,
+  intending to close over the current binding of the loop variable, and find
+  (usually after a painful process of debugging and learning)
+  that all the created function objects have captured
+  the same value---the one current in the last iteration executed.
 
-Instead, each iteration has its own distinct variable.
-The first iteration uses the variable created by the initial declaration.
-The expression executed at the end of each iteration uses
-a fresh variable $v''$,
-bound to the value of the current iteration variable,
-and then modifies $v''$ as required for the next iteration.%
+  Instead, each iteration has its own distinct variable.
+  The first iteration uses the variable created by the initial declaration.
+  The expression executed at the end of each iteration uses
+  a fresh variable $v''$,
+  bound to the value of the current iteration variable,
+  and then modifies $v''$ as required for the next iteration.%
 }
 
 \LMHash{}%
@@ -18549,13 +18548,13 @@ It is a compile-time error if $T$ is not assignable to
 \code{Iterable<\DYNAMIC>}.
 
 \commentary{%
-It follows that it is a compile-time error
-% The following error exists also in the case where \id{} is definitely
-% unassigned before the loop: The loop could run >1 time.
-if $D$ is empty and \id{} is a final variable.
-Also, it is a dynamic error if $e$ has type \DYNAMIC,
-but $e$ evaluates to an instance of a type
-which is not a subtype of \code{Iterable<\DYNAMIC>}.%
+  It follows that it is a compile-time error
+  % The following error exists also in the case where \id{} is definitely
+  % unassigned before the loop: The loop could run >1 time.
+  if $D$ is empty and \id{} is a final variable.
+  Also, it is a dynamic error if $e$ has type \DYNAMIC,
+  but $e$ evaluates to an instance of a type
+  which is not a subtype of \code{Iterable<\DYNAMIC>}.%
 }
 
 
@@ -18589,8 +18588,8 @@ The stream $o$ is listened to, producing a stream subscription $u$,
 and execution of the asynchronous for-in loop is suspended
 until a stream event is available.
 \commentary{%
-This allows other asynchronous events to execute
-while this loop is waiting for stream events.%
+  This allows other asynchronous events to execute
+  while this loop is waiting for stream events.%
 }
 
 Pausing an asynchronous for loop means pausing
@@ -18600,8 +18599,8 @@ If the subscription is already paused, an implementation may omit
 further calls to \code{pause}.
 
 \commentary{%
-The \code{pause} call can throw, although that should never happen
-for a correctly implemented stream.%
+  The \code{pause} call can throw, although that should never happen
+  for a correctly implemented stream.%
 }
 
 \LMHash{}%
@@ -18610,15 +18609,15 @@ the statement $s$ is executed with \id{} bound to
 the value of the current data event.
 
 \commentary{%
-Either execution of $s$ is completely synchronous, or it contains an
-asynchronous construct (\AWAIT, \code{\AWAIT\,\,\FOR}, \YIELD, or \YIELD*)
-which will pause the stream subscription of its surrounding asynchronous loop.
-This ensures that no other event of $u$ occurs
-before execution of $s$ is complete,
-if $o$ is a correctly implemented stream.
-If $o$ doesn't act as a valid stream,
-for example by not respecting pause requests,
-the behavior of the asynchronous loop may become unpredictable.%
+  Either execution of $s$ is completely synchronous, or it contains an
+  asynchronous construct (\AWAIT, \code{\AWAIT\,\,\FOR}, \YIELD, or \YIELD*)
+  which will pause the stream subscription of its surrounding asynchronous loop.
+  This ensures that no other event of $u$ occurs
+  before execution of $s$ is complete,
+  if $o$ is a correctly implemented stream.
+  If $o$ doesn't act as a valid stream,
+  for example by not respecting pause requests,
+  the behavior of the asynchronous loop may become unpredictable.%
 }
 
 \LMHash{}%
@@ -18641,9 +18640,9 @@ Otherwise the execution of $f$ is suspended again, waiting for
 the next stream subscription event,
 and $u$ is resumed if it has been paused.
 \commentary{%
-The \code{resume} call can throw, in which case the asynchronous for
-loop also throws.
-That should never happen for a correctly implemented stream.%
+  The \code{resume} call can throw, in which case the asynchronous for
+  loop also throws.
+  That should never happen for a correctly implemented stream.%
 }
 
 \LMHash{}%
@@ -18666,9 +18665,9 @@ It is a compile-time error if a traditional for loop (\ref{forLoop}) is
 prefixed by the \AWAIT{} keyword.
 
 \rationale{%
-An asynchronous loop would make no sense within a synchronous function,
-for the same reasons that an await expression makes no sense
-in a synchronous function.%
+  An asynchronous loop would make no sense within a synchronous function,
+  for the same reasons that an await expression makes no sense
+  in a synchronous function.%
 }
 
 
@@ -18705,10 +18704,10 @@ then the while statement is re-executed.
 If the execution breaks without a label,
 execution of the while statement completes normally.
 \commentary{%
-If the execution breaks with a label that prefixes the \WHILE{} statement,
-it does end execution of the loop,
-but the break itself is handled by
-the surrounding labeled statement (\ref{labels}).%
+  If the execution breaks with a label that prefixes the \WHILE{} statement,
+  it does end execution of the loop,
+  but the break itself is handled by
+  the surrounding labeled statement (\ref{labels}).%
 }
 
 \LMHash{}%
@@ -18791,9 +18790,9 @@ or the form
 \end{normativeDartCode}
 
 \commentary{%
-Note that each expression $e_j, j \in 1 .. n$ occurs in a constant context
-(\ref{constantContexts}),
-which means that \CONST{} modifiers need not be specified explicitly.%
+  Note that each expression $e_j, j \in 1 .. n$ occurs in a constant context
+  (\ref{constantContexts}),
+  which means that \CONST{} modifiers need not be specified explicitly.%
 }
 
 \LMHash{}%
@@ -18811,14 +18810,14 @@ $e_j, j \in 1 .. n$ are not either:
 \end{itemize}
 
 \commentary{%
-In other words, all the expressions in the cases evaluate to constants of
-the exact same user defined class or are of certain known types.
-%% TODO(eernst): Update when we specify inference: const List<int> xs = [];
-%% may be a counter-example: The value is a list that "knows" it is a
-%% `List<int>` independently of the type annotation, but it wouldn't be a
-%% `List<int>` if that type annotation hadn't been there.
-Note that the values of the expressions are known at compile time,
-and are independent of any type annotations.%
+  In other words, all the expressions in the cases evaluate to constants of
+  the exact same user defined class or are of certain known types.
+  %% TODO(eernst): Update when we specify inference: const List<int> xs = [];
+  %% may be a counter-example: The value is a list that "knows" it is a
+  %% `List<int>` independently of the type annotation, but it wouldn't be a
+  %% `List<int>` if that type annotation hadn't been there.
+  Note that the values of the expressions are known at compile time,
+  and are independent of any type annotations.%
 }
 
 \LMHash{}%
@@ -18827,18 +18826,18 @@ do not have primitive equality
 (\ref{theOperatorEqualsEquals}).
 
 \rationale{%
-The prohibition on user defined equality allows us to
-implement the switch efficiently for user defined types.
-We could formulate matching in terms of identity instead,
-with the same efficiency.
-However, if a type defines an equality operator,
-programmers would presumably find it quite surprising
-if equal objects did not match.%
+  The prohibition on user defined equality allows us to
+  implement the switch efficiently for user defined types.
+  We could formulate matching in terms of identity instead,
+  with the same efficiency.
+  However, if a type defines an equality operator,
+  programmers would presumably find it quite surprising
+  if equal objects did not match.%
 }
 
 \commentary{%
-The \SWITCH{} statement should only be used in
-very limited situations (e.g., interpreters or scanners).%
+  The \SWITCH{} statement should only be used in
+  very limited situations (e.g., interpreters or scanners).%
 }
 
 \LMHash{}%
@@ -18874,8 +18873,8 @@ It is a dynamic error if the value of $e$ is
 not an instance of the same class as the constants $e_1, \ldots, e_n$.
 
 \commentary{%
-Note that if there are no case clauses ($n = 0$),
-the type of $e$ does not matter.%
+  Note that if there are no case clauses ($n = 0$),
+  the type of $e$ does not matter.%
 }
 
 \LMHash{}%
@@ -18948,28 +18947,28 @@ a \BREAK, \CONTINUE, \RETHROW, or \RETURN{} statement,
 or an expression statement where the expression is a \THROW{} expression.
 
 \rationale{%
-The behavior of switch cases intentionally differs from the C tradition.
-Implicit fall through is a known cause of programming errors
-and therefore disallowed.
-Why not simply break the flow implicitly at the end of every case,
-rather than requiring explicit code to do so?
-This would indeed be cleaner.
-It would also be cleaner to insist that each case have
-a single (possibly compound) statement.
-We have chosen not to do so in order to
-facilitate porting of switch statements from other languages.
-Implicitly breaking the control flow at the end of a case would silently alter
-the meaning of ported code that relied on fall-through,
-potentially forcing the programmer to deal with subtle bugs.
-Our design ensures that the difference is immediately brought to
-the coder's attention.
-The programmer will be notified at compile time if they forget to end a case
-with a statement that terminates the straight-line control flow.
+  The behavior of switch cases intentionally differs from the C tradition.
+  Implicit fall through is a known cause of programming errors
+  and therefore disallowed.
+  Why not simply break the flow implicitly at the end of every case,
+  rather than requiring explicit code to do so?
+  This would indeed be cleaner.
+  It would also be cleaner to insist that each case have
+  a single (possibly compound) statement.
+  We have chosen not to do so in order to
+  facilitate porting of switch statements from other languages.
+  Implicitly breaking the control flow at the end of a case would silently
+  alter the meaning of ported code that relied on fall-through,
+  potentially forcing the programmer to deal with subtle bugs.
+  Our design ensures that the difference is immediately brought to
+  the coder's attention.
+  The programmer will be notified at compile time if they forget to end a case
+  with a statement that terminates the straight-line control flow.
 
-The sophistication of the analysis of fall-through is another issue.
-For now, we have opted for a very straightforward syntactic requirement.
-There are obviously situations where code does not fall through,
-and yet does not conform to these simple rules, e.g.:%
+  The sophistication of the analysis of fall-through is another issue.
+  For now, we have opted for a very straightforward syntactic requirement.
+  There are obviously situations where code does not fall through,
+  and yet does not conform to these simple rules, e.g.:%
 }
 
 \begin{dartCode}
@@ -18979,8 +18978,8 @@ and yet does not conform to these simple rules, e.g.:%
 \end{dartCode}
 
 \rationale{%
-Very elaborate code in a case clause is probably bad style in any case,
-and such code can always be refactored.%
+  Very elaborate code in a case clause is probably bad style in any case,
+  and such code can always be refactored.%
 }
 
 \LMHash{}%
@@ -18995,8 +18994,8 @@ It is a static warning if all of the following conditions hold:
 \end{itemize}
 
 \commentary{%
-In other words, a static warning will be emitted
-if a switch statement over an enum is not exhaustive.%
+  In other words, a static warning will be emitted
+  if a switch statement over an enum is not exhaustive.%
 }
 
 
@@ -19038,9 +19037,9 @@ Otherwise $s_h$ are the last statements of the switch case,
 and execution of the switch case completes normally.
 
 \commentary{%
-In other words, there is no implicit fall-through between non-empty cases.
-The last case in a switch (default or otherwise) can `fall-through'
-to the end of the statement.%
+  In other words, there is no implicit fall-through between non-empty cases.
+  The last case in a switch (default or otherwise) can `fall-through'
+  to the end of the statement.%
 }
 
 If execution of $\{s_h\}$ breaks with no label (\ref{statementCompletion}),
@@ -19093,11 +19092,11 @@ and let \code{\ON\,\,$T$\,\,\CATCH\,\,($p_1$,\,\,$p_2$)}
 be the immediately enclosing catch clause (\ref{try}).
 
 \rationale{%
-A \RETHROW{} statement always appears inside a \CATCH{} clause,
-and every \CATCH{} clause is treated as some \CATCH{} clause of the form
-\code{\ON\,\,$T$\,\,\CATCH\,\,(p1,\,\,p2)}.
-So we can consider the \RETHROW{} statement to be enclosed in
-a \CATCH{} clause of that form.%
+  A \RETHROW{} statement always appears inside a \CATCH{} clause,
+  and every \CATCH{} clause is treated as some \CATCH{} clause of the form
+  \code{\ON\,\,$T$\,\,\CATCH\,\,(p1,\,\,p2)}.
+  So we can consider the \RETHROW{} statement to be enclosed in
+  a \CATCH{} clause of that form.%
 }
 
 \LMHash{}%
@@ -19139,10 +19138,10 @@ A \FINALLY{} clause, which consists of a block statement.
 \end{enumerate}
 
 \rationale{%
-The syntax is designed to be upward compatible with
-existing Javascript programs.
-The \ON{} clause can be omitted,
-leaving what looks like a Javascript catch clause.%
+  The syntax is designed to be upward compatible with
+  existing Javascript programs.
+  The \ON{} clause can be omitted,
+  leaving what looks like a Javascript catch clause.%
 }
 
 \LMHash{}%
@@ -19309,17 +19308,17 @@ $S$ is not \VOID,
 and $S$ is not assignable to $T$.
 
 \commentary{%
-Note that $T$ cannot be \VOID, \DYNAMIC, or \code{Null} in the last case,
-because all types are assignable to those types.
-An error will not be raised if $f$ has no declared return type,
-since the return type would be \DYNAMIC, to which every type is assignable.
-However, a synchronous non-generator function
-that declares a return type which is not ``voidy''
-must return an expression explicitly.%
+  Note that $T$ cannot be \VOID, \DYNAMIC, or \code{Null} in the last case,
+  because all types are assignable to those types.
+  An error will not be raised if $f$ has no declared return type,
+  since the return type would be \DYNAMIC, to which every type is assignable.
+  However, a synchronous non-generator function
+  that declares a return type which is not ``voidy''
+  must return an expression explicitly.%
 }
 \rationale{%
-This helps catch situations where users forget
-to return an object in a return statement.%
+  This helps catch situations where users forget
+  to return an object in a return statement.%
 }
 \EndCase
 
@@ -19335,10 +19334,10 @@ unless \flatten{T}
 is \VOID, \DYNAMIC, or \code{Null}.
 %
 \rationale{%
-An asynchronous non-generator always returns a future of some sort.
-If no expression is given, the future will be completed with the null object
-(\ref{null})
-which motivates this rule.%
+  An asynchronous non-generator always returns a future of some sort.
+  If no expression is given, the future will be completed with the null object
+  (\ref{null})
+  which motivates this rule.%
 }
 % Returning with an object in an void async function only ok
 % when that value is async-"voidy".
@@ -19357,30 +19356,31 @@ It is a compile-time error if $s$ is \code{\RETURN{} $e$;},
 and \code{Future<\flatten{S}>} is not assignable to $T$.
 
 \commentary{%
-Note that \flatten{T} cannot be \VOID, \DYNAMIC, or \code{Null}
-in the last case,
-because then \code{Future<$U$>} is assignable to $T$ for \emph{all} $U$.
-In particular, when $T$ is \code{FutureOr<Null>}
-(which is equivalent to \code{Future<Null>}),
-\code{Future<\flatten{S}>} is assignable to $T$ for all $S$.
-This means that no compile-time error is raised,
-but \emph{only} the null object (\ref{null})
-or an instance of \code{Future<Null>} can successfully be returned at run time.
-This is not an anomaly,
-it corresponds to the treatment of a synchronous function
-with return type \code{Null};
-but tools may choose to give a hint that a downcast is unlikely to succeed.
+  Note that \flatten{T} cannot be \VOID, \DYNAMIC, or \code{Null}
+  in the last case,
+  because then \code{Future<$U$>} is assignable to $T$ for \emph{all} $U$.
+  In particular, when $T$ is \code{FutureOr<Null>}
+  (which is equivalent to \code{Future<Null>}),
+  \code{Future<\flatten{S}>} is assignable to $T$ for all $S$.
+  This means that no compile-time error is raised,
+  but \emph{only} the null object (\ref{null})
+  or an instance of \code{Future<Null>}
+  can successfully be returned at run time.
+  This is not an anomaly,
+  it corresponds to the treatment of a synchronous function
+  with return type \code{Null};
+  but tools may choose to give a hint that a downcast is unlikely to succeed.
 
-An error will not be raised if $f$ has no declared return type,
-since the return type would be \DYNAMIC,
-and \code{Future<\flatten{S}>} is assignable to \DYNAMIC{} for all $S$.
-However, an asynchronous non-generator function
-that declares a return type which is not ``voidy''
-must return an expression explicitly.%
+  An error will not be raised if $f$ has no declared return type,
+  since the return type would be \DYNAMIC,
+  and \code{Future<\flatten{S}>} is assignable to \DYNAMIC{} for all $S$.
+  However, an asynchronous non-generator function
+  that declares a return type which is not ``voidy''
+  must return an expression explicitly.%
 }
 \rationale{%
-This helps catch situations where users forget
-to return an object in a return statement of an asynchronous function.%
+  This helps catch situations where users forget
+  to return an object in a return statement of an asynchronous function.%
 }
 \EndCase
 
@@ -19390,10 +19390,10 @@ It is a compile-time error if a return statement of
 the form \code{\RETURN{} $e$;} appears in a generator function.
 
 \rationale{%
-In the case of a generator function, the object returned by the function is
-the iterable or stream associated with it,
-and individual elements are added to that iterable using yield statements,
-and so returning an object makes no sense.%
+  In the case of a generator function, the object returned by the function is
+  the iterable or stream associated with it,
+  and individual elements are added to that iterable using yield statements,
+  and so returning an object makes no sense.%
 }
 \EndCase
 
@@ -19404,14 +19404,14 @@ the form \code{\RETURN{} $e$;} appears in a generative constructor
 (\ref{generativeConstructors}).
 
 \rationale{%
-It is quite easy to forget to add the \FACTORY{} modifier for a constructor,
-accidentally converting a factory into a generative constructor.
-The static checker may detect a type mismatch
-in some, but not all, of these cases.
-The rule above helps catch such errors,
-which can otherwise be very hard to recognize.
-There is no real downside to it,
-as returning an object from a generative constructor is meaningless.%
+  It is quite easy to forget to add the \FACTORY{} modifier for a constructor,
+  accidentally converting a factory into a generative constructor.
+  The static checker may detect a type mismatch
+  in some, but not all, of these cases.
+  The rule above helps catch such errors,
+  which can otherwise be very hard to recognize.
+  There is no real downside to it,
+  as returning an object from a generative constructor is meaningless.%
 }
 \EndCase
 
@@ -19490,8 +19490,8 @@ A \Index{labeled case clause} is a case clause within a switch statement
 prefixed by a label $L$.
 
 \rationale{%
-The sole role of labels is to provide targets for
-the break (\ref{break}) and continue (\ref{continue}) statements.%
+  The sole role of labels is to provide targets for
+  the break (\ref{break}) and continue (\ref{continue}) statements.%
 }
 
 \begin{grammar}
@@ -19513,9 +19513,9 @@ The scope of a label that labels a statement $s$ is $s$.
 The scope of a label that labels a case clause of a switch statement $s$ is $s$.
 
 \rationale{%
-Labels should be avoided by programmers at all costs.
-The motivation for including labels in the language
-is primarily making Dart a better target for code generation.%
+  Labels should be avoided by programmers at all costs.
+  The motivation for including labels in the language
+  is primarily making Dart a better target for code generation.%
 }
 
 
@@ -19621,8 +19621,8 @@ Next, $o$ is added to the iterable or stream associated
 with the immediately enclosing function.
 
 \commentary{%
-Note that a dynamic error occurs if the dynamic type of $o$
-is not a subtype of the element type of said iterable or stream.%
+  Note that a dynamic error occurs if the dynamic type of $o$
+  is not a subtype of the element type of said iterable or stream.%
 }
 
 \LMHash{}%
@@ -19633,12 +19633,12 @@ then the \YIELD{} statement returns without an object
 otherwise it completes normally.
 
 \rationale{%
-The stream associated with an asynchronous generator could be canceled
-by any code with a reference to that stream at any point
-where the generator was passivated.
-Such a cancellation constitutes an irretrievable error for the generator.
-At this point, the only plausible action for the generator is
-to clean up after itself via its \FINALLY{} clauses.%
+  The stream associated with an asynchronous generator could be canceled
+  by any code with a reference to that stream at any point
+  where the generator was passivated.
+  Such a cancellation constitutes an irretrievable error for the generator.
+  At this point, the only plausible action for the generator is
+  to clean up after itself via its \FINALLY{} clauses.%
 }
 
 \LMHash{}%
@@ -19650,19 +19650,19 @@ in which case the nearest enclosing asynchronous for loop
 if any, is paused first.
 
 \rationale{%
-If a \YIELD{} occurred inside an infinite loop
-and the enclosing function never suspended,
-there might not be an opportunity for consumers of the enclosing stream
-to run and access the data in the stream.
-The stream might then accumulate an unbounded number of elements.
-Such a situation is untenable.
-Therefore, we allow the enclosing function to be suspended
-when a new object is added to its associated stream.
-However, it is not essential (and in fact, can be quite costly)
-to suspend the function on every \YIELD.
-The implementation is free to decide
-how often to suspend the enclosing function.
-The only requirement is that consumers are not blocked indefinitely.%
+  If a \YIELD{} occurred inside an infinite loop
+  and the enclosing function never suspended,
+  there might not be an opportunity for consumers of the enclosing stream
+  to run and access the data in the stream.
+  The stream might then accumulate an unbounded number of elements.
+  Such a situation is untenable.
+  Therefore, we allow the enclosing function to be suspended
+  when a new object is added to its associated stream.
+  However, it is not essential (and in fact, can be quite costly)
+  to suspend the function on every \YIELD.
+  The implementation is free to decide
+  how often to suspend the enclosing function.
+  The only requirement is that consumers are not blocked indefinitely.%
 }
 
 \LMHash{}%
@@ -19834,8 +19834,8 @@ The expression $c$ is evaluated to an object $r$.
 % This error can occur due to implicit casts and null.
 It is a dynamic type error if $r$ is not of type \code{bool}.
 \commentary{%
-Hence it is a compile-time error if that situation arises
-during evaluation of an assertion in a \CONST{} constructor invocation.%
+  Hence it is a compile-time error if that situation arises
+  during evaluation of an assertion in a \CONST{} constructor invocation.%
 }
 If $r$ is \TRUE{} then execution of the assert statement completes normally
 (\ref{statementCompletion}).
@@ -19850,14 +19850,14 @@ It is a compile-time error if the type of $c$
 may not be assigned to \code{bool}.
 
 \rationale{%
-Why is this a statement, not a built in function call?
-Because it is handled magically
-so it has no effect and no overhead when assertions are disabled.
-Also, in the absence of final methods,
-one could not prevent it being overridden
-(though there is no real harm in that).
-It cannot be viewed as a function call that is being optimized away
-because the arguments might have side effects.%
+  Why is this a statement, not a built in function call?
+  Because it is handled magically
+  so it has no effect and no overhead when assertions are disabled.
+  Also, in the absence of final methods,
+  one could not prevent it being overridden
+  (though there is no real harm in that).
+  It cannot be viewed as a function call that is being optimized away
+  because the arguments might have side effects.%
 }
 
 
@@ -19912,20 +19912,20 @@ The members of a library $L$ are those top level declarations given within $L$.
 A library contains a string which is derived from \synt{libraryDeclaration}.
 
 \commentary{%
-We could say that \synt{libraryDeclaration} is a
-\Index{start symbol}
-of the grammar,
-because the syntactic derivation of any library starts from there.
-Unlike a traditional context free grammar,
-the Dart grammar does not have exactly one start symbol.
-In particular, \synt{partDeclaration}
-(\ref{parts})
-is used in the same manner to derive the contents of a part.
-There could be more, e.g.,
-a hypothetical Dart REPL (read-eval-print loop) could use
-\synt{expression} or \synt{statement} as a start symbol.
-So there is no grammar for Dart programs as such,
-only for some building blocks that are used to construct Dart programs.%
+  We could say that \synt{libraryDeclaration} is a
+  \Index{start symbol}
+  of the grammar,
+  because the syntactic derivation of any library starts from there.
+  Unlike a traditional context free grammar,
+  the Dart grammar does not have exactly one start symbol.
+  In particular, \synt{partDeclaration}
+  (\ref{parts})
+  is used in the same manner to derive the contents of a part.
+  There could be more, e.g.,
+  a hypothetical Dart REPL (read-eval-print loop) could use
+  \synt{expression} or \synt{statement} as a start symbol.
+  So there is no grammar for Dart programs as such,
+  only for some building blocks that are used to construct Dart programs.%
 }
 
 \LMHash{}%
@@ -19935,27 +19935,28 @@ An \Index{explicitly named library} begins with the word \LIBRARY{}
 followed by a qualified identifier that gives the name of the library.
 
 \commentary{%
-Technically, each dot and identifier is a separate token
-and so spaces between them are acceptable.
-However, the actual library name is the concatenation of
-the simple identifiers and dots and contains no spaces.%
+  Technically, each dot and identifier is a separate token
+  and so spaces between them are acceptable.
+  However, the actual library name is the concatenation of
+  the simple identifiers and dots and contains no spaces.%
 }
 
 \LMHash{}%
 An implicitly named library has the empty string as its name.
 
 \rationale{%
-The name of a library is used to tie it to
-separately compiled parts of the library (called parts) and
-can be used for printing and, more generally, reflection.
-The name may be relevant for further language evolution.%
+  The name of a library is used to tie it to
+  separately compiled parts of the library (called parts) and
+  can be used for printing and, more generally, reflection.
+  The name may be relevant for further language evolution.%
 }
 
 \commentary{%
-Libraries intended for widespread use should avoid name collisions.
-Dart's \code{pub} package management system provides a mechanism for doing so.
-Each pub package is guaranteed a unique name,
-effectively enforcing a global namespace.%
+  Libraries intended for widespread use should avoid name collisions.
+  Dart's \code{pub} package management system provides
+  a mechanism for doing so.
+  Each pub package is guaranteed a unique name,
+  effectively enforcing a global namespace.%
 }
 
 \LMHash{}%
@@ -19974,8 +19975,8 @@ A private declaration declared within a library $L$
 can only be accessed by code within $L$.
 
 \commentary{%
-Since top level privates are not imported,
-using the top level privates of another library is never possible.%
+  Since top level privates are not imported,
+  using the top level privates of another library is never possible.%
 }
 
 \LMHash{}%
@@ -19995,10 +19996,10 @@ has two declarations with the same basename,
 except when they are a getter and a setter.
 
 \commentary{%
-Two distinct names $n_1$ and $n_2$ can only have the same basename
-when they are of the form \id{} and \code{\id=},
-so this kind of conflict \emph{always} involves a setter.
-But the other declaration could be a function, a class, etc.%
+  Two distinct names $n_1$ and $n_2$ can only have the same basename
+  when they are of the form \id{} and \code{\id=},
+  so this kind of conflict \emph{always} involves a setter.
+  But the other declaration could be a function, a class, etc.%
 }
 
 
@@ -20050,9 +20051,9 @@ In this case we say that \id{} is an \Index{import prefix},
 or simply a \Index{prefix}.
 
 \commentary{%
-Note that the grammar enforces that a deferred import
-includes a prefix clause,
-so we can refer to \emph{the} prefix clause of a deferred import.%
+  Note that the grammar enforces that a deferred import
+  includes a prefix clause,
+  so we can refer to \emph{the} prefix clause of a deferred import.%
 }
 
 \LMHash{}%
@@ -20079,18 +20080,18 @@ even if restricted via \SHOW, \HIDE, or \AS,
 preempts the automatic import.
 
 \rationale{%
-It would be nice if there was nothing special about \code{dart:core}.
-However, its use is pervasive,
-which leads to the decision to import it automatically.
-On the other hand, some library $L$ may wish to define entities
-with names used by \code{dart:core}
-(which it can easily do, as the names declared by a library take precedence).
-Other libraries may wish to use $L$,
-and may want to use members of $L$ that conflict with the core library
-without having to use a prefix and without encountering errors.
-The above rule makes this possible,
-essentially canceling \code{dart:core}'s special treatment
-by means of yet another special rule.%
+  It would be nice if there was nothing special about \code{dart:core}.
+  However, its use is pervasive,
+  which leads to the decision to import it automatically.
+  On the other hand, some library $L$ may wish to define entities
+  with names used by \code{dart:core}
+  (which it can easily do, as the names declared by a library take precedence).
+  Other libraries may wish to use $L$,
+  and may want to use members of $L$ that conflict with the core library
+  without having to use a prefix and without encountering errors.
+  The above rule makes this possible,
+  essentially canceling \code{dart:core}'s special treatment
+  by means of yet another special rule.%
 }
 
 \subsubsection{The Imported Namespace}
@@ -20107,20 +20108,20 @@ A \Index{system library} is a library that is part of the Dart implementation.
 Any other library is a \Index{non-system library}.
 
 \commentary{%
-A system library can generally be recognized by having
-a URI that starts with `\code{dart:}'.%
+  A system library can generally be recognized by having
+  a URI that starts with `\code{dart:}'.%
 }
 
 \rationale{%
-The special rules for system libraries exist for the following reason.
-Normal conflicts are resolved at deployment time,
-but the functionality of a system library is
-injected into an application at run time,
-and may vary over time as the platform is upgraded.
-Thus, conflicts with a system library can arise
-outside the developer's control.
-To avoid breaking deployed applications in this way,
-conflicts with the system libraries are treated specially.%
+  The special rules for system libraries exist for the following reason.
+  Normal conflicts are resolved at deployment time,
+  but the functionality of a system library is
+  injected into an application at run time,
+  and may vary over time as the platform is upgraded.
+  Thus, conflicts with a system library can arise
+  outside the developer's control.
+  To avoid breaking deployed applications in this way,
+  conflicts with the system libraries are treated specially.%
 }
 
 \LMHash{}%
@@ -20134,10 +20135,10 @@ to the exported namespace of $L$
 (\ref{namespaceCombinators}).
 
 \commentary{%
-Note that the namespace provided by an import directive $I$ is not
-the same as the namespace imported from $I$.
-The latter includes conflict resolution,
-and is defined later in this section.%
+  Note that the namespace provided by an import directive $I$ is not
+  the same as the namespace imported from $I$.
+  The latter includes conflict resolution,
+  and is defined later in this section.%
 }
 
 \LMHash{}%
@@ -20147,7 +20148,7 @@ Let \List{I}{1}{m} be the import directives of $L$,
 and let \List{L}{1}{m} be libraries
 such that $I_i$ refers to $L_i$ for all $i \in 1 .. m$.
 \commentary{%
-It is not an error to have multiple imports of the same library.%
+  It is not an error to have multiple imports of the same library.%
 }
 
 \LMHash{}%
@@ -20168,9 +20169,9 @@ the same as the basename of a top-level declaration in $L$,
 or whose basename is the prefix of an import directive in $L$.
 
 \commentary{%
-This step ensures that \SHOW{} and \HIDE{} directives are taken into account,
-and that an import prefix as well as a local declaration
-will shadow an imported name.%
+  This step ensures that \SHOW{} and \HIDE{} directives are taken into account,
+  and that an import prefix as well as a local declaration
+  will shadow an imported name.%
 }
 \EndCase
 
@@ -20213,19 +20214,19 @@ In this situation we say that \NamespaceName{\metavar{one},i} is a
 because it maps a library prefix to a namespace.
 
 \commentary{%
-A prefix namespace is not a Dart object,
-it is merely a device which is used to manage
-expressions of the form \synt{qualifiedName} and what they refer to
-during static analysis.
-Consequently, any attempt to use a prefix namespace as an object
-is a compile-time error, e.g.,
-it cannot be the result of an expression evaluation.
+  A prefix namespace is not a Dart object,
+  it is merely a device which is used to manage
+  expressions of the form \synt{qualifiedName} and what they refer to
+  during static analysis.
+  Consequently, any attempt to use a prefix namespace as an object
+  is a compile-time error, e.g.,
+  it cannot be the result of an expression evaluation.
 
-Note that if $l$ and $q$ are such that
-$I_l$ and $I_q$ both have the same prefix $p$
-then
-$\NamespaceName{\metavar{one},l} = \NamespaceName{\metavar{one},q} =
-\NamespaceName{\metavar{one},l} \cup \NamespaceName{\metavar{one},q}$.%
+  Note that if $l$ and $q$ are such that
+  $I_l$ and $I_q$ both have the same prefix $p$
+  then
+  $\NamespaceName{\metavar{one},l} = \NamespaceName{\metavar{one},q} =
+  \NamespaceName{\metavar{one},l} \cup \NamespaceName{\metavar{one},q}$.%
 }
 \EndCase
 
@@ -20256,11 +20257,11 @@ Let \NamespaceName{\metavar{extensions}} be a namespace that
 for each extension $E$ in $\cal E$ maps a fresh name to $E$.
 
 \commentary{%
-\NamespaceName{\metavar{extensions}} provides a fresh name
-allowing implicit access to each extension exported by an imported library
-and not removed by \HIDE{} or \SHOW,
-even the ones that cannot be accessed using their declared name,
-because of a name clash.%
+  \NamespaceName{\metavar{extensions}} provides a fresh name
+  allowing implicit access to each extension exported by an imported library
+  and not removed by \HIDE{} or \SHOW,
+  even the ones that cannot be accessed using their declared name,
+  because of a name clash.%
 }
 
 \LMHash{}%
@@ -20283,9 +20284,9 @@ is the conflict narrowed namespace
 of \NamespaceName{\metavar{exported},i}.
 
 \commentary{%
-So the namespace imported by $L_i$ contains the bindings exported by $L_i$,
-except the ones removed by namespace combinators,
-and except the ones removed by conflict merging.%
+  So the namespace imported by $L_i$ contains the bindings exported by $L_i$,
+  except the ones removed by namespace combinators,
+  and except the ones removed by conflict merging.%
 }
 
 \LMHash{}%
@@ -20375,11 +20376,11 @@ as defined previously
 \end{itemize}
 
 \rationale{%
-The purpose of having members of the imported library in
-\NamespaceName{\metavar{deferred}}
-is to ensure that usages of members that have not yet been loaded
-can be resolved normally and has a well-defined behavior,
-which will raise errors.%
+  The purpose of having members of the imported library in
+  \NamespaceName{\metavar{deferred}}
+  is to ensure that usages of members that have not yet been loaded
+  can be resolved normally and has a well-defined behavior,
+  which will raise errors.%
 }
 
 \LMHash{}%
@@ -20397,10 +20398,10 @@ Whether a repeated call to \code{$p$.loadLibrary()} succeeds will vary,
 as described below.
 
 \commentary{%
-Note that it is a compile-time error for a deferred prefix
-to be used in more than one import,
-which means that the update of the binding of $p$
-does not interfere with other imports.%
+  Note that it is a compile-time error for a deferred prefix
+  to be used in more than one import,
+  which means that the update of the binding of $p$
+  does not interfere with other imports.%
 }
 
 \LMHash{}%
@@ -20425,12 +20426,12 @@ The effect of a repeated invocation of \code{$p$.loadLibrary()} is as follows:
 \end{itemize}
 
 \commentary{%
-In other words, a successful \code{loadLibrary()} guarantees that
-the import can be successfully accessed through the import prefix.
-If an invocation of \code{loadLibrary()} is initiated after
-another invocation has completed successfully,
-it is guaranteed to also complete successfully (success is idempotent).
-We do not specify which object the returned future resolves to.%
+  In other words, a successful \code{loadLibrary()} guarantees that
+  the import can be successfully accessed through the import prefix.
+  If an invocation of \code{loadLibrary()} is initiated after
+  another invocation has completed successfully,
+  it is guaranteed to also complete successfully (success is idempotent).
+  We do not specify which object the returned future resolves to.%
 }
 \EndCase
 
@@ -20467,9 +20468,9 @@ maps $p$ to a non-deferred prefix run-time namespace \NamespaceName{p}
 containing the mappings of \NamespaceName{i}.
 
 \commentary{%
-\NamespaceName{p} may have additional mappings
-because there can be several imports with the same prefix
-as long as they are all immediate.%
+  \NamespaceName{p} may have additional mappings
+  because there can be several imports with the same prefix
+  as long as they are all immediate.%
 }
 
 \LMHash{}%
@@ -20518,8 +20519,8 @@ Let \NamespaceName{\metavar{public}} be the public namespace of $L$
 (\ref{librariesAndScripts}).
 
 \commentary{%
-Note that private names and import prefixes are not present
-in \NamespaceName{\metavar{public}}.%
+  Note that private names and import prefixes are not present
+  in \NamespaceName{\metavar{public}}.%
 }
 
 \LMHash{}%
@@ -20552,18 +20553,20 @@ is conflicted
 (\ref{conflictMergingOfNamespaces}).
 
 \rationale{%
-This rule is more strict than the corresponding rule for imports:
-When two imported declarations have a name clash, it is only an error to
-\emph{use} the conflicted name, it is not an error that the name clash exists.
-With exported names, it is an error that the name clash exists.
-The reason for this difference is that
-the conflict could silently break importers of the current library $L$,
-if we were to use the same approach for exports as for imports:
-If a library $L'$ imports $L$
-and uses a name $n$ which is re-exported by $L$ from $L_n$
-then the addition of a declaration named $n$ to some other re-exported library
-will make the use of $n$ in $L'$ an error,
-and the maintainers of $L'$ may not be in a position to change $L$.%
+  This rule is more strict than the corresponding rule for imports:
+  When two imported declarations have a name clash, it is only an error to
+  \emph{use} the conflicted name,
+  it is not an error that the name clash exists.
+  With exported names, it is an error that the name clash exists.
+  The reason for this difference is that
+  the conflict could silently break importers of the current library $L$,
+  if we were to use the same approach for exports as for imports:
+  If a library $L'$ imports $L$
+  and uses a name $n$ which is re-exported by $L$ from $L_n$
+  then the addition of a declaration named $n$
+  to some other re-exported library
+  will make the use of $n$ in $L'$ an error,
+  and the maintainers of $L'$ may not be in a position to change $L$.%
 }
 
 \LMHash{}%
@@ -20621,8 +20624,8 @@ and each key $n$ of \NamespaceName{b}
 to \Namespace{b}{n}.
 
 \commentary{%
-Note that this \emph{is} a namespace because the union is only defined
-when the mapping of any given key is unambiguous.%
+  Note that this \emph{is} a namespace because the union is only defined
+  when the mapping of any given key is unambiguous.%
 }
 
 \LMHash{}%
@@ -20668,21 +20671,21 @@ $\NamespaceName{j} = \Hide{[\List{id}{1}{k}]}{\NamespaceName{j-1}}$.
 Then \NamespaceName{\metavar{end}} is \NamespaceName{n}.
 
 \commentary{%
-\NamespaceName{\metavar{end}} will always agree with
-\NamespaceName{\metavar{start}} wherever both are defined,
-and the set of names where \NamespaceName{\metavar{end}} is defined
-is always a subset of that of \NamespaceName{\metavar{start}}.
-In that sense, this is a \emph{narrowing} procedure.%
+  \NamespaceName{\metavar{end}} will always agree with
+  \NamespaceName{\metavar{start}} wherever both are defined,
+  and the set of names where \NamespaceName{\metavar{end}} is defined
+  is always a subset of that of \NamespaceName{\metavar{start}}.
+  In that sense, this is a \emph{narrowing} procedure.%
 }
 
 \commentary{%
-Note that it is possible to use \HIDE{} or \SHOW{} on an identifier
-which is not in the given namespace.%
+  Note that it is possible to use \HIDE{} or \SHOW{} on an identifier
+  which is not in the given namespace.%
 }
 \rationale{%
-Allowing this prevents situations where, e.g.,
-removing a declaration from a library $L$ would cause
-breakage in a library that imports $L$.%
+  Allowing this prevents situations where, e.g.,
+  removing a declaration from a library $L$ would cause
+  breakage in a library that imports $L$.%
 }
 
 
@@ -20768,14 +20771,14 @@ and one of the following conditions holds:
 \end{itemize}
 
 \commentary{%
-In short, conflict merging takes a list of namespaces and produces
-a namespace that is the union of several disjoint namespaces
-(because all name clashes have been eliminated):
-A conflict namespace that records all unresolved name clashes,
-and a list of namespaces where clashing names have been removed.
-Some name clashes have been resolved by preferring
-declarations from non-system libraries
-over declarations from system libraries.%
+  In short, conflict merging takes a list of namespaces and produces
+  a namespace that is the union of several disjoint namespaces
+  (because all name clashes have been eliminated):
+  A conflict namespace that records all unresolved name clashes,
+  and a list of namespaces where clashing names have been removed.
+  Some name clashes have been resolved by preferring
+  declarations from non-system libraries
+  over declarations from system libraries.%
 }
 
 \LMHash{}%
@@ -20813,8 +20816,8 @@ may be found.
 A part contains a string which is derived from \synt{partDeclaration}.
 
 \commentary{%
-So we could say that \synt{partDeclaration} is a start symbol of the grammar,
-as discussed in Sect.~\ref{librariesAndScripts}.%
+  So we could say that \synt{partDeclaration} is a start symbol of the grammar,
+  as discussed in Sect.~\ref{librariesAndScripts}.%
 }
 
 \LMHash{}%
@@ -20855,13 +20858,13 @@ It is a compile-time error if $L_1$ and $L_2$ both contain
 a part directive with URI $u$.
 
 \commentary{%
-In particular, it is an error to use the same part twice
-in the same program
-(\ref{scripts}).
-Note that a relative URI is interpreted as relative to the location of the
-enclosing library (\ref{uris}), which means that $L_1$ and $L_2$ may both
-have a part identified by \code{'myPart.dart'}, but they are not the same
-URI unless $L_1$ and $L_2$ have the same location.%
+  In particular, it is an error to use the same part twice
+  in the same program
+  (\ref{scripts}).
+  Note that a relative URI is interpreted as relative to the location of the
+  enclosing library (\ref{uris}), which means that $L_1$ and $L_2$ may both
+  have a part identified by \code{'myPart.dart'}, but they are not the same
+  URI unless $L_1$ and $L_2$ have the same location.%
 }
 
 
@@ -20899,25 +20902,26 @@ If \code{main} cannot be called with one or two positional arguments,
 it is invoked with no arguments.
 
 \commentary{%
-Note that if \code{main} requires more than two positional arguments,
-the library is not considered a script.%
+  Note that if \code{main} requires more than two positional arguments,
+  the library is not considered a script.%
 }
 
 \commentary{%
-A Dart program will typically be executed by executing a script.%
+  A Dart program will typically be executed by executing a script.%
 }
 
 \LMHash{}%
 It is a compile-time error if a library's export scope contains a declaration
 named \code{main}, and the library is not a script.
 \commentary{%
-This restriction ensures that all top-level \code{main} declarations
-introduce a script main-function, so there cannot be a top-level getter or field
-named \code{main}, nor can it be a function that requires more than two
-arguments. The restriction allows tools to fail early on invalid \code{main}
-methods, without needing to know whether a library will be used as the entry
-point of a Dart program. It is possible that this restriction will be removed
-in the future.%
+  This restriction ensures that all top-level \code{main} declarations
+  introduce a script main-function, so there cannot be
+  a top-level getter or field
+  named \code{main}, nor can it be a function that requires more than two
+  arguments. The restriction allows tools to fail early on invalid \code{main}
+  methods, without needing to know whether a library will be used as the entry
+  point of a Dart program. It is possible that this restriction will be removed
+  in the future.%
 }
 
 
@@ -20993,13 +20997,14 @@ This specification does not discuss the interpretation of URIs,
 with the following exceptions.
 
 \rationale{%
-The interpretation of URIs is mostly left to
-the surrounding computing environment.
-For example, if Dart is running in a web browser,
-that browser will likely interpret some URIs.
-While it might seem attractive to specify, say, that
-URIs are interpreted with respect to a standard such as IETF RFC 3986,
-in practice this will usually depend on the browser and cannot be relied upon.%
+  The interpretation of URIs is mostly left to
+  the surrounding computing environment.
+  For example, if Dart is running in a web browser,
+  that browser will likely interpret some URIs.
+  While it might seem attractive to specify, say, that
+  URIs are interpreted with respect to a standard such as IETF RFC 3986,
+  in practice this will usually depend on the browser
+  and cannot be relied upon.%
 }
 
 \LMHash{}%
@@ -21011,8 +21016,8 @@ A URI of the form \code{package:$s$} is interpreted in
 an implementation specific manner.
 
 \rationale{%
-The intent is that, during development, Dart programmers can rely on
-a package manager to find elements of their program.%
+  The intent is that, during development, Dart programmers can rely on
+  a package manager to find elements of their program.%
 }
 
 \LMHash{}%
@@ -21020,9 +21025,7 @@ Otherwise, any relative URI is interpreted as relative to
 the location of the current library.
 All further interpretation of URIs is implementation dependent.
 
-\commentary{%
-This means it is dependent on the runtime.%
-}
+\commentary{This means it is dependent on the runtime.}
 
 
 \section{Types}
@@ -21032,28 +21035,28 @@ This means it is dependent on the runtime.%
 Dart supports static typing based on interface types.
 
 \rationale{%
-The type system is sound in the sense that
-if a variable of type $T$ refers to an object of type $S$ at run time,
-then $S$ is a subtype of $T$.
-In other words, the contents of the heap satisfies the expectations
-expressed by static typing.
+  The type system is sound in the sense that
+  if a variable of type $T$ refers to an object of type $S$ at run time,
+  then $S$ is a subtype of $T$.
+  In other words, the contents of the heap satisfies the expectations
+  expressed by static typing.
 
-However, type parameters are covariant
-(e.g., \SubtypeNE{\code{List<int>}}{\code{List<num>}})
-and this implies that certain operations are subject to dynamic type checks
-(such as \code{myList.add(1.5)}, which will throw at run time
-if \code{myList} has declared type \code{List<num>},
-but it is actually a \code{List<int>}).
-Hence, a program can be free of compile-time errors,
-and it may still incur a type error at run time.
+  However, type parameters are covariant
+  (e.g., \SubtypeNE{\code{List<int>}}{\code{List<num>}})
+  and this implies that certain operations are subject to dynamic type checks
+  (such as \code{myList.add(1.5)}, which will throw at run time
+  if \code{myList} has declared type \code{List<num>},
+  but it is actually a \code{List<int>}).
+  Hence, a program can be free of compile-time errors,
+  and it may still incur a type error at run time.
 
-This choice was made deliberately during the early days of Dart
-(and it is undoubtedly controversial).
-It represents a trade-off where
-the potential for run-time type errors is the cost,
-and the benefit is simpler programs.
-In recent years, Dart has evolved to have more and more static type safety,
-e.g., null safety, and this trend is likely to continue.%
+  This choice was made deliberately during the early days of Dart
+  (and it is undoubtedly controversial).
+  It represents a trade-off where
+  the potential for run-time type errors is the cost,
+  and the benefit is simpler programs.
+  In recent years, Dart has evolved to have more and more static type safety,
+  e.g., null safety, and this trend is likely to continue.%
 }
 
 
@@ -21069,18 +21072,18 @@ Type annotations are used during static checking and when running programs.
 Types are specified using the following grammar rules.
 
 \commentary{%
-A \synt{typeIdentifier} is an identifier which can be the name of a type,
-that is,
-it denotes an \synt{IDENTIFIER} which is not a \synt{BUILT\_IN\_IDENTIFIER}
-(\ref{identifierReference}).%
+  A \synt{typeIdentifier} is an identifier which can be the name of a type,
+  that is,
+  it denotes an \synt{IDENTIFIER} which is not a \synt{BUILT\_IN\_IDENTIFIER}
+  (\ref{identifierReference}).%
 }
 
 \commentary{%
-Non-terminals with names of the form \synt{\ldots{}NotFunction}
-derive terms which are types that are not function types.
-Note that it \emph{does} derive the type \FUNCTION,
-which is not itself a function type,
-but it is the least upper bound of all function types.%
+  Non-terminals with names of the form \synt{\ldots{}NotFunction}
+  derive terms which are types that are not function types.
+  Note that it \emph{does} derive the type \FUNCTION,
+  which is not itself a function type,
+  but it is the least upper bound of all function types.%
 }
 
 \begin{grammar}
@@ -21147,12 +21150,12 @@ Similarly, the static checker must emit static warnings
 for at least the situations specified as such in this specification.
 
 \commentary{%
-Nothing precludes additional tools that implement alternative static analyses
-(e.g., interpreting the existing type annotations in a sound manner
-such as either non-variant generics, or inferring declaration based variance
-from the actual declarations).
-However, using these tools must not preclude
-successful compilation and execution of Dart code.%
+  Nothing precludes additional tools that implement alternative static analyses
+  (e.g., interpreting the existing type annotations in a sound manner
+  such as either non-variant generics, or inferring declaration based variance
+  from the actual declarations).
+  However, using these tools must not preclude
+  successful compilation and execution of Dart code.%
 }
 
 \LMHash{}%
@@ -21257,11 +21260,11 @@ for the situation where $o$ was obtained as a fresh instance
 \ref{lists}, \ref{maps}, \ref{new}, \ref{functionInvocation}).
 
 \commentary{%
-In particular, the dynamic type of an instance never changes.
-It is at times only specified that the given class implements
-a certain type, e.g., for a list literal.
-In these cases the dynamic type is implementation dependent,
-except of course that said superinterface constraint must be satisfied.%
+  In particular, the dynamic type of an instance never changes.
+  It is at times only specified that the given class implements
+  a certain type, e.g., for a list literal.
+  In these cases the dynamic type is implementation dependent,
+  except of course that said superinterface constraint must be satisfied.%
 }
 
 \LMHash{}%
@@ -21269,27 +21272,27 @@ The dynamic types of a running Dart program are equivalent to
 the static types with regard to subtyping.
 
 \commentary{%
-Certain dynamic type checks are performed during execution
-(\ref{variables},
-\ref{redirectingGenerativeConstructors},
-\ref{executionOfInitializerLists},
-\ref{factories},
-\ref{redirectingFactoryConstructors},
-\ref{lists},
-\ref{new},
-\ref{bindingActualsToFormals},
-\ref{ordinaryInvocation},
-\ref{assignment},
-\ref{typeCast},
-\ref{localVariableDeclaration},
-\ref{asynchronousFor-in},
-\ref{return},
-\ref{yieldEach},
-\ref{assert}).
-As specified in those locations,
-these dynamic checks are based on the dynamic types of instances,
-and the actual types of declarations
-(\ref{actualTypes}).%
+  Certain dynamic type checks are performed during execution
+  (\ref{variables},
+  \ref{redirectingGenerativeConstructors},
+  \ref{executionOfInitializerLists},
+  \ref{factories},
+  \ref{redirectingFactoryConstructors},
+  \ref{lists},
+  \ref{new},
+  \ref{bindingActualsToFormals},
+  \ref{ordinaryInvocation},
+  \ref{assignment},
+  \ref{typeCast},
+  \ref{localVariableDeclaration},
+  \ref{asynchronousFor-in},
+  \ref{return},
+  \ref{yieldEach},
+  \ref{assert}).
+  As specified in those locations,
+  these dynamic checks are based on the dynamic types of instances,
+  and the actual types of declarations
+  (\ref{actualTypes}).%
 }
 
 \LMHash{}%
@@ -21300,14 +21303,14 @@ two \code{Type} objects are equal according to operator \lit{==}
 if{}f the corresponding types are subtypes of each other.
 
 \commentary{%
-For example, the \code{Type} objects for the types
-\DYNAMIC{} and \code{Object} are equal to each other
-and hence \code{dynamic\,==\,Object} must evaluate to \TRUE.
-No constraints are imposed on the built-in function \code{identical},
-so \code{identical(dynamic, Object)} may be \TRUE{} or \FALSE.
+  For example, the \code{Type} objects for the types
+  \DYNAMIC{} and \code{Object} are equal to each other
+  and hence \code{dynamic\,==\,Object} must evaluate to \TRUE.
+  No constraints are imposed on the built-in function \code{identical},
+  so \code{identical(dynamic, Object)} may be \TRUE{} or \FALSE.
 
-Similarly, \code{Type} instances for distinct type alias declarations
-declaring a name for the same function type are equal:%
+  Similarly, \code{Type} instances for distinct type alias declarations
+  declaring a name for the same function type are equal:%
 }
 
 \begin{dartCode}
@@ -21321,10 +21324,10 @@ declaring a name for the same function type are equal:%
 
 \LMHash{}%
 \commentary{%
-Instances of \code{Type} can be obtained in various ways,
-for example by using reflection,
-by reading the \code{runtimeType} of an object,
-or by evaluating a \emph{type literal} expression.%
+  Instances of \code{Type} can be obtained in various ways,
+  for example by using reflection,
+  by reading the \code{runtimeType} of an object,
+  or by evaluating a \emph{type literal} expression.%
 }
 
 \LMHash{}%
@@ -21335,7 +21338,7 @@ an identifier denoting a type parameter of a generic class or function.
 It is a \emph{constant type literal} if it does not denote a type parameter,
 and it is not qualified by a deferred prefix.
 \commentary{%
-A constant type literal is a constant expression (\ref{constants}).%
+  A constant type literal is a constant expression (\ref{constants}).%
 }
 
 
@@ -21347,8 +21350,8 @@ A \Index{type alias} declares a name for a type,
 or for a mapping from type arguments to types.
 
 \commentary{%
-It is common to use the phrase ``a typedef'' for such a declaration,
-because of the prominent occurrence of the token \TYPEDEF.%
+  It is common to use the phrase ``a typedef'' for such a declaration,
+  because of the prominent occurrence of the token \TYPEDEF.%
 }
 
 \begin{grammar}
@@ -21387,12 +21390,12 @@ it is a compile-time error if $T$ is not regular-bounded,
 and it is a compile-time error if any type occurring in $T$ is not well-bounded.
 
 \commentary{%
-This means that the bounds declared for
-the formal type parameters of a generic type alias
-must be such that when they are satisfied,
-the bounds that pertain to the body are also satisfied,
-and a type occurring as a subterm of the body can violate its bounds,
-but only if it is a correct super-bounded type.%
+  This means that the bounds declared for
+  the formal type parameters of a generic type alias
+  must be such that when they are satisfied,
+  the bounds that pertain to the body are also satisfied,
+  and a type occurring as a subterm of the body can violate its bounds,
+  but only if it is a correct super-bounded type.%
 }
 
 \LMHash{}%
@@ -21453,18 +21456,18 @@ then \DefineSymbol{T_j} is \DYNAMIC,
 otherwise $T_j$ is $T_j?$.
 
 \commentary{%
-This means that the older forms allow for a parameter type to be omitted,
-in which case it is taken to be \DYNAMIC,
-but the parameter name cannot be omitted.
-This behavior is error prone,
-and hence the newer form (with \lit{=}) is recommended.
-For instance, the declaration \code{\TYPEDEF{} $F$(int);}
-specifies that $F$ denotes the type
-\code{\DYNAMIC{} \FUNCTION(\DYNAMIC)},
-and it is documented, but technically ignored,
-that the parameter has the name \code{int}.
-It is extremely likely that a reader will misread this,
-and assume that \code{int} is the parameter type.%
+  This means that the older forms allow for a parameter type to be omitted,
+  in which case it is taken to be \DYNAMIC,
+  but the parameter name cannot be omitted.
+  This behavior is error prone,
+  and hence the newer form (with \lit{=}) is recommended.
+  For instance, the declaration \code{\TYPEDEF{} $F$(int);}
+  specifies that $F$ denotes the type
+  \code{\DYNAMIC{} \FUNCTION(\DYNAMIC)},
+  and it is documented, but technically ignored,
+  that the parameter has the name \code{int}.
+  It is extremely likely that a reader will misread this,
+  and assume that \code{int} is the parameter type.%
 }
 
 \LMHash{}%
@@ -21473,12 +21476,12 @@ a formal parameter in these older forms,
 or if a formal parameter has the modifier \COVARIANT.
 
 \commentary{%
-Note that the old forms can only define function types,
-and they cannot denote the type of a generic function.
-When such a type alias has type parameters,
-it always expresses a family of non-generic function types.
-These restrictions exist because that syntax was defined
-before generic functions were added to Dart.%
+  Note that the old forms can only define function types,
+  and they cannot denote the type of a generic function.
+  When such a type alias has type parameters,
+  it always expresses a family of non-generic function types.
+  These restrictions exist because that syntax was defined
+  before generic functions were added to Dart.%
 }
 
 \LMHash{}%
@@ -21506,18 +21509,18 @@ the type alias declarations that $D$ depends on.
 A compile-time error occurs if $D \in M$.
 
 \commentary{%
-In other words, it is an error for a type alias declaration
-to depend on itself, directly or indirectly.%
+  In other words, it is an error for a type alias declaration
+  to depend on itself, directly or indirectly.%
 }
 
 \commentary{%
-This kind of error may also arise when type arguments have been
-omitted in the program, but are added during static analysis
-via instantiation to bound
-(\ref{instantiationToBound})
-or via type inference,
-which will be specified later
-(\ref{overview}).%
+  This kind of error may also arise when type arguments have been
+  omitted in the program, but are added during static analysis
+  via instantiation to bound
+  (\ref{instantiationToBound})
+  or via type inference,
+  which will be specified later
+  (\ref{overview}).%
 }
 
 \LMHash{}%
@@ -21535,8 +21538,8 @@ in a scope where $F$ resolves to $D$
 $[U_1/X_1, \ldots, U_s/X_s]T$.
 
 \commentary{%
-Note that $s$ can be zero, in which case $F$ is non-generic,
-and we are just replacing the type alias name by its body.%
+  Note that $s$ can be zero, in which case $F$ is non-generic,
+  and we are just replacing the type alias name by its body.%
 }
 
 \LMHash{}%
@@ -21550,12 +21553,12 @@ When no further steps are possible we say that the resulting type is the
 of $U$.
 
 \commentary{%
-Note that the transitive alias expansion exists,
-because it is an error for a type alias declaration
-to depend on itself.
-However, it may be large.
-For instance, \code{\TYPEDEF{} $F$<$X$> = Map<$X$, $X$>;} yields
-an exponential size increase for \code{$F$<$F$<\ldots$F$<int>\ldots{}>{}>}.%
+  Note that the transitive alias expansion exists,
+  because it is an error for a type alias declaration
+  to depend on itself.
+  However, it may be large.
+  For instance, \code{\TYPEDEF{} $F$<$X$> = Map<$X$, $X$>;} yields
+  an exponential size increase for \code{$F$<$F$<\ldots$F$<int>\ldots{}>{}>}.%
 }
 
 \LMHash{}%
@@ -21586,9 +21589,9 @@ respectively
 `\code{$q$.$C$.\id\;\metavar{args}}'.
 
 \commentary{%
-This means that it is possible to use a type alias
-to invoke a static member of a class or a mixin.
-For example:%
+  This means that it is possible to use a type alias
+  to invoke a static member of a class or a mixin.
+  For example:%
 }
 
 \begin{dartCode}
@@ -21604,17 +21607,17 @@ For example:%
 \end{dartCode}
 
 \rationale{%
-Note that the type arguments passed to $C$ respectively \code{$p$.$C$}
-are erased,
-such that the resulting expression can be a correct static member invocation.
-If a future version of Dart allows type arguments to be passed via the class
-in an invocation of a static member,
-it may be preferable to preserve these type arguments.
-At that time,
-existing invocations where type arguments are passed in this manner
-will not break,
-because it is currently an error for a static member to depend on the value
-of a formal type parameter of the enclosing class.%
+  Note that the type arguments passed to $C$ respectively \code{$p$.$C$}
+  are erased,
+  such that the resulting expression can be a correct static member invocation.
+  If a future version of Dart allows type arguments to be passed via the class
+  in an invocation of a static member,
+  it may be preferable to preserve these type arguments.
+  At that time,
+  existing invocations where type arguments are passed in this manner
+  will not break,
+  because it is currently an error for a static member to depend on the value
+  of a formal type parameter of the enclosing class.%
 }
 
 \LMHash{}%
@@ -21713,16 +21716,16 @@ but we will need to introduce a few concepts first,
 in order to clarify what those rules mean.
 
 \commentary{%
-A reader who has read many research papers about object-oriented type systems
-may find the meaning of the given notation obvious,
-but we still need to clarify a few details about how to handle
-syntactically different denotations of the same type,
-and how to choose the right initial environment, $\Delta$.
-%
-For a reader who is not familiar with the notation used in this section,
-the explanations given here should suffice to clarify what it means,
-with reference to the natural language explanations given at the end of
-the section for obtaining an intuition about the meaning.%
+  A reader who has read many research papers about object-oriented type systems
+  may find the meaning of the given notation obvious,
+  but we still need to clarify a few details about how to handle
+  syntactically different denotations of the same type,
+  and how to choose the right initial environment, $\Delta$.
+  %
+  For a reader who is not familiar with the notation used in this section,
+  the explanations given here should suffice to clarify what it means,
+  with reference to the natural language explanations given at the end of
+  the section for obtaining an intuition about the meaning.%
 }
 
 \LMHash{}%
@@ -21735,9 +21738,9 @@ and type casts
 (\ref{typeCast}).
 
 \commentary{%
-A variant of the rules described here is shown in an appendix
-(\ref{algorithmicSubtyping}),
-demonstrating that Dart subtyping can be decided efficiently.%
+  A variant of the rules described here is shown in an appendix
+  (\ref{algorithmicSubtyping}),
+  demonstrating that Dart subtyping can be decided efficiently.%
 }
 
 \LMHash{}%
@@ -21753,14 +21756,14 @@ they are never a type argument of another type,
 nor a return type or a formal parameter type,
 and it is always the case that $S$ is a subtype of the bound of $X$.
 \commentary{%
-The motivation for $X \& S$ is that it represents
-the type of a local variable $v$
-whose type is declared to be the type variable $X$,
-and which is known to have type $S$ due to promotion.
-Similarly, $X \& S$ may be seen as an intersection type,
-which is a subtype of $X$ and also a subtype of $S$.
-Intersection types are \emph{not} supported in general,
-only in this special case.%
+  The motivation for $X \& S$ is that it represents
+  the type of a local variable $v$
+  whose type is declared to be the type variable $X$,
+  and which is known to have type $S$ due to promotion.
+  Similarly, $X \& S$ may be seen as an intersection type,
+  which is a subtype of $X$ and also a subtype of $S$.
+  Intersection types are \emph{not} supported in general,
+  only in this special case.%
 }
 Every other form of type may occur during static analysis
 as well as during execution,
@@ -21880,15 +21883,15 @@ A \Index{meta-variable} is a symbol which stands for a syntactic construct
 that satisfies some static semantic requirements.
 
 \commentary{%
-For instance, $X$ is a meta-variable standing for
-an identifier \code{W},
-but only if \code{W} denotes a type variable declared in an enclosing scope.
-In the definitions below, we specify this by saying that
-`$X$ ranges over type variables'.
-Similarly, $C$ is a meta-variable standing for
-a \synt{typeName}, for instance, \code{p.D},
-but only if \code{p.D} denotes a class in the given scope.
-We specify this as `$C$ ranges over classes'.%
+  For instance, $X$ is a meta-variable standing for
+  an identifier \code{W},
+  but only if \code{W} denotes a type variable declared in an enclosing scope.
+  In the definitions below, we specify this by saying that
+  `$X$ ranges over type variables'.
+  Similarly, $C$ is a meta-variable standing for
+  a \synt{typeName}, for instance, \code{p.D},
+  but only if \code{p.D} denotes a class in the given scope.
+  We specify this as `$C$ ranges over classes'.%
 }
 
 \LMHash{}%
@@ -21917,46 +21920,46 @@ each occurrence of a given meta-variable by
 concrete syntax denoting the same type.
 
 \commentary{%
-In general, this means that two or more occurrences of
-a given meta-variable in a rule
-stands for identical pieces of syntax,
-and the instantiation of the rule proceeds as
-a simple search-and-replace operation.
-For instance,
-rule~\SrnReflexivity{} in Figure~\ref{fig:subtypeRules}
-can be used to conclude
-\Subtype{\emptyset}{\code{int}}{\code{int}},
-where $\emptyset$ denotes the empty environment
-(any environment would suffice because no type variables occur).
+  In general, this means that two or more occurrences of
+  a given meta-variable in a rule
+  stands for identical pieces of syntax,
+  and the instantiation of the rule proceeds as
+  a simple search-and-replace operation.
+  For instance,
+  rule~\SrnReflexivity{} in Figure~\ref{fig:subtypeRules}
+  can be used to conclude
+  \Subtype{\emptyset}{\code{int}}{\code{int}},
+  where $\emptyset$ denotes the empty environment
+  (any environment would suffice because no type variables occur).
 
-However, the wording `denoting the same type' above covers
-additional situations as well:
-For instance, we may use rule~\SrnReflexivity{}
-to show that \code{p1.C} is a subtype of
-\code{p2.C} when \code{C} is a class declared in a
-library $L$ which is imported by libraries $L_1$ and $L_2$ and
-used in declarations there,
-when $L_1$ and $L_2$ are imported with prefixes
-\code{p1} respectively \code{p2} by the current library.
-The important point is that all occurrences of the same meta-variable
-in a given rule instantiation stands for the same type,
-even in the case where that type is not denoted by
-the same syntax in both cases.
+  However, the wording `denoting the same type' above covers
+  additional situations as well:
+  For instance, we may use rule~\SrnReflexivity{}
+  to show that \code{p1.C} is a subtype of
+  \code{p2.C} when \code{C} is a class declared in a
+  library $L$ which is imported by libraries $L_1$ and $L_2$ and
+  used in declarations there,
+  when $L_1$ and $L_2$ are imported with prefixes
+  \code{p1} respectively \code{p2} by the current library.
+  The important point is that all occurrences of the same meta-variable
+  in a given rule instantiation stands for the same type,
+  even in the case where that type is not denoted by
+  the same syntax in both cases.
 
-Conversely, we can \emph{not} use the same rule to conclude
-that \code{C} is a subtype of \code{C}
-in the case where the former denotes a class declared in library $L_1$
-and the latter denotes a class declared in $L_2$, with $L_1 \not= L_2$.
-This situation can arise without compile-time errors, e.g.,
-if $L_1$ and $L_2$ are imported indirectly into the current library
-and the two ``meanings'' of \code{C} are used
-as type annotations on variables or formal parameters of functions
-declared in intermediate libraries importing $L_1$ respectively $L_2$.
-The failure to prove
-``\Subtype{\emptyset}{\code{C}}{\code{C}}''
-will then occur, e.g., in a situation where we check whether
-such a variable can be passed as an actual argument to such a function,
-because the two occurrences of \code{C} do not denote the same type.%
+  Conversely, we can \emph{not} use the same rule to conclude
+  that \code{C} is a subtype of \code{C}
+  in the case where the former denotes a class declared in library $L_1$
+  and the latter denotes a class declared in $L_2$, with $L_1 \not= L_2$.
+  This situation can arise without compile-time errors, e.g.,
+  if $L_1$ and $L_2$ are imported indirectly into the current library
+  and the two ``meanings'' of \code{C} are used
+  as type annotations on variables or formal parameters of functions
+  declared in intermediate libraries importing $L_1$ respectively $L_2$.
+  The failure to prove
+  ``\Subtype{\emptyset}{\code{C}}{\code{C}}''
+  will then occur, e.g., in a situation where we check whether
+  such a variable can be passed as an actual argument to such a function,
+  because the two occurrences of \code{C} do not denote the same type.%
 }
 
 \LMHash{}%
@@ -21964,18 +21967,20 @@ Every \synt{typeName} used in a type mentioned in this section is assumed to
 have no compile-time error and denote a type.
 
 \commentary{%
-That is, no subtyping relationship can be proven for
-a type that is or contains an undefined name
-or a name that denotes something other than a type.
-Note that it is not necessary in order to determine a subtyping relationship
-that every type satisfies the declared bounds,
-the subtyping relation does not depend on bounds.
-However, if an attempt is made to prove a subtype relationship
-and one or more \synt{typeName}s receives an actual type argument list
-whose length does not match the declaration
-(including the case where some type arguments are given to a non-generic class,
-and the case where a generic class occurs, but no type arguments are given)
-then the attempt to prove the relationship simply fails.%
+  That is, no subtyping relationship can be proven for
+  a type that is or contains an undefined name
+  or a name that denotes something other than a type.
+  Note that it is not necessary in order to determine a subtyping relationship
+  that every type satisfies the declared bounds,
+  the subtyping relation does not depend on bounds.
+  However, if an attempt is made to prove a subtype relationship
+  and one or more \synt{typeName}s receives an actual type argument list
+  whose length does not match the declaration
+  (including the case where some type arguments are given
+  to a non-generic class,
+  and the case where a generic class occurs,
+  but no type arguments are given)
+  then the attempt to prove the relationship simply fails.%
 }
 
 \LMHash{}%
@@ -21989,9 +21994,9 @@ At a given location where the type variables in scope are
 we define the environment as follows:
 $\Delta = \{\,X_1 \mapsto B_1,\ \ldots\ X_s \mapsto B_s\,\}$.
 \commentary{%
-That is, $\Delta(X_1) = B_1$, and so on,
-and $\Delta$ is undefined when applied to a type variable $Y$
-which is not in $\{\,\List{X}{1}{s}\,\}$.%
+  That is, $\Delta(X_1) = B_1$, and so on,
+  and $\Delta$ is undefined when applied to a type variable $Y$
+  which is not in $\{\,\List{X}{1}{s}\,\}$.%
 }
 When the rules are used to show that a given subtype relationship exists,
 this is the initial value of $\Delta$.
@@ -22006,16 +22011,16 @@ which is the operator that produces the union of disjoint sets,
 and gives priority to the right hand operand in case of conflicts.
 
 \commentary{%
-So
-$\{ \code{X} \mapsto \code{int}, \code{Y} \mapsto \code{double} \} \uplus
-\{ \code{Z} \mapsto \code{Object} \} =
-\{ \code{X} \mapsto \code{int}, \code{Y} \mapsto \code{double}, \code{Z} \mapsto \code{Object} \}$
-and
-$\{ \code{X} \mapsto \code{int}, \code{Y} \mapsto \code{FutureOr<List<double>{}>} \} \uplus
-\{ \code{Y} \mapsto \code{int} \} =
-\{ \code{X} \mapsto \code{int}, \code{Y} \mapsto \code{int} \}$.
-Note that operator $\uplus$ is concerned with scopes and shadowing,
-with no connection to, e.g., subtypes or instance method overriding.%
+  So
+  $\{ \code{X} \mapsto \code{int}, \code{Y} \mapsto \code{double} \} \uplus
+  \{ \code{Z} \mapsto \code{Object} \} =
+  \{ \code{X} \mapsto \code{int}, \code{Y} \mapsto \code{double}, \code{Z} \mapsto \code{Object} \}$
+  and
+  $\{ \code{X} \mapsto \code{int}, \code{Y} \mapsto \code{FutureOr<List<double>{}>} \} \uplus
+  \{ \code{Y} \mapsto \code{int} \} =
+  \{ \code{X} \mapsto \code{int}, \code{Y} \mapsto \code{int} \}$.
+  Note that operator $\uplus$ is concerned with scopes and shadowing,
+  with no connection to, e.g., subtypes or instance method overriding.%
 }
 
 \LMHash{}%
@@ -22042,10 +22047,10 @@ When that is not the case for a given premise,
 we specify the meaning explicitly.
 
 \commentary{%
-Instantiation of a rule, mentioned above,
-denotes the consistent replacement of meta-variables
-by actual syntactic terms denoting types everywhere in the rule,
-that is, in the premises as well as in the conclusion, simultaneously.%
+  Instantiation of a rule, mentioned above,
+  denotes the consistent replacement of meta-variables
+  by actual syntactic terms denoting types everywhere in the rule,
+  that is, in the premises as well as in the conclusion, simultaneously.%
 }
 
 
@@ -22062,11 +22067,11 @@ each of the premises of $R$,
 continuing until a rule with no premises is reached.
 
 \commentary{%
-For rule \SrnNull, note that the \code{Null} type
-is a subtype of all non-$\bot$ types,
-even though it doesn't actually extend or implement those types.
-The other types are effectively treated as if they were nullable,
-which makes the null object (\ref{null}) assignable to them.%
+  For rule \SrnNull, note that the \code{Null} type
+  is a subtype of all non-$\bot$ types,
+  even though it doesn't actually extend or implement those types.
+  The other types are effectively treated as if they were nullable,
+  which makes the null object (\ref{null}) assignable to them.%
 }
 
 \LMHash{}%
@@ -22096,10 +22101,10 @@ Rule~\SrnRightFunction{} has as a premise that `$T$ is a function type'.
 This means that $T$ is a type of one of the forms introduced in
 section~\ref{typeOfAFunction}.
 \commentary{%
-This is the same as the forms of type that occur at top level
-in the conclusions of
-rule~\SrnPositionalFunctionType{} and
-rule~\SrnNamedFunctionType.%
+  This is the same as the forms of type that occur at top level
+  in the conclusions of
+  rule~\SrnPositionalFunctionType{} and
+  rule~\SrnNamedFunctionType.%
 }
 
 \LMHash{}%
@@ -22132,31 +22137,31 @@ the set of direct superinterfaces of $C$
 (\ref{superinterfaces}).
 
 \commentary{%
-Note that one of the direct superinterfaces of $C$ is
-the interface of the superclass of $C$,
-and that may be a mixin application
-(\ref{mixinApplication}),
-in which case $D$ in the rule is
-the synthetic class which specifies
-the semantics of that mixin application.%
+  Note that one of the direct superinterfaces of $C$ is
+  the interface of the superclass of $C$,
+  and that may be a mixin application
+  (\ref{mixinApplication}),
+  in which case $D$ in the rule is
+  the synthetic class which specifies
+  the semantics of that mixin application.%
 }
 
 \commentary{%
-The last premise of rule~\SrnSuperinterface{}
-substitutes the actual type arguments \List{S}{1}{s} for the
-formal type parameters \List{X}{1}{s},
-because \List{T}{1}{m} may contain those formal type parameters.%
+  The last premise of rule~\SrnSuperinterface{}
+  substitutes the actual type arguments \List{S}{1}{s} for the
+  formal type parameters \List{X}{1}{s},
+  because \List{T}{1}{m} may contain those formal type parameters.%
 }
 
 \commentary{%
-The rules~\SrnCovariance{} and~\SrnSuperinterface{}
-are applicable to interfaces,
-but they can be used with classes as well,
-because a non-generic class $C$ which is used as a type
-denotes the interface of $C$,
-and similarly for a parameterized type
-\code{$C$<\List{T}{1}{k}>}
-where $C$ denotes a generic class.%
+  The rules~\SrnCovariance{} and~\SrnSuperinterface{}
+  are applicable to interfaces,
+  but they can be used with classes as well,
+  because a non-generic class $C$ which is used as a type
+  denotes the interface of $C$,
+  and similarly for a parameterized type
+  \code{$C$<\List{T}{1}{k}>}
+  where $C$ denotes a generic class.%
 }
 
 
@@ -22164,165 +22169,166 @@ where $C$ denotes a generic class.%
 \LMLabel{informalSubtypeRuleDescriptions}
 
 \commentary{%
-This section gives an informal and non-normative natural language description
-of each rule in Figure~\ref{fig:subtypeRules}.
+  This section gives an informal and non-normative natural language description
+  of each rule in Figure~\ref{fig:subtypeRules}.
 
-The descriptions use the rule numbers to make the connection explicit,
-and also adds names to the rules that may be helpful in order to understand
-the role played by each rule.
+  The descriptions use the rule numbers to make the connection explicit,
+  and also adds names to the rules that may be helpful in order to understand
+  the role played by each rule.
 
-In the following, many rules contain meta-variables
-(\ref{metaVariables})
-like $S$ and $T$,
-and it is always the case that they can stand for arbitrary types.
-For example, rule~\SrnRightFutureOrA{} says that
-``The type $S$ is a \ldots{} of \code{FutureOr<$T$>} \ldots'',
-and this is taken to mean that for any arbitrary types $S$ and $T$,
-showing that $S$ is a subtype of $T$ is sufficient to show that $S$ is
-a subtype of \code{FutureOr<$T$>}.
+  In the following, many rules contain meta-variables
+  (\ref{metaVariables})
+  like $S$ and $T$,
+  and it is always the case that they can stand for arbitrary types.
+  For example, rule~\SrnRightFutureOrA{} says that
+  ``The type $S$ is a \ldots{} of \code{FutureOr<$T$>} \ldots'',
+  and this is taken to mean that for any arbitrary types $S$ and $T$,
+  showing that $S$ is a subtype of $T$ is sufficient to show that $S$ is
+  a subtype of \code{FutureOr<$T$>}.
 
-Another example is the wording in rule~\SrnReflexivity{}:
-``\ldots{} in any environment $\Delta$'',
-which indicates that the rule can be applied no matter which bindings
-of type variables to bounds there exist in the environment.
-It should be noted that the environment matters even with rules
-where it is simply stated as a plain $\Delta$ in the conclusion
-and in one or more premises,
-because the proof of those premises could, directly or indirectly,
-include the application of a rule where the environment is used.
+  Another example is the wording in rule~\SrnReflexivity{}:
+  ``\ldots{} in any environment $\Delta$'',
+  which indicates that the rule can be applied no matter which bindings
+  of type variables to bounds there exist in the environment.
+  It should be noted that the environment matters even with rules
+  where it is simply stated as a plain $\Delta$ in the conclusion
+  and in one or more premises,
+  because the proof of those premises could, directly or indirectly,
+  include the application of a rule where the environment is used.
 
-\def\Item#1#2{\item[#1]{\textbf{#2:}}}
-\begin{itemize}
-\Item{\SrnReflexivity}{Reflexivity}
-  Every type is a subtype of itself, in any environment $\Delta$.
-  In the following rules except for a few,
-  the rule is also valid in any environment
-  and the environment is never used explicitly,
-  so we will not repeat that.
-\Item{\SrnTop}{Top}
-  Every type is a subtype of \code{Object},
-  every type is a subtype of \DYNAMIC,
-  and every type is a subtype of \VOID.
-  Note that this implies that these types are equivalent
-  according to the subtype relation.
-  We denote these types,
-  and others with the same property (such as \code{FutureOr<Object>}),
-  as top types
-  (\ref{superBoundedTypes}).
-\Item{\SrnBottom}{Bottom}
-  Every type is a supertype of $\bot$.
-\Item{\SrnNull}{Null}
-  Every type other than $\bot$ is a supertype of \code{Null}.
-\Item{\SrnLeftTypeAlias}{Type Alias Left}
-  An application of a type alias to some actual type arguments is
-  a subtype of another type $T$
-  if the expansion of the type alias to the type that it denotes
-  is a subtype of $T$.
-  Note that a non-generic type alias is handled by letting $s = 0$.
-\Item{\SrnRightTypeAlias}{Type Alias Right}
-  A type $S$ is a subtype of an application of a type alias
-  if $S$ is a subtype of
-  the expansion of the type alias to the type that it denotes.
-  Note that a non-generic type alias is handled by letting $s = 0$.
-\Item{\SrnLeftFutureOr}{Left FutureOr}
-  The type \code{FutureOr<$S$>} is a subtype of a given type $T$
-  if $S$ is a subtype of $T$ and \code{Future<$S$>} is a subtype of $T$,
-  for every type $S$ and $T$.
-\Item{\SrnTypeVariableReflexivityA}{Left Promoted Variable}
-  The type $X \& S$ is a subtype of $X$.
-\Item{\SrnRightPromotedVariable}{Right Promoted Variable A}
-  The type $S$ is a subtype of $X \& T$ if
-  $S$ is a subtype of both $X$ and $T$.
-\Item{\SrnRightFutureOrA}{Right FutureOr A}
-  The type $S$ is a subtype of \code{FutureOr<$T$>} if
-  $S$ is a subtype of \code{Future<$T$>}.
-\Item{\SrnRightFutureOrB}{Right FutureOr B}
-  The type $S$ is a subtype of \code{FutureOr<$T$>} if
-  $S$ is a subtype of $T$.
-\Item{\SrnLeftPromotedVariable}{Left Promoted Variable B}
-  The type $X \& S$ is a subtype of $T$ if
-  $S$ is a subtype of $T$.
-\Item{\SrnLeftVariableBound}{Left Variable Bound}
-  The type variable $X$ is a subtype of a type $T$ if
-  the bound of $X$
-  (as specified in the current environment $\Delta$)
-  is a subtype of $T$.
-\Item{\SrnRightFunction}{Right Function}
-  Every function type is a subtype of the type \FUNCTION.
-\Item{\SrnPositionalFunctionType}{Positional Function Type}
-  A function type $F_1$ with positional optional parameters
-  is a subtype of
-  another function type $F_2$ with positional optional parameters
-  if the former has at most
-  the same number of required parameters as the latter,
-  and the latter has at least
-  the same total number of parameters as the former;
-  the return type of $F_1$ is a subtype of that of $F_2$;
-  and each parameter type of $F_1$ is a \emph{supertype} of
-  the corresponding parameter type of $F_2$, if any.
-  Note that the relationship to function types with no optional parameters,
-  and the relationship between function types with no optional parameters,
-  is covered by letting $k_2 = 0$ respectively $k_1 = k_2 = 0$.
-  For every subtype relation considered in this rule,
-  the formal type parameters of $F_1$ and $F_2$ must be taken into account
-  (as reflected in the use of the extended environment $\Delta'$).
-  We can assume without loss of generality
-  that the names of type variables are pairwise identical,
-  because we consider types of generic functions to be equivalent under
-  consistent renaming
-  (\ref{typeOfAFunction}).
-  In short, ``during the proof, we will rename them as needed''.
-  Finally, note that the relationship between non-generic function types
-  is covered by letting $s = 0$.
-\Item{\SrnNamedFunctionType}{Named Function Type}
-  A function type $F_1$ with named optional parameters is a subtype of
-  another function type $F_2$ with named optional parameters
-  if they have the same number of required parameters,
-  and the set of names of named parameters for the latter is a subset
-  of that for the former;
-  the return type of $F_1$ is a subtype of that of $F_2$;
-  and each parameter type of $F_1$ is a \emph{supertype} of
-  the corresponding parameter type of $F_2$, if any.
-  Note that the relationship to function types with no optional parameters,
-  and the relationship between function types with no optional parameters,
-  is covered by letting $k_2 = 0$ respectively $k_1 = k_2 = 0$,
-  and also that the latter case is identical to the rule obtained from
-  rule~\SrnPositionalFunctionType{}
-  concerning subtyping among function types with no optional parameters.
-  As in rule~\SrnPositionalFunctionType,
-  we can assume without loss of generality
-  that the names of type variables are pairwise identical.
-  Similarly, non-generic functions are covered by letting $s = 0$.
-\Item{\SrnCovariance}{Class Covariance}
-  A parameterized type based on a generic class $C$ is a subtype of
-  a parameterized type based on the same class $C$ if
-  each actual type argument of the former is a subtype of
-  the corresponding actual type argument of the latter.
-  This rule may have $s = 0$ and cover a non-generic class as well,
-  but that is redundant because this is already covered by
-  rule~\SrnReflexivity.
-\Item{\SrnSuperinterface}{Superinterface}
-  Considering the case where $s = 0$ and $m = 0$ first,
-  a parameterized type based on a non-generic class $C$ is a subtype of
-  a parameterized type based on a different non-generic class $D$ if
-  $D$ is a direct superinterface of $C$.
-  When $s > 0$ or $m > 0$, this rule describes a subtype relationship
-  which includes one or more generic classes,
-  in which case we need to give names to the formal type parameters of $C$,
-  and specify how they are used in the specification of the superinterface
-  based on $D$.
-  With those pieces in place, we can specify the subtype relationship
-  that exists between two parameterized types based on $C$ and $D$.
-  %
-  %% TODO(eernst): Note that the specification of how to pass type arguments in
-  %% \ref{mixinApplication} is incorrect, and also that it will need to be
-  %% rewritten completely for the integration of the new mixin construct.
-  The case where the superclass is a mixin application is covered via
-  the equivalence with a declaration of a regular (possibly generic) superclass
-  (\ref{mixinApplication}),
-  and this means that there may be multiple subtype steps from
-  a given class declaration to the class specified in an \EXTENDS{} clause.
-\end{itemize}%
+  \def\Item#1#2{\item[#1]{\textbf{#2:}}}
+  \begin{itemize}
+  \Item{\SrnReflexivity}{Reflexivity}
+    Every type is a subtype of itself, in any environment $\Delta$.
+    In the following rules except for a few,
+    the rule is also valid in any environment
+    and the environment is never used explicitly,
+    so we will not repeat that.
+  \Item{\SrnTop}{Top}
+    Every type is a subtype of \code{Object},
+    every type is a subtype of \DYNAMIC,
+    and every type is a subtype of \VOID.
+    Note that this implies that these types are equivalent
+    according to the subtype relation.
+    We denote these types,
+    and others with the same property (such as \code{FutureOr<Object>}),
+    as top types
+    (\ref{superBoundedTypes}).
+  \Item{\SrnBottom}{Bottom}
+    Every type is a supertype of $\bot$.
+  \Item{\SrnNull}{Null}
+    Every type other than $\bot$ is a supertype of \code{Null}.
+  \Item{\SrnLeftTypeAlias}{Type Alias Left}
+    An application of a type alias to some actual type arguments is
+    a subtype of another type $T$
+    if the expansion of the type alias to the type that it denotes
+    is a subtype of $T$.
+    Note that a non-generic type alias is handled by letting $s = 0$.
+  \Item{\SrnRightTypeAlias}{Type Alias Right}
+    A type $S$ is a subtype of an application of a type alias
+    if $S$ is a subtype of
+    the expansion of the type alias to the type that it denotes.
+    Note that a non-generic type alias is handled by letting $s = 0$.
+  \Item{\SrnLeftFutureOr}{Left FutureOr}
+    The type \code{FutureOr<$S$>} is a subtype of a given type $T$
+    if $S$ is a subtype of $T$ and \code{Future<$S$>} is a subtype of $T$,
+    for every type $S$ and $T$.
+  \Item{\SrnTypeVariableReflexivityA}{Left Promoted Variable}
+    The type $X \& S$ is a subtype of $X$.
+  \Item{\SrnRightPromotedVariable}{Right Promoted Variable A}
+    The type $S$ is a subtype of $X \& T$ if
+    $S$ is a subtype of both $X$ and $T$.
+  \Item{\SrnRightFutureOrA}{Right FutureOr A}
+    The type $S$ is a subtype of \code{FutureOr<$T$>} if
+    $S$ is a subtype of \code{Future<$T$>}.
+  \Item{\SrnRightFutureOrB}{Right FutureOr B}
+    The type $S$ is a subtype of \code{FutureOr<$T$>} if
+    $S$ is a subtype of $T$.
+  \Item{\SrnLeftPromotedVariable}{Left Promoted Variable B}
+    The type $X \& S$ is a subtype of $T$ if
+    $S$ is a subtype of $T$.
+  \Item{\SrnLeftVariableBound}{Left Variable Bound}
+    The type variable $X$ is a subtype of a type $T$ if
+    the bound of $X$
+    (as specified in the current environment $\Delta$)
+    is a subtype of $T$.
+  \Item{\SrnRightFunction}{Right Function}
+    Every function type is a subtype of the type \FUNCTION.
+  \Item{\SrnPositionalFunctionType}{Positional Function Type}
+    A function type $F_1$ with positional optional parameters
+    is a subtype of
+    another function type $F_2$ with positional optional parameters
+    if the former has at most
+    the same number of required parameters as the latter,
+    and the latter has at least
+    the same total number of parameters as the former;
+    the return type of $F_1$ is a subtype of that of $F_2$;
+    and each parameter type of $F_1$ is a \emph{supertype} of
+    the corresponding parameter type of $F_2$, if any.
+    Note that the relationship to function types with no optional parameters,
+    and the relationship between function types with no optional parameters,
+    is covered by letting $k_2 = 0$ respectively $k_1 = k_2 = 0$.
+    For every subtype relation considered in this rule,
+    the formal type parameters of $F_1$ and $F_2$ must be taken into account
+    (as reflected in the use of the extended environment $\Delta'$).
+    We can assume without loss of generality
+    that the names of type variables are pairwise identical,
+    because we consider types of generic functions to be equivalent under
+    consistent renaming
+    (\ref{typeOfAFunction}).
+    In short, ``during the proof, we will rename them as needed''.
+    Finally, note that the relationship between non-generic function types
+    is covered by letting $s = 0$.
+  \Item{\SrnNamedFunctionType}{Named Function Type}
+    A function type $F_1$ with named optional parameters is a subtype of
+    another function type $F_2$ with named optional parameters
+    if they have the same number of required parameters,
+    and the set of names of named parameters for the latter is a subset
+    of that for the former;
+    the return type of $F_1$ is a subtype of that of $F_2$;
+    and each parameter type of $F_1$ is a \emph{supertype} of
+    the corresponding parameter type of $F_2$, if any.
+    Note that the relationship to function types with no optional parameters,
+    and the relationship between function types with no optional parameters,
+    is covered by letting $k_2 = 0$ respectively $k_1 = k_2 = 0$,
+    and also that the latter case is identical to the rule obtained from
+    rule~\SrnPositionalFunctionType{}
+    concerning subtyping among function types with no optional parameters.
+    As in rule~\SrnPositionalFunctionType,
+    we can assume without loss of generality
+    that the names of type variables are pairwise identical.
+    Similarly, non-generic functions are covered by letting $s = 0$.
+  \Item{\SrnCovariance}{Class Covariance}
+    A parameterized type based on a generic class $C$ is a subtype of
+    a parameterized type based on the same class $C$ if
+    each actual type argument of the former is a subtype of
+    the corresponding actual type argument of the latter.
+    This rule may have $s = 0$ and cover a non-generic class as well,
+    but that is redundant because this is already covered by
+    rule~\SrnReflexivity.
+  \Item{\SrnSuperinterface}{Superinterface}
+    Considering the case where $s = 0$ and $m = 0$ first,
+    a parameterized type based on a non-generic class $C$ is a subtype of
+    a parameterized type based on a different non-generic class $D$ if
+    $D$ is a direct superinterface of $C$.
+    When $s > 0$ or $m > 0$, this rule describes a subtype relationship
+    which includes one or more generic classes,
+    in which case we need to give names to the formal type parameters of $C$,
+    and specify how they are used in the specification of the superinterface
+    based on $D$.
+    With those pieces in place, we can specify the subtype relationship
+    that exists between two parameterized types based on $C$ and $D$.
+    %
+    %% TODO(eernst): Note that the specification of how to pass type arguments
+    %% in \ref{mixinApplication} is incorrect, and also that it will need to be
+    %% rewritten completely for the integration of the new mixin construct.
+    The case where the superclass is a mixin application is covered via
+    the equivalence with a declaration of
+    a regular (possibly generic) superclass
+    (\ref{mixinApplication}),
+    and this means that there may be multiple subtype steps from
+    a given class declaration to the class specified in an \EXTENDS{} clause.
+  \end{itemize}%
 }
 
 
@@ -22344,20 +22350,20 @@ In this case we say that the types $S$ and $T$ are
 \Index{assignable}.
 
 \rationale{%
-This rule may surprise readers accustomed to conventional typechecking.
-The intent of the \AssignableRelationSymbol{} relation
-is not to ensure that an assignment is guaranteed to succeed dynamically.
-Instead, it aims to only flag assignments
-that are almost certain to be erroneous,
-without precluding assignments that may work.
+  This rule may surprise readers accustomed to conventional typechecking.
+  The intent of the \AssignableRelationSymbol{} relation
+  is not to ensure that an assignment is guaranteed to succeed dynamically.
+  Instead, it aims to only flag assignments
+  that are almost certain to be erroneous,
+  without precluding assignments that may work.
 
-For example, assigning an object of static type \code{Object}
-to a variable with static type \code{String},
-while not guaranteed to be correct,
-might be fine if the run-time value happens to be a string.
+  For example, assigning an object of static type \code{Object}
+  to a variable with static type \code{String},
+  while not guaranteed to be correct,
+  might be fine if the run-time value happens to be a string.
 
-A static analyzer or compiler
-may support more strict static checks as an option.%
+  A static analyzer or compiler
+  may support more strict static checks as an option.%
 }
 
 
@@ -22380,12 +22386,12 @@ come in two variants:
 \end{enumerate}
 
 \commentary{%
-Note that the non-generic case is covered by having $s = 0$,
-in which case the type parameter declarations are omitted
-(\ref{generics}).
-The case with no optional parameters is covered by having $k = 0$;
-note that all rules involving function types of the two kinds
-coincide in this case.%
+  Note that the non-generic case is covered by having $s = 0$,
+  in which case the type parameter declarations are omitted
+  (\ref{generics}).
+  The case with no optional parameters is covered by having $k = 0$;
+  note that all rules involving function types of the two kinds
+  coincide in this case.%
 }
 
 \LMHash{}%
@@ -22393,14 +22399,14 @@ Two function types are considered equal if consistent renaming of type
 parameters can make them identical.
 
 \commentary{%
-A common way to say this is that we do not distinguish
-function types which are alpha-equivalent.
-For the subtyping rule below this means we can assume that
-a suitable renaming has already taken place.
-In cases where this is not possible
-because the number of type parameters in the two types differ
-or the bounds are different,
-no subtype relationship exists.%
+  A common way to say this is that we do not distinguish
+  function types which are alpha-equivalent.
+  For the subtyping rule below this means we can assume that
+  a suitable renaming has already taken place.
+  In cases where this is not possible
+  because the number of type parameters in the two types differ
+  or the bounds are different,
+  no subtype relationship exists.%
 }
 
 \LMHash{}%
@@ -22409,8 +22415,8 @@ the class \FUNCTION{} (\ref{functionType}),
 and which has a method named \CALL,
 whose signature is the function type $C$ itself.
 \commentary{%
-Consequently, all function types are subtypes of \FUNCTION{}
-(\ref{subtypes}).%
+  Consequently, all function types are subtypes of \FUNCTION{}
+  (\ref{subtypes}).%
 }
 
 
@@ -22440,18 +22446,18 @@ application is equivalent to a class with \code{implements Function}, and
 that clause has no effect, the resulting class also does not
 implement \FUNCTION.
 \commentary{%
-The \FUNCTION{} class declares no concrete instance members,
-so the mixin application creates a sub-class of
-the superclass with no new members and no new interfaces.%
+  The \FUNCTION{} class declares no concrete instance members,
+  so the mixin application creates a sub-class of
+  the superclass with no new members and no new interfaces.%
 }
 
 \rationale{%
-Since using \FUNCTION{} in these ways has no effect, it would be
-reasonable to disallow it completely, like we do extending, implementing or
-mixing in types like \code{int} or \code{String}.
-For backwards compatibility with Dart 1 programs,
-the syntax is allowed to remain, even if it has no effect.
-Tools may choose to warn users that their code has no effect.%
+  Since using \FUNCTION{} in these ways has no effect, it would be
+  reasonable to disallow it completely, like we do extending, implementing or
+  mixing in types like \code{int} or \code{String}.
+  For backwards compatibility with Dart 1 programs,
+  the syntax is allowed to remain, even if it has no effect.
+  Tools may choose to warn users that their code has no effect.%
 }
 
 
@@ -22466,16 +22472,16 @@ assumes that every member access has a corresponding member
 with a signature that admits the given access.
 
 \commentary{%
-For instance,
-when the receiver in an ordinary method invocation has type \DYNAMIC,
-any method name can be invoked,
-with any number of type arguments or none,
-with any number of positional arguments,
-and any set of named arguments,
-of any type,
-without error.
-Note that the invocation will still cause a compile-time error
-if there is an error in one or more arguments or other subterms.%
+  For instance,
+  when the receiver in an ordinary method invocation has type \DYNAMIC,
+  any method name can be invoked,
+  with any number of type arguments or none,
+  with any number of positional arguments,
+  and any set of named arguments,
+  of any type,
+  without error.
+  Note that the invocation will still cause a compile-time error
+  if there is an error in one or more arguments or other subterms.%
 }
 
 \LMHash{}%
@@ -22487,14 +22493,14 @@ If a generic type is used but type arguments are not provided,
 the type arguments default to type \DYNAMIC.
 
 \commentary{%
-%% TODO(eernst): Amend when adding specification of instantiate-to-bound.
-This means that given a generic declaration
-\code{$G$<$P_1, \ldots,\ P_n$>$\ldots$},
-where $P_i$ is a formal type parameter declaration, $i \in 1 .. n$,
-the type $G$ is equivalent to
+  %% TODO(eernst): Amend when adding specification of instantiate-to-bound.
+  This means that given a generic declaration
+  \code{$G$<$P_1, \ldots,\ P_n$>$\ldots$},
+  where $P_i$ is a formal type parameter declaration, $i \in 1 .. n$,
+  the type $G$ is equivalent to
 
-\noindent
-\code{$G$<$\DYNAMIC, \ldots,\ \DYNAMIC{}$>}.%
+  \noindent
+  \code{$G$<$\DYNAMIC, \ldots,\ \DYNAMIC{}$>}.%
 }
 
 \LMHash{}%
@@ -22507,9 +22513,9 @@ it evaluates to a \code{Type} object representing the \DYNAMIC{} type,
 even though \DYNAMIC{} is not a class.
 
 \commentary{%
-This \code{Type} object must compare equal to the corresponding \code{Type}
-objects for \code{Object} and \VOID{} according to operator \lit{==}
-(\ref{dynamicTypeSystem}).%
+  This \code{Type} object must compare equal to the corresponding \code{Type}
+  objects for \code{Object} and \VOID{} according to operator \lit{==}
+  (\ref{dynamicTypeSystem}).%
 }
 
 \LMHash{}%
@@ -22555,16 +22561,18 @@ whenever doing so is sound.
   Static analysis will then process $e$ as a function expression invocation
   where an object of static type $F$ is applied to the given argument part.
   \commentary{%
-  So this is always a compile-time error.
-  For instance, \code{$d$.runtimeType(42)} is a compile-time error,
-  because it is checked as a
-  function expression invocation where an entity of static type \code{Type} is
-  invoked. Note that it could actually succeed: An overriding implementation
-  of \code{runtimeType} could return an instance whose dynamic type is a subtype
-  of \code{Type} that has a \CALL{} method.
-  We decided to make it an error because it is likely to be a mistake,
-  especially in cases like \code{$d$.hashCode()}
-  where a developer might have forgotten that \code{hashCode} is a getter.%
+    So this is always a compile-time error.
+    For instance, \code{$d$.runtimeType(42)} is a compile-time error,
+    because it is checked as a
+    function expression invocation where
+    an entity of static type \code{Type} is
+    invoked. Note that it could actually succeed: An overriding implementation
+    of \code{runtimeType} could return an instance
+    whose dynamic type is a subtype
+    of \code{Type} that has a \CALL{} method.
+    We decided to make it an error because it is likely to be a mistake,
+    especially in cases like \code{$d$.hashCode()}
+    where a developer might have forgotten that \code{hashCode} is a getter.%
   }
 
 \item
@@ -22621,24 +22629,24 @@ whenever doing so is sound.
 \end{itemize}
 
 \commentary{%
-Note that only very few forms of instance method invocation with a
-receiver of type \DYNAMIC{} can be a compile-time error.
-Of course, some expressions like \code{x[1, 2]} are syntax errors
-even though they could also be considered "invocations",
-and subexpressions are checked separately so
-any given actual argument could be a compile-time error.
-But almost any given argument list shape could be handled via
-\code{noSuchMethod},
-and an argument of any type could be accepted because any
-formal parameter in an overriding declaration could have its type
-annotation contravariantly changed to \code{Object}.
-So it is a natural consequence of the principle of
-that
-a \DYNAMIC{} receiver admits almost all instance method invocations.
-The few cases where an instance method invocation with
-a receiver of type \DYNAMIC{} is an error
-are either guaranteed to fail at run time,
-or they are very, very likely to be developer mistakes.%
+  Note that only very few forms of instance method invocation with a
+  receiver of type \DYNAMIC{} can be a compile-time error.
+  Of course, some expressions like \code{x[1, 2]} are syntax errors
+  even though they could also be considered "invocations",
+  and subexpressions are checked separately so
+  any given actual argument could be a compile-time error.
+  But almost any given argument list shape could be handled via
+  \code{noSuchMethod},
+  and an argument of any type could be accepted because any
+  formal parameter in an overriding declaration could have its type
+  annotation contravariantly changed to \code{Object}.
+  So it is a natural consequence of the principle of
+  that
+  a \DYNAMIC{} receiver admits almost all instance method invocations.
+  The few cases where an instance method invocation with
+  a receiver of type \DYNAMIC{} is an error
+  are either guaranteed to fail at run time,
+  or they are very, very likely to be developer mistakes.%
 }
 
 
@@ -22653,26 +22661,26 @@ The type \code{FutureOr<$T$>} is a non-class type
 which is regular-bounded for all $T$.
 
 \commentary{%
-The subtype relations involving \code{FutureOr} are specified elsewhere
-(\ref{subtypeRules}).
-Note, however, that they entail certain useful properties:
+  The subtype relations involving \code{FutureOr} are specified elsewhere
+  (\ref{subtypeRules}).
+  Note, however, that they entail certain useful properties:
 
-\begin{itemize}
-\item[$\bullet$]
-  $T <: \code{FutureOr<$T$>}$.
-\item[$\bullet$]
-  $\code{Future<$T$>} <: \code{FutureOr<$T$>}$.
-\item[$\bullet$]
-  If $T <: S$ and $\code{Future<$T$>} <: S$, then $\code{FutureOr<$T$>} <: S$.
-\end{itemize}
+  \begin{itemize}
+  \item[$\bullet$]
+    $T <: \code{FutureOr<$T$>}$.
+  \item[$\bullet$]
+    $\code{Future<$T$>} <: \code{FutureOr<$T$>}$.
+  \item[$\bullet$]
+    If $T <: S$ and $\code{Future<$T$>} <: S$, then $\code{FutureOr<$T$>} <: S$.
+  \end{itemize}
 
-That is, \code{FutureOr} is in a sense
-the union of $T$ and the corresponding future type.
-The last point guarantees that
-\code{FutureOr<$T$>} <: \code{Object},
-and also that \code{FutureOr} is covariant in its type parameter,
-just like class types:
-if $S$ <: $T$ then \code{FutureOr<$S$>} <: \code{FutureOr<$T$>}.%
+  That is, \code{FutureOr} is in a sense
+  the union of $T$ and the corresponding future type.
+  The last point guarantees that
+  \code{FutureOr<$T$>} <: \code{Object},
+  and also that \code{FutureOr} is covariant in its type parameter,
+  just like class types:
+  if $S$ <: $T$ then \code{FutureOr<$S$>} <: \code{FutureOr<$T$>}.%
 }
 
 \LMHash{}%
@@ -22683,31 +22691,32 @@ The name \code{FutureOr} as an expression
 denotes a \code{Type} object representing the type \code{FutureOr<dynamic>}.
 
 \rationale{%
-The \code{FutureOr<$T$>} type represents a case where an object can be
-either an instance of the type $T$
-or the type \code{Future<$T$>}.
-Such cases occur naturally in asynchronous code.
-The available alternative would be to use a top type (e.g., \DYNAMIC{}),
-but \code{FutureOr} allows some tools to provide a more precise type analysis.%
+  The \code{FutureOr<$T$>} type represents a case where an object can be
+  either an instance of the type $T$
+  or the type \code{Future<$T$>}.
+  Such cases occur naturally in asynchronous code.
+  The available alternative would be to use a top type (e.g., \DYNAMIC{}),
+  but \code{FutureOr} allows some tools to provide
+  a more precise type analysis.%
 }
 
 \LMHash{}%
 The type \code{FutureOr<$T$>} has an interface that is identical to that
 of \code{Object}.
 \commentary{%
-That is, only members that \code{Object} has can be invoked
-on an object with static type \code{FutureOr<$T$>}.%
+  That is, only members that \code{Object} has can be invoked
+  on an object with static type \code{FutureOr<$T$>}.%
 }
 
 \rationale{%
-We only want to allow invocations of members that are inherited from
-a common supertype of both $T$ and \code{Future<$T$>}.
-In most cases the only common supertype is \code{Object}.
-The exceptions, like \code{FutureOr<Future<Object\gtgt}
-which has \code{Future<Object>} as common supertype,
-are few and not practically useful,
-so for now we choose to only allow invocations of
-members inherited from \code{Object}.%
+  We only want to allow invocations of members that are inherited from
+  a common supertype of both $T$ and \code{Future<$T$>}.
+  In most cases the only common supertype is \code{Object}.
+  The exceptions, like \code{FutureOr<Future<Object\gtgt}
+  which has \code{Future<Object>} as common supertype,
+  are few and not practically useful,
+  so for now we choose to only allow invocations of
+  members inherited from \code{Object}.%
 }
 
 \LMHash{}%
@@ -22730,43 +22739,43 @@ The special type \VOID{} is used to indicate
 that the value of an expression is meaningless and intended to be discarded.
 
 \commentary{%
-A typical case is that the type \VOID{} is used as the return type
-of a function that ``does not return anything''.
-Technically, there will always be \emph{some} object
-which is returned
-(\ref{functions}).
-But it is perfectly meaningful to have a function
-whose sole purpose is to create side-effects,
-such that \emph{any} use of the returned object
-would be misguided.
-%
-This does not mean that there is anything wrong
-with the returned object as such.
-It could be any object whatsoever.
-But the developer who chose the return type \VOID{}
-did that to indicate that it is a misunderstanding to
-ascribe any meaning to that object,
-or to use it for any purpose.%
+  A typical case is that the type \VOID{} is used as the return type
+  of a function that ``does not return anything''.
+  Technically, there will always be \emph{some} object
+  which is returned
+  (\ref{functions}).
+  But it is perfectly meaningful to have a function
+  whose sole purpose is to create side-effects,
+  such that \emph{any} use of the returned object
+  would be misguided.
+  %
+  This does not mean that there is anything wrong
+  with the returned object as such.
+  It could be any object whatsoever.
+  But the developer who chose the return type \VOID{}
+  did that to indicate that it is a misunderstanding to
+  ascribe any meaning to that object,
+  or to use it for any purpose.%
 }
 
 \commentary{%
-The type \VOID{} is a top type
-(\ref{superBoundedTypes}),
-so \VOID{} and \code{Object} are subtypes of each other
-(\ref{subtypes}),
-which also implies that any object can be
-the value of an expression of type \VOID.
-%
-Consequently, any instance of type \code{Type} which reifies the type \VOID{}
-must compare equal (according to the \lit{==} operator \ref{equality})
-to any instance of \code{Type} which reifies the type \code{Object}
-(\ref{dynamicTypeSystem}).
-It is not guaranteed that \code{identical(\VOID, Object)} evaluates to true.
-In fact, it is not recommended that implementations strive to achieve this,
-because it may be more important to ensure that diagnostic messages
-(including stack traces and dynamic error messages)
-preserve enough information to use the word `void' when referring to types
-which are specified as such in source code.%
+  The type \VOID{} is a top type
+  (\ref{superBoundedTypes}),
+  so \VOID{} and \code{Object} are subtypes of each other
+  (\ref{subtypes}),
+  which also implies that any object can be
+  the value of an expression of type \VOID.
+  %
+  Consequently, any instance of type \code{Type} which reifies the type \VOID{}
+  must compare equal (according to the \lit{==} operator \ref{equality})
+  to any instance of \code{Type} which reifies the type \code{Object}
+  (\ref{dynamicTypeSystem}).
+  It is not guaranteed that \code{identical(\VOID, Object)} evaluates to true.
+  In fact, it is not recommended that implementations strive to achieve this,
+  because it may be more important to ensure that diagnostic messages
+  (including stack traces and dynamic error messages)
+  preserve enough information to use the word `void' when referring to types
+  which are specified as such in source code.%
 }
 
 \LMHash{}%
@@ -22789,55 +22798,55 @@ unless it is permitted according to one of the following rules.
 \item
   In a type cast \code{$e$ as $T$}, $e$ may have type \VOID.
   \rationale{%
-  Developers thus obtain the ability to \emph{override} the constraints
-  on usages of values with static type \VOID.
-  This means that it is not enforced that such values are discarded,
-  but they can only be used when the wish to do so
-  has been indicated explicitly.%
+    Developers thus obtain the ability to \emph{override} the constraints
+    on usages of values with static type \VOID.
+    This means that it is not enforced that such values are discarded,
+    but they can only be used when the wish to do so
+    has been indicated explicitly.%
   }
 \item
   In a parenthesized expression \code{($e$)}, $e$ may have type \VOID.
   \rationale{%
-  Note that \code{($e$)} itself has type \VOID,
-  which implies that it must occur in some context
-  where it is not an error to have it.%
+    Note that \code{($e$)} itself has type \VOID,
+    which implies that it must occur in some context
+    where it is not an error to have it.%
   }
 \item
   In a conditional expression \code{$e$\,?\,$e_1$\,:\,$e_2$},
   $e_1$ and $e_2$ may have type \VOID.
   \rationale{%
-  The static type of the conditional expression is then \VOID,
-  even if one of the branches has a different type,
-  which means that the conditional expression must again occur
-  in some context where it is not an error to have it.%
+    The static type of the conditional expression is then \VOID,
+    even if one of the branches has a different type,
+    which means that the conditional expression must again occur
+    in some context where it is not an error to have it.%
   }
 \item
   In a null coalescing expression \code{$e_1$\,??\,$e_2$},
   $e_2$ may have type \VOID.
   \rationale{%
-  The static type of the null coalescing expression is then \VOID,
-  which in turn restricts where it can occur.%
+    The static type of the null coalescing expression is then \VOID,
+    which in turn restricts where it can occur.%
   }
 \item
   In an expression of the form \code{\AWAIT\,\,$e$}, $e$ may have type \VOID.
   \rationale{%
-  This rule was adopted because it was a substantial breaking change
-  to turn this situation into an error
-  at the time where the treatment of \VOID{} was changed.
-  Tools may choose to give a hint in such cases.%
+    This rule was adopted because it was a substantial breaking change
+    to turn this situation into an error
+    at the time where the treatment of \VOID{} was changed.
+    Tools may choose to give a hint in such cases.%
   }
 \item
   \commentary{%
-  In a return statement \code{\RETURN\,$e$;},
-  $e$ may have type \VOID{} in a number of situations
-  (\ref{return}).%
+    In a return statement \code{\RETURN\,$e$;},
+    $e$ may have type \VOID{} in a number of situations
+    (\ref{return}).%
   }
 \item
   \commentary{%
-  In an arrow function body \code{=> $e$},
-  the returned expression $e$ may have type \VOID{}
-  in a number of situations
-  (\ref{functions}).%
+    In an arrow function body \code{=> $e$},
+    the returned expression $e$ may have type \VOID{}
+    in a number of situations
+    (\ref{functions}).%
   }
 \item
   An initializing expression for a variable of type \VOID{}
@@ -22848,10 +22857,10 @@ unless it is permitted according to one of the following rules.
   whose statically known type annotation is \VOID{}
   may have type \VOID.
   \rationale{%
-  Usages of that parameter in the body of the callee
-  are statically expected to be constrained by having type \VOID.
-  See the discussion about soundness below
-  (\ref{voidSoundness}).%
+    Usages of that parameter in the body of the callee
+    are statically expected to be constrained by having type \VOID.
+    See the discussion about soundness below
+    (\ref{voidSoundness}).%
   }
 \item
   In an expression of the form \code{$e_1$\,=\,$e_2$}
@@ -22859,10 +22868,10 @@ unless it is permitted according to one of the following rules.
   denoting a variable or formal parameter of type \VOID,
   $e_2$ may have type \VOID.
   \rationale{%
-  Usages of that variable or formal parameter
-  are statically expected to be constrained by having type \VOID.
-  See the discussion about soundness below
-  (\ref{voidSoundness}).%
+    Usages of that variable or formal parameter
+    are statically expected to be constrained by having type \VOID.
+    See the discussion about soundness below
+    (\ref{voidSoundness}).%
   }
 \item
   Let $e$ be an expression ending in a \synt{cascadeSection}
@@ -22905,9 +22914,7 @@ such that \code{Stream<\VOID{}>} is the most specific
 instantiation of \code{Stream} that is a superinterface of $T$,
 unless the iteration variable has type \VOID.
 
-\commentary{%
-Here are some examples:%
-}
+\commentary{Here are some examples:}
 
 \begin{dartCode}
 \FOR{} (Object x in <\VOID>[]) \{\} // \comment{Error.}
@@ -22917,9 +22924,9 @@ Here are some examples:%
 \end{dartCode}
 
 \commentary{%
-However, in the examples that are not errors
-the usage of \code{x} in the loop body is constrained,
-because it has type \VOID.%
+  However, in the examples that are not errors
+  the usage of \code{x} in the loop body is constrained,
+  because it has type \VOID.%
 }
 
 
@@ -22932,26 +22939,26 @@ an expression with static type \VOID{}
 are not strictly enforced.
 
 \commentary{%
-The usage of a ``void value'' is not a soundness issue, that is,
-no invariants needed for correct execution of a Dart program
-can be violated because of such a usage.%
+  The usage of a ``void value'' is not a soundness issue, that is,
+  no invariants needed for correct execution of a Dart program
+  can be violated because of such a usage.%
 }
 
 \rationale{%
-It could be said that the type \VOID{} is used
-to help developers maintain a certain self-imposed discipline
-about the fact that certain objects are not \emph{intended} to be used.
-%
-Because of the fact that enforcement is not necessary,
-and because of the treatment of \VOID{} in earlier versions of Dart,
-the language uses a \emph{best effort} approach to ensure
-that the value of an expression of type \VOID{}
-will not be used.%
+  It could be said that the type \VOID{} is used
+  to help developers maintain a certain self-imposed discipline
+  about the fact that certain objects are not \emph{intended} to be used.
+  %
+  Because of the fact that enforcement is not necessary,
+  and because of the treatment of \VOID{} in earlier versions of Dart,
+  the language uses a \emph{best effort} approach to ensure
+  that the value of an expression of type \VOID{}
+  will not be used.%
 }
 
 \commentary{%
-In fact, there are numerous ways in addition to the type cast
-in which a developer can get access to such an object:%
+  In fact, there are numerous ways in addition to the type cast
+  in which a developer can get access to such an object:%
 }
 
 \begin{dartCode}
@@ -22980,72 +22987,72 @@ Object f<X>(X x) => x;
 \end{dartCode}
 
 \commentary{%
-At (1), a variable \code{x} of type \VOID{} is passed to
-a generic function \code{f},
-which is allowed because the actual type argument \VOID{} is inferred,
-and it is allowed to pass an actual argument of type \VOID{} to
-a formal parameter with the same type.
-%
-However, no special treatment is given when an expression has a type
-which is or contains a type variable whose value could be \VOID,
-so we are allowed to return \code{x} in the body of \code{f},
-even though this means that we indirectly get access to the value
-of an expression of type \VOID, under the static type \code{Object}.
+  At (1), a variable \code{x} of type \VOID{} is passed to
+  a generic function \code{f},
+  which is allowed because the actual type argument \VOID{} is inferred,
+  and it is allowed to pass an actual argument of type \VOID{} to
+  a formal parameter with the same type.
+  %
+  However, no special treatment is given when an expression has a type
+  which is or contains a type variable whose value could be \VOID,
+  so we are allowed to return \code{x} in the body of \code{f},
+  even though this means that we indirectly get access to the value
+  of an expression of type \VOID, under the static type \code{Object}.
 
-At (2), we indirectly obtain access to the value of
-the variable \code{x} with type \VOID,
-because we use an assignment to get access to the instance of \code{B}
-which was created with type argument \VOID{} under the type
-\code{A<Object>}.
-Note that \code{A<Object>} and \code{A<\VOID{}>} are subtypes of each other,
-that is, they are equivalent according to the subtype rules,
-so neither static nor dynamic type checks will fail.
+  At (2), we indirectly obtain access to the value of
+  the variable \code{x} with type \VOID,
+  because we use an assignment to get access to the instance of \code{B}
+  which was created with type argument \VOID{} under the type
+  \code{A<Object>}.
+  Note that \code{A<Object>} and \code{A<\VOID{}>} are subtypes of each other,
+  that is, they are equivalent according to the subtype rules,
+  so neither static nor dynamic type checks will fail.
 
-At (3), we indirectly obtain access to the value of
-the variable \code{x} with type \VOID{}
-under the static type \code{Object},
-because the statically known method signature of \code{foo}
-has parameter type \VOID,
-but the actual implementation of \code{foo} which is invoked
-is an override whose parameter type is \code{Object},
-which is allowed because \code{Object} and \VOID{} are both top types.%
+  At (3), we indirectly obtain access to the value of
+  the variable \code{x} with type \VOID{}
+  under the static type \code{Object},
+  because the statically known method signature of \code{foo}
+  has parameter type \VOID,
+  but the actual implementation of \code{foo} which is invoked
+  is an override whose parameter type is \code{Object},
+  which is allowed because \code{Object} and \VOID{} are both top types.%
 }
 
 \rationale{%
-Obviously, the support for preventing developers from using objects
-obtained from expressions of type \VOID{} is far from sound,
-in the sense that there are many ways to circumvent the rule
-that such an object should be discarded.
+  Obviously, the support for preventing developers from using objects
+  obtained from expressions of type \VOID{} is far from sound,
+  in the sense that there are many ways to circumvent the rule
+  that such an object should be discarded.
 
-However, we have chosen to focus on the simple, first-order usage
-(where an expression has type \VOID, and the value is used),
-and we have left higher-order cases largely unchecked,
-relying on additional tools such as linters to perform an analysis
-which covers indirect data flows.
+  However, we have chosen to focus on the simple, first-order usage
+  (where an expression has type \VOID, and the value is used),
+  and we have left higher-order cases largely unchecked,
+  relying on additional tools such as linters to perform an analysis
+  which covers indirect data flows.
 
-It would certainly have been possible to define sound rules,
-such that the value of an expression of type \VOID{}
-would be guaranteed to be discarded after some number of transfers
-from one variable or parameter to the next one, all with type \VOID,
-explicitly, or as the value of a type parameter.
-In particular, we could require that method overrides should
-never override return type \code{Object} by return type \VOID,
-or parameter types in the opposite direction;
-parameterized types with type argument \VOID{} could not be assigned
-to variables where the corresponding type argument is anything other than
-\VOID, etc.\ etc.
+  It would certainly have been possible to define sound rules,
+  such that the value of an expression of type \VOID{}
+  would be guaranteed to be discarded after some number of transfers
+  from one variable or parameter to the next one, all with type \VOID,
+  explicitly, or as the value of a type parameter.
+  In particular, we could require that method overrides should
+  never override return type \code{Object} by return type \VOID,
+  or parameter types in the opposite direction;
+  parameterized types with type argument \VOID{} could not be assigned
+  to variables where the corresponding type argument is anything other than
+  \VOID, etc.\ etc.
 
-But this would be quite impractical.
-In particular, the need to either prevent a large number of type variables
-from ever having the value \VOID,
-or preventing certain usages of values whose type is such a type variable,
-or whose type contains such a type variable,
-that would be severely constraining on a very large part of all Dart code.
+  But this would be quite impractical.
+  In particular, the need to either prevent a large number of type variables
+  from ever having the value \VOID,
+  or preventing certain usages of values whose type is such a type variable,
+  or whose type contains such a type variable,
+  that would be severely constraining on a very large part of all Dart code.
 
-So we have chosen to help developers maintain this self-imposed discipline
-in simple and direct cases,
-and leave it to ad-hoc reasoning or separate tools to ensure
-that the indirect cases are covered as closely as needed in practice.%
+  So we have chosen to help developers maintain this self-imposed discipline
+  in simple and direct cases,
+  and leave it to ad-hoc reasoning or separate tools to ensure
+  that the indirect cases are covered as closely as needed in practice.%
 }
 
 
@@ -23068,9 +23075,9 @@ A \emph{generic instantiation} is the operation where
 a generic type is applied to actual type arguments.
 
 \commentary{%
-So a parameterized type is the syntactic concept that corresponds to
-the semantic concept of a generic instantiation.
-When using the former, we will often leave the latter implicit.%
+  So a parameterized type is the syntactic concept that corresponds to
+  the semantic concept of a generic instantiation.
+  When using the former, we will often leave the latter implicit.%
 }
 
 \LMHash{}%
@@ -23151,11 +23158,11 @@ The \Index{actual type} of $D$ and of $n$ in a given context is
 then the actual value of $T$ in that context.
 
 \commentary{%
-In the non-generic case where $s = 0$,
-the actual type is equal to the declared type,
-in the sense that we use simple terms like \code{int} to denote both.
-Note that \List{X}{1}{s} may be declared by multiple entities, e.g.,
-one or more enclosing generic functions and an enclosing generic class.%
+  In the non-generic case where $s = 0$,
+  the actual type is equal to the declared type,
+  in the sense that we use simple terms like \code{int} to denote both.
+  Note that \List{X}{1}{s} may be declared by multiple entities, e.g.,
+  one or more enclosing generic functions and an enclosing generic class.%
 }
 
 \LMHash{}%
@@ -23164,9 +23171,9 @@ The \Index{actual bound} of $X$ in a given context is
 the actual value of $B$ in that context.
 
 \commentary{%
-Note that even though $X$ may occur in $B$
-it does not occur in the actual value of $B$,
-because no type has an actual value that includes a type variable.%
+  Note that even though $X$ may occur in $B$
+  it does not occur in the actual value of $B$,
+  because no type has an actual value that includes a type variable.%
 }
 
 
@@ -23271,8 +23278,8 @@ where $L_i$ is the least upper bound of $T_i$ and $S_i, i \in 0 .. r$
 \end{itemize}
 
 \commentary{%
-Note that the non-generic case is covered by using $s = 0$,
-in which case the type parameter declarations are omitted (\ref{generics}).%
+  Note that the non-generic case is covered by using $s = 0$,
+  in which case the type parameter declarations are omitted (\ref{generics}).%
 }
 
 
@@ -23301,12 +23308,12 @@ In particular, a compile-time error occurs if a reserved word is used
 where an identifier is expected.
 
 \commentary{%
-Note that reserved words occur bold and unquoted in grammar rules
-(e.g., \ASSERT{})
-even though the consistent notation would use quotes
-(e.g., \lit{assert}).
-This notational abuse occurs because we believe
-it makes the grammar rules more readable.%
+  Note that reserved words occur bold and unquoted in grammar rules
+  (e.g., \ASSERT{})
+  even though the consistent notation would use quotes
+  (e.g., \lit{assert}).
+  This notational abuse occurs because we believe
+  it makes the grammar rules more readable.%
 }
 
 \begin{grammar}
@@ -23325,8 +23332,8 @@ before the rule for \synt{BUILT\_IN\_IDENTIFIER}
 (\ref{identifierReference}).
 
 \commentary{%
-This ensures that \synt{IDENTIFIER} and \synt{IDENTIFIER\_NO\_DOLLAR} do not
-derive any reserved words, and they do not derive any built-in identifiers.
+  This ensures that \synt{IDENTIFIER} and \synt{IDENTIFIER\_NO\_DOLLAR} do not
+  derive any reserved words, and they do not derive any built-in identifiers.
 }
 
 
@@ -23391,47 +23398,47 @@ the declaration of a function $f$ is the formal parameter scope of $f$
 Operator precedence is given implicitly by the grammar.
 
 \commentary{%
-The following non-normative table may be helpful
-\newline
+  The following non-normative table may be helpful
+  \newline
 
-\begin{tabular}{| r | r | r | r |}
-\hline
-Description & Operator & Associativity & Precedence \\
-\hline
-Unary postfix & \code{$e$.}, \code{$e$?.}, \code{$e$++}, \code{$e$-{}-}, \code{$e1$[$e2$]},
-\code{$e$()} & None & 16 \\
-\hline
-Unary prefix & \code{-$e$}, \code{!$e$}, \code{\gtilde$e$}, \code{++$e$}, \code{-{}-$e$}, \code{\AWAIT{} $e$} & None & 15\\
-\hline
-Multiplicative & \code{*}, \code{/}, \code{\gtilde/}, \code{\%} & Left & 14\\
-\hline
-Additive & \code{+}, \code{-} & Left & 13\\
-\hline
-Shift & \code{\ltlt}, \code{\gtgt}, \code{\gtgtgt} & Left & 12\\
-\hline
-Bitwise AND & \code{\&} & Left & 11\\
-\hline
-Bitwise XOR & \code{\^{}} & Left & 10\\
-\hline
-Bitwise Or & \code{|} & Left & 9\\
-\hline
-Relational & \code{<}, \code{>}, \code{<=}, \code{>=}, \AS, \IS, \code{\IS{}!} & None & 8\\
-\hline
-Equality & \code{==}, \code{!=} & None & 7\\
-\hline
-Logical AND & \code{\&\&} & Left & 6\\
-\hline
-Logical Or & \code{||} & Left & 5\\
-\hline
-If-null & \code{??} & Left & 4\\
-\hline
-Conditional & \code{$e1$\,?\,$e2$\,:\,$e3$} & Right & 3\\
-\hline
-Cascade & \code{..} & Left & 2\\
-\hline
-Assignment & \code{=}, \code{*=}, \code{/=}, \code{+=}, \code{-=}, \code{\&=}, \code{\^{}=}, etc. & Right & 1\\
-\hline
-\end{tabular}%
+  \begin{tabular}{| r | r | r | r |}
+  \hline
+  Description & Operator & Associativity & Precedence \\
+  \hline
+  Unary postfix & \code{$e$.}, \code{$e$?.}, \code{$e$++}, \code{$e$-{}-}, \code{$e1$[$e2$]},
+  \code{$e$()} & None & 16 \\
+  \hline
+  Unary prefix & \code{-$e$}, \code{!$e$}, \code{\gtilde$e$}, \code{++$e$}, \code{-{}-$e$}, \code{\AWAIT{} $e$} & None & 15\\
+  \hline
+  Multiplicative & \code{*}, \code{/}, \code{\gtilde/}, \code{\%} & Left & 14\\
+  \hline
+  Additive & \code{+}, \code{-} & Left & 13\\
+  \hline
+  Shift & \code{\ltlt}, \code{\gtgt}, \code{\gtgtgt} & Left & 12\\
+  \hline
+  Bitwise AND & \code{\&} & Left & 11\\
+  \hline
+  Bitwise XOR & \code{\^{}} & Left & 10\\
+  \hline
+  Bitwise Or & \code{|} & Left & 9\\
+  \hline
+  Relational & \code{<}, \code{>}, \code{<=}, \code{>=}, \AS, \IS, \code{\IS{}!} & None & 8\\
+  \hline
+  Equality & \code{==}, \code{!=} & None & 7\\
+  \hline
+  Logical AND & \code{\&\&} & Left & 6\\
+  \hline
+  Logical Or & \code{||} & Left & 5\\
+  \hline
+  If-null & \code{??} & Left & 4\\
+  \hline
+  Conditional & \code{$e1$\,?\,$e2$\,:\,$e3$} & Right & 3\\
+  \hline
+  Cascade & \code{..} & Left & 2\\
+  \hline
+  Assignment & \code{=}, \code{*=}, \code{/=}, \code{+=}, \code{-=}, \code{\&=}, \code{\^{}=}, etc. & Right & 1\\
+  \hline
+  \end{tabular}%
 }
 
 
@@ -23484,17 +23491,17 @@ This appendix presents a variant of the subtype rules given
 in Figure~\ref{fig:subtypeRules} on page~\pageref{fig:subtypeRules}.
 
 \commentary{%
-The rules will prove the same set of subtype relationships,
-but the rules given here show that there is an efficient implementation
-that will determine whether \SubtypeStd{S}{T} holds,
-for any given types $S$ and $T$.
-It is easy to see that the algorithmic rules will prove at most
-the same subtype relationships,
-because all rules given here can be proven
-by means of rules in Figure~\ref{fig:subtypeRules}.
-It is also relatively straightforward to sketch out proofs
-that the algorithmic rules can prove at least the same subtype relationships,
-also when the following ordering and termination constraints are observed.%
+  The rules will prove the same set of subtype relationships,
+  but the rules given here show that there is an efficient implementation
+  that will determine whether \SubtypeStd{S}{T} holds,
+  for any given types $S$ and $T$.
+  It is easy to see that the algorithmic rules will prove at most
+  the same subtype relationships,
+  because all rules given here can be proven
+  by means of rules in Figure~\ref{fig:subtypeRules}.
+  It is also relatively straightforward to sketch out proofs
+  that the algorithmic rules can prove at least the same subtype relationships,
+  also when the following ordering and termination constraints are observed.%
 }
 
 \LMHash{}%
@@ -23509,18 +23516,18 @@ not a function type,
 and not a parameterized type.
 
 \commentary{%
-In other words, rule \AppSrnReflexivity{} is used for
-special types like \DYNAMIC, \VOID, and \FUNCTION,
-and it is used for non-generic classes,
-but it is not used for any type where it is an operation
-that takes more than one comparison to detect whether
-it is the same as some other type.
-%
-The point is that the remaining rules will force
-a structural traversal anyway, as far as needed,
-and we may hence just as well omit the initial structural traversal
-which might take many steps only to report that two large type terms
-are not quite identical.%
+  In other words, rule \AppSrnReflexivity{} is used for
+  special types like \DYNAMIC, \VOID, and \FUNCTION,
+  and it is used for non-generic classes,
+  but it is not used for any type where it is an operation
+  that takes more than one comparison to detect whether
+  it is the same as some other type.
+  %
+  The point is that the remaining rules will force
+  a structural traversal anyway, as far as needed,
+  and we may hence just as well omit the initial structural traversal
+  which might take many steps only to report that two large type terms
+  are not quite identical.%
 }
 
 \LMHash{}%
@@ -23529,11 +23536,11 @@ A rule given here numbered $N.1$ is inserted immediately after rule $N$,
 followed by rule $N.2$, and so on,
 followed by the rule whose number is $N+1$.
 \commentary{%
-So the order is
-\AppSrnReflexivity, \SrnTop--\SrnTypeVariableReflexivityA,
-\AppSrnTypeVariableReflexivityB, \AppSrnTypeVariableReflexivityC,
-\AppSrnTypeVariableReflexivityD,
-\SrnRightPromotedVariable, and so on.%
+  So the order is
+  \AppSrnReflexivity, \SrnTop--\SrnTypeVariableReflexivityA,
+  \AppSrnTypeVariableReflexivityB, \AppSrnTypeVariableReflexivityC,
+  \AppSrnTypeVariableReflexivityD,
+  \SrnRightPromotedVariable, and so on.%
 }
 
 \LMHash{}%
@@ -23550,43 +23557,44 @@ except if $R$ is
 \SrnRightFutureOrA, \SrnRightFutureOrB,
 \AppSrnRightFutureOrC, or \AppSrnRightFutureOrD.
 \commentary{%
-In particular, for the original query \SubtypeStd{S}{T},
-we do not backtrack into trying to use a rule that has
-a higher rule number than that of $R$,
-except that we may try all of
-the rules with \code{FutureOr<$T$>} to the right.%
+  In particular, for the original query \SubtypeStd{S}{T},
+  we do not backtrack into trying to use a rule that has
+  a higher rule number than that of $R$,
+  except that we may try all of
+  the rules with \code{FutureOr<$T$>} to the right.%
 }
 
 \commentary{%
-Apart from the fact that the full complexity of subtyping
-is potentially incurred each time it is checked whether a premise holds,
-the checks applied for each rule is associated with an amount of work
-which is constant for all rules except the following:
-First, the group of rules
-\SrnRightFutureOrA, \SrnRightFutureOrB,
-\AppSrnRightFutureOrC, and \AppSrnRightFutureOrD{}
-may cause backtracking to take place.
-Next, rules \SrnPositionalFunctionType--\SrnCovariance{}
-require work proportional to the size of $S$ and $T$,
-due to the number of premises that must be checked.
-Finally, rule~\SrnSuperinterface{} requires work
-proportional to the size of $S$,
-and it may also incur the cost of searching up to the entire set of
-direct and indirect superinterfaces of the candidate subtype $S$,
-until the corresponding premise for one of them is shown to hold,
-if any.
+  Apart from the fact that the full complexity of subtyping
+  is potentially incurred each time it is checked whether a premise holds,
+  the checks applied for each rule is associated with an amount of work
+  which is constant for all rules except the following:
+  First, the group of rules
+  \SrnRightFutureOrA, \SrnRightFutureOrB,
+  \AppSrnRightFutureOrC, and \AppSrnRightFutureOrD{}
+  may cause backtracking to take place.
+  Next, rules \SrnPositionalFunctionType--\SrnCovariance{}
+  require work proportional to the size of $S$ and $T$,
+  due to the number of premises that must be checked.
+  Finally, rule~\SrnSuperinterface{} requires work
+  proportional to the size of $S$,
+  and it may also incur the cost of searching up to the entire set of
+  direct and indirect superinterfaces of the candidate subtype $S$,
+  until the corresponding premise for one of them is shown to hold,
+  if any.
 
-Additional optimizations are applicable.
-For instance,
-we can immediately conclude that the subtype relationship does not hold
-when we are about to check rule~\SrnSuperinterface{}
-if $T$ is a type variable or a function type.
-For several other forms of type, e.g.,
-a promoted type variable,
-\code{Object}, \DYNAMIC, \VOID,
-\code{FutureOr<$T$>} for any $T$, or \FUNCTION,
-it is known that it will never occur as $T$ for rule~\SrnSuperinterface,
-which means that this seemingly expensive step can be confined to some extent.%
+  Additional optimizations are applicable.
+  For instance,
+  we can immediately conclude that the subtype relationship does not hold
+  when we are about to check rule~\SrnSuperinterface{}
+  if $T$ is a type variable or a function type.
+  For several other forms of type, e.g.,
+  a promoted type variable,
+  \code{Object}, \DYNAMIC, \VOID,
+  \code{FutureOr<$T$>} for any $T$, or \FUNCTION,
+  it is known that it will never occur as $T$ for rule~\SrnSuperinterface,
+  which means that this seemingly expensive step
+  can be confined to some extent.%
 }
 
 
@@ -23594,59 +23602,59 @@ which means that this seemingly expensive step can be confined to some extent.%
 \LMLabel{integerImplementations}
 
 \commentary{%
-The \code{int} type represents integers.
-The specification is written with 64-bit two's complement integers as the
-intended implementation. But when Dart is compiled to JavaScript,
-the implementation of \code{int} will instead use the JavaScript number type
-and the corresponding JavaScript operations,
-except for bit operations as explained below.
+  The \code{int} type represents integers.
+  The specification is written with 64-bit two's complement integers as the
+  intended implementation. But when Dart is compiled to JavaScript,
+  the implementation of \code{int} will instead use the JavaScript number type
+  and the corresponding JavaScript operations,
+  except for bit operations as explained below.
 
-This introduces a number of differences:
+  This introduces a number of differences:
 
-\begin{itemize}
-\item[$\bullet$]
-  Valid values of JavaScript \code{int} are any IEEE-754 64-bit
-  floating point number with no fractional part.  This includes
-  positive and negative \Index{infinity}, which can be reached by
-  overflowing (integer division by zero is still a dynamic error).
-  Otherwise valid integer literals (including any leading minus sign)
-  that represent invalid JavaScript \code{int} values are compile-time
-  errors when compiling to JavaScript.  Operations on integers may
-  lose precision, because the operands and the result are represented
-  as 64-bit floating point numbers that are limited to 53 significant
-  bits.
-\item[$\bullet$]
-  JavaScript \code{int} instances also implement \code{double}, and
-  integer-valued \code{double} instances also implement \code{int}.
-  The \code{int} and \code{double} class are still separate subclasses
-  of the class \code{num}, but \emph{instances} of either class that
-  represent an integer act as if they are actually instances of a
-  common subclass implementing both \code{int} and \code{double}.
-  Fractional numbers only implement \code{double}.
-\item[$\bullet$]
-  Bitwise operations on integers (\lit{\&}, \lit{|}, \lit{\^},
-  \lit{\gtilde}, \lit{\ltlt}, and \lit{\gtgt}) all truncate the
-  operands to 32-bit two's complement integers, perform 32-bit
-  operations on those, and the resulting 32 bits are interpreted as a
-  32-bit unsigned integer. For example, \code{-1\,\ltlt\,1} evaluates
-  to 4294967294 (also known as \code{(-2).toUnsigned(32)}). The right
-  shift operator, \lit{\gtgt}, performs a signed right shift on the
-  32 bits when the original number is negative, and an unsigned right
-  shift when the original number is non-negative. Both kinds of shift
-  writes bit $k+1$ into position $k$, $0 \leq k < 31$; but the signed
-  shift leaves bit 31 unchanged, and the unsigned shift writes a 0
-  as bit 31. For example:
-  \code{0x80000002\,\gtgt\,1\ ==\ 0x40000001}, but
-  \code{-0x7FFFFFFE\,\gtgt\,1\ ==\ 0xC0000001}.
-  In this example we note that both \code{0x80000002} and \code{-0x7FFFFFFE}
-  yield the 32-bit two's complement representation \code{0x80000002},
-  but they have different values for the IEEE 754 sign bit.
-\item[$\bullet$]
-  The \code{identical} method cannot distinguish the values $0.0$ and
-  $-0.0$, and it cannot recognize any \Index{NaN} value as identical
-  to itself.  For efficiency, the \code{identical} operation uses the
-  JavaScript \code{===} operator.
-\end{itemize}%
+  \begin{itemize}
+  \item[$\bullet$]
+    Valid values of JavaScript \code{int} are any IEEE-754 64-bit
+    floating point number with no fractional part. This includes
+    positive and negative \Index{infinity}, which can be reached by
+    overflowing (integer division by zero is still a dynamic error).
+    Otherwise valid integer literals (including any leading minus sign)
+    that represent invalid JavaScript \code{int} values are compile-time
+    errors when compiling to JavaScript. Operations on integers may
+    lose precision, because the operands and the result are represented
+    as 64-bit floating point numbers that are limited to 53 significant
+    bits.
+  \item[$\bullet$]
+    JavaScript \code{int} instances also implement \code{double}, and
+    integer-valued \code{double} instances also implement \code{int}.
+    The \code{int} and \code{double} class are still separate subclasses
+    of the class \code{num}, but \emph{instances} of either class that
+    represent an integer act as if they are actually instances of a
+    common subclass implementing both \code{int} and \code{double}.
+    Fractional numbers only implement \code{double}.
+  \item[$\bullet$]
+    Bitwise operations on integers (\lit{\&}, \lit{|}, \lit{\^},
+    \lit{\gtilde}, \lit{\ltlt}, and \lit{\gtgt}) all truncate the
+    operands to 32-bit two's complement integers, perform 32-bit
+    operations on those, and the resulting 32 bits are interpreted as a
+    32-bit unsigned integer. For example, \code{-1\,\ltlt\,1} evaluates
+    to 4294967294 (also known as \code{(-2).toUnsigned(32)}). The right
+    shift operator, \lit{\gtgt}, performs a signed right shift on the
+    32 bits when the original number is negative, and an unsigned right
+    shift when the original number is non-negative. Both kinds of shift
+    writes bit $k+1$ into position $k$, $0 \leq k < 31$; but the signed
+    shift leaves bit 31 unchanged, and the unsigned shift writes a 0
+    as bit 31. For example:
+    \code{0x80000002\,\gtgt\,1\ ==\ 0x40000001}, but
+    \code{-0x7FFFFFFE\,\gtgt\,1\ ==\ 0xC0000001}.
+    In this example we note that both \code{0x80000002} and \code{-0x7FFFFFFE}
+    yield the 32-bit two's complement representation \code{0x80000002},
+    but they have different values for the IEEE 754 sign bit.
+  \item[$\bullet$]
+    The \code{identical} method cannot distinguish the values $0.0$ and
+    $-0.0$, and it cannot recognize any \Index{NaN} value as identical
+    to itself. For efficiency, the \code{identical} operation uses the
+    JavaScript \code{===} operator.
+  \end{itemize}%
 }
 
 \printindex
@@ -23665,7 +23673,7 @@ implementation, and the relevant tool support.
 
 In order to support more fine-grained update propagation from this
 language specification to artifacts that depend on it, location
-markers have been added.  The idea is that each logical unit (section,
+markers have been added. The idea is that each logical unit (section,
 subsection, etc) and each paragraph containing normative text should
 be addressable using these markers, such that source code (compilers
 and other tools, tests, etc.) can contain location markers, and the
@@ -23674,9 +23682,9 @@ document viewer search features.
 
 An SHA1 hash value of the text is associated with each location
 marker, such that changes in the text will incur changes in this hash
-value.  Consequently, source code in tools/tests that depend on
+value. Consequently, source code in tools/tests that depend on
 specific parts of the spec may be flagged for revision by checking
-whether these hash values have changed:  If a given test T depends on
+whether these hash values have changed: If a given test T depends on
 a paragraph with hash value V in the spec, and the search for V fails
 in a new version of the spec, then that paragraph has changed and T
 should be revisited and possible revised.
@@ -23685,7 +23693,7 @@ As a result, the search for parts of source code and similar artifacts
 in likely need of updates because of spec changes can be performed
 mechanically, which should help ensure that the conformance of all
 artifacts depending on this spec is maintained more easily, and hence
-more consistently.  Note that it makes no difference whether the need
+more consistently. Note that it makes no difference whether the need
 for an update has arisen in a very recent version of the spec or it
 has existed for a long time, because the hash value just remains
 different as long as the text is different from what it was when the
@@ -23697,14 +23705,14 @@ Concretely, this is based on the commands \LMHash and \LMLabel.
 \LMHash{V} is used to add the text V in the margin, intended to mark
 a paragraph of normative text with the SHA1 hash value of the text, V.
 \LMLabel{L} has the effect of \label{L}, and moreover it shows the
-text sec:L in the margin.  In order to indicate a dependency on a
+text sec:L in the margin. In order to indicate a dependency on a
 section or subsection an \LMLabel location marker is used, and in
 order to indicate a dependency on a specific paragraph, the hash value
 of that paragraph is used.
 
 In this file, each normative paragraph has had the command \LMHash{}
 added at the beginning, such that each of these paragraphs can be
-decorated with their hash value.  Similarly, all \section{}s,
+decorated with their hash value. Similarly, all \section{}s,
 \subsection{}s, \subsubsection{}s, and \paragraph{}s have had
 their \label commands changed to \LMLabel, such that they are
 decorated with logical names.
@@ -23713,14 +23721,14 @@ decorated with logical names.
 
 The design of location markers was proposed by Erik Ernst and
 developed through discussions with several others, in particular Gilad
-Bracha and Lars Bak.  Some discussions along the way that gave rise to
+Bracha and Lars Bak. Some discussions along the way that gave rise to
 the given design are outlined below.
 
 The basic idea is that a hash value based on the actual text will
 serve well to identify a piece of text, because it will change
 whenever the text changes, and it remains the same if the text is
 moved to a different location; in other words, it characterizes the
-text itself, independently of the rest of the document.  Hence:
+text itself, independently of the rest of the document. Hence:
 
   - references to specific paragraphs in the spec are easy to create:
     copy the marker and paste it into the source code (but see below
@@ -23749,19 +23757,19 @@ However, there is a conflict in this scenario: Lars pointed out that
 it is very inconvenient to have to create a lot of revision control
 commits (e.g., new versions of tests), just because a large number of
 artifacts depend on a specific hash value that changed, if that change
-has no real impact on each of those artifacts.  The obvious solution
+has no real impact on each of those artifacts. The obvious solution
 to this problem would be to use symbolic names and keep the actual
 hash values out of the primary artifacts.
 
 This approach has been used for \section{}s, \subsection{}s, etc., by
-using their labels as location markers.  For instance, dependency on
+using their labels as location markers. For instance, dependency on
 \subsubsection{New} would be marked as a dependency on 'sec:new',
 which will (most likely) exist with the same label in the spec for a
-long time.  To detect a need for updates, the hash value associated
+long time. To detect a need for updates, the hash value associated
 with \subsubsection{New} from the date of the latest check of this
 kind to the dependent artifact should be compared with the current
-hash value for the same \subsubsection{}:  The artifact should be
-revisited iff those hash values differ.  As an easy approximation to
+hash value for the same \subsubsection{}: The artifact should be
+revisited iff those hash values differ. As an easy approximation to
 this scheme, the hash values for all location markers would be
 computed for each spec update, and the location markers that have new
 hash values should cause revisits to all artifacts depending on that
@@ -23770,16 +23778,16 @@ location marker.
 The symbolic location markers on larger units like \section{}
 etc. enable location marking in a hierarchical fashion: Dependencies
 on a \subsubsection{} or on a \section{} can be chosen according to
-the actual needs with each dependent artifact.  In general, fine
+the actual needs with each dependent artifact. In general, fine
 granularity helps avoiding false positives, where an update somewhere
 in a large unit will flag too many dependent artifacts for revisits.
 In contrast, coarse granularity enables other artifacts to declare the
 actual dependencies when small units would be impractical because the
-artifact depends on so many of them.  But there is a problem at the
+artifact depends on so many of them. But there is a problem at the
 bottom of this hierarchy, namely with paragraphs.
 
 It would be very inconvenient to have to invent a logical name for
-every paragraph.  Similarly, using a simple paragraph numbering would
+every paragraph. Similarly, using a simple paragraph numbering would
 be unstable (add one new paragraph in the beginning of a section, and
 all the rest have new numbers, creating a massive flood of false
 update alerts, or, even worse, corrupting the declared dependencies in
@@ -23790,16 +23798,16 @@ Artifacts that depend on very specific elements in the spec may
 declare so by using an actual hash value for a given paragraph, and in
 return they pay in terms of potential updates to the marker when that
 paragraph changes, even in cases where the actual change makes no
-difference for that particular artifact.  This choice of granularity
+difference for that particular artifact. This choice of granularity
 vs. stability is up to the creator of each artifact.
 
 ** Maintenance of this document
 
 The invariant that each normative paragraph is associated with a line
-containing the text \LMHash{} should be maintained.  Extra occurrences
+containing the text \LMHash{} should be maintained. Extra occurrences
 of \LMHash{} can be added if needed, e.g., in order to make
-individual \item{}s in itemized lists addressable.  Each \LM.. command
-must occur on a separate line.  \LMHash{} must occur immediately
+individual \item{}s in itemized lists addressable. Each \LM.. command
+must occur on a separate line. \LMHash{} must occur immediately
 before the associated paragraph, and \LMLabel must occur immediately
 after the associated \section, \subsection{} etc.
 

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -6015,11 +6015,14 @@ where $\metavar{members}'$ are the member declarations of
 the mixin declaration $M$ except that all superinvocations are treated
 as if \SUPER{} was a valid expression with static type $M_S$.
 It is a compile-time error for the mixin $M$ if this $N$ class
-declaration would cause a compile-time error, \commentary{that is, if the
-required superinterfaces, the implemented interfaces and the declarations do not
-define a consistent interface, if any member declaration contains a
-compile-time error other than a super-invocation, or if a super-invocation
-is not valid against the interface $M_S$}.
+declaration would cause a compile-time error,
+\commentary{%
+that is, if the required superinterfaces, the implemented interfaces
+and the declarations do not define a consistent interface,
+if any member declaration contains a compile-time error
+other than a super-invocation,
+or if a super-invocation is not valid against the interface $M_S$.%
+}
 The interface introduced by the mixin declaration $M$ has the same member
 signatures and superinterfaces as $M_I$.
 

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -514,6 +514,7 @@ We distinguish between normative and non-normative text.
 Normative text defines the rules of Dart.
 It is given in this font.
 At this time, non-normative text includes:
+
 \begin{itemize}
 \item[Rationale]
   Discussion of the motivation for language design decisions appears in italics.
@@ -655,6 +656,7 @@ The specifications of operators often involve statements such as
 \IndexCustom{\rm\code{$x$.\metavar{op}($y$)}}{%
   x.op(y)@\code{$x$.\metavar{op}($y$)}}.
 Such specifications should be understood as a shorthand for:
+
 \begin{itemize}
 \item
   $x$ $op$ $y$ is equivalent to the method invocation
@@ -1991,6 +1993,7 @@ The formal parameter part optionally specifies
 the formal type parameter list of the function,
 and it always specifies its formal parameter list.
 A function body is either:
+
 \begin{itemize}
 \item
   a block statement (\ref{blocks}) containing
@@ -2038,6 +2041,7 @@ OR
   }
   Let $T$ be the declared return type of the function that has this body.
   It is a compile-time error if one of the following conditions hold:
+
   \begin{itemize}
   \item The function is synchronous, $T$ is not \VOID,
     and it would have been a compile-time error
@@ -2322,6 +2326,7 @@ the corresponding parameter list with a trailing comma.
 
 \LMHash{}%
 A \Index{required formal parameter} may be specified in one of three ways:
+
 \begin{itemize}
 \item
   By means of a function signature that names the parameter and
@@ -2854,6 +2859,7 @@ are its static and instance members.
 
 \LMHash{}%
 A class declaration introduces two scopes:
+
 \begin{itemize}
 \item
   A \IndexCustom{type-parameter scope}{scope!type parameter},
@@ -4230,6 +4236,7 @@ and consists of a comma-separated list of individual \Index{initializers}.
 
 \commentary{%
 There are three kinds of initializers.
+
 \begin{itemize}
 \item[$\bullet$] A \emph{superinitializer} identifies a
   \emph{superconstructor}\,---\,that is,
@@ -4348,6 +4355,7 @@ Let \DefineSymbol{f} be a final instance variable declared in
 the immediately enclosing class or enum.
 A compile-time error occurs unless $f$ is initialized
 by one of the following means:
+
 \begin{itemize}
 \item $f$ is declared by an initializing variable declaration.
 \item $f$ is initialized by means of an initializing formal of $k$.
@@ -4693,6 +4701,7 @@ ordinary factory constructors could simply create
 instances of other classes and return them,
 and that redirecting factories are unnecessary.
 However, redirecting factories have several advantages:
+
 \begin{itemize}
 \item
   An abstract class may provide a constant constructor
@@ -4894,6 +4903,7 @@ The name $S'$ is a fresh identifier.
 If no \WITH{} clause is specified then the \EXTENDS{} clause of
 a class $C$ specifies its superclass.
 If no \EXTENDS{} clause is specified, then either:
+
 \begin{itemize}
 \item $C$ is \code{Object}, which has no superclass. OR
 \item Class $C$ is deemed to have an \EXTENDS{} clause of the form
@@ -4951,6 +4961,7 @@ class G<T> extends T \{\}
 %% TODO(eernst): Consider replacing all occurrences of `a superclass`
 %% by `a direct or indirect superclass`, because it's too confusing.
 A class $S$ is a \Index{superclass} of a class $C$ if{}f either:
+
 \begin{itemize}
 \item $S$ is the superclass of $C$, or
 \item $S$ is a superclass of a class $S'$,
@@ -5708,6 +5719,7 @@ Let $J$ be an interface and $K$ be a library.
 We define $\inherited{J, K}$ to be the set of member signatures
 \DefineSymbol{m}
 such that all of the following hold:
+
 \begin{itemize}
 \item $m$ is accessible to $K$ and
 \item $A$ is a direct superinterface of $J$ and either
@@ -5722,6 +5734,7 @@ such that all of the following hold:
 Furthermore, we define $\overrides{J, K}$ to be
 the set of member signatures \DefineSymbol{m'}
 such that all of the following hold:
+
 \begin{itemize}
 \item $J$ is the interface of a class $C$.
 \item $C$ declares a member signature $m$.
@@ -6264,6 +6277,7 @@ or in order to resolve an invocation explicitly%
 
 \LMHash{}%
 An extension declaration introduces two scopes:
+
 \begin{itemize}
 \item
   A \IndexCustom{type-parameter scope}{scope!type parameter},
@@ -6768,6 +6782,7 @@ if at least one of the following conditions is satisfied:
 \item
   $E_1$ and $E_2$ are both declared in a system library,
   or neither of them is declared in a system library, and
+
   \begin{itemize}
   \item \SubtypeNE{T_1}{T_2}, but not \SubtypeNE{T_2}{T_1}, or
   \item \SubtypeNE{T_1}{T_2}, \SubtypeNE{T_2}{T_1}, and
@@ -6992,6 +7007,7 @@ proceeds as follows:
 Evaluate $e_1$ to an object $o$.
 Let $u$ be a fresh final variable bound to $o$.
 Then $e$ evaluates to a function object which is equivalent to:
+
 \begin{itemize}
 \item
 \begin{normativeDartCode}
@@ -7415,6 +7431,7 @@ This enables typechecking code such as:%
 \commentary{%
 Even where type parameters are in scope
 there are numerous restrictions at this time:
+
 \begin{itemize}
 \item[$\bullet$]
   A type parameter cannot be used to name a constructor in
@@ -7706,6 +7723,7 @@ Any use of a type $T$ which is not well-bounded is a compile-time error.
 \LMHash{}%
 It is a compile-time error if a parameterized type $T$ is super-bounded
 when it is used in any of the following ways:
+
 \begin{itemize}
 \item $T$ is an immediate subterm of a new expression
   (\ref{new})
@@ -8313,6 +8331,7 @@ each of which begin with the character \lit{@},
 followed by a constant expression $e$ derivable from
 \synt{metadatum}.
 It is a compile-time error if $e$ is not one of the following:
+
 \begin{itemize}
 \item A reference to a constant variable.
 \item A call to a constant constructor.
@@ -8503,6 +8522,7 @@ and throws the same exception object and stack trace.
 \LMHash{}%
 The predefined Dart function \code{identical()}
 is defined such that \code{identical($c_1$, $c_2$)} if{}f:
+
 \begin{itemize}
 \item $c_1$ evaluates to either the null object (\ref{null})
   or an instance of \code{bool} and \code{$c_1$ == $c_2$}, OR
@@ -8510,6 +8530,7 @@ is defined such that \code{identical($c_1$, $c_2$)} if{}f:
 \item $c_1$ and $c_2$ are constant strings and \code{$c_1$ == $c_2$}, OR
 \item $c_1$ and $c_2$ are instances of \code{double}
   and one of the following holds:
+
   \begin{itemize}
   \item $c_1$ and $c_2$ are non-zero and \code{$c_1$ == $c_2$}.
   \item Both $c_1$ and $c_2$ are $+0.0$.
@@ -8871,6 +8892,7 @@ are the following:
 A
 \Index{constant type expression}
 is one of:
+
 \begin{itemize}
 \item
   An simple or qualified identifier
@@ -9246,6 +9268,7 @@ The static type of a double literal is \code{double}.
 If $l$ is an integer literal with numeric value $i$ and static type \code{int},
 and $l$ is not the operand of a unary minus operator,
 then evaluation of $l$ proceeds as follows:
+
 \begin{itemize}
   \item{} If $l$ is a hexadecimal integer literal,
   $2^{63} \le i < 2^{64}$ and the \code{int} class is implemented as
@@ -9591,6 +9614,7 @@ just like single-line string interpolation.%
 \LMHash{}%
 Strings support escape sequences for special characters.
 The escapes are:
+
 \begin{itemize}
 \item
   \syntax{`\\n'} for newline, equivalent to \syntax{`\\x0A'}.
@@ -9697,6 +9721,7 @@ which could again be interpolated recursively.%
 An unescaped \lit{\$} character in a string signifies
 the beginning of an interpolated expression.
 The \lit{\$} sign may be followed by either:
+
 \begin{itemize}
 \item A single identifier \id{} that does not contain the \lit{\$} character
   (but it can be a built-in identifier),
@@ -9711,12 +9736,15 @@ An interpolated string, $s$, with content
 (where any of $s_0, \ldots, s_n$ can be empty)
 is evaluated by evaluating each expression $e_i$ ($1 \le i \le n$)
 into a string $r_i$ in the order they occur in the source text, as follows:
+
 \begin{itemize}
 \item Evaluate $e_i$ to an object $o_i$.
 \item Invoke the \code{toString} method on $o_i$ with no arguments,
   and let $r_i$ be the returned object.
 \item If $r_i$ is the null object, a dynamic error occurs.
 \end{itemize}
+
+\LMHash{}%
 Finally, the result of the evaluation of $s$ is
 the concatenation of the strings $s_0$, $r_1$, \ldots, $r_n$, and $s_n$.
 
@@ -10713,6 +10741,7 @@ the result of evaluating a constant expression.%
 A run-time list literal
 \code{<$T$>[\List{\ell}{1}{m}]}
 is evaluated as follows:
+
 \begin{itemize}
 \item
   The elements \List{\ell}{1}{m} are evaluated
@@ -11122,6 +11151,7 @@ In this case $\ell$ is of the form
 The condition $b$ is always inferred with a context type of \code{bool}.
 
 Assume that `\code{\ELSE\,\,$\ell_2$}' is not present. Then:
+
 \begin{itemize}
 \item
   If the inferred element type of $\ell_1$ is $S$,
@@ -11465,6 +11495,7 @@ the result of evaluating a constant expression.%
 \LMHash{}%
 A run-time set literal \code{<$T$>\{\List{\ell}{1}{n}\}}
 is evaluated as follows:
+
 \begin{itemize}
 \item
   The elements \List{\ell}{1}{m} are evaluated
@@ -11660,6 +11691,7 @@ the result of evaluating a constant expression.%
 A run-time map literal
 \code{<$T_1, T_2$>\{\List{\ell}{1}{m}\}}
 is evaluated as follows:
+
 \begin{itemize}
 \item
   The elements \List{\ell}{1}{m} are evaluated
@@ -11862,6 +11894,7 @@ as follows, using the first applicable case:
 \begin{itemize}
 \item If $T$ is \code{$X$\,\&\,$S$}
   for some type variable $X$ and type $S$ then
+
   \begin{itemize}
   \item if $S$ derives a future type $U$
     then \DefEquals{\flatten{T}}{\code{\flatten{U}}}.
@@ -11886,6 +11919,7 @@ structure of $T$:
 
 \begin{itemize}
 \item If $T$ is \code{$X$\,\&\,$S$} then
+
   \begin{itemize}
   \item if $S$ derives a future type $U$,
     then \code{$T <: S$} and \code{$S <: U$}, so \code{$T <: U$}.
@@ -12532,11 +12566,11 @@ let $i$ be the value of
 Which is well-defined for the same reason.%
 }
 
-\LMHash{}%
 \begin{itemize}
 \item If during execution of the program,
   a constant object expression has already evaluated to
   an instance $j$ of class $R$ with type arguments $U_i, 1 \le i \le m$, then:
+
   \begin{itemize}
   \item For each instance variable $f$ of $i$,
     let $v_{if}$ be the value of the instance variable $f$ in $i$, and
@@ -12723,6 +12757,7 @@ When iteration over the iterable is started, by getting
 an iterator $j$ from the iterable and calling \code{moveNext()},
 execution of the body of $f$ will begin.
 When execution of the body of $f$ completes (\ref{statementCompletion}),
+
 \begin{itemize}
 \item If it returns without an object or it completes normally
   (\ref{statementCompletion}),
@@ -12808,12 +12843,14 @@ corresponding to the element type of $f$
 (\ref{functions}).
 When $s$ is listened to, execution of the body of $f$ will begin.
 When execution of the body of $f$ completes:
+
 \begin{itemize}
 \item If it completes normally or returns without an object
   (\ref{statementCompletion}),
   then if $s$ has been canceled
   then its cancellation future is completed with the null object (\ref{null}).
 \item If it throws an exception object $e$ and stack trace $t$:
+
   \begin{itemize}
   \item If $s$ has been canceled then its cancellation future is completed
     with error $e$ and stack trace $t$.
@@ -13542,6 +13579,7 @@ and its result is then the result of evaluating $i$:
 Otherwise $o$ has no method named \CALL.
 A new instance $im$ of the predefined class \code{Invocation} is created,
 such that:
+
 \begin{itemize}
 \item \code{$im$.isMethod} evaluates to \TRUE.
 \item \code{$im$.memberName} evaluates to the symbol \code{\#call}.
@@ -14411,6 +14449,7 @@ Let $i$ be an invocation of the form \code{$e$.remainder($e_2$)}
 and let $C$ be the context type of $i$.
 The context type of $e_2$ is then determined as follows:
 If \SubtypeNE{T}{\code{num}} and not \SubtypeNE{T}{\code{Never}}, then:
+
 \begin{itemize}
   \item{} If \SubtypeNE{\code{int}}{C} and not \SubtypeNE{\code{num}}{C},
       and \SubtypeNE{T}{\code{int}}
@@ -14420,10 +14459,13 @@ If \SubtypeNE{T}{\code{num}} and not \SubtypeNE{T}{\code{Never}}, then:
      then the context type of $e_2$ is \code{double}.
   \item{} Otherwise the context type of $e_2$ is \code{num}.
 \end{itemize}
+
+\LMHash{}%
 Let further $S$ be the static type of $e_2$.
 If \SubtypeNE{T}{\code{num}} and not \SubtypeNE{T}{\code{Never}}
 and $S$ is assignable to \code{num},
 then the static type of $i$ is determined as follows:
+
 \begin{itemize}
   \item{} If \SubtypeNE{T}{\code{double}}
     then the static type of $i$ is $T$.
@@ -14441,6 +14483,7 @@ Let $i$ be an invocation of the form \code{$e$.clamp($e_2$,\,\,$e_3$)},
 where \SubtypeNE{T}{\code{num}} and not \SubtypeNE{T}{\code{Never}},
 and let $C$ be the context type of $i$.
 The context type of $e_2$ and $e_3$ is then determined as follows:
+
 \begin{itemize}
   \item{} If \SubtypeNE{T}{\code{int}},
     \SubtypeNE{\code{int}}{S} and not \SubtypeNE{\code{num}}{S},
@@ -14450,8 +14493,11 @@ The context type of $e_2$ and $e_3$ is then determined as follows:
     then the context type of $e_2$ and $e_3$ is \code{double}.
   \item{} Otherwise the context type of $e_2$ and $e_3$ is \code{num}.
 \end{itemize}
+
+\LMHash{}%
 Let further $T_2$ be the static type of $e_2$ and $T_3$ be the static type
 of $e_3$.
+
 \begin{itemize}
   \item{} If all of $T$, $T_2$ and $T_3$ are subtypes of \code{int}, but
     not subtypes of \code{Never}, then the static type of $i$ is \code{int}.
@@ -14534,6 +14580,7 @@ Then the value of $i$ is the value of
 If getter lookup has also failed,
 then a new instance $im$ of the predefined class \code{Invocation} is created,
 such that:
+
 \begin{itemize}
 \item \code{$im$.isMethod} evaluates to \TRUE.
 \item \code{$im$.memberName} evaluates to the symbol \code{m}.
@@ -15043,6 +15090,7 @@ The value of $i$ is the result returned by the call to the getter function.
 If the getter lookup has failed,
 then a new instance $im$ of the predefined class \code{Invocation} is created,
 such that:
+
 \begin{itemize}
 \item \code{$im$.isGetter} evaluates to \TRUE.
 \item \code{$im$.memberName} evaluates to the symbol \code{m}.
@@ -15148,6 +15196,7 @@ Let $o$ be an object, and let $u$ be a fresh final variable bound to $o$.
 The \Index{closurization of method} $f$ on object $o$
 is defined to be equivalent
 (\commentary{except for equality, as noted below}) to:
+
 \begin{itemize}
 %\item $(a) \{\RETURN{}$ $u$ $op$ $a;$\} if $f$ is named $op$
 %  and $op$ is one of \code{<, >, <=, >=, ==, -, +, /, \gtilde/, *, \%, $|$,
@@ -15303,7 +15352,6 @@ The \Index{closurization of a method} $f$ with respect to the class $S$
 is defined to be equivalent
 (\commentary{except for equality, as noted below}) to:
 
-\LMHash{}%
 \begin{itemize}
 %\item $(a) \{\RETURN{}$ \SUPER{} $op$ $a;$\} if $f$ is named $op$
 %   and $op$ is one of \code{<, >, <=, >=, ==, -, +, /, \gtilde/, *, \%, $|$,
@@ -15859,6 +15907,7 @@ its formal parameter bound to $o_2$ and \THIS{} bound to $o_1$.
 \LMHash{}%
 If the setter lookup has failed, then a new instance $im$ of
 the predefined class \code{Invocation} is created, such that:
+
 \begin{itemize}
 \item \code{$im$.isSetter} evaluates to \TRUE.
 \item \code{$im$.memberName} evaluates to the symbol \code{v=}.
@@ -16228,6 +16277,7 @@ Otherwise the value of $c$ is the result of evaluating the expression $e_3$.
 If $e_1$ shows that a local variable $v$ has type $T$,
 then the type of $v$ is known to be $T$ in $e_2$,
 unless any of the following are true:
+
 \begin{itemize}
 \item $v$ is potentially mutated in $e_2$,
 \item $v$ is potentially mutated within a function other
@@ -16315,6 +16365,7 @@ Otherwise the result of evaluating $b$ is $o_2$.
 A logical boolean expression $b$ of the form $e_1 \&\& e_2$
 shows that a local variable $v$ has type $T$
 if both of the following conditions hold:
+
 \begin{itemize}
 \item Either $e_1$ shows that $v$ has type $T$
   or $e_2$ shows that $v$ has type $T$.
@@ -16326,6 +16377,7 @@ if both of the following conditions hold:
 If $e_1$ shows that a local variable $v$ has type $T$,
 then the type of $v$ is known to be $T$ in $e_2$,
 unless any of the following are true:
+
 \begin{itemize}
 %% The first item here is unnecessary for soundness,
 %% and is retained mainly for backwards compatibility.
@@ -16375,6 +16427,7 @@ or an expression $e_1$, with argument $e_2$.
 \LMHash{}%
 Evaluation of an equality expression $ee$ of the form \code{$e_1$ == $e_2$}
 proceeds as follows:
+
 \begin{itemize}
 \item The expression $e_1$ is evaluated to an object $o_1$.
 \item The expression $e_2$ is evaluated to an object $o_2$.
@@ -16390,6 +16443,7 @@ Otherwise,
 Evaluation of an equality expression $ee$ of the form
 \code{\SUPER{} == $e$}
 proceeds as follows:
+
 \begin{itemize}
 \item The expression $e$ is evaluated to an object $o$.
 \item If either \THIS{} or $o$ is the null object (\ref{null}),
@@ -16585,6 +16639,7 @@ and let $C$ be the context type of $e$.
 
 If \SubtypeNE{T}{\code{num}} and not \SubtypeNE{T}{\code{Never}}, then
 the context type of $e_2$ is determined as follows:
+
 \begin{itemize}
   \item{} If \SubtypeNE{\code{int}}{C} and not \SubtypeNE{\code{num}}{C},
       and \SubtypeNE{T}{\code{int}}
@@ -16594,10 +16649,13 @@ the context type of $e_2$ is determined as follows:
      then the context type of $e_2$ is \code{double}.
   \item{} Otherwise the context type of $e_2$ is \code{num}.
 \end{itemize}
+
+\LMHash{}%
 Let further $S$ be the static type of $e_2$.
 If \SubtypeNE{T}{\code{num}} and not \SubtypeNE{T}{\code{Never}}
 and $S$ is assignable to \code{num},
 then the static type of $e$ is determined as follows:
+
 \begin{itemize}
   \item{} If \SubtypeNE{T}{\code{double}}
     then the static type of $e$ is $T$.
@@ -16655,6 +16713,7 @@ and let $C$ be the context type of $e$.
 
 If \SubtypeNE{T}{\code{num}} and not \SubtypeNE{T}{\code{Never}}, then
 the context type of $e_2$ is determined as follows:
+
 \begin{itemize}
   \item{} If \SubtypeNE{\code{int}}{C} and not \SubtypeNE{\code{num}}{C},
       and \SubtypeNE{T}{\code{int}}
@@ -16664,10 +16723,13 @@ the context type of $e_2$ is determined as follows:
      then the context type of $e_2$ is \code{double}.
   \item{} Otherwise the context type of $e_2$ is \code{num}.
 \end{itemize}
+
+\LMHash{}%
 Let further $S$ be the static type of $e_2$.
 If \SubtypeNE{T}{\code{num}} and not \SubtypeNE{T}{\code{Never}}
 and $S$ is assignable to \code{num},
 then the static type of $e$ is determined as follows:
+
 \begin{itemize}
   \item{} If \SubtypeNE{T}{\code{double}}
     then the static type of $e$ is $T$.
@@ -18335,6 +18397,7 @@ may not be assigned to \code{bool}.
 If $b$ shows that a local variable $v$ has type $T$,
 then the type of $v$ is known to be $T$ in $s_1$,
 unless any of the following are true
+
 \begin{itemize}
 \item $v$ is potentially mutated in $s_1$,
 \item $v$ is potentially mutated within a function other
@@ -18727,6 +18790,7 @@ It is a compile-time error unless each expression
 $e_j, j \in 1 .. n$ is constant.
 It is a compile-time error if the value of the expressions
 $e_j, j \in 1 .. n$ are not either:
+
 \begin{itemize}
 \item instances of the same class $C$, for all $j \in 1 .. n$, or
 \item instances of a class that implements \code{int},
@@ -18910,6 +18974,7 @@ and such code can always be refactored.%
 
 \LMHash{}%
 It is a static warning if all of the following conditions hold:
+
 \begin{itemize}
 \item The switch statement does not have a default clause.
 \item The static type of $e$ is an enumerated
@@ -19384,6 +19449,7 @@ Then the return statement returns the object $r$
 
 \LMHash{}%
 Let $U$ be the run-time type of $r$.
+
 \begin{itemize}
 \item
   If the body of $f$ is marked \ASYNC{} (\ref{functions})
@@ -19589,6 +19655,7 @@ The only requirement is that consumers are not blocked indefinitely.%
 
 \LMHash{}%
 If the enclosing function $m$ is marked \code{\SYNC*} (\ref{functions}) then:
+
 \begin{itemize}
 \item
   Execution of the function $m$ immediately enclosing $s$ is suspended
@@ -19674,6 +19741,7 @@ The current call to \code{moveNext()} returns \TRUE.
 
 \LMHash{}%
 If $m$ is marked \code{\ASYNC*} (\ref{functions}), then:
+
 \begin{itemize}
 \item
   % This error can occur due to implicit casts.
@@ -19686,6 +19754,7 @@ If $m$ is marked \code{\ASYNC*} (\ref{functions}), then:
 \item
   The $o$ stream is listened to, creating a subscription $s$,
   and for each event $x$, or error $e$ with stack trace $t$, of $s$:
+
   \begin{itemize}
   \item
     If the stream $u$ associated with $m$ has been paused,
@@ -20323,6 +20392,7 @@ does not interfere with other imports.%
 
 \LMHash{}%
 The effect of a repeated invocation of \code{$p$.loadLibrary()} is as follows:
+
 \begin{itemize}
 \item
   If another invocation of \code{$p$.loadLibrary()} has already succeeded,
@@ -20330,6 +20400,7 @@ The effect of a repeated invocation of \code{$p$.loadLibrary()} is as follows:
   Otherwise,
 \item
   If another invocation of \code{$p$.loadLibrary()} has failed:
+
   \begin{itemize}
   \item
     If the failure is due to a compilation error,
@@ -20758,6 +20829,7 @@ two part directives with the same URI.
 \LMHash{}%
 We say that a library $L_1$ is \Index{reachable from} a library $L$ if
 any of the following is true (\ref{imports}, \ref{exports}):
+
 \begin{itemize}
 \item $L$ and $L_1$ is the same library.
 \item $L$ imports or exports a library $L_2$, and $L_1$ is reachable from $L_2$.
@@ -20858,6 +20930,7 @@ contains a string interpolation.
 A \Index{configurable URI} $c$ of the form
 \code{\metavar{uri} $\metavar{configurationUri}_1$ \ldots $\metavar{configurationUri}_n$}
 \IndexCustom{specifies a URI}{specify a URI} as follows:
+
 \begin{itemize}
 \item
   Let $u$ be \metavar{uri}.
@@ -20865,6 +20938,7 @@ A \Index{configurable URI} $c$ of the form
   For each of the following configuration URIs of the form
   \code{\IF{} ($\metavar{test}_i$) $\metavar{uri}_i$},
   in source order, do the following.
+
   \begin{itemize}
   \item
     If $\metavar{test}_i$ is \code{\metavar{ids}}
@@ -21067,6 +21141,7 @@ successful compilation and execution of Dart code.%
 
 \LMHash{}%
 A type $T$ is \Index{malformed} if{}f:
+
 \begin{itemize}
 \item
   $T$ has the form \id{} or the form \code{\metavar{prefix}.\id},
@@ -22564,6 +22639,7 @@ which is regular-bounded for all $T$.
 The subtype relations involving \code{FutureOr} are specified elsewhere
 (\ref{subtypeRules}).
 Note, however, that they entail certain useful properties:
+
 \begin{itemize}
 \item[$\bullet$]
   $T <: \code{FutureOr<$T$>}$.
@@ -23123,6 +23199,7 @@ Let $F$ and $G$ be function types.
 If $F$ and $G$ differ in their number of required parameters,
 then the least upper bound of $F$ and $G$ is \FUNCTION.
 Otherwise:
+
 \begin{itemize}
 \item If
 
@@ -23508,6 +23585,7 @@ and the corresponding JavaScript operations,
 except for bit operations as explained below.
 
 This introduces a number of differences:
+
 \begin{itemize}
 \item[$\bullet$]
   Valid values of JavaScript \code{int} are any IEEE-754 64-bit

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -18926,6 +18926,7 @@ Matching of a \CASE{} clause \CASE{} $e_{k}: s_{k}$ of a switch statement
 \}
 \end{normativeDartCode}
 
+\noindent
 against the value of a variable \id{} proceeds as follows:
 
 \LMHash{}%

--- a/specification/pubspec.yaml
+++ b/specification/pubspec.yaml
@@ -1,7 +1,7 @@
 name: scripts
 publish_to: none
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=3.7.0 <4.0.0"
 dependencies:
   convert: ^3.0.1
   crypto: ^3.0.1

--- a/specification/scripts/addlatexhash.dart
+++ b/specification/scripts/addlatexhash.dart
@@ -51,8 +51,13 @@ cutMatch(line, match, {startOffset = 0, endOffset = 0, glue = ""}) {
 }
 
 cutRegexp(line, re, {startOffset = 0, endOffset = 0, glue = ""}) {
-  return cutMatch(line, re.firstMatch(line),
-      startOffset: startOffset, endOffset: endOffset, glue: glue);
+  return cutMatch(
+    line,
+    re.firstMatch(line),
+    startOffset: startOffset,
+    endOffset: endOffset,
+    glue: glue,
+  );
 }
 
 /// Removes the rest of [line] starting from the beginning of the
@@ -298,7 +303,7 @@ class HashAnalyzer {
   static const PENDING_IS_SECTION = 1;
   static const PENDING_IS_SUBSECTION = 2;
   static const PENDING_IS_SUBSUBSECTION = 3;
-  static const PENDING_IS_PARAGRAPH = 1;
+  static const PENDING_IS_PARAGRAPH = 4;
 
   var lineNumber = 0;
   var pendingSectioning = PENDING_IS_NONE;
@@ -509,8 +514,10 @@ addHashMarks(lines, hashEvents, listSink) {
       var start = hashEvent.startLineNumber;
       var end = hashEvent.endLineNumber;
       final hashValue = computeHashString(lines, start + 1, end, listSink);
-      lines[start] =
-          lines[start].replaceAll(latexArgumentRE, "{" + hashValue + "}");
+      lines[start] = lines[start].replaceAll(
+        latexArgumentRE,
+        "{" + hashValue + "}",
+      );
       listSink.write("  $hashValue\n");
     } else if (hashEvent is HashLabelEvent) {
       listSink.write("${hashEvent.labelText}\n");

--- a/specification/scripts/simplify_specification.dart
+++ b/specification/scripts/simplify_specification.dart
@@ -281,10 +281,17 @@ extension on List<String?> {
           if (itemLine!.startsWith(r"\end{itemize}")) {
             // No extra lines, at the end of the outermost itemized list: Done.
             return itemIndex + 1;
+          } else if (itemLine.trimLeft().startsWith(r"\item")) {
+            // No extra lines, starting a new item.
+            buffer = StringBuffer(itemLine);
+            gatherIndex = itemIndex;
+            continue;
+          } else {
+            // Some extra text found, gather it.
+            buffer = StringBuffer(itemLine); // Not starting with `\item`.
+            gatherIndex = itemIndex + 1;
+            continue;
           }
-          // Some extra text found, gather it.
-          gatherIndex = itemIndex + 1;
-          continue;
         }
       }
       // `gatherLine` is text belonging to the current `\item`.

--- a/specification/scripts/simplify_specification.dart
+++ b/specification/scripts/simplify_specification.dart
@@ -235,6 +235,9 @@ extension on List<String?> {
   /// lines whose text was gathered to null (which means that they are
   /// ignored).
   (bool, int) _gatherItems(final int listIndex) {
+    if (listIndex >= 1995) {
+      print('>>> listIndex: $listIndex'); // DEBUG
+    }
     final length = this.length;
     var itemIndex = _findItem(listIndex + 1);
     var itemLine = this[itemIndex]; // Invariant.

--- a/specification/scripts/simplify_specification.dart
+++ b/specification/scripts/simplify_specification.dart
@@ -29,9 +29,9 @@ void fail(String message) {
   exit(-1);
 }
 
-extension _RemoveCommentsExtension on List<String> {
-  static final commentRegexp = RegExp("[^%\\]%\|^%");
-
+extension on List<String> {
+    static final commentRegexp = RegExp("[^%\\\\]%\|^%");
+    
   List<String> get removeComments {
     final result = List<String>.from(this);
     final length = this.length;
@@ -41,14 +41,25 @@ extension _RemoveCommentsExtension on List<String> {
       if (match != null) {
         final cutPosition = match.start == 0 ? 0 : match.start + 1;
         final resultLine = line.substring(0, cutPosition);
-        print('>>> line $index: "${line.substring(cutPosition, line.length)}"');
+        result[index] = resultLine;
       } else if (line.startsWith("\\end{document}")) {
         // All text beyond `\end{document}` is a comment.
-        result.removeRange(index, result.length);
+        result.removeRange(index + 1, result.length);
         break;
       }
     }
     return result;
+  }
+
+  List<String> removeTrailingWhitespace {
+    final result = List<String>.from(this);
+    final length = result.length;
+    for (int index = 0; index < length; ++index) {
+        final line = result[index];
+        if () {
+          
+        }
+    }
   }
 }
 
@@ -56,8 +67,8 @@ void main() {
   final inputFile = File(specificationFilename);
   if (!inputFile.existsSync()) fail("Specification not found");
   final contents = inputFile.readAsLinesSync();
-  final simplifiedContents = contents.removeComments; /*
-          .removeTrailingWhitespace
+  final simplifiedContents = contents.removeComments
+          .removeTrailingWhitespace;/*
           .removeCommentary
           .removeRationale
           .joinLines;*/

--- a/specification/scripts/simplify_specification.dart
+++ b/specification/scripts/simplify_specification.dart
@@ -67,9 +67,13 @@ extension on List<String?> {
       if (line == null) continue; // It isn't, but flow-analysis doesn't know.
       final match = _commentRegExp.firstMatch(line);
       if (match != null) {
-        final cutPosition = match.start == 0 ? 0 : match.start + 1;
-        final resultLine = line.substring(0, cutPosition);
-        this[i] = resultLine;
+        if (match.start == 0) {
+          this[i] = null; // A comment-only line disappears entirely.
+        } else {
+          final cutPosition = match.start + 1;
+          final resultLine = line.substring(0, cutPosition);
+          this[i] = resultLine;
+        }
       } else if (line.startsWith("\\end{document}")) {
         // All text beyond `\end{document}` is a comment.
         for (int j = i + 1; j < length; ++j) this[j] = null;
@@ -92,8 +96,7 @@ extension on List<String?> {
     for (int i = 0; i < length; ++i) {
       final line = this[i];
       if (line == null) continue;
-      if (line.startsWith(r"\LMHash{}") ||
-          line.startsWith(r"\BlindDefineSymbol{")) {
+      if (line.startsWith(r"\BlindDefineSymbol{")) {
         this[i] = null;
         continue;
       }
@@ -141,7 +144,7 @@ extension on List<String?> {
         }
       }
       if (inParagraph) {
-        !!!
+        throw 0; // !!!
       }
     }
   }
@@ -155,8 +158,8 @@ void main() {
       List<String?>.from(contents, growable: false)
         ..removeComments()
         ..removeTrailingWhitespace()
-        ..removeNonNormative()
-        ..joinLines();
+        ..removeNonNormative() /*
+        ..joinLines()*/;
   final simplifiedContents = workingContents.whereType<String>().toList();
   final outputFile = File(outputFilename);
   final outputSink = outputFile.openWrite();

--- a/specification/scripts/simplify_specification.dart
+++ b/specification/scripts/simplify_specification.dart
@@ -259,6 +259,9 @@ extension on List<String?> {
         this[itemIndex] = buffer.toString();
         return gatherIndex;
       }
+      if (gatherIndex >= 8538) {
+        print('gatherIndex: $gatherIndex'); // DEBUG
+      }
       final foundItem = trimmedGatherLine.startsWith(r"\item");
       final foundEnd = trimmedGatherLine.startsWith(r"\end{itemize}");
       if (foundItem || foundEnd) {

--- a/specification/scripts/simplify_specification.dart
+++ b/specification/scripts/simplify_specification.dart
@@ -65,10 +65,6 @@ extension on List<String?> {
 
   static String _lineStart(String line) {
     final indentation = _indentation(line);
-    if (indentation > 0)
-      print(
-        '>>> indentation: $indentation. Returning: ${"${' ' * indentation}}"}',
-      ); // DEBUG
     return "${' ' * indentation}}";
   }
 

--- a/specification/scripts/simplify_specification.dart
+++ b/specification/scripts/simplify_specification.dart
@@ -30,14 +30,16 @@ void fail(String message) {
 }
 
 extension on List<String> {
-    static final commentRegexp = RegExp("[^%\\\\]%\|^%");
-    
-  List<String> get removeComments {
-    final result = List<String>.from(this);
+  static final _commentRegexp = RegExp("[^%\\\\]%\|^%");
+
+  (List<String?>, int) get _setup => (List<String>.from(this, growable: false), length);
+
+  List<String?> get removeComments {
+    final (result = List<String>.from(this);
     final length = this.length;
     for (int index = 0; index < length; ++index) {
       final line = result[index];
-      final match = commentRegexp.firstMatch(line);
+      final match = _commentRegexp.firstMatch(line);
       if (match != null) {
         final cutPosition = match.start == 0 ? 0 : match.start + 1;
         final resultLine = line.substring(0, cutPosition);

--- a/specification/scripts/simplify_specification.dart
+++ b/specification/scripts/simplify_specification.dart
@@ -22,15 +22,44 @@ library;
 import 'dart:io';
 
 const specificationFilename = 'dartLangSpec.tex';
-const simplifiedFilename = 'dartLangSpec-simple.tex';
+const outputFilename = 'dartLangSpec-simple.tex';
 
 void fail(String message) {
   print("simplify_specification error: $message");
   exit(-1);
 }
 
+extension _RemoveCommentsExtension on List<String> {
+  static final commentRegexp = RegExp("[^%]%\|^%");
+
+  List<String> get removeComments {
+    final result = List<String>.from(this);
+    final length = this.length;
+    var inBackMatter = false;
+    for (int index = 0; index < length; ++index) {
+      final line = result[index];
+      final match = commentRegexp.firstMatch(line);
+      if (match != null) {
+        final cutPosition = match.start == 0 ? 0 : match.start + 1;
+        final resultLine = line.substring(0, cutPosition);
+        print('>>> line: "$line", output: "$resultLine"');
+      }
+    }
+    return result;
+  }
+}
+
 void main() {
-  final specificationFile = File(specificationFilename);
-  if (!specificationFile.existsSync()) fail("Specification not found");
-  
+  final inputFile = File(specificationFilename);
+  if (!inputFile.existsSync()) fail("Specification not found");
+  final contents = inputFile.readAsLinesSync();
+  final simplifiedContents = contents.removeComments; /*
+          .removeTrailingWhitespace
+          .removeCommentary
+          .removeRationale
+          .joinLines;*/
+
+  final outputFile = File(outputFilename);
+  final outputSink = outputFile.openWrite();
+  simplifiedContents.forEach(outputSink.writeln);
 }

--- a/specification/scripts/simplify_specification.dart
+++ b/specification/scripts/simplify_specification.dart
@@ -140,7 +140,7 @@ extension on List<String?> {
             }
           } else {
             final lineStart = _lineStart(line);
-            while (i < length && this[i]?.startsWith(lineStart) == false) {
+            while (i < length && this[i]?.startsWith(lineStart) != true) {
               this[i] = null;
               ++i;
             }
@@ -151,10 +151,9 @@ extension on List<String?> {
     }
   }
 
-  /*
+  // TODO!!!
   void joinLines() {
     bool inFrontMatter = true;
-    bool inParagraph = false;
     for (int i = 0; i < length; ++i) {
       final line = this[i];
       if (line == null) continue;
@@ -162,27 +161,29 @@ extension on List<String?> {
         if (line.startsWith(r"\begin{document}")) inFrontMatter = false;
         continue;
       }
-      if (!inParagraph) {
-        if (line.isNotEmpty &&
-            !line.startsWith(r"\newcommand{") &&
-            !line.startsWith(r"\section{") &&
-            !line.startsWith(r"\subsection{") &&
-            !line.startsWith(r"\subsubsection{") &&
-            !line.startsWith(r"\begin{") &&
-            !line.startsWith(r"\end{") &&
-            !line.startsWith(r"\LMLabel{") &&
-            !line.startsWith(r"\Index{") &&
-            !line.startsWith(r"\IndexCustom{") &&
-            !line.startsWith(r"\noindent") &&
-            !line.contains(r"\item")) {
-          inParagraph = true;
+      if (line.startsWith(r"\LMHash{}")) {
+        final longLineIndex = i;
+        final buffer = StringBuffer('');
+        for (
+          int gatherIndex = longLineIndex + 1;
+          gatherIndex < length;
+          ++gatherIndex
+        ) {
+          var gatherLine = this[gatherIndex];
+          if (gatherLine == null) continue;
+          if (gatherLine.isEmpty) {
+            i = gatherIndex;
+            this[longLineIndex] = buffer.toString();
+            continue;
+          }
+          this[gatherIndex] = null;
+          buffer.write(gatherLine);
+          buffer.write(' ');
         }
-      }
-      if (inParagraph) {
-        throw 0; // !!!
+        assert(i < length);
       }
     }
-  }*/
+  }
 }
 
 void main() {
@@ -193,8 +194,8 @@ void main() {
       List<String?>.from(contents, growable: false)
         ..removeComments()
         ..removeTrailingWhitespace()
-        ..removeNonNormative() /*
-        ..joinLines()*/;
+        ..removeNonNormative()
+        ..joinLines();
   final simplifiedContents = workingContents.whereType<String>().toList();
   final outputFile = File(outputFilename);
   final outputSink = outputFile.openWrite();

--- a/specification/scripts/simplify_specification.dart
+++ b/specification/scripts/simplify_specification.dart
@@ -333,6 +333,24 @@ extension on List<String?> {
       }
     }
   }
+
+  void removeSpuriousEmptyLines() {
+    final length = this.length;
+    bool previousLineWasEmpty = false;
+    for (int i = 0; i < length; ++i) {
+      var line = this[i];
+      if (line == null) continue;
+      if (line.isEmpty) {
+        if (previousLineWasEmpty) {
+          this[i] = null;
+        } else {
+          previousLineWasEmpty = true;
+        }
+      } else {
+        previousLineWasEmpty = false;
+      }
+    }
+  }
 }
 
 void main() {
@@ -344,7 +362,9 @@ void main() {
         ..removeComments()
         ..removeTrailingWhitespace()
         ..removeNonNormative()
-        ..joinLines();
+        ..joinLines()
+        ..removeTrailingWhitespace()
+        ..removeSpuriousEmptyLines();
   final simplifiedContents = workingContents.whereType<String>().toList();
   final outputFile = File(outputFilename);
   final outputSink = outputFile.openWrite();

--- a/specification/scripts/simplify_specification.dart
+++ b/specification/scripts/simplify_specification.dart
@@ -30,19 +30,22 @@ void fail(String message) {
 }
 
 extension _RemoveCommentsExtension on List<String> {
-  static final commentRegexp = RegExp("[^%]%\|^%");
+  static final commentRegexp = RegExp("[^%\\]%\|^%");
 
   List<String> get removeComments {
     final result = List<String>.from(this);
     final length = this.length;
-    var inBackMatter = false;
     for (int index = 0; index < length; ++index) {
       final line = result[index];
       final match = commentRegexp.firstMatch(line);
       if (match != null) {
         final cutPosition = match.start == 0 ? 0 : match.start + 1;
         final resultLine = line.substring(0, cutPosition);
-        print('>>> line: "$line", output: "$resultLine"');
+        print('>>> line $index: "${line.substring(cutPosition, line.length)}"');
+      } else if (line.startsWith("\\end{document}")) {
+        // All text beyond `\end{document}` is a comment.
+        result.removeRange(index, result.length);
+        break;
       }
     }
     return result;

--- a/specification/scripts/simplify_specification.dart
+++ b/specification/scripts/simplify_specification.dart
@@ -51,6 +51,12 @@ void fail(String message) {
   exit(-1);
 }
 
+// Several steps in the algorithm are processing ranges of lines.
+// Typically, those ranges are not expected to include the last line in
+// the specification (we're just processing a block of sorts, somewhere
+// in the middle of the document). This function is called after loops
+// that are doing this kind of processing because the loop is expected
+// to reach a `return` statement rather than completing normally.
 Never endOfTextFailure() {
   throw StateError("Internal error: reached end of text.");
 }

--- a/specification/scripts/simplify_specification.dart
+++ b/specification/scripts/simplify_specification.dart
@@ -35,6 +35,9 @@ extension on List<String> {
 
 extension on List<String?> {
   static final _commentRegexp = RegExp("[^%\\\\]%\|^%");
+  static final _commentaryRationaleRegexp = RegExp(
+    "^\\\(commentary\|rationale\)\{",
+  );
 
   static bool _isWhitespace(String text, int index) {
     int codeUnit = text.codeUnitAt(index);
@@ -79,6 +82,20 @@ extension on List<String?> {
       }
     }
   }
+
+  void removeCommentaryAndRationale() {
+    for (int i = 0; i < length; ++i) {
+      final line = this[i];
+      if (line == null) continue;
+      final match = _commentaryRationaleRegexp.firstMatch(line);
+      if (line.startsWith(r"\commentary{") || line.startsWith(r"\rationale{")) {
+        print(line);
+        while (i < length && !line.startsWith("}")) {
+          this[i] = null;
+        }
+      }
+    }
+  }
 }
 
 void main() {
@@ -88,10 +105,9 @@ void main() {
   final simplifiedContents =
       contents.setup
         ..removeComments()
-        ..removeTrailingWhitespace(); /*
-          .removeCommentary
-          .removeRationale
-          .joinLines;*/
+        ..removeTrailingWhitespace()
+        ..removeCommentaryAndRationale(); /*
+        ..joinLines;*/
 
   final outputFile = File(outputFilename);
   final outputSink = outputFile.openWrite();

--- a/specification/scripts/simplify_specification.dart
+++ b/specification/scripts/simplify_specification.dart
@@ -202,7 +202,7 @@ extension on List<String?> {
       final line = this[searchIndex];
       if (line == null) continue;
       final trimmedLine = line.trimLeft();
-      if (trimmedLine.startsWith(r"\end{itemize}") == true) {
+      if (trimmedLine.startsWith(r"\end{itemize}")) {
         throw "_findItem did not find any items";
       }
       if (trimmedLine.startsWith(r"\item")) {
@@ -306,7 +306,7 @@ extension on List<String?> {
   /// Also handle nested itemized lists (no attempt to balance them, we
   /// just rely on finding `\end{itemize}` at the beginning of a line).
   int _processItemizedList(final int listIndex) {
-    var itemIndex = listIndex + 1;
+    var itemIndex = listIndex;
     var done = false;
     do {
       (done, itemIndex) = _gatherItems(itemIndex);

--- a/specification/scripts/simplify_specification.dart
+++ b/specification/scripts/simplify_specification.dart
@@ -32,10 +32,10 @@ void fail(String message) {
 extension on List<String?> {
   static final _commentRegExp = RegExp(r"^%|[^%\\]%");
   static final _commentaryRationaleRegExp = RegExp(
-    r"^ *\\(commentary|rationale){",
+    r"^ *\(?\\(commentary|rationale){",
   );
   static final _bracesRegExp = RegExp(r"\\[a-zA-Z]*{.*}");
-  static final _parenBracesRexExp = RegExp(r"(\\[a-zA-Z]*{.*})");
+  static final _parenBracesRexExp = RegExp(r"\(\\[a-zA-Z]*{.*}\)");
 
   static bool _isWhitespace(String text, int index) {
     int codeUnit = text.codeUnitAt(index);
@@ -117,35 +117,26 @@ extension on List<String?> {
         final matchParenthesizedOneliner = _parenBracesRexExp.firstMatch(line);
         if (matchParenthesizedOneliner != null) {
           if (matchParenthesizedOneliner.start == 0 &&
-              matchParenthesizedOneliner.end == line.length - 1) {
-            print('>>> matchParenthesizedOneliner, all: "$line"'); // DEBUG
+              matchParenthesizedOneliner.end == line.length) {
             this[i] = null;
           } else {
-            final resultLine = line.replaceRange(
+            this[i] = line.replaceRange(
               matchParenthesizedOneliner.start,
               matchParenthesizedOneliner.end,
               '',
             );
-            this[i] = resultLine;
-            print(
-              '>>> matchParenthesizedOneliner, some: "$line", "$resultLine"',
-            ); // DEBUG
           }
         } else {
           final matchOneliner = _bracesRegExp.firstMatch(line);
           if (matchOneliner != null) {
-            if (matchOneliner.start == 0 &&
-                matchOneliner.end == line.length - 1) {
-              print('>>> matchOneliner, all: "$line"'); // DEBUG
+            if (matchOneliner.start == 0 && matchOneliner.end == line.length) {
               this[i] = null;
             } else {
-              final resultLine = line.replaceRange(
+              this[i] = line.replaceRange(
                 matchOneliner.start,
                 matchOneliner.end,
                 '',
               );
-              this[i] = resultLine;
-              print('>>> matchOneliner, some: "$line", "$resultLine"'); // DEBUG
             }
           } else {
             final lineStart = _lineStart(line);

--- a/specification/scripts/simplify_specification.dart
+++ b/specification/scripts/simplify_specification.dart
@@ -37,6 +37,8 @@ extension on String {
   bool get isItem => startsWith(r"\item");
   bool get startsCode => startsWith(r"\begin{normativeDartCode}");
   bool get endsCode => startsWith(r"\end{normativeDartCode}");
+  bool get startsMinipage => contains(r"\begin{minipage}");
+  bool get endsMinipage => contains(r"\end{minipage}");
 }
 
 extension on List<String?> {
@@ -255,10 +257,16 @@ extension on List<String?> {
     var buffer = StringBuffer(itemLine!.trimRight());
     var insertSpace = true;
     var inCode = false;
+    var inMinipage = false;
 
     for (var gatherIndex = itemIndex + 1; gatherIndex < length; ++gatherIndex) {
       var gatherLine = this[gatherIndex]; // Invariant.
       if (gatherLine == null) continue;
+      if (gatherLine.startsMinipage) inMinipage = true;
+      if (inMinipage) {
+        if (gatherLine.endsMinipage) inMinipage = false;
+        continue;
+      }
       if (gatherLine.startsCode) inCode = true;
       if (inCode) {
         if (gatherLine.endsCode) inCode = false;

--- a/specification/scripts/simplify_specification.dart
+++ b/specification/scripts/simplify_specification.dart
@@ -1,0 +1,36 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// Create a simplified version of 'dartLangSpec.tex'.
+///
+/// This script creates a version of 'dartLangSpec.tex' that does not
+/// contain comments, commentary text, or rationale text. It eliminates
+/// all newline characters in a paragraph (that is, each paragraph is
+/// entirely on the same line).
+///
+/// The purpose of this transformation is that the output can be grepped
+/// more effectively (the original version may have a newline in the
+/// middle of the phrase that we're looking for), and more precisely
+/// (the originl version could have hits in comments, commentary, etc,
+/// and it is assumed that we only want to find normative text).
+///
+/// The script should be executed with '..' as the current directory,
+/// that is, the directory where 'dartLangSpec.tex' is located.
+library;
+
+import 'dart:io';
+
+const specificationFilename = 'dartLangSpec.tex';
+const simplifiedFilename = 'dartLangSpec-simple.tex';
+
+void fail(String message) {
+  print("simplify_specification error: $message");
+  exit(-1);
+}
+
+void main() {
+  final specificationFile = File(specificationFilename);
+  if (!specificationFile.existsSync()) fail("Specification not found");
+  
+}

--- a/specification/scripts/simplify_specification.dart
+++ b/specification/scripts/simplify_specification.dart
@@ -251,6 +251,9 @@ extension on List<String?> {
       if (trimmedGatherLine.startsWith(r"\begin{itemize}")) {
         // We do not gather a nested itemized list into the current item.
         // Finalize the current item.
+        if (gatherIndex == 2044) {
+          print('>>> gatherIndex: $gatherIndex, itemIndex: $itemIndex');
+        }
         this[itemIndex] = buffer.toString();
         // Set up the first item of the nested itemized list.
         itemIndex = _findItem(gatherIndex + 1);

--- a/specification/scripts/simplify_specification.dart
+++ b/specification/scripts/simplify_specification.dart
@@ -258,7 +258,7 @@ extension on List<String?> {
       if (gatherLine.startsWith(r"\end{itemize}")) {
         // At the end of the outermost itemized list: Done.
         this[itemIndex] = buffer.toString();
-        return gatherIndex + 1;
+        return gatherIndex;
       }
       final foundItem = trimmedGatherLine.startsWith(r"\item");
       final foundEnd = trimmedGatherLine.startsWith(r"\end{itemize}");
@@ -276,8 +276,16 @@ extension on List<String?> {
           // Gather lines after the nested itemized list, if any. Note
           /// that `itemLine` does not contain `\item`, but it's treated
           /// as if it did contain `\item`.
+          if (gatherIndex == 2075) {
+            print('>>> gatherIndex: $gatherIndex'); //DEBUG
+          }
           itemIndex = _findText(gatherIndex + 1);
           itemLine = this[itemIndex]; // Restore the `itemLine` invariant.
+          if (itemLine!.startsWith(r"\end{itemize}")) {
+            // No extra lines, at the end of the outermost itemized list: Done.
+            return itemIndex + 1;
+          }
+          // Some extra text found, gather it.
           gatherIndex = itemIndex + 1;
           continue;
         }

--- a/specification/scripts/simplify_specification.dart
+++ b/specification/scripts/simplify_specification.dart
@@ -36,7 +36,7 @@ extension on List<String> {
 extension on List<String?> {
   static final _commentRegexp = RegExp("[^%\\\\]%\|^%");
   static final _commentaryRationaleRegexp = RegExp(
-    "^\\\(commentary\|rationale\)\{",
+    "^ *\\\(commentary\|rationale\)\{",
   );
 
   static bool _isWhitespace(String text, int index) {
@@ -88,9 +88,10 @@ extension on List<String?> {
       final line = this[i];
       if (line == null) continue;
       final match = _commentaryRationaleRegexp.firstMatch(line);
-      if (line.startsWith(r"\commentary{") || line.startsWith(r"\rationale{")) {
-        print(line);
-        while (i < length && !line.startsWith("}")) {
+      if (match != null) {
+        final lineStart = '${line.substring(0, match.start - 1)}}';
+        print('>>> line: $line, lineStart: $lineStart'); // DEBUG
+        while (i < length && !line.startsWith(lineStart)) {
           this[i] = null;
         }
       }

--- a/specification/scripts/simplify_specification.dart
+++ b/specification/scripts/simplify_specification.dart
@@ -168,6 +168,7 @@ extension on List<String?> {
         final longLineIndex = lineIndex;
         final buffer = StringBuffer('');
         var firstInParagraph = true;
+        var doTrimLeft = false;
         for (
           var gatherIndex = longLineIndex + 1;
           gatherIndex < length;
@@ -185,7 +186,22 @@ extension on List<String?> {
           } else {
             buffer.write(' ');
           }
-          buffer.write(gatherLine);
+          final endsInPercent =
+              gatherLine.isNotEmpty &&
+              gatherLine.codeUnitAt(gatherLine.length - 1) == 37;
+          final String addLine;
+          if (doTrimLeft && endsInPercent) {
+            addLine = gatherLine.substring(0, gatherLine.length - 1).trimLeft();
+          } else if (doTrimLeft) {
+            addLine = gatherLine.trimLeft();
+            doTrimLeft = false;
+          } else if (endsInPercent) {
+            addLine = gatherLine.substring(0, gatherLine.length - 1);
+            doTrimLeft = true;
+          } else {
+            addLine = gatherLine;
+          }
+          buffer.write(addLine);
           this[gatherIndex] = gatherLine = null;
         }
         assert(lineIndex < length);

--- a/specification/scripts/simplify_specification.dart
+++ b/specification/scripts/simplify_specification.dart
@@ -276,9 +276,6 @@ extension on List<String?> {
           // Gather lines after the nested itemized list, if any. Note
           /// that `itemLine` does not contain `\item`, but it's treated
           /// as if it did contain `\item`.
-          if (gatherIndex == 2075) {
-            print('>>> gatherIndex: $gatherIndex'); //DEBUG
-          }
           itemIndex = _findText(gatherIndex + 1);
           itemLine = this[itemIndex]; // Restore the `itemLine` invariant.
           if (itemLine!.startsWith(r"\end{itemize}")) {

--- a/specification/scripts/simplify_specification.dart
+++ b/specification/scripts/simplify_specification.dart
@@ -246,9 +246,6 @@ extension on List<String?> {
       if (trimmedGatherLine.startsWith(r"\begin{itemize}")) {
         // We do not gather a nested itemized list into the current item.
         // Finalize the current item.
-        if (gatherIndex == 5725) {
-          print('gatherIndex: $gatherIndex'); // DEBUG
-        }
         this[itemIndex] = buffer.toString();
         // Set up the first item of the nested itemized list.
         itemIndex = _findItem(gatherIndex + 1);
@@ -291,7 +288,7 @@ extension on List<String?> {
           } else {
             // Some extra text found, gather it.
             buffer = StringBuffer(itemLine); // Not starting with `\item`.
-            gatherIndex = itemIndex + 1;
+            gatherIndex = itemIndex;
             continue;
           }
         }

--- a/specification/scripts/simplify_specification.dart
+++ b/specification/scripts/simplify_specification.dart
@@ -53,12 +53,23 @@ extension on List<String?> {
         codeUnit == 0xFEFF; // Zero Width No-Break Space (BOM)
   }
 
+  static int _indentation(String text) {
+    final length = text.length;
+    for (int i = 0; i < length; ++i) {
+      if (!_isWhitespace(text, i)) {
+        return i;
+      }
+    }
+    return length;
+  }
+
   static String _lineStart(String line) {
-    if (line.startsWith('        ')) return '        }';
-    if (line.startsWith('      ')) return '      }';
-    if (line.startsWith('    ')) return '    }';
-    if (line.startsWith('  ')) return '  }';
-    return '}';
+    final indentation = _indentation(line);
+    if (indentation > 0)
+      print(
+        '>>> indentation: $indentation. Returning: ${"${' ' * indentation}}"}',
+      ); // DEBUG
+    return "${' ' * indentation}}";
   }
 
   void removeComments() {
@@ -71,6 +82,10 @@ extension on List<String?> {
           this[i] = null; // A comment-only line disappears entirely.
         } else {
           final cutPosition = match.start + 1;
+          if (line.codeUnitAt(cutPosition) == 37) {
+            // An indented comment-only line disappears entirely.
+            this[i] = null;
+          }
           final resultLine = line.substring(0, cutPosition);
           this[i] = resultLine;
         }

--- a/specification/scripts/simplify_specification.dart
+++ b/specification/scripts/simplify_specification.dart
@@ -257,6 +257,7 @@ extension on List<String?> {
       }
       if (gatherLine.startsWith(r"\end{itemize}")) {
         // At the end of the outermost itemized list: Done.
+        this[itemIndex] = buffer.toString();
         return (true, gatherIndex + 1);
       }
       final foundItem = trimmedGatherLine.startsWith(r"\item");

--- a/specification/scripts/simplify_specification.dart
+++ b/specification/scripts/simplify_specification.dart
@@ -36,7 +36,7 @@ extension on List<String> {
 extension on List<String?> {
   static final _commentRegexp = RegExp("[^%\\\\]%\|^%");
   static final _commentaryRationaleRegexp = RegExp(
-    "^ *\\\(commentary\|rationale\)\{",
+    r"^\\\(commentary\|rationale\){",
   );
 
   static bool _isWhitespace(String text, int index) {
@@ -84,6 +84,7 @@ extension on List<String?> {
   }
 
   void removeCommentaryAndRationale() {
+    print(_commentaryRationaleRegexp);
     for (int i = 0; i < length; ++i) {
       final line = this[i];
       if (line == null) continue;

--- a/specification/scripts/simplify_specification.dart
+++ b/specification/scripts/simplify_specification.dart
@@ -151,9 +151,9 @@ extension on List<String?> {
     }
   }
 
-  // TODO!!!
   void joinLines() {
     bool inFrontMatter = true;
+    L:
     for (int i = 0; i < length; ++i) {
       final line = this[i];
       if (line == null) continue;
@@ -174,7 +174,7 @@ extension on List<String?> {
           if (gatherLine.isEmpty) {
             i = gatherIndex;
             this[longLineIndex] = buffer.toString();
-            continue;
+            continue L;
           }
           this[gatherIndex] = null;
           buffer.write(gatherLine);

--- a/specification/scripts/simplify_specification.dart
+++ b/specification/scripts/simplify_specification.dart
@@ -180,19 +180,17 @@ extension on List<String?> {
         this[paragraphIndex] = buffer.toString();
         return gatherIndex;
       }
-      if (insertSpace) {
-        buffer.write(' ');
-      }
+      final spacing = insertSpace ? ' ' : '';
       final endsInPercent = gatherLine.endsWith('%');
       final String addLine;
       if (endsInPercent) {
-        addLine = gatherLine.substring(0, gatherLine.length - 1);
+        addLine = gatherLine.substring(0, gatherLine.length - 1).trimLeft();
         insertSpace = false;
       } else {
-        addLine = gatherLine;
+        addLine = gatherLine.trimLeft();
         insertSpace = true;
       }
-      buffer.write(addLine.trimLeft());
+      if (addLine.isNotEmpty) buffer.write('$spacing$addLine');
       this[gatherIndex] = null;
     }
     throw "Internal error: _gatherParagraph reached end of text";
@@ -299,19 +297,17 @@ extension on List<String?> {
         }
       }
       // `gatherLine` is text belonging to the current `\item`.
-      if (insertSpace) {
-        buffer.write(' ');
-      }
+      final spacing = insertSpace ? ' ' : '';
       final endsInPercent = gatherLine.endsWith('%');
       final String addLine;
       if (endsInPercent) {
-        addLine = gatherLine.substring(0, gatherLine.length - 1);
+        addLine = gatherLine.substring(0, gatherLine.length - 1).trimLeft();
         insertSpace = false;
       } else {
-        addLine = gatherLine;
+        addLine = gatherLine.trimLeft();
         insertSpace = true;
       }
-      buffer.write(addLine.trimLeft());
+      if (addLine.isNotEmpty) buffer.write('$spacing$addLine');
       this[gatherIndex] = null;
     }
     throw "_gatherItems reached end of text";

--- a/specification/scripts/simplify_specification.dart
+++ b/specification/scripts/simplify_specification.dart
@@ -35,6 +35,8 @@ extension on String {
   bool get endsList =>
       startsWith(r"\end{itemize}") || startsWith(r"\end{enumerate}");
   bool get isItem => startsWith(r"\item");
+  bool get startsCode => startsWith(r"\begin{normativeDartCode}");
+  bool get endsCode => startsWith(r"\end{normativeDartCode}");
 }
 
 extension on List<String?> {
@@ -252,10 +254,16 @@ extension on List<String?> {
     var itemLine = this[itemIndex]; // Invariant.
     var buffer = StringBuffer(itemLine!.trimRight());
     var insertSpace = true;
+    var inCode = false;
 
     for (var gatherIndex = itemIndex + 1; gatherIndex < length; ++gatherIndex) {
       var gatherLine = this[gatherIndex]; // Invariant.
       if (gatherLine == null) continue;
+      if (gatherLine.startsCode) inCode = true;
+      if (inCode) {
+        if (gatherLine.endsCode) inCode = false;
+        continue;
+      }
       final trimmedGatherLine = gatherLine.trimLeft();
       if (trimmedGatherLine.startsList) {
         // We do not gather a nested itemized list into the current item.

--- a/specification/scripts/simplify_specification.dart
+++ b/specification/scripts/simplify_specification.dart
@@ -264,7 +264,27 @@ extension on List<String?> {
       if (gatherLine == null) continue;
       if (gatherLine.startsMinipage) inMinipage = true;
       if (inMinipage) {
-        if (gatherLine.endsMinipage) inMinipage = false;
+        if (gatherLine.endsMinipage) {
+          inMinipage = false;
+          // Finalize current item, set up new.
+          this[itemIndex] = buffer.toString();
+          itemIndex = _findText(gatherIndex + 1);
+          itemLine = this[itemIndex]; // Restore the `itemLine` invariant.
+          if (itemLine!.endsList) {
+            // No extra lines, at the end of the outermost itemized list: Done.
+            return itemIndex + 1;
+          } else if (itemLine.trimLeft().isItem) {
+            // No extra lines, starting a new item.
+            buffer = StringBuffer(itemLine);
+            gatherIndex = itemIndex;
+            continue;
+          } else {
+            // Some extra text found, gather it.
+            buffer = StringBuffer(itemLine); // Not starting with `\item`.
+            gatherIndex = itemIndex;
+            continue;
+          }
+        }
         continue;
       }
       if (gatherLine.startsCode) inCode = true;

--- a/specification/scripts/simplify_specification.dart
+++ b/specification/scripts/simplify_specification.dart
@@ -246,14 +246,16 @@ extension on List<String?> {
       if (trimmedGatherLine.startsWith(r"\begin{itemize}")) {
         // We do not gather a nested itemized list into the current item.
         // Finalize the current item.
+        if (gatherIndex == 5725) {
+          print('gatherIndex: $gatherIndex'); // DEBUG
+        }
         this[itemIndex] = buffer.toString();
         // Set up the first item of the nested itemized list.
         itemIndex = _findItem(gatherIndex + 1);
         itemLine = this[itemIndex];
         buffer = StringBuffer(itemLine!);
-        gatherIndex = itemIndex + 1;
-        gatherLine = this[gatherIndex]; // Restore the invariant.
-        if (gatherLine == null) continue;
+        gatherIndex = itemIndex;
+        continue;
       }
       if (gatherLine.startsWith(r"\end{itemize}")) {
         // At the end of the outermost itemized list: Done.

--- a/specification/scripts/simplify_specification.dart
+++ b/specification/scripts/simplify_specification.dart
@@ -164,6 +164,7 @@ extension on List<String?> {
       if (line.startsWith(r"\LMHash{}")) {
         final longLineIndex = i;
         final buffer = StringBuffer('');
+        var firstInParagraph = true;
         for (
           int gatherIndex = longLineIndex + 1;
           gatherIndex < length;
@@ -177,8 +178,12 @@ extension on List<String?> {
             continue L;
           }
           this[gatherIndex] = null;
+          if (firstInParagraph) {
+            firstInParagraph = false;
+          } else {
+            buffer.write(' ');
+          }
           buffer.write(gatherLine);
-          buffer.write(' ');
         }
         assert(i < length);
       }


### PR DESCRIPTION
The language specification uses semantic line breaks and rather short lines. This means that it gets somewhat inconvenient to search in a number of situations. For example, we may find the command `\Error{compile-time error}` on one line and the text that describes which error it is on the next line. Also, when searching the language specification for hard facts it may create some noise that a rather large portion of the language specification is commentary, rationale, and comments.

This PR adds a small script that processes the language specification such that it is more convenient to search for hard facts: It removes comments, commentary, and rationale, and it joins paragraphs written as several lines into a single line. This terse version of the language specification can be created by invoking `make terse`.
