### PR TITLE
Fix typo.

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -6042,7 +6042,7 @@ The interface $M_S$ is called the
 \Index{superinvocation interface} of the mixin declaration $M$.
 \commentary{%
   If the mixin declaration $M$ has only one declared superinterface, $T_1$,
-  then the superinvocation interface $M_{super}$ has exactly the same members
+  then the superinvocation interface $M_S$ has exactly the same members
   as the interface $T_1$.%
 }
 


### PR DESCRIPTION
Fix typo: the superinvocation interface is `M_S`, not `M_super` (which is a class name).

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
