### PR TITLE
Remove rules about DartDoc comments in the language specification

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -42,9 +42,8 @@
 % release of this document.
 %
 % Sep 2025
-% - Remove the rules about scoping with DartDoc comments. This topic is now
-%   handled by each of the tools that process those comments in any way, and
-%   this document only specifies the syntax of DartDoc comments.
+% - Remove the rules about DartDoc comments. This topic is now handled by each
+%   of the tools that process those comments in any way.
 %
 % Jul 2025
 % - Clarify that operator `[]` and `[]=` are included in the `void` allowlist
@@ -23411,28 +23410,14 @@ are sections of program text that are used for documentation.
 Dart supports both single-line and multi-line comments.
 A \Index{single line comment} begins with the token \code{//}.
 Everything between \code{//} and the end of line
-must be ignored by the Dart compiler
-unless the comment is a documentation comment.
+must be ignored by the Dart compiler.
 
 \LMHash{}%
 A \Index{multi-line comment} begins with the token \code{/*}
 and ends with the token \code{*/}.
-Everything between \code{/}* and \code{*}/
-must be ignored by the Dart compiler
-unless the comment is a documentation comment.
+Everything between \code{/*} and \code{*/}
+must be ignored by the Dart compiler.
 Comments may nest.
-
-\LMHash{}%
-\IndexCustom{Documentation comments}{documentation comments}
-are comments that begin with the tokens \code{///} or \code{/**}.
-
-\rationale{%
-  Documentation comments are intended to be processed by
-  a tool that produces human readable documentation.
-  However, this document does not place any constraints
-  on the interpretation or use of documentation comments,
-  that is determined by each of the relevant tools.%
-}
 
 
 \subsection{Operator Precedence}

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -41,6 +41,11 @@
 % version of the language which will actually be specified by the next stable
 % release of this document.
 %
+% Sep 2025
+% - Remove the rules about scoping with DartDoc comments. This topic is now
+%   handled by each of the tools that process those comments in any way, and
+%   this document only specifies the syntax of DartDoc comments.
+%
 % Jul 2025
 % - Clarify that operator `[]` and `[]=` are included in the `void` allowlist
 %   rule about formal parameters of type `void`, and so are setters.
@@ -23420,25 +23425,14 @@ Comments may nest.
 \LMHash{}%
 \IndexCustom{Documentation comments}{documentation comments}
 are comments that begin with the tokens \code{///} or \code{/**}.
-Documentation comments are intended to be processed by
-a tool that produces human readable documentation.
 
-\LMHash{}%
-The current scope for a documentation comment immediately preceding
-the declaration of a class $C$ is the
-\IndexCustom{body scope}{scope!for statement body}
-of $C$.
-
-\LMHash{}%
-The current scope for a documentation comment immediately preceding
-the declaration of a non-redirecting generative constructor $k$
-with initializing formals is the formal parameter initializer scope of $k$
-(\ref{generativeConstructors}).
-
-\LMHash{}%
-Otherwise, the current scope for a documentation comment immediately preceding
-the declaration of a function $f$ is the formal parameter scope of $f$
-(\ref{formalParameters}).
+\rationale{%
+  Documentation comments are intended to be processed by
+  a tool that produces human readable documentation.
+  However, this document does not place any constraints
+  on the interpretation or use of documentation comments,
+  that is determined by each of the relevant tools.%
+}
 
 
 \subsection{Operator Precedence}


### PR DESCRIPTION
Update: This PR removes everything in the language specification that is concerned with documentation comments. The treatment of this topic area is now fully determined by each tool team.

---

Previous description:

The language specification specifies the syntax that makes a comment a DartDoc comment, which is unchanged. This PR adds a paragraph of 'rationale' text explaining that everything else is tool specific behavior, and it removes the rules about scoping in DartDoc comments.

There were no rules about the locations where a DartDoc comment can occur, which means that it is still "any location where a comment can occur".  Moreover, each tool can freely choose that a DartDoc comment is processed in a specific way when it occurs in a specific kind of location (including that it is ignored, or a diagnostic message is emitted).