### PR TITLE
Perform a change which was part of PR 4669, but omitted by mistake

### DIFF
--- a/working/augmentations/feature-specification.md
+++ b/working/augmentations/feature-specification.md
@@ -746,9 +746,6 @@ signature *matches* an introductory signature if:
 
 *   For each corresponding pair of parameters:
 
-    *   They have the same name. _This is trivial for named parameters, but may
-        fail to hold for positional parameters._
-
     *   They have the same type (or the augmenting declaration omits the type).
 
     *   They both have the modifier `covariant`, or none of them have it.


### PR DESCRIPTION
This is an update that should have been performed as part of #4669, but was omitted by mistake: The requirement that parameters (in general) in an augmentation chain should have the same name is obsolete; this requirement is satisfied by construction with named parameters, and it is superseded by new rules for positional parameters. Hence, this PR removes that requirement.