### PR TITLE
Clarify the `void` allowlist wrt `[]` and `[]=`

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -41,6 +41,10 @@
 % version of the language which will actually be specified by the next stable
 % release of this document.
 %
+% Jul 2025
+% - Clarify that operator `[]` and `[]=` are included in the `void` allowlist
+%   rule about formal parameters of type `void`.
+%
 % May 2025
 % - Add `s?.length` as a constant expression in the case where `s` satisfies
 %   some requirements.
@@ -22873,7 +22877,7 @@ unless it is permitted according to one of the following rules.
   may have type \VOID.
   \rationale{Usages of that variable are constrained.}
 \item
-  An actual parameter expression corresponding to a formal parameter
+  An actual argument expression corresponding to a formal parameter
   whose statically known type annotation is \VOID{}
   may have type \VOID.
   \rationale{%
@@ -22881,6 +22885,13 @@ unless it is permitted according to one of the following rules.
     are statically expected to be constrained by having type \VOID.
     See the discussion about soundness below
     (\ref{voidSoundness}).%
+  }
+  This rule also applies to the index operators \code{[]} and \code{[]=}.
+  \commentary{%
+    For example, $e_1$ and $e_2$ may have type \VOID{}
+    in an expression of the form \code{$e_0$[$e_1$] = $e_2$}
+    when the parameters of the statically known operator \code{[]=}
+    both have type \VOID{}.%
   }
 \item
   In an expression of the form \code{$e_1$\,=\,$e_2$}


### PR DESCRIPTION
This PR adds a clarification to the `void` allowlist, specifying explicitly that `e1` can have type `void` in the case where `e0[e1]` is encountered and the statically known operator `[]` of `e1` has a parameter whose type is `void`, and similarly for `e0[e1] = e2` where both `e1` and `e2` can have type `void` when the corresponding formal parameters have type `void`.