### PR TITLE
Update the primary constructors proposal to give the body access to header parameters

### DIFF
--- a/working/2364 - primary constructors/feature-specification.md
+++ b/working/2364 - primary constructors/feature-specification.md
@@ -1,17 +1,17 @@
-# Primary Constructors
+# Declaring and Primary Constructors
 
 Author: Erik Ernst
 
 Status: Draft
 
-Version: 1.6
+Version: 1.8
 
-Experiment flag: primary-constructors
+Experiment flag: declaring-constructors
 
-This document specifies _primary constructors_. This is a feature that
+This document specifies _declaring constructors_. This is a feature that
 allows one constructor and a set of instance variables to be specified in a
 concise form in the header of the declaration, or in the body. In the case
-where the constructor is specified in the header, some elements are still
+where the constructor is specified in the header, some elements can still be
 specified in the class body, if present: The in-header constructor can have
 an initializer list in the body, including assertions, instance variable
 initializers, and/or a superinitializer. The in-header constructor can also
@@ -27,7 +27,8 @@ feature have taken place in github issues marked with the
 
 Recently, [Bob proposed][] that primary body constructors should use the syntax
 `this.name(...)` rather than `primary C.name(...)`. This proposal includes
-that choice.
+that choice. Several recent updates to this proposal are based on ideas from
+that proposal.
 
 [struct proposal]: https://github.com/dart-lang/language/blob/master/working/extension_structs/overview.md
 [kotlin primary constructors]: https://kotlinlang.org/docs/classes.html#constructors
@@ -38,7 +39,7 @@ that choice.
 
 ## Introduction
 
-Primary constructors is a conciseness feature. It does not provide any new
+Declaring constructors is a conciseness feature. It does not provide any new
 semantics at all. It just allows us to express something which is already
 possible in Dart, using a less verbose notation. Consider this sample class
 with two fields and a constructor:
@@ -52,34 +53,38 @@ class Point {
 }
 ```
 
-A primary constructor in the header allows us to define the same class much
+A declaring constructor in the header allows us to define the same class much
 more concisely:
 
 ```dart
-// A declaration with the same meaning, using a primary header constructor.
+// A declaration with the same meaning, using a declaring header constructor.
 class Point(var int x, var int y);
 ```
 
-A class that has a primary header constructor can not have any other
+A class that has a declaring header constructor can not have any other
 generative non-redirecting constructors. This requirement must be upheld
-because it must be guaranteed that the primary header constructor is
+because it must be guaranteed that the declaring header constructor is
 actually executed on every newly created instance of this class. This rule
 is further motivated below.
 
-A primary body constructor is slightly less concise, but it allows the
+A declaring header constructor is also known as a _primary constructor_, 
+because all other generative constructors must invoke the primary one
+(directly or indirectly).
+
+A declaring body constructor is slightly less concise, but it allows the
 class header to remain simpler and more readable when there are many
-parameters. The previous example would look as follows using a primary body
-constructor:
+parameters. The previous example would look as follows using a declaring
+body constructor:
 
 ```dart
-// A declaration with the same meaning, using a primary body constructor.
+// A declaration with the same meaning, using a declaring body constructor.
 class Point {
   this(var int x, var int y);
 }
 ```
 
 In the examples below we show the current syntax directly followed by a
-declaration using a primary constructor. The meaning of the two (or more)
+declaration using a declaring constructor. The meaning of the two (or more)
 class declarations with the same name is always the same. Of course, we
 would have a name clash if we actually put those two declarations into the
 same library, so we should read the examples as "you can write this _or_
@@ -93,17 +98,17 @@ class Point {
   Point(this.x, this.y);
 }
 
-// Using a primary header constructor.
+// Using a declaring header constructor (aka primary constructor).
 class Point(var int x, var int y);
 
-// Using a primary body constructor.
+// Using a declaring body constructor.
 class Point {
   this(var int x, var int y);
 }
 ```
 
 These examples will serve as an illustration of the proposed syntax, but
-they will also illustrate the semantics of the primary constructor
+they will also illustrate the semantics of the declaring constructor
 declarations, because those declarations work exactly the same as the
 declarations using the current syntax.
 
@@ -126,16 +131,16 @@ Similarly, with this feature a regular (non-declaring) formal parameter can
 not be declared with the syntax `var name`, it must have a type (`T name`)
 or the type must be omitted (`name`).
 
-A primary header constructor can have a body and/or an initializer list.
+A declaring header constructor can have a body and/or an initializer list.
 These elements are placed in the class body in a declaration that provides
 "the rest" of the constructor declaration which is given in the header.
 
-The parameter list of a primary constructor (in the header or in the body)
+The parameter list of a declaring constructor (in the header or in the body)
 uses a slightly different grammar than other functions. The difference is
 that it can include declaring formal parameters. They can be recognized
 unambiguously because they have the modifier `var` or `final`.
 
-A primary body constructor can have a body and an initializer list as well
+A declaring body constructor can have a body and an initializer list as well
 as initializing formals and super parameters, just like other constructors
 in the body.
 
@@ -153,13 +158,13 @@ class ModifierClass {
   ModifierClass(this.x);
 }
 
-// Using a primary header constructor.
+// Using a primary constructor.
 class ModifierClass(this.x) {
   late int x;
   external double d;
 }
 
-// Using a primary body constructor.
+// Using a declaring body constructor.
 class ModifierClass {
   late int x;
   external double d;
@@ -184,11 +189,11 @@ class B extends A {
   B(super.a);
 }
 
-// Using a primary header constructor.
+// Using a primary constructor.
 class A(final int a);
 class B(super.a) extends A;
 
-// Using a primary body constructor.
+// Using a declaring body constructor.
 class A {
   this(final int a);
 }
@@ -208,10 +213,10 @@ class Point {
   const Point._(this.x, this.y);
 }
 
-// Using a primary header constructor.
+// Using a primary constructor.
 class const Point._(final int x, final int y);
 
-// Using a primary body constructor.
+// Using a declaring body constructor.
 class Point {
   const this._(final int x, final int y);
 }
@@ -220,7 +225,7 @@ class Point {
 Note that the class header contains syntax that resembles the constructor
 declaration, which may be helpful when reading the code.
 
-With the primary header constructor, the modifier `const` could have been
+With the primary constructor, the modifier `const` could have been
 placed on the class (`const class`) rather than on the class name. This
 proposal puts it on the class name because the notion of a "constant class"
 conflicts with with actual semantics: It is the constructor which is
@@ -232,23 +237,23 @@ the rest of the language to say that this particular primary constructor is
 a "constant constructor". Hence `class const Name` rather than `const class
 Name`.
 
-The modifier `final` on a parameter in a primary constructor specifies that
-the instance variable declaration which is induced by this primary
+The modifier `final` on a parameter in a declaring constructor specifies
+that the instance variable declaration which is induced by this declaring
 constructor parameter is `final`.
 
 In the case where the declaration is an `extension type`, the modifier
 `final` on the representation variable can be specified or omitted. Note
-that an extension type declaration is specified to use a primary header
+that an extension type declaration is specified to use a primary
 constructor (in that case there is no other choice, it is in the grammar
 rules):
 
 ```dart
-// Using a primary header constructor.
+// Using a primary constructor.
 extension type I.name(int x);
 ```
 
-Optional parameters can be declared as usual in a primary constructor, with
-default values that must be constant as usual:
+Optional parameters can be declared as usual in a declaring constructor,
+with default values that must be constant as usual:
 
 ```dart
 // Current syntax.
@@ -258,10 +263,10 @@ class Point {
   Point(this.x, [this.y = 0]);
 }
 
-// Using a primary header constructor.
+// Using a primary constructor.
 class Point(var int x, [var int y = 0]);
 
-// Using a primary body constructor.
+// Using a declaring body constructor.
 class Point {
   this(var int x, [var int y = 0]);
 }
@@ -290,10 +295,10 @@ class Point {
   Point(this.x, {required this.y});
 }
 
-// Using a primary header constructor.
+// Using a primary constructor.
 class Point(var int x, {required var int y});
 
-// Using a primary body constructor.
+// Using a declaring body constructor.
 class Point {
   this(var int x, {required var int y});
 }
@@ -310,13 +315,13 @@ class D<TypeVariable extends Bound> extends A with M implements B, C {
   const D.named(this.x, [this.y = 0]);
 }
 
-// Using a primary header constructor.
+// Using a primary constructor.
 class const D<TypeVariable extends Bound>.named(
   var int x, [
   var int y = 0,
 ]) extends A with M implements B, C;
 
-// Using a primary body constructor.
+// Using a declaring body constructor.
 class D<TypeVariable extends Bound> extends A with M implements B, C {
   const this.named(
     var int x, [
@@ -325,7 +330,7 @@ class D<TypeVariable extends Bound> extends A with M implements B, C {
 }
 ```
 
-It is possible to specify assertions on a primary constructor, just like
+It is possible to specify assertions on a declaring constructor, just like
 the ones that we can specify in the initializer list of a regular
 constructor:
 
@@ -337,22 +342,22 @@ class Point {
   Point(this.x, this.y): assert(0 <= x && x <= y * y);
 }
 
-// Using a primary header constructor.
+// Using a primary constructor.
 class Point(var int x, var int y) {
   this : assert(0 <= x && x <= y * y);
 }
 
-// Using a primary body constructor.
+// Using a declaring body constructor.
 class Point {
   this(var int x, var int y): assert(0 <= x && x <= y * y);
 }
 ```
 
-When using a primary body constructor it is possible to use an initializer
-list in order to invoke a superconstructor and/or initialize some
-explicitly declared instance variables with a computed value. The primary
-header constructor can have the same elements, but they are declared in the
-class body.
+When using a declaring body constructor it is possible to use an
+initializer list in order to invoke a superconstructor and/or initialize
+some explicitly declared instance variables with a computed value. The
+declaring header constructor can have the same elements, but they are
+declared in the class body.
 
 ```dart
 // Current syntax.
@@ -369,7 +374,7 @@ class B extends A {
       : s1 = y.toString(), super.someName(x + 1);
 }
 
-// Using primary constructors.
+// Using declaring constructors.
 class const A.someName(final int x);
 
 class B extends A {
@@ -381,15 +386,15 @@ class B extends A {
 }
 ```
 
-A formal parameter of a primary constructor which does not have the
+A formal parameter of a declaring constructor which does not have the
 modifier `var` or `final` does not implicitly induce an instance
-variable. This makes it possible to use a primary constructor (thus
+variable. This makes it possible to use a declaring constructor (thus
 avoiding the duplication of instance variable names and types) even in the
 case where some parameters should not introduce any instance variables (so
 they are just "normal" parameters).
 
-With a primary header constructor, the formal parameters in the header are
-introduced into a new scope. This means that the parameters whose name is
+With a declaring header constructor, the formal parameters in the header are
+introduced into a new scope. This means that each parameter whose name is
 not introduced by any nested scope (e.g., the class body scope) is in scope
 in the class body. It is a compile-time error to refer to such a parameter
 anywhere except in an initializing expression of a non-late instance
@@ -403,30 +408,35 @@ class DeltaPoint {
   DeltaPoint(this.x, int delta): y = x + delta;
 }
 
-// Using a primary header constructor.
+// Using a primary constructor.
 class DeltaPoint(final int x, int delta) {
   final int y = x + delta;
 }
 ```
 
 This is possible because it is guaranteed that the non-late initializers
-are evaluated during the execution of the primary header constructor, such
-that the value of a variable like `delta` is only used at a point in time
-where it exists.
+are evaluated during the execution of the declaring header constructor,
+such that the value of a variable like `delta` is only used at a point in
+time where it exists.
 
 Similarly, if an identifier expression in an initializing expression of a
 non-late instance variable declaration resolves to an instance variable
 (this is currently an error, there is no access to `this`), and there is a
-primary header constructor parameter that corresponds to this instance
+declaring header constructor parameter that corresponds to this instance
 variable (that is, a declaring parameter or an initializing formal with the
 same name), it will evaluate to the value of the parameter.  For example,
 `x` is used in the initializer for `y` in the example above, which is
 possible because of this mechanism.
 
-This can only work if the primary header constructor is guaranteed to be
+This can only work if the declaring header constructor is guaranteed to be
 executed. Hence the rule, mentioned above, that there cannot be any other
-non-redirecting generative constructors in a class that has a primary
+non-redirecting generative constructors in a class that has a declaring
 header constructor.
+
+This further motivates the special terminology where a declaring header
+constructor is known as a primary constructor as well: The _primary_
+constructor is more powerful than other declaring constructors because it
+changes the scoping for the entire class declaration.
 
 Finally, here is an example that illustrates how much verbosity this
 feature tends to eliminate:
@@ -467,7 +477,7 @@ class E extends A {
   }
 }
 
-// Using a primary header constructor.
+// Using a primary constructor.
 class A(String _);
 
 class E({
@@ -490,7 +500,7 @@ class E({
   }
 }
 
-// Using a primary body constructor.
+// Using a declaring body constructor.
 class A {
   this(String _);
 }
@@ -530,7 +540,7 @@ separate proposal, [here][inferred-required] or [here][simpler-parameters].
 ### Syntax
 
 The grammar is modified as follows. Note that the changes include support
-for extension type declarations, because they're intended to use primary
+for extension type declarations, because they're intended to use declaring
 constructors as well.
 
 ```ebnf
@@ -539,12 +549,12 @@ constructors as well.
      'class' <classNamePart> <superclass>? <interfaces>? <classBody>
    | ...;
 
-<primaryHeaderConstructorNoConst> ::= // New rule.
+<primaryConstructorNoConst> ::= // New rule.
      <typeIdentifier> <typeParameters>?
      ('.' <identifierOrNew>)? <declaringParameterList>
 
 <classNamePart> ::= // New rule.
-     'const'? <primaryHeaderConstructorNoConst>
+     'const'? <primaryConstructorNoConst>
    | <typeWithParameters>;
 
 <typeWithParameters> ::= <typeIdentifier> <typeParameters>?
@@ -640,19 +650,19 @@ whose class body is `{}`.
 Let _D_ be a class, extension type, or enum declaration.
 
 A compile-time error occurs if _D_ includes a `<classNamePart>` that
-contains a `<primaryHeaderConstructorNoConst>`, and the body of _D_
-contains a `<constructorSignature>` beginning with `this` that contains a
+contains a `<primaryConstructorNoConst>`, and the body of _D_ contains a
+`<constructorSignature>` beginning with `this` that contains a
 `<declaringParameterList>`.
 
 *That is, it is an error to have a declaring parameter list of a primary
 constructor both in the header and in the body.*
 
 A compile-time error occurs if _D_ includes a `<classNamePart>` that
-does not contain a `<primaryHeaderConstructorNoConst>`, and the body of _D_
+does not contain a `<primaryConstructorNoConst>`, and the body of _D_
 contains a `<constructorSignature>` beginning with `this` that does not
 contain a `<declaringParameterList>`.
 
-*It is an error to have a primary constructor in the class body, but
+*It is an error to have a declaring constructor in the class body, but
 no declaring parameter list, neither in the header nor in the body. Note
 that constant constructors are included because a
 `<constantConstructorSignature>` contains a `<constructorSignature>`.*
@@ -660,59 +670,85 @@ that constant constructors are included because a
 A compile-time error occurs if _D_ includes a `<classNamePart>` beginning
 with `const`, and the body of _D_ contains a `<constructorSignature>`
 beginning with `this` which is not part of a
-`<constantConstructorSignature>`.
+`<constantConstructorSignature>`, and vice versa.
 
 *That is, it is an error for the header to contain `const` if there is a
-primary constructor in the body as well, and it does not contain
-`const`. In short, if the header says `const` then a primary body
-constructor must also say `const`. On the other hand, it is allowed to omit
-`const` in the header and have `const` in a primary body
-constructor. Finally, it is allowed to omit `const` in both locations. In
-this case the constructor is not constant.*
+declaring constructor in the body as well, and it does not contain `const`;
+and it is an error for the header to not contain `const` if there is a
+declaring constructor in the body as well, and it does contain `const`.
+They must agree. Finally, it is of course allowed to omit `const` in both
+locations. In this case the constructor is not constant.*
 
-*The meaning of a primary constructor is defined in terms of rewriting it to a
-body constructor and zero or more instance variable declarations. This implies
-that there is a class body when there is a primary constructor. We do not wish
-to define primary constructors such that the absence or presence of a primary
-constructor can change the length of the superclass chain, and hence `class C;`
-has a class body just like `class C(int i);` and just like `class C extends
-Object {}`, and all three of them have `Object` as their direct superclass.*
+*The meaning of a declaring constructor is defined in terms of rewriting it
+to a body constructor (a regular one, not declaring) and zero or more
+instance variable declarations. This implies that there is a class body
+when there is a declaring constructor. We do not wish to define declaring
+constructors such that the absence or presence of a declaring constructor
+can change the length of the superclass chain, and hence `class C;` has a
+class body just like `class C(int i);` and just like `class C extends
+Object {}`, and all three of them have `Object` as their direct
+superclass.*
+
+Finally, a compile-time error occurs in the case where an identifier
+expression is resolved to yield the value of a declaring or initializing
+formal parameter in a declaring header constructor, and this identifier
+occurs in a function literal, and the corresponding instance variable is
+non-final.
+
+*The point is that it is highly confusing if such a parameter reference is
+considered to be "the same thing" as the variable with the same name which
+is in scope, but the parameter has the initial value of that instance
+variable, and the instance variable has been modified in the meantime.*
+
+*For example:*
+
+```dart
+class C(var int x) {
+  var closure = () => x; // Warning!
+}
+
+main() {
+  var c = C(1);
+  c.x = 2;
+  print(c.closure()); // Prints 1.
+}
+```
 
 ### Static processing
 
-Consider a class, enum, or extension type declaration _D_ with a primary
+Consider a class, enum, or extension type declaration _D_ with a declaring
 header constructor *(note that it cannot be a `<mixinApplicationClass>`,
-because that kind of declaration does not support primary constructors,
+because that kind of declaration does not support declaring constructors,
 that is a syntax error)*. This declaration is treated as a class, enum,
-respectively extension type declaration without a primary header
+respectively extension type declaration without a declaring header
 constructor which is obtained as described in the following. This
-determines the dynamic semantics of a primary constructor.
+determines the dynamic semantics of a declaring constructor.
 
 A compile-time error occurs if the body of _D_ contains a non-redirecting
-generative constructor. *This ensures that every constructor invocation
-for this class will invoke the primary header constructor, either directly
-or via a series of generative redirecting constructors. This is required in
+generative constructor. *This ensures that every constructor invocation for
+this class will invoke the declaring header constructor, either directly or
+via a series of generative redirecting constructors. This is required in
 order to allow initializers with no access to `this` to use the
 parameters.*
 
-The declaring parameter list of the primary header constructor introduces a
-new scope, the _declaring parameter scope_, whose enclosing scope is the
+The declaring parameter list of the declaring header constructor introduces
+a new scope, the _declaring parameter scope_, whose enclosing scope is the
 type parameter scope of _D_, if any, and otherwise the enclosing library
 scope. The body scope of _D_ has the declaring parameter scope as its
 enclosing scope.
 
-*This implies that every parameter of the primary header constructor is in
-scope in the class body, unless the class body has a declaration with the
-same name (which would shadow the parameter).*
+*This implies that every parameter of the declaring header constructor is
+in scope in the class body, unless the class body has a declaration with
+the same name (which would shadow the parameter).*
 
-A compile-time error occurs if an identifier resolves to a primary header
+A compile-time error occurs if an identifier resolves to a declaring header
 constructor parameter, unless the identifier occurs in an initializing
 expression of a non-late instance variable declaration.
 
-*We can only use these parameters when it is guaranteed that the primary
+*We can only use these parameters when it is guaranteed that the declaring
 header constructor is currently being executed.*
 
-Assume that the primary header constructor has a declaring parameter with
+Assume that the declaring header constructor has a declaring parameter with
 the name `n`, or an initializing formal parameter with the name `n`. Assume
 that an initializing expression of a non-late instance variable contains an
 identifier expression of the form `n` which is resolved as a reference to
@@ -722,17 +758,17 @@ identifier expression evaluates to the value of the parameter.
 
 *This means that initializing expressions can, apparently, use the value of
 instance variables declared by the same class (not, e.g., inherited ones).
-They will actually get the value of the primary header parameter, but this
-value is also guaranteed to be the initial value of the corresponding
+They will actually get the value of the declaring header parameter, but
+this value is also guaranteed to be the initial value of the corresponding
 instance variable.*
 
 *Note that it only applies to identifier expressions. In particular, this
 does not allow initializing expressions to assign to other instance
 variables.*
 
-The following errors apply to formal parameters of a primary constructor,
+The following errors apply to formal parameters of a declaring constructor,
 be it in the header or in the body. Let _p_ be a formal parameter of a
-primary constructor in a class `C`:
+declaring constructor in a class `C`:
 
 A compile-time error occurs if _p_ contains a term of the form `this.v`, or
 `super.v` where `v` is an identifier, and _p_ has the modifier
@@ -747,18 +783,18 @@ neither `var` nor `final`. *This parameter does not induce an instance
 variable, so there is no setter.*
 
 Conversely, it is not an error for the modifier `covariant` to occur on a
-declaring formal parameter _p_ of a primary constructor. This extends the
+declaring formal parameter _p_ of a declaring constructor. This extends the
 existing allowlist of places where `covariant` can occur.
 
-*A primary body constructor does not give rise to additional scopes or
+*A declaring body constructor does not give rise to additional scopes or
 additional rules about access to `this`. The following applies to both the
-header and the body form of primary constructors.*
+header and the body form of declaring constructors.*
 
-The semantics of the primary constructor is found in the following steps,
+The semantics of the declaring constructor is found in the following steps,
 where _D_ is the class, extension type, or enum declaration in the program
-that includes a primary constructor, and _D2_ is the result of the
+that includes a declaring constructor, and _D2_ is the result of the
 derivation of the semantics of _D_. The derivation step will delete
-elements that amount to the primary constructor; it will add a new
+elements that amount to the declaring constructor; it will add a new
 constructor _k_; it will add zero or more instance variable declarations.
 
 Where no processing is mentioned below, _D2_ is identical to _D_. Changes
@@ -779,21 +815,21 @@ value then `p` is considered to have the declared type `Object?`.
 have chosen the more strictly checked type `Object?` instead, in order to
 avoid introducing run-time type checking implicitly.*
 
-The current scope of the formal parameter list of the primary constructor
+The current scope of the formal parameter list of the declaring constructor
 in _D_ is the body scope of the class.
 
 *We need to ensure that the meaning of default value expressions is
-well-defined, taking into account that a primary header constructor is
+well-defined, taking into account that a declaring header constructor is
 physically located in a different scope than in-body constructors. We do
 this by specifying the current scope explicitly as the body scope, in spite
-of the fact that the primary constructor is actually placed outside the
+of the fact that the declaring constructor is actually placed outside the
 braces that delimit the class body.*
 
 Next, _k_ has the modifier `const` iff the keyword `const` occurs just
 before the name of _D_ or before `this`, or if _D_ is an `enum`
 declaration.
 
-Consider the case where _D_ is a primary header constructor. If the name
+Consider the case where _D_ is a declaring header constructor. If the name
 `C` in _D_ and the type parameter list, if any, is followed by `.id` where
 `id` is an identifier then _k_ has the name `C.id`. If it is followed by
 `.new` then _k_ has the name `C`. If it is not followed by `.`  then _k_
@@ -802,7 +838,7 @@ has the name `C`. If it exists, _D2_ omits the part derived from
 any, in _D_. Moreover, _D2_ omits the formal parameter list _L_ that
 follows the name, type parameter list, if any, and `.id`, if any.
 
-Otherwise, _D_ is a primary body constructor. If the reserved word `this`
+Otherwise, _D_ is a declaring body constructor. If the reserved word `this`
 is followed by `.id` where `id` is an identifier then _k_ has the name
 `C.id`. If it is followed by `.new` then _k_ has the name `C`. If it is not
 followed by `.`  then _k_ has the name `C`.
@@ -841,35 +877,22 @@ If there is an initializer list following the formal parameter list _L_ then
 _k_ has an initializer list with the same elements in the same order.
 
 *The current scope of the initializer list in _D_ is the body scope of the
-enclosing declaration even when _D_ is a primary header constructor, which
+enclosing declaration even when _D_ is a declaring header constructor, which
 means that they preserve their semantics when moved into the body.*
 
 Finally, _k_ is added to _D2_, and _D_ is replaced by _D2_.
 
-### Warnings
-
-The language does not specify warnings, but the following is recommended:
-
-A warning is emitted in the case where an identifier expression is resolved
-to yield the value of a declaring or initializing formal parameter in a
-primary header constructor, and this identifier occurs in a function
-literal, and the corresponding instance variable is non-final.
-
-The point is that it is highly confusing if such a parameter reference is
-considered to be "the same thing" as the variable with the same name which
-is in scope, but the parameter has the initial value of that instance
-variable, and the instance variable has been modified in the meantime.
-
 ### Discussion
 
-This proposal includes support for adding the primary header parameters to
+This proposal includes support for adding the declaring header parameters to
 the scope of the class, as proposed by Slava Egorov.
 
 It uses a simple scoping structure based directly on the syntax: The
-primary header parameters are added to the scope which is the enclosing
+declaring header parameters are added to the scope which is the enclosing
 scope of the class body scope. This allows non-late instance variable
-initializers (and no other locations) to use the primary header parameters
-whose name is not also the name of a declaration in the class body.
+initializers (and no other locations) to use the declaring header
+parameters whose name is not also the name of a declaration in the class
+body.
 
 For parameters which are directly associated with an instance variable
 declaration (that is, a declaring parameter or an initializing formal
@@ -883,7 +906,7 @@ guaranteed to also be the initial value of the corresponding instance
 variable.
 
 This differs from an approach in the case where there is an instance
-variable and a primary header parameter with the same name where there is
+variable and a declaring header parameter with the same name where there is
 no correspondence:
 
 ```dart
@@ -893,13 +916,13 @@ class A(int x) {
 }
 ```
 
-In this case the primary header parameter `x` is just a plain parameter (it
+In this case the declaring header parameter `x` is just a plain parameter (it
 does not declare an instance variable named `x` and it doesn't initialize
 any such instance variable). With this proposal the occurrence of `x` in
 the initializing expression of `y` is a compile-time error (there is no
 access to `this`, and the "backup rule" doesn't apply).
 
-Alternatively, if we simply say that the primary header parameters are in
+Alternatively, if we simply say that the declaring header parameters are in
 scope in the non-late instance variable initializers then we'd allow `x` to
 refer to the parameter even though it has nothing whatsoever to do with the
 instance variable named `x`. This proposal does not use this alternative
@@ -907,6 +930,15 @@ approach because it is considered highly confusing that the two occurrences
 of `x` in the class body are completely different entities.
 
 ### Changelog
+
+1.8 - July 16, 2025
+
+* Rename the feature to 'declaring constructors', which is more informative.
+  This means that a primary body constructor is now an in-body declaring
+  constructor, and an in-header primary constructor is an in-header declaring
+  constructor. On top of this, the in-header form is also known as a
+  _primary_ constructor, because every other generative constructor must
+  ultimately invoke the primary one.
 
 1.7 - July 4, 2025
 

--- a/working/2364 - primary constructors/feature-specification.md
+++ b/working/2364 - primary constructors/feature-specification.md
@@ -128,8 +128,8 @@ style whereby formal parameters are never modified will have a
 [parameter_assignments]: https://dart.dev/tools/linter-rules/parameter_assignmentshttps://dart.dev/tools/linter-rules/parameter_assignments
 
 Similarly, with this feature a regular (non-declaring) formal parameter can
-not be declared with the syntax `var name`, it must have a type (`T name`)
-or the type must be omitted (`name`).
+not use the syntax `var name`, it must have a type (`T name`) or the type
+must be omitted (`name`).
 
 A declaring header constructor can have a body and/or an initializer list.
 These elements are placed in the class body in a declaration that provides

--- a/working/2364 - primary constructors/feature-specification.md
+++ b/working/2364 - primary constructors/feature-specification.md
@@ -533,7 +533,7 @@ The grammar is modified as follows. Note that the changes include support
 for extension type declarations, because they're intended to use primary
 constructors as well.
 
-```
+```ebnf
 <classDeclaration> ::= // First alternative modified.
      (<classModifiers> | <mixinClassModifiers>)
      'class' <classNamePart> <superclass>? <interfaces>? <classBody>


### PR DESCRIPTION
This PR updates the primary constructors proposal to include support for access to header parameters in non-late instance variable initializers, and in general updates the static analysis and semantics to the new syntax introduced by #4428.

The approach relies on a very simple change to the scoping structure: The primary header parameters are added to a new scope which is the enclosing scope of the class body scope. This is completely standard according to the syntactic structure, just like the scoping around a function body and its formal parameter declarations.

This means that header parameters with a fresh name (that is, not clashing with the names declared in the class body) are in scope in the class body. It is an error to refer to them in any other location than an initializing expression of a non-late instance variable.

For the case where a name `n` in an initializing expression of a non-late instance variable is resolved to an instance variable declared by the class which has a corresponding primary header parameter (which is necessarily a declaring parameter with name `n`, or an initializing formal parameter with name `n`), it evaluates to the value of the parameter.

The difference between this approach and an approach where the primary header parameters are simply added to the scope of said initializing expressions is that we avoid allowing the given name to refer to two completely unrelated entities:

```dart
class A(final int x, int y) {
  String y;
  int z = x + y;
}
```

If we simply specify that the parameter `int y` is in scope for the initializing expression `x + y` then it all compiles and "works", but it is highly confusing that `y` does not refer to the instance variable named `y`, it refers to the parameter, and there is no relationship whatsoever between the parameter `y` and the instance variable `y`, they're just separate entities.

With this proposal it is a compile-time error for the initializing expression of `z` to refer to `y`: It can't refer to the instance variable because there is no access to `this`, and it can't use the "backup rule" that turns the evaluation of the instance variable into a parameter read (because that parameter has no relation to that instance variable). The point is that this error is useful because the situation is error prone.

In summary, the approach taken in this PR is to only allow an identifier expression like `y` to refer to a parameter if it resolves to an instance variable (according to the normal scope rules), and there is a _corresponding_ primary header parameter. If there is no parameter with the given name, or there is a parameter but it doesn't correspond to the given instance variable, it's an error.
