### PR TITLE
Upload the specification PDF to a PR specific subdirectory

### DIFF
--- a/.cloud_build/specification/cloudbuild.yaml
+++ b/.cloud_build/specification/cloudbuild.yaml
@@ -7,4 +7,4 @@ options:
 artifacts:
   objects:
     location: 'gs://dart-specification/'
-    paths: ['artifacts/**']
+    paths: ['specification/artifacts/**']

--- a/.cloud_build/specification/cloudbuild.yaml
+++ b/.cloud_build/specification/cloudbuild.yaml
@@ -1,6 +1,6 @@
 steps:
 - name: 'ubuntu'
-  script: 'pwd; ls; ls specification; ls specification/scripts'
+  script: 'pwd; ls -l specification/scripts'
 - name: 'bash'
   args: ['specification/scripts/build_pdf']
 options:

--- a/.cloud_build/specification/cloudbuild.yaml
+++ b/.cloud_build/specification/cloudbuild.yaml
@@ -1,7 +1,7 @@
 steps:
-- name: 'bash'
-  args: ['specification/scripts/build_pdf']
 - name: 'ubuntu'
   script: pwd
+- name: 'bash'
+  args: ['specification/scripts/build_pdf']
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/.cloud_build/specification/cloudbuild.yaml
+++ b/.cloud_build/specification/cloudbuild.yaml
@@ -1,6 +1,6 @@
 steps:
 - name: 'ubuntu'
-  script: pwd
+  script: 'pwd; ls; ls specification; ls specification/scripts'
 - name: 'bash'
   args: ['specification/scripts/build_pdf']
 options:

--- a/.cloud_build/specification/cloudbuild.yaml
+++ b/.cloud_build/specification/cloudbuild.yaml
@@ -1,2 +1,3 @@
 steps:
-- name:  'gcr.io/cloud-builders/docker'
+- name: 'bash'
+  args: ['specification/scripts/build_pdf']

--- a/.cloud_build/specification/cloudbuild.yaml
+++ b/.cloud_build/specification/cloudbuild.yaml
@@ -1,3 +1,5 @@
 steps:
 - name: 'bash'
   args: ['specification/scripts/build_pdf']
+- name: 'ubuntu'
+  script: pwd

--- a/.cloud_build/specification/cloudbuild.yaml
+++ b/.cloud_build/specification/cloudbuild.yaml
@@ -3,3 +3,5 @@ steps:
   args: ['specification/scripts/build_pdf']
 - name: 'ubuntu'
   script: pwd
+options:
+  logging: CLOUD_LOGGING_ONLY

--- a/.cloud_build/specification/cloudbuild.yaml
+++ b/.cloud_build/specification/cloudbuild.yaml
@@ -2,4 +2,9 @@ steps:
 - name: 'ubuntu'
   args: ['specification/scripts/build_pdf']
 options:
+  automapSubstitutions: true
   logging: CLOUD_LOGGING_ONLY
+artifacts:
+  objects:
+    location: 'gs://dart-specification/'
+    paths: ['artifacts/**']

--- a/.cloud_build/specification/cloudbuild.yaml
+++ b/.cloud_build/specification/cloudbuild.yaml
@@ -1,0 +1,2 @@
+steps:
+- name:  'gcr.io/cloud-builders/docker'

--- a/.cloud_build/specification/cloudbuild.yaml
+++ b/.cloud_build/specification/cloudbuild.yaml
@@ -1,7 +1,5 @@
 steps:
 - name: 'ubuntu'
-  script: 'pwd; ls -l specification/scripts'
-- name: 'bash'
   args: ['specification/scripts/build_pdf']
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/.cloud_build/specification/cloudbuild.yaml
+++ b/.cloud_build/specification/cloudbuild.yaml
@@ -6,5 +6,5 @@ options:
   logging: CLOUD_LOGGING_ONLY
 artifacts:
   objects:
-    location: 'gs://dart-specification/'
+    location: 'gs://dart-specification/$_PR_NUMBER/'
     paths: ['specification/artifacts/**']

--- a/specification/.gitignore
+++ b/specification/.gitignore
@@ -11,3 +11,4 @@ dartLangSpec-terse.tex
 *-list.txt
 .dart_tool/
 .packages
+firebase/

--- a/specification/scripts/build_pdf
+++ b/specification/scripts/build_pdf
@@ -2,7 +2,7 @@
 
 apt-get update -qq
 apt-get install \
-    make \
+    build-essential \
     texlive-latex-base \
     texlive-latex-extra \
     texlive-fonts-recommended \

--- a/specification/scripts/build_pdf
+++ b/specification/scripts/build_pdf
@@ -1,4 +1,4 @@
-#!/bin/bash --norc
+#!/usr/bin/env bash --norc
 
 sudo apt-get update -qq
 sudo apt-get install \

--- a/specification/scripts/build_pdf
+++ b/specification/scripts/build_pdf
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash --norc
+#!/bin/bash --norc
 
 sudo apt-get update -qq
 sudo apt-get install \

--- a/specification/scripts/build_pdf
+++ b/specification/scripts/build_pdf
@@ -2,6 +2,7 @@
 
 apt-get update -qq
 apt-get install \
+    make \
     texlive-latex-base \
     texlive-latex-extra \
     texlive-fonts-recommended \

--- a/specification/scripts/build_pdf
+++ b/specification/scripts/build_pdf
@@ -9,5 +9,5 @@ apt-get install -y --no-install-recommends \
     lmodern
 cd specification
 make
-mkdir firebase
-cp dartLangSpec.pdf firebase/DartLangSpecDraft.pdf
+mkdir artifacts
+cp dartLangSpec.pdf artifacts/DartLangSpecDraft.pdf

--- a/specification/scripts/build_pdf
+++ b/specification/scripts/build_pdf
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S bash --norc
 
-sudo apt-get update -qq
-sudo apt-get install \
+apt-get update -qq
+apt-get install \
     texlive-latex-base \
     texlive-latex-extra \
     texlive-fonts-recommended \

--- a/specification/scripts/build_pdf
+++ b/specification/scripts/build_pdf
@@ -1,4 +1,4 @@
-#!/bin/bash --norc
+#!/usr/bin/env -S bash --norc
 
 sudo apt-get update -qq
 sudo apt-get install \

--- a/specification/scripts/build_pdf
+++ b/specification/scripts/build_pdf
@@ -1,0 +1,12 @@
+#!/bin/bash --norc
+
+sudo apt-get update -qq
+sudo apt-get install \
+    texlive-latex-base \
+    texlive-latex-extra \
+    texlive-fonts-recommended \
+    lmodern
+cd specification
+make
+mkdir firebase
+cp dartLangSpec.pdf firebase/DartLangSpecDraft.pdf

--- a/specification/scripts/build_pdf
+++ b/specification/scripts/build_pdf
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S bash --norc
 
 apt-get update -qq
-apt-get install \
+apt-get install -y --no-install-recommends \
     build-essential \
     texlive-latex-base \
     texlive-latex-extra \


### PR DESCRIPTION
In `.cloud_build/specification/cloudbuild.yaml` it is specified that the PDF of the specification which was created by specification/scripts/build_pdf` should be uploaded; this PR changes the destination such that each PR will upload to its own subdirectory.