### PR TITLE
Adjust the grammar to allow additional augmenting variable declarations

### DIFF
--- a/working/augmentations/feature-specification.md
+++ b/working/augmentations/feature-specification.md
@@ -887,6 +887,12 @@ It's a **compile-time error** if:
     an instance member that can be abstract. In that case, if no declaration
     provides a body, it is considered abstract.*
 
+*Using the general [compile-time error principle], some additional situations
+are errors. In particular, a compile-time error occurs if, after application of
+all augmentations, a static or library variable has no initializing expression,
+and its type is not nullable, and the declaration does not have the modifier
+`late` nor the modifier `external`.*
+
 ### Augmenting enums
 
 An augmentation of an enum type can add new members to the enum, including new
@@ -1005,6 +1011,8 @@ the combined declaration.*
 [analyzer package]: https://pub.dev/packages/analyzer
 
 ### Compile errors with augmentations
+
+[compile-time error principle]: #compile-errors-with-augmentations
 
 Prior to augmentations, the definition of a semantic entity is produced by a
 single syntactic declaration. That allows the language specification to refer to


### PR DESCRIPTION
See https://github.com/dart-lang/language/issues/4623 for background discussions.

This PR simplifies and generalizes the grammar rules containing `'augment'` and deriving `<declaration>` such that 26 new forms of augmenting declaration can be derived. The rationale is that they are conceptually and semantically consistent with the specification rules on similar matters, it was just the grammar that prevented them from being expressed.

The specification already contains a rule that makes it an error for an augmenting declaration to contain a constant variable declaration:

> It's a **compile-time error** if:
> *   ...
> *   A `const` variable declaration is augmented or augmenting.

This implies that two of those 26 forms will always be an error. I preferred to handle it this way because it keeps the grammar simpler and more readable, and the desired errors will be reported even though they are not syntax errors.

As a consequence of this simplification, `<memberDeclaration>` was simplified as well, as `'augment'?` was moved up to the rule `<memberDeclarations>`.

(This PR also fixes one typo.)