### PR TITLE
Add rules to the void usage allowlist about elements

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -42,8 +42,8 @@
 % release of this document.
 %
 % Jan 2026
-% - Specify that collection literal elements are treated like formal parameters
-%   with respect to the `void` usage allowlist.
+% - Specify that collection elements are allowed to have type `void` in a
+%   collection literal where the corresponding actual type argument is `void`.
 %
 % Oct 2025
 % - Simplify the member declaration grammar by using a `memberDeclaration` to


### PR DESCRIPTION
See #4574 and dart-lang/sdk#58456 for background discussions.

The language team decided at the meeting Nov 26, 2025 that collection literal elements should be given a treatment with respect to expressions of type `void` which is similar to the one which is given to actual arguments in function invocations. For example:

```dart
void f(void _) {}

final void v = null;

void main() {
  // Actual arguments.
  f(v); // OK, `v` is passed to a formal parameter whose type is `void`.
  print(v); // Error, no exception applies so we can't use the value of `v`.

  // Collection literal elements.
  <void>[v]; // OK, the element type of the list literal is `void`.
  <Object?>[v]; // Error, no exception applies so we can't use the value of `v`.

  // Nested elements will propagate the value if they don't use it.
  <void>[
    v, // OK.
    if (2 > 1) v else v, // OK.
    ?v, // Error, this element uses the value of `v` to test for null.
  ];
}
```

This PR introduces two new entries in the allowlist that makes it a non-error for an expression to occur in specific situations, such that, roughly, occurrences of void expressions in void collection literals is no longer an error.

The behavior of the analyzer and the common front end is already as specified in this CL in many cases, but the handling of null-aware elements in particular needs to be updated.

```dart
// Implemented behavior that differs from the updated spec.

void v = null;

void main() {
  <void>[?v]; // Missing compile-time error.
  <void, void>{?v: v, v: ?v, ?v: ?v}; // Multiple wrong behaviors.
}
```

The 'wrong behaviors' stand for differences among tools: The analyzer does not report any of the 4 compile-time errors; the CFE reports an error at a wrong position followed by two errors which are likely to be reported for a wrong reason. So there will be a need to make some small adjustments to the tools.