### PR TITLE
Fix a typo in Private named parameters proposal

### DIFF
--- a/accepted/future-releases/2509-private-named-parameters/feature-specification.md
+++ b/accepted/future-releases/2509-private-named-parameters/feature-specification.md
@@ -422,7 +422,7 @@ If there is no error then:
 ```dart
 // Note: Also uses an in-body primary constructor.
 class Id {
-  late final int _region = 0;
+  late final int _region;
 
   this({this._region, final int _value}) : assert(_region > 0 && _value > 0);
 


### PR DESCRIPTION
Fix a typo (final variable already initialized).