### PR TITLE
Removing a requirement in `toi_promote` which is confusing and unnece…

### DIFF
--- a/resources/type-system/flow-analysis.md
+++ b/resources/type-system/flow-analysis.md
@@ -472,8 +472,8 @@ Definitions:
   - Let `p2` be the set `p1 \ { provisionalType }` _(where `\` denotes set
     difference)_.
   - If the `written` type is in `p2` then `newPromotionChain` is
-    `[...promotionChain, written]`. _Writing a value
-    whose static type is a type of interest promotes to that type._
+    `[...promotionChain, written]`. _Writing a value whose static type is a
+    type of interest promotes to that type._
     - _By precondition, `written <: declared` and `written <: T` for all types
       in `promotionChain`. Therefore, `newPromotionChain` satisfies the
       definition of a promotion chain, and is valid for declared type


### PR DESCRIPTION
This PR is about flow analysis. It removes a condition from a case in the definition of `toi_promote` because this condition is confusing and unnecessary. For more details look at https://github.com/dart-lang/language/issues/4506.