### PR TITLE
Adjust wording in the 'Private named parameters' proposal

### DIFF
--- a/accepted/future-releases/2509-private-named-parameters/feature-specification.md
+++ b/accepted/future-releases/2509-private-named-parameters/feature-specification.md
@@ -228,9 +228,9 @@ encapsulation.
 
 The basic idea is simple. We let users use a private name in a named parameter
 when the parameter also initializes or declares a field. The compiler removes
-the `_` from the argument name but keeps it for the corresponding field. In
-other words, we do exactly what users are doing by hand when they write an
-initializer like:
+the `_` from the argument name at call sites but keeps it for the corresponding
+field. In other words, we do exactly what users are doing by hand when they
+write an initializer like:
 
 ```dart
 class House {


### PR DESCRIPTION
The beginning of the 'private named parameters' proposal may currently be interpreted to mean that a declaring or initializing formal with a name of the form `_id` is treated as if it had had the name `id` for all purposes other than the naming of the implicitly induced instance variable. It is in fact still accessed as `_id` in the initializer list and (if not declaring or initializing) in the constructor body. This PR adds a few words to make it explicit that the corresponding public name is only used at call sites. It could be spelled out even more. However, that's probably not necessary because the details are given later in the proposal, and we just want to get the reader on track to the overall properties of the proposal here.
