### PR TITLE
Add rules about constant primary constructors and initialization

### DIFF
--- a/accepted/future-releases/primary-constructors/feature-specification.md
+++ b/accepted/future-releases/primary-constructors/feature-specification.md
@@ -4,7 +4,7 @@ Author: Erik Ernst
 
 Status: Accepted
 
-Version: 1.14
+Version: 1.15
 
 Experiment flag: primary-constructors
 
@@ -680,10 +680,14 @@ contains a body part for the primary constructor, and it has an initializer
 list, and the initializer list contains an expression which is not potentially
 constant.
 
-Moreover, for every `<constObjectExpression>` invoking a constructor of _D_, a
-compile-time error occurs if the result of substituting actual arguments of the
-constructor invocation into one of the above mentioned initializing expressions
-or initializer list elements yields an expression which is not constant.
+Moreover, for every constant expression which is an instance creation that
+invokes a constructor of _D_, a compile-time error occurs if the result of
+substituting actual arguments of the constructor invocation into one of the
+above mentioned initializing expressions or initializer list elements yields an
+expression which is not constant.
+
+*This is the same as the existing check on constant constructor invocations, but
+it applies to two new pieces of syntax.*
 
 Consider a class, mixin class, enum, or extension type declaration _D_ with
 a primary constructor *(note that it cannot be a `<mixinApplicationClass>`,
@@ -967,6 +971,11 @@ far removed from any syntactic hint that the constructor must be constant
 of declaration, and the constructor might be non-const).
 
 ### Changelog
+
+1.15 - March 11, 2026
+
+* Generalize potentially constant expressions. Specify compile-time errors
+  associated with constant expressions and initialization expressions.
 
 1.14 - March 4, 2026
 


### PR DESCRIPTION
The primary constructor feature specification did not specify the treatment of constant primary constructors with respect to initialization. This PR adds a paragraph of normative text and a commentary paragraph to specify that primary parameters are considered to be potentially constant in initializers (in non-late variable declarations as well as in the initializer list), and it is an error unless said expressions are potentially constant.

If we do not specify this relaxation then the initializing expressions of non-late instance variables must be constant, which would cause the primary parameters to be useless for any class with constant constructors in those initializing expressions.

The corresponding clarification about the initializer list of the body part of a constant primary constructor is needed because we previously left it unspecified, but it should be unsurprising because it just means that we're treating the primary constructor body part the same as a normal in-body constructor.