### PR TITLE
Add redirection to firebase.json

### DIFF
--- a/specification/firebase.json
+++ b/specification/firebase.json
@@ -8,7 +8,12 @@
     ],
     "redirects": [
       {
-        "source": "pr/:pr/DartLangSpecDraft.pdf",
+         "source": "/DartLangSpecDraft.pdf",
+         "destination": "https://storage.googleapis.com/dart-specification/DartLangSpecDraft.pdf",
+         "type": 302
+      },
+      {
+        "source": "/pr/:pr/DartLangSpecDraft.pdf",
         "destination": "https://storage.googleapis.com/dart-specification/pr/:pr/DartLangSpecDraft.pdf",
         "type": 301
       },


### PR DESCRIPTION
This PR adds a redirection to the `firebase.json` specification of the language repository˜ such that `DartLangSpecDraft.pdf` can be fetched from a Google cloud storage bucket.