### PR TITLE
Fix #4652: allow augmenting setters to choose parameter name

### DIFF
--- a/working/augmentations/feature-specification.md
+++ b/working/augmentations/feature-specification.md
@@ -839,8 +839,9 @@ It's a **compile-time** error if:
 For purposes of augmentation, a variable declaration is treated as implicitly
 defining a getter whose return type is the type of the variable. If the variable
 is not `final`, or is `late` without an initializer, then the variable
-declaration also implicitly defines a setter with a parameter named `_` whose
-type is the type of the variable.
+declaration also implicitly defines a setter with a single required positional
+parameter whose type is the type of the variable. The variable declaration does
+not determine the name of that parameter.
 
 If the variable is `abstract`, then the getter and setter are incomplete,
 otherwise they are complete. *For non-abstract variables, the compiler


### PR DESCRIPTION
This PR updates the augmentations specification so that the implicit setter
induced by a variable declaration no longer has a fixed parameter name `_`.

Previously, the spec said that for augmentation purposes a non-`final` variable
(or a `late` variable without an initializer) implicitly defines a setter with a
parameter named `_`. After the recent changes around `_`, this made it
impossible for an augmenting setter declaration to choose its own parameter
name.

This PR changes that wording so that the implicit setter is specified only in
terms of its shape and type:

- it has a single required positional parameter
- the parameter type is the type of the variable
- the variable declaration does not determine the parameter name

This restores the intended ability for an augmenting setter declaration to use a
source-level parameter name such as:

```dart
augment set i(myName) {
  _i = myName;
}