### PR TITLE
Remove spurious `const` in extension type grammar rule

### DIFF
--- a/working/augmentations/feature-specification.md
+++ b/working/augmentations/feature-specification.md
@@ -173,7 +173,7 @@ extensionTypeDeclaration ::=
     'extension' 'type' 'const'? typeIdentifier
     typeParameters? representationDeclaration interfaces?
     memberedDeclarationBody
-  | 'augment' 'extension' 'type' 'const'? typeIdentifier
+  | 'augment' 'extension' 'type' typeIdentifier
     typeParameters? interfaces?
     memberedDeclarationBody
 


### PR DESCRIPTION
The augmentation feature specification has a `const` keyword in the grammar rule for an augmenting extension type declaration. I believe this keyword should be removed: It is present in the case where a primary constructor is declared by some class/mixin class/extension type/enum declaration header and the primary constructor is constant, but it is never (otherwise) present in the header of a declaration that does not declare a primary constructor.