### PR TITLE
Update augmentation specification with primary constructors.

### DIFF
--- a/working/augmentations/feature-specification.md
+++ b/working/augmentations/feature-specification.md
@@ -254,8 +254,8 @@ When there are no values, the enum still requires a leading `;` before the first
 member to avoid ambiguity.
 
 ```
-enumType ::= 'augment'? 'enum' classNameMaybePrimary typeParameters?
-    mixins? interfaces? enumBody?
+enumType ::=
+    'augment'? 'enum' classNameMaybePrimary mixins? interfaces? enumBody
 
 enumBody ::=
     '{' (enumEntry (',' enumEntry)* (',')?)? (';' memberDeclarations)? '}'
@@ -290,53 +290,27 @@ always uses the same `on` clause as the introductory declaration.
 Both `class` and `enum` declarations can use the primary constructor syntax
 for declaring an initializing _(non-redirecting generative)_ constructor.
 
-The primary constructor syntax does not allow an extra `augment` to be added
-to the class header. As an exception, a primary constructor declaration does
-not need an extra `augment`, on top of the one on the class or enum declaration
-itself, if it declares an augmenting constructor using the primary constructor
-syntax, and it does not have an in-body part. If the declaration _does_ haven
-an in-body part (`this;` or `this: ...`), that in-body part must be prefixed by
-`augment` if the constructor declaration is augmenting.
-
-A primary constructor declaration introduces or augments an initializing
-constructor, and makes it so that that constructor is a primary constructor
-for the entire class or enum.
-
-If a complete primary constructor has a declaring parameter, that parameter
-declaration introduces a complete introducing or augmenting variable
-declaration, which is `final` if the declaring parameter has the `final`
-modifier, and is implicitly augmenting if there is a prior declaration of
-the same getter and/or setter. *(The `augment` modifier does not apply
-to parameters, so the declaring parameter cannot be marked as augmenting
-a variable.)*
-
-It's a **compile-time error** if a class or enum has two distinct
-initializing constructors, and either of them is declared as a
-primary constructor.
-*If the class or enum has a primary constructor, it cannot have any other
-initializing constructors, and therefore no other primary constructors,
-since those are always initializing.*
-That also implies that it is a compile-time error if a class or enum has two
-distinct constructors which are both declared as primary.
-
-The declarations of a class or enum can contain both primary and non-primary
-declarations of the same constructor. The class has a primary constructor
-if at least one declaration uses the primary constructor syntax.
+See [Generative constructors](#generative_constructor_declarations).
 
 ### Instance variable initializer expressions
 
 If a class or enum has a primary constructor, then the scope of non-`late`
-instance variable initializer expressions are the initializer list scope
+instance variable initializer expressions is the initializer list scope
 of that constructor.
 
 It's a compile-time error if a non-`late` instance variable initializer
-expressions refers to a varible introduced by the constructor's
-initializer list scope if the surrounding class/enum declaration does
+expressions refers to a variable introduced by the constructor's
+initializer list scope, and the surrounding class or enum declaration does
 _not_ have a primary constructor declaration which declares the
 corresponding parameter's name.
+_A primary constructor must declare all parameters, but it can omit declaring
+a positional parameter's name by using `_` instead of the name.
+If it does so, that parameter's name cannot be used by instance variable
+initializers of that class or enum declaration._
+
 _The scope exists and is used whether this particular declaration writes
-a primary constructor or not, but for readability reasons, code can only
-refer to veriables of that scope if there appears to be a declaration of
+a primary constructor or not, but for readability reasons, code may only
+refer to variables of that scope, if there appears to be a declaration of
 the variable's name in the surrounding code._
 
 ## Static semantics
@@ -615,24 +589,24 @@ files.
 
 Some terminology:
 
-*   The *source code* of a declaration is the span of character from the
-    first non-whitspace character of the declaration to the last non-whitspace
+*   The *source code* of a declaration is the span of characters from the
+    first non-whitespace character of the declaration to the last non-whitespace
     character of the declaration, as matched by the relevant grammar production.
     *Metadata is not considered part of the declaration, it precedes the
     declaration in the source.*
 
-*   A syntactic declaration *occurs in* a Dart file if the declaration's source
+*   A syntactic declaration, *D*, *occurs in* a Dart file *F* if *D*'s source
     code occurs in that file.
 
-*   A Dart file *includes* a part file if the Dart file has a `part` directive
-    with a URI denoting another part file.
+*   A Dart file, *F*, *includes* a part file *P* if the Dart file *F*
+    has a `part` directive whose URI denotes *P*.
 
-*   A Dart file *contains* (aka. transitively includes) a part file
-    if the Dart file includes the part file, or if the Dart file includes
-    another part file, and that other part file contains the part file.
+*   A Dart file, *F*, *contains* (aka. transitively includes) a part file *P*
+    if *F* (directly) *includes* *P*, or if *F* *includes* a part file *Q*
+    and *Q* *contains* *P*.
 
-*   A Dart file *contains* a declaration if the declaration occurs in the file
-    itself or in any of the part files that the Dart file contains.
+*   A Dart file *contains* a declaration *D* if the declaration *D* *occurs in*
+    the file *F* itself, or if *D* occurs in a file *P* and *F* *contains* *P*.
 
 For any two distinct syntactic declarations *A* and *B*:
 
@@ -652,7 +626,8 @@ For any two distinct syntactic declarations *A* and *B*:
             the position is the start position of that identifier
             in the source.
             *(Includes an unnamed local variable declared with a `_` as
-            identifier.)*
+            identifier. A primary constructor declaration's position is
+            that of the class name.)*
         *   If the declaration is an unnamed `extension` declaration,
             its position is the position of the `on` keyword.
 
@@ -1039,7 +1014,7 @@ For ordering purposes, these implicit declarations are _before_ any members
 declared in the declaration.
 
 *Any declaration of the same members must be augmenting (they are not
-introdoctory) and must not be complete.*
+introductory) and must not be complete.*
 *Declaring an instance member named `values` will conflict with the
 static `values` declaration as a normal scope name conflict.*
 
@@ -1048,130 +1023,125 @@ It's a **compile-time error** if:
 *   An enum doesn't have any values after all augmentations are applied. *The
     grammar allows an enum declaration to not have any values so that other
     declarations of the same enum can add them, but ultimately the enum must
-    end up with some.*
+    end up with at least one value.*
 
 ### Augmenting constructors
 
-Augmenting constructors works similar to augmenting a function, with some extra
-rules to handle features unique to constructors like redirections and
-initializer lists, and special handling of primary constructors.
+Augmenting a constructor works similarly to augmenting a function, with some
+extra rules to handle features unique to constructors, like redirections and
+initializer lists, and the primary constructor syntax.
 
-It is **not** a compile-time error for an incomplete factory constructor to
+
+<!-- It is **not** a compile-time error for an incomplete factory constructor to
 omit default values. *That is, they are treated similarly to abstract
 instance methods in this respect. This allows the augmenting declaration to
-implement the constructor by adding a redirection or a body.*
+implement the constructor by adding a redirection or a body.* -->
 
-It's a **compile-time error** if:
+A constructor declaration is a _factory constructor declaration_ if it
+has a `factory` keyword, and it is a _generative constructor declaration_ if
+it does not, including when it is a primary constructor declaration.
 
-*   The signature of the augmenting constructor does not [match][signature
-    matching] the signature of the corresponding introductory constructor.
+A constructor declaration is a _const constructor declaration_ if, and only if,
+it has a `const` keyword.
+_For a primary constructor, the `const` keyword goes before the class name
+in the header._
 
-*   A `class` or `enum` constructor is declared as a primary constructor,
-    using primary constructor syntax for at least one declaration of that
-    constructor, and the class or enum has any other initializing constructor.
+#### Factory constructor declarations
 
-*   More than one declaration in the augmentation chain specifies a default
-    value for the same optional parameter. This is an error even in the
-    case where all of them are identical. *Default values are defined by
-    the introductory declaration or an augmentation, but at most once.*
+A factory constructor declaration is a _non-redirecting factory constructor
+declaration_, and is a _complete_ declaration, if it has a body (`{...}`
+or `=> ...;`) or an `external` keyword.
 
-*   The augmentation chain has exactly one specification of a default value
-    for an optional parameter, and the constructor is a redirecting factory.
+A factory constructor declaration is a _redirecting factory constructor
+declaration_ and is _complete_ if it has a redirection clause (`= TargetType;`).
 
-*   No declaration in the augmentation chain specifies a default value for
-    an optional parameter whose declared type is potentially non-nullable,
-    and the constructor is not a redirecting factory.
+_A factory constructor declaration with no body and no redirection clause,
+ended by a single `;`, is not a complete declaration, and does not decide
+whether the factory constructor being defined will is redirecting or not.
+Only the (single) complete declaration forces that decision._
 
-*   The introductory constructor is `const` and the augmenting constructor
-    is not, or vice versa. *An augmentation can't change whether or not a
-    constructor is const because that affects whether users are allowed to use
-    the constructor in a const context.*
+#### Generative constructor declarations.
 
-*   A redirecting generative constructor augments an initializing generative
-    constructor.
+A **primary constructor** declaration causes the constructor it defines
+be a primary constructor, and the class to have a primary constructor.
+_This means the class cannot have any other initializing constructors,
+which is reflected by the consistency rules below, and it changes the
+scope used for instance variable initializer expressions._
 
-*   An initializing generative constructor augments a redirecting generative
-    constructor.
+_A primary constructor declaration always has an in-header part which
+contains a parameter list, and optionally a `const` and a constructor-
+name identifier, (`class const C.id(int x)`). It may also have an
+in-body `this`-part which can contain an initializer list or body,
+and can have metadata attached (`this: super(x) { print('done'); }`)._
 
-*   The introductory constructor is marked `factory` and the augmenting
-    constructor is not, or vice versa. *An augmentation can't change whether or
-    not a constructor is generative because that affects whether users are
-    allowed to call the constructor in a subclass's initializer list.*
+A primary constructor declaration is an _initializing constructor declaration_.
+A primary constructor declaration is _complete_ if (any of):
+  * It has an initializing formal parameter (`this.name`).
+  * It has a super parameter (`super.name`).
+  * It has a declaring parameter (`final int name`).
+  * It has an in-body `this`-part that:
+      * has a body (`{...}`) and/or
+      * has an initializer list (`: ...`).
+A primary constructor declaration is an _augmenting declaration_ if
+(either of):
+  * It has an in-body `this`-part with an `augment` keyword
+    (`augment this ...`).
+  * It has no in-body `this`-part, and there is another declaration of
+    the same constructor which occurs _before_ this constructor.
+Otherwise it is an _introductory declaration_.
+_An augmenting primary constructor with no in-body `this`-part does not
+have a separate `augment` keyword. Such a constructor is necessarily part
+of an augmenting class or enum declaration,
+and its header-part is likely on the same line as the `augment` keyword
+of that declaration. This is considered sufficient, rather than forcing
+a the author of a class declaration like `augment class C(final int x);`
+to add a body and in-body `this`-part just to write an `augment` on it,
+or alternatively to require a second `augment` keyword in the header as
+`augment class augment C(final int x);`._
 
-*   A factory constructor has no complete declaration.
+If a complete primary constructor has a declaring parameter, that parameter
+declaration also counts as a complete introductory or augmenting variable
+declaration, which is `final` if the declaring parameter has the `final`
+modifier, and is augmenting if there is a prior declaration of
+the same getter and/or setter. *(The `augment` modifier does not apply
+to parameters, so the declaring parameter cannot be marked as augmenting
+a variable.)*
 
-    *A factory constructor which has `;` instead of a body or redirection,
-    is incomplete. This allows, and requires, an augmentation to fill in an
-    implementation.
-    A valid non-redirecting generative constructor can have no body,
-    also written as `;`. Thus it is not an error for a _generative_
-    constructor to be incomplete after all augmentation are applied. It is
-    simply an initializing constructor with no body.*
+An in-body generative constructor declaration is an _initializing constructor
+declaration_ and is _complete_ if (any of):
+  * It has an `external` keyword.
+  * It has an initializing formal parameter (`this.name`).
+  * It has a super parameter (`super.name`).
+  * It has a body (`{...}` instead of).
+  * It has an initializer list (`: ...`).
 
-#### Factory constructors
-A factory constructor has a `factory` modifier in its declaration.
+*(An in-body initializing constructor cannot have declaring parameters,
+those are only available to primary constructor declarations.
+Had they been allowed, they'd also make the constructor complete.)*
 
-A factory constructor declaration is incomplete if it has no body,
-and is ended by a `;`.
+An in-body generative constructor declaration is a _redirecting generative
+constructor declaration_ and is _complete_ if it has a redirection clause
+(`: this(args);` or (`: this.name(args);`).
 
-A factory contructor is complete if it has a redirection, `= ConstructorName;`,
-in which case it's a redirecting factory constructor,
-or it has a function body, `=> expression` or `{...}`, in which case
-it's a non-redirecting factory constructor.
+*The declarations of a class or enum can contain both primary and non-primary
+declarations of the same constructor. The class has a primary constructor
+if at least one declaration uses the primary constructor syntax.*
 
-It's a **compile-time error** if:
-
-* All declarations of a factory constructor are incomplete.
-
-#### Generative constructors
-
-A generative constructor is _complete_ and _redirecting_ if contains
-a redirection clause, like `: this.name(...);`.
-
-A generative constructor is _complete_ and _initializing_ if it contains
-any of:
-
-* An `external` modifier.
-
-* An initializing formal parameter (`this.name`).
-
-* A `super` parameter (`super.name`).
-
-* A declaring parameter (`final int name`), only valid in a primary constructor.
-
-* An initializer list (like `: param = expr, ...` or `: super(args)`).
-
-* A body (does not end in `;`).
-
-_This applies both to primary constructor declarations and
-non-primary constructor declarations, where the primary constructor
-declaration declares its initializer list and body in an in-body
-constructor part, like `this: ... { ... }`. An in-body constructor
-part of `this;` does not make the declaration complete._
-
-A generative constructor declaration is _incomplete_ if it is not
-_complete_.
-
-A generative constructor declaration is _redirecting_ if it's
-a complete redirecting declaration, or if it augments a declaration
-which is redirecting.
-
-A generative constructor declaration is _initializing_ (not redirecting)
-if it's a primary constructor declaration, a complete and initializing
-declartion, or if it augments a declaration which is initializing.
-
-_The introductory declaration may not decide whether a generative
-constructor is initializing or redirecting. It's decided by the
-first declaration which is complete or which is a primary constructor
-(which must be initializing), and all later augmentations must not
-contradict that decision._
+*An in-body generative constructor declaration with no special parameters,
+initializer list, body or redirection, like `ClassName()`, does not decide
+whether the constructor is redirecting or initializing. That is decided by
+any declaration which is complete, or which is a primary constructor
+since those must be initializing.*
 
 If all _declarations_ of a generative constructor are incomplete,
-then the constructor is an _initializing_ constructor with the
-implementation defined by the introductory declaration.
+*(and therefore contains no redirecting generative constructor declarations,
+since those are all complete)*,
+then the constructor being defined is an _initializing_ constructor
+with the signature of the introductory declaration, the default values
+introduced by any declaration, no initializer list and no body.
 *(A declaration of `C();` is defined as incomplete, but is also
-a valid concrete implementation of a trivial constructor.)*
-
+historically a valid concrete implementation of a trivial constructor,
+and this ensures that it keeps working that way.)*
 
 Example:
 ```dart
@@ -1187,7 +1157,8 @@ augment class C {
   factory augment C.fact() = C.other;
 }
 ```
-and with a primary constructor:
+
+Example with a primary constructor:
 ```dart
 class const D(int x) {
   /// Creates a `D`.
@@ -1203,13 +1174,90 @@ augment class D(final int x) {
   augment D(int _);
 }
 ```
+
+#### Consistency rules for constructor declarations
+
+It's a **compile-time error** if the the declarations of a class or enum
+contain constructor declarations where:
+
+*   There is an augmenting constructor declaration with no corresponding
+    (earlier) introductory declaration.
+*   There is an introductory constructor declaration with any other declaration
+    for that constructor which is before it.
+    _Same two rules as for other augmentations. The first declaration must be
+    introductory, any non-first declaration must be augmenting._
+
+*   There exist two constructor declarations for the same constructor, and
+    (any of):
+      * Both are complete declarations.
+        _(As everywhere else, there can be at most one complete declaration.)_
+      * One is a const constructor declaration and the other is not.
+      * One is a factory constructor declaration and the other is a
+        generative constructor declaration.
+      * One is a redirecting factory constructor declaration and the other
+        is a non-redirecting factory constructor declaration.
+        _Redundant since both would be complete declarations too, but
+        included for completeness, in case later language features
+        would make it not be redundant._
+      * One is an initializing constructor declaration and the other is
+        a redirecting generative constructor declaration.
+
+    _If there are more than two declarations of a constructor, and one of
+    them does not match the rest for one of these rules, there is more than
+    one way that that program has a compile-time error. How to report that
+    usefully is up to the tool that checks for errors. It may be sufficient
+    to point to the one declaration that stands out, or it can choose to
+    report every declaration that has an error compared to the introductory
+    declaration._
+
+*   The signature of an augmenting constructor does not [match][signature
+    matching] the signature of the corresponding introductory constructor.
+    _The signature of a constructor using the privately-named-parameters
+    feature uses the public name for that parameter._
+
+*   There is a primary constructor declaration, and there is an initializing
+    constructor declaration for any other constructor.
+    _If a class or enum has a primary constructor declaration, that constructor
+    must still be the only initializing constructor, just as specified
+    by the primary-constructors feature. That restriction applies to the entire
+    class or enum being defined, not just a single declaration, and applies
+    in both directions if two separate class declarations have primary
+    constructor declarations for different constructors._
+
+*   Two different declarations of the same constructor both specify a
+    default value of the same parameter.
+    *This is an error even in it is the same default value.
+    Parameter default values can be defined by the introductory declaration
+    or by an augmenting declaration, but at most once.*
+
+*   A constructor declaration has a default value for a parameter,
+    and there is a redirecting factory constructor declaration for the same
+    constructor. *It can be the same declaration. Redirecting factory
+    constructors cannot declare default values.*
+
+*   A constructor declaration declares an optional parameter with a non-null
+    type, and no declaration for the same constructor:
+      * declares a default value for that parameter, or
+      * is a redirecting factory constructor declaration.
+    *Non-redirecting factory constructors must have default values for
+    non-nullable optional parameters.*
+
+*   There is a factory constructor declaration and no complete constructor
+    declaration for the same constructor.
+    *A factory constructor which has `;` instead of a body or redirection
+    is incomplete, and it's not deciding whether the constructor is redirecting
+    or not. This allows, and requires due to this rule, another declaration
+    to fill in an implementation.*
+    *Generative constructors may have no complete declarations, they'll then
+    get a trivial default implementation as described above.*
+
 #### Instance variable initialization during constructor invocation
 
 When invoking an initializing generative constructor to initialize
 a new object, instance variable initialization happens before executing
 the initializer list.
 
-This is true for augmented classes, with and without primary constructors.
+This is true whether or not the class or enum has a primary constructor.
 
 When invoking the initializing constructor to initialize a new object,
 the first thing that happens is that actual arguments are bound to formal
@@ -1218,20 +1266,21 @@ parameters, which provides the bindings for the initializer list scope.
 Then all non-`late` instance variable declarations of the class which have
 an initializer expression are processed in their source order.
 
-Each instance variable is initialized in turn, by evaluating its initializer expression. If the class has a primary constructor, the initializer expression
+Each instance variable is initialized in turn, by evaluating its initializer
+expression. If the class has a primary constructor, the initializer expression
 is evaluated in the initializer list scope, otherwise it's evaluated in the
 class scope, and if the evaluation completes with a value, the instance
 variable is initialized to that value.
 
 After all instance variable initializers have been executed,
-constructor execution continues with executing as normal,
-starting with variable initialization by initializing formals
-and declaring parameters.
+constructor execution continues with executing as in Dart before this feature,
+starting with the variable initialization of the parameter list, by initializing
+formals and declaring parameters.
 
-_This is how primary constructors already work. The only difference is
-that because a single constructor can have more than one declaration,
-the complete declaration of a primary constructor may not be a primary
-constructor declaration._
+_This is how primary constructors already work. The only difference is that
+because a single constructor can be introduced by more than one declaration,
+the complete declaration, the actual implementation, of a primary constructor
+might not be a primary constructor declaration._
 
 ### Augmenting extension types
 

--- a/working/augmentations/feature-specification.md
+++ b/working/augmentations/feature-specification.md
@@ -2,7 +2,7 @@
 
 Authors: rnystrom@google.com, jakemac@google.com, lrn@google.com, eernst@google.com
 
-Version: 1.43 (see [Changelog](#Changelog) at end)
+Version: 1.44 (see [Changelog](#Changelog) at end)
 
 Experiment flag: augmentations
 
@@ -159,9 +159,17 @@ and extensions are discussed in subsequent sections.)*
 ```
 classDeclaration ::=
     'augment'? (classModifiers | mixinClassModifiers)
-    'class' typeWithParameters superclass? interfaces?
+    'class' classNameMaybePrimary superclass? interfaces?
     memberedDeclarationBody
   | classModifiers 'mixin'? 'class' mixinApplicationClass
+
+primaryConstructor ::= // From primary constructors specification.
+     'const'? typeWithParameters ('.' identifierOrNew)?
+     declaringParameterList;
+
+classNameMaybePrimary ::= // From primary constructors specification.
+     primaryConstructor
+   | typeWithParameters;
 
 mixinDeclaration ::=
     'base'? 'mixin' typeIdentifier typeParameters?
@@ -182,6 +190,9 @@ memberedDeclarationBody ::=
   | ';'
 
 memberDeclarations ::= (metadata 'augment'? memberDeclaration)*
+
+primaryConstructorBodySignature ::= // From primary constructors specification
+     'augment'? 'this' initializers?;
 
 memberDeclaration ::= declaration
   | methodSignature functionBody
@@ -243,8 +254,8 @@ When there are no values, the enum still requires a leading `;` before the first
 member to avoid ambiguity.
 
 ```
-enumType ::= 'augment'? 'enum' typeIdentifier typeParameters?
-    mixins? interfaces? enumBody
+enumType ::= 'augment'? 'enum' classNameMaybePrimary typeParameters?
+    mixins? interfaces? enumBody?
 
 enumBody ::=
     '{' (enumEntry (',' enumEntry)* (',')?)? (';' memberDeclarations)? '}'
@@ -273,6 +284,60 @@ Just make two separate unnamed extensions.*
 
 Also note that an augmentation of an extension can't specify an `on` clause. It
 always uses the same `on` clause as the introductory declaration.
+
+## Primary constructors
+
+Both `class` and `enum` declarations can use the primary constructor syntax
+for declaring an initializing _(non-redirecting generative)_ constructor.
+
+The primary constructor syntax does not allow an extra `augment` to be added
+to the class header. As an exception, a primary constructor declaration does
+not need an extra `augment`, on top of the one on the class or enum declaration
+itself, if it declares an augmenting constructor using the primary constructor
+syntax, and it does not have an in-body part. If the declaration _does_ haven
+an in-body part (`this;` or `this: ...`), that in-body part must be prefixed by
+`augment` if the constructor declaration is augmenting.
+
+A primary constructor declaration introduces or augments an initializing
+constructor, and makes it so that that constructor is a primary constructor
+for the entire class or enum.
+
+If a complete primary constructor has a declaring parameter, that parameter
+declaration introduces a complete introducing or augmenting variable
+declaration, which is `final` if the declaring parameter has the `final`
+modifier, and is implicitly augmenting if there is a prior declaration of
+the same getter and/or setter. *(The `augment` modifier does not apply
+to parameters, so the declaring parameter cannot be marked as augmenting
+a variable.)*
+
+It's a **compile-time error** if a class or enum has two distinct
+initializing constructors, and either of them is declared as a
+primary constructor.
+*If the class or enum has a primary constructor, it cannot have any other
+initializing constructors, and therefore no other primary constructors,
+since those are always initializing.*
+That also implies that it is a compile-time error if a class or enum has two
+distinct constructors which are both declared as primary.
+
+The declarations of a class or enum can contain both primary and non-primary
+declarations of the same constructor. The class has a primary constructor
+if at least one declaration uses the primary constructor syntax.
+
+### Instance variable initializer expressions
+
+If a class or enum has a primary constructor, then the scope of non-`late`
+instance variable initializer expressions are the initializer list scope
+of that constructor.
+
+It's a compile-time error if a non-`late` instance variable initializer
+expressions refers to a varible introduced by the constructor's
+initializer list scope if the surrounding class/enum declaration does
+_not_ have a primary constructor declaration which declares the
+corresponding parameter's name.
+_The scope exists and is used whether this particular declaration writes
+a primary constructor or not, but for readability reasons, code can only
+refer to veriables of that scope if there appears to be a declaration of
+the variable's name in the surrounding code._
 
 ## Static semantics
 
@@ -550,42 +615,80 @@ files.
 
 Some terminology:
 
+*   The *source code* of a declaration is the span of character from the
+    first non-whitspace character of the declaration to the last non-whitspace
+    character of the declaration, as matched by the relevant grammar production.
+    *Metadata is not considered part of the declaration, it precedes the
+    declaration in the source.*
+
 *   A syntactic declaration *occurs in* a Dart file if the declaration's source
     code occurs in that file.
 
-*   A Dart file *includes* a part file, if the Dart file has a `part` directive
-    with a URI denoting that part file.
+*   A Dart file *includes* a part file if the Dart file has a `part` directive
+    with a URI denoting another part file.
+
+*   A Dart file *contains* (aka. transitively includes) a part file
+    if the Dart file includes the part file, or if the Dart file includes
+    another part file, and that other part file contains the part file.
 
 *   A Dart file *contains* a declaration if the declaration occurs in the file
-    itself or any of the part files it transitively includes.
+    itself or in any of the part files that the Dart file contains.
 
-For any two syntactic declarations *A*, and *B*:
+For any two distinct syntactic declarations *A* and *B*:
 
 *   If *A* and *B* occur in the same file:
 
-    *   If *A*'s declared name is syntactically before *B*'s declared name,
-        in source order, then *A* is before *B.* *This rule wouldn't work for
-        unnamed extensions since there is no identifier to look at, but
-        unnamed declarations can't be augmented, so this isn't a problem.*
+    *   If *A*'s _position_ is before *B*'s position in the source code
+        of the file, then *A* is before *B*.
 
-    *   Otherwise *B* is before *A*.
+        The _position_ of a declaration is defined by the first of these rules
+        that apply:
 
-*   Else if the file where *A* occurs includes the file where *B* occurs then
+        *   If the declaration is a constructor declaration with no
+            class name, its position is the start position of the `new` or
+            `factory` keyword in the source.
+        *   If the declaration contains an identifier for the declared name,
+            or a qualified identifier for a constructor name,
+            the position is the start position of that identifier
+            in the source.
+            *(Includes an unnamed local variable declared with a `_` as
+            identifier.)*
+        *   If the declaration is an unnamed `extension` declaration,
+            its position is the position of the `on` keyword.
+
+        _You cannot augment an unnamed `extension` declaration, because
+        an augmentation needs to repeat the same name._
+
+    *   If *B*'s position is before *A*'s position, then *B* is before *A*.
+
+    *   If *A*'s and *B*'s position are the same, but they are not the same
+        declaration, then *A* and *B* must be a primary constructor declaration
+        and its surrounding type-introducing declaration.
+        In that case, the type introducing declaration is before the
+        primary constructor declaration.
+        *(The same effect can be achieved by making the position of a
+        primary constructor be at the end of the class name identifier
+        instead of at the start.)*
+
+*   Else if the file where *A* occurs contains the file where *B* occurs then
     *A* is before *B*.
 
-*   Else if the file where *B* occurs includes the file where *A* occurs then
+*   Else if the file where *B* occurs contains the file where *A* occurs then
     *B* is before *A*.
 
     *In other words, if there is a `part` chain from the file where one
-    augmentation is declared to the file where the other is, then the outer one
+    declaration occurs to the file where the other occurs, then the outer one
     comes first.*
 
 *   Otherwise, *A* and *B* are in sibling branches of the part tree:
 
-    *   Let *F* be the least containing file for those two files. *Find the
-        nearest root file in the part subtree that contains both A and B.
-        Neither A nor B will occur directly in F because if it did, then the
-        previous clauses would have handled it.*
+    *   Let *F* be the unique Dart file which contains both *A* and *B*,
+        but which does not include a part file which also contains both
+        *A* and *B*. _Such a file must exist for any two declarations
+        because a declaration only exists in one file, and the part files
+        form a tree._
+        Neither *A* nor *B* will occur directly in *F* because if they did,
+        then the previous clauses would have handled it.*
 
     *   If the `part` directive in *F* including the file that contains *A* is
         syntactically before the `part` directive in *F* including the file that
@@ -924,13 +1027,23 @@ enum values. Enum values are appended in augmentation application order.
 Enum values themselves can't be augmented since they are essentially constant
 variables and constant variables can't be augmented.
 
-It's a **compile-time error** if:
+An introductory `enum` declaration introduces implicit introductory and
+complete declarations of:
+ * `String toString()`
+ * `int get index`
+ * `int get hashCode`
+ * `bool operator ==(Object)`
+ * `static const List<E> values;` where `E` is the enum type.
 
-*   A declaration inside an augmenting enum declaration has the name `values`,
-    `index`, `hashCode`, or `==`. *It has always been an error for an enum
-    declaration to declare a member named `index`, `hashCode`, `==`, or
-    `values`, and this rule just clarifies that this error is applicable for
-    augmenting declarations as well.*
+For ordering purposes, these implicit declarations are _before_ any members
+declared in the declaration.
+
+*Any declaration of the same members must be augmenting (they are not
+introdoctory) and must not be complete.*
+*Declaring an instance member named `values` will conflict with the
+static `values` declaration as a normal scope name conflict.*
+
+It's a **compile-time error** if:
 
 *   An enum doesn't have any values after all augmentations are applied. *The
     grammar allows an enum declaration to not have any values so that other
@@ -941,7 +1054,7 @@ It's a **compile-time error** if:
 
 Augmenting constructors works similar to augmenting a function, with some extra
 rules to handle features unique to constructors like redirections and
-initializer lists.
+initializer lists, and special handling of primary constructors.
 
 It is **not** a compile-time error for an incomplete factory constructor to
 omit default values. *That is, they are treated similarly to abstract
@@ -952,6 +1065,10 @@ It's a **compile-time error** if:
 
 *   The signature of the augmenting constructor does not [match][signature
     matching] the signature of the corresponding introductory constructor.
+
+*   A `class` or `enum` constructor is declared as a primary constructor,
+    using primary constructor syntax for at least one declaration of that
+    constructor, and the class or enum has any other initializing constructor.
 
 *   More than one declaration in the augmentation chain specifies a default
     value for the same optional parameter. This is an error even in the
@@ -970,23 +1087,91 @@ It's a **compile-time error** if:
     constructor is const because that affects whether users are allowed to use
     the constructor in a const context.*
 
+*   A redirecting generative constructor augments an initializing generative
+    constructor.
+
+*   An initializing generative constructor augments a redirecting generative
+    constructor.
+
 *   The introductory constructor is marked `factory` and the augmenting
     constructor is not, or vice versa. *An augmentation can't change whether or
     not a constructor is generative because that affects whether users are
     allowed to call the constructor in a subclass's initializer list.*
 
-*   A factory constructor is incomplete after all augmentations are applied.
+*   A factory constructor has no complete declaration.
 
-    *A constructor whose body is `;` is considered incomplete. This allows an
-    augmentation to fill in a more interesting body if it wants to. But Dart
-    also allows a generative constructor to have a body of `;` which is treated
-    as equivalent to `{}`. Thus it is not an error for a _generative_
-    constructor to be incomplete after all augmentations are applied. It is
-    simply treated as having an empty body.*
+    *A factory constructor which has `;` instead of a body or redirection,
+    is incomplete. This allows, and requires, an augmentation to fill in an
+    implementation.
+    A valid non-redirecting generative constructor can have no body,
+    also written as `;`. Thus it is not an error for a _generative_
+    constructor to be incomplete after all augmentation are applied. It is
+    simply an initializing constructor with no body.*
 
-An incomplete constructor can be completed by adding an initializer list and/or
-a body, or by adding a redirection:
+#### Factory constructors
+A factory constructor has a `factory` modifier in its declaration.
 
+A factory constructor declaration is incomplete if it has no body,
+and is ended by a `;`.
+
+A factory contructor is complete if it has a redirection, `= ConstructorName;`,
+in which case it's a redirecting factory constructor,
+or it has a function body, `=> expression` or `{...}`, in which case
+it's a non-redirecting factory constructor.
+
+It's a **compile-time error** if:
+
+* All declarations of a factory constructor are incomplete.
+
+#### Generative constructors
+
+A generative constructor is _complete_ and _redirecting_ if contains
+a redirection clause, like `: this.name(...);`.
+
+A generatice constructor is _complete_ and _initializing_ if it contains
+any of:
+
+* An initializing formal parameter (`this.name`).
+
+* A `super` parameter (`super.name`).
+
+* A declaring parameter (`final int name`), only valid in a primary constructor.
+
+* An initializer list (like `: param = expr, ...` or `: super(args)`).
+
+* A body (does not end in `;`).
+
+_This applies both to primary constructor declarations and
+non-primary constructor declarations, where the primary constructor
+declaration declares its initializer list and body in an in-body
+constructor part, like `this: ... { ... }`. An in-body constructor
+part of `this;` does not make the declaration complete._
+
+A generative constructor declaration is _incomplete_ if it is not
+_complete_.
+
+A generative constructor declaration is _redirecting_ if it's
+a complete redirecting declaration, or if it augments a declaration
+which is redirecting.
+
+A generative constructor declaration is _initializing_ (not redirecting)
+if it's a primary constructor declaration, a complete and initializing
+declartion, or if it augments a declaration which is initializing.
+
+_The introductory declaration may not decide whether a generative
+constructor is initializing or redirecting. It's decided by the
+first declaration which is complete or which is a primary constructor
+(which must be initializing), and all later augmentations must not
+contradict that decision._
+
+If all _declarations_ of a generative constructor are incomplete,
+then the constructor is an _initializing_ constructor with the
+implementation defined by the introductory declaration.
+*(A declaration of `C();` is defined as incomplete, but is also
+a valid concrete implementation of a trivial constructor.)*
+
+
+Example:
 ```dart
 class C {
   C.generative();
@@ -1000,15 +1185,68 @@ augment class C {
   factory augment C.fact() = C.other;
 }
 ```
+and with a primary constructor:
+```dart
+class const D(int x) {
+  /// Creates a `D`.
+  this;
+
+  augment const new(@Since("3.15") int x);
+}
+
+augment class D(final int x) {
+  augment this { print("Initialized D"); }
+
+  @Deprecated("Was a bad idea anyway");
+  augment D(int _);
+}
+```
+#### Instance variable initialization during constructor invocation
+
+When invoking an initializing generative constructor to initialize
+a new object, instance variable initialization happens before executing
+the initializer list.
+
+This is true for augmented classes, with and without primary constructors.
+
+When invoking the initializing constructor to initialize a new object,
+the first thing that happens is that actual arguments are bound to formal
+parameters, which provides the bindings for the initializer list scope.
+
+Then all non-`late` instance variable declarations of the class which have
+an initializer expression are processed in their source order.
+
+Each instance variable is initialized in turn, by evaluating its initializer expression. If the class has a primary constructor, the initializer expression
+is evaluated in the initializer list scope, otherwise it's evaluated in the
+class scope, and if the evaluation completes with a value, the instance
+variable is initialized to that value.
+
+After all instance variable initializers have been executed,
+constructor execution continues with executing as normal,
+starting with variable initialization by initializing formals
+and declaring parameters.
+
+_This is how primary constructors already work. The only difference is
+that because a single constructor can have more than one declaration,
+the complete declaration of a primary constructor may not be a primary
+constructor declaration._
 
 ### Augmenting extension types
 
-When augmenting an extension type declaration, the parenthesized clause where
-the representation type is specified is treated as a constructor that has a
-single positional parameter, a single initializer from the parameter to the
-representation field, and an empty body. This constructor is complete.
+When introducing an extension type declaration, the parenthesized clause where
+the representation type is specified introduces a complete generative constructor
+that has a single parameter.
 
-The extension also introduces a complete getter for the representation variable.
+The extension type representation clause also introduces a complete getter
+for the representation variable.
+
+These complete members are declared by the representation type clause,
+which orders them _before_ any member declarations inside the extension
+type declaration.
+
+*When augmenting an extension type declaration, the representation
+type declaration cannot be repeated, an augmenting extension type
+declaration cannot have a primary constructor.*
 
 *In other words, we treat the representation field clause as declaring an
 implicit constructor and final field for the representation variable. Since they
@@ -1337,6 +1575,21 @@ fully captured by that paragraph). It's probably safest to be pessimistic
 and assume the third point is always true.
 
 ## Changelog
+
+### 1.44
+
+*   Add primary constructors.
+
+*   Fix the Before/After relation definitions (prior definition used
+    "_includes_" transitively even if it was only declared for
+    direct part includes).
+
+*   Change restriction against declaring `toString` etc. in an `enum` to
+    having the introductory `enum` introduce those members as complete
+    declarations.
+    Then you can still `@something augment toString();` to add metadata.
+    (Existing language allows abstract declarations of all mentioned
+    members except `values`.)
 
 ### 1.43
 

--- a/working/augmentations/feature-specification.md
+++ b/working/augmentations/feature-specification.md
@@ -1128,8 +1128,10 @@ It's a **compile-time error** if:
 A generative constructor is _complete_ and _redirecting_ if contains
 a redirection clause, like `: this.name(...);`.
 
-A generatice constructor is _complete_ and _initializing_ if it contains
+A generative constructor is _complete_ and _initializing_ if it contains
 any of:
+
+* An `external` modifier.
 
 * An initializing formal parameter (`this.name`).
 

--- a/working/augmentations/feature-specification.md
+++ b/working/augmentations/feature-specification.md
@@ -293,17 +293,18 @@ always uses the same `on` clause as the introductory declaration.
 
 ## Primary constructors
 
-Both `class` and `enum` declarations can use the primary constructor syntax
-for declaring an initializing _(non-redirecting generative)_ constructor.
+A `class`, `enum` or `extension type` declarationscan use the primary
+constructor syntax for declaring an initializing _(non-redirecting
+generative)_ constructor.
 
-See [Generative constructors](#generative_constructor_declarations).
+See [Generative constructors](#generative-constructor-declarations).
 
 ### Instance variable initializer expressions
 
-If a class or enum has a primary constructor, then the scope of non-`late`
-instance variable initializer expressions is the initializer list scope
-of that constructor, rather than the body scope of the surrounding class
-or enum declaration.
+If a class or enum has a primary constructor, then the current scope of
+the initializer expression of a non-`late` instance variable is the
+primary initializer scope, rather than the body scope of the
+surrounding class or enum declaration.
 
 It's a compile-time error if a non-`late` instance variable initializer
 expressions refers to a variable introduced by the constructor's
@@ -1037,12 +1038,6 @@ Augmenting a constructor works similarly to augmenting a function, with some
 extra rules to handle features unique to constructors, like redirections and
 initializer lists, and the primary constructor syntax.
 
-
-<!-- It is **not** a compile-time error for an incomplete factory constructor to
-omit default values. *That is, they are treated similarly to abstract
-instance methods in this respect. This allows the augmenting declaration to
-implement the constructor by adding a redirection or a body.* -->
-
 A constructor declaration is a _factory constructor declaration_ if it
 has a `factory` keyword, and it is a _generative constructor declaration_ if
 it does not, including when it is a primary constructor declaration.
@@ -1089,12 +1084,14 @@ A primary constructor declaration is _complete_ if (any of):
   * It has an in-body `this`-part that:
       * has a body (`{...}`) and/or
       * has an initializer list (`: ...`).
+  * It's in an extension type declaration.
 A primary constructor declaration is an _augmenting declaration_ if
 (either of):
   * It has an in-body `this`-part with an `augment` keyword
     (`augment this ...`).
-  * It has no in-body `this`-part, and there is another declaration of
-    the same constructor which occurs _before_ this constructor.
+  * It has no in-body `this`-part, and there is another constructor
+    declaration with the same name which occurs _before_ this
+    constructor declaration.
 Otherwise it is an _introductory declaration_.
 _An augmenting primary constructor with no in-body `this`-part does not
 have a separate `augment` keyword. Such a constructor is necessarily part
@@ -1124,7 +1121,8 @@ constructor declaration_ and is _complete_ if (any of):
 
 *(A non-primary initializing constructor cannot have declaring parameters,
 those are only available to primary constructor declarations.
-Had they been allowed, they'd also make the constructor complete.)*
+If declaring parameters ever become valid for a non-primary generative
+constructor, they'll also make the constructor complete.)*
 
 A non-primary generative constructor declaration is a _redirecting generative
 constructor declaration_ and is _complete_ if it has a redirection clause
@@ -1143,12 +1141,18 @@ since those must be initializing.*
 If all _declarations_ of a generative constructor are incomplete,
 *(and therefore contains no redirecting generative constructor declarations,
 since those are all complete)*,
-then the constructor being defined is an _initializing_ constructor
-with the signature of the introductory declaration, the default values
-introduced by any declaration, no initializer list and no body.
+then the constructor being defined is an _initializing_ constructor,
+which is `const` if the declarations are, and which has normal parameters
+corresponding to the signature and default values defined by all
+the declarations, no initializer list, invoking the "unnamed" superclass
+constructor with no arguments, and with no body.
 *(A declaration of `C();` is defined as incomplete, but is also
 historically a valid concrete implementation of a trivial constructor,
-and this ensures that it keeps working that way.)*
+and this ensures that it keeps working that way. Effectively if a
+generative constructor has no complete declaration, it gets a "default
+constructor" implementation with normal parameters for the combined
+parameters declared by all of the incomplete constructors. Those
+parameters may be visible in instance variable initializers.)*
 
 Example:
 ```dart
@@ -1164,13 +1168,17 @@ augment class C {
   augment factory C.fact() = C.other;
 }
 ```
+Here `C.other` has only incomplete declarations.
+The class gets an implementation of that constructor equivalent to
+`C.other(): super();`.
+
 
 Example with a primary constructor:
 ```dart
 class const D(int x) {
+  final int squared = x * x;
   /// Creates a `D`.
   this;
-
   augment const new(@Since("3.15") int x);
 }
 
@@ -1181,6 +1189,22 @@ augment class const D(final int x) {
   augment const D(int _);
 }
 ```
+
+Example with incomplete primary constructor.
+```dart
+class const D(int _) {
+  /// Don't know yet.
+  init;
+}
+augment class const D(int x) {
+  final int squared = x * x;
+}
+```
+Here the `D.new` constructor has only incomplete declarations.
+It gest a default implementation equivalent to `D(int x): super();`,
+based on the names and types of all declarations, and it can use `x`
+in its instance variable declarations (which is exactly how the second
+class declaration would work by itself without augmentations).
 
 #### Consistency rules for constructor declarations
 
@@ -1223,7 +1247,8 @@ contain constructor declarations where:
     feature uses the public name for that parameter._
 
 *   There is a primary constructor declaration, and there is an initializing
-    constructor declaration for any other constructor.
+    constructor declaration with a different name, and the enclosing
+    declaration is a class or enum declaration.
     _If a class or enum has a primary constructor declaration, that constructor
     must still be the only initializing constructor, just as specified
     by the primary-constructors feature. That restriction applies to the entire

--- a/working/augmentations/feature-specification.md
+++ b/working/augmentations/feature-specification.md
@@ -177,9 +177,8 @@ mixinDeclaration ::=
   | 'augment' 'base'? 'mixin' typeIdentifier typeParameters?
     interfaces? memberedDeclarationBody
 
-extensionTypeDeclaration ::=
-    'extension' 'type' 'const'? typeIdentifier
-    typeParameters? representationDeclaration interfaces?
+extensionTypeDeclaration ::= // From primary constructors specification
+    'extension' 'type' primaryConstructor interfaces?
     memberedDeclarationBody
   | 'augment' 'extension' 'type' typeIdentifier
     typeParameters? interfaces?
@@ -192,7 +191,7 @@ memberedDeclarationBody ::=
 memberDeclarations ::= (metadata 'augment'? memberDeclaration)*
 
 primaryConstructorBodySignature ::= // From primary constructors specification
-     'augment'? 'this' initializers?;
+     'augment'? 'this' initializers?
 
 memberDeclaration ::= declaration
   | methodSignature functionBody
@@ -220,7 +219,14 @@ declaration ::=
   | redirectingFactoryConstructorSignature ';'
   | constantConstructorSignature (redirection | initializers)? ';'
   | constructorSignature (redirection | initializers)? ';'
+  | primaryConstructorBodySignature ';'
 ```
+
+*As introduced by the primary constructor feature, introductory extension type
+declarations use the primary constructor syntax, but **must** have precisely
+one parameter. That parameter must be declaring and `final`, but it can omit
+the `final` keyword. Augmenting extension type declarations cannot write
+primary constructors.*
 
 As with top-level declarations, we also reuse the abstract member syntax with a
 `static` modifier to allow declaring incomplete static fields, methods, getters,
@@ -296,7 +302,8 @@ See [Generative constructors](#generative_constructor_declarations).
 
 If a class or enum has a primary constructor, then the scope of non-`late`
 instance variable initializer expressions is the initializer list scope
-of that constructor.
+of that constructor, rather than the body scope of the surrounding class
+or enum declaration.
 
 It's a compile-time error if a non-`late` instance variable initializer
 expressions refers to a variable introduced by the constructor's
@@ -1004,7 +1011,6 @@ variables and constant variables can't be augmented.
 
 An introductory `enum` declaration introduces implicit introductory and
 complete declarations of:
- * `String toString()`
  * `int get index`
  * `int get hashCode`
  * `bool operator ==(Object)`
@@ -1041,8 +1047,9 @@ A constructor declaration is a _factory constructor declaration_ if it
 has a `factory` keyword, and it is a _generative constructor declaration_ if
 it does not, including when it is a primary constructor declaration.
 
-A constructor declaration is a _const constructor declaration_ if, and only if,
-it has a `const` keyword.
+A constructor declaration is a _const constructor declaration_ if
+it has a `const` keyword, or if it is a generative constructor declaration
+of an enum declaration, and otherwise it is not.
 _For a primary constructor, the `const` keyword goes before the class name
 in the header._
 
@@ -1057,13 +1064,13 @@ declaration_ and is _complete_ if it has a redirection clause (`= TargetType;`).
 
 _A factory constructor declaration with no body and no redirection clause,
 ended by a single `;`, is not a complete declaration, and does not decide
-whether the factory constructor being defined will is redirecting or not.
+whether the factory constructor being defined is redirecting or not.
 Only the (single) complete declaration forces that decision._
 
 #### Generative constructor declarations.
 
 A **primary constructor** declaration causes the constructor it defines
-be a primary constructor, and the class to have a primary constructor.
+to be a primary constructor, and the class to have a primary constructor.
 _This means the class cannot have any other initializing constructors,
 which is reflected by the consistency rules below, and it changes the
 scope used for instance variable initializer expressions._
@@ -1094,7 +1101,7 @@ have a separate `augment` keyword. Such a constructor is necessarily part
 of an augmenting class or enum declaration,
 and its header-part is likely on the same line as the `augment` keyword
 of that declaration. This is considered sufficient, rather than forcing
-a the author of a class declaration like `augment class C(final int x);`
+the author of a class declaration like `augment class C(final int x);`
 to add a body and in-body `this`-part just to write an `augment` on it,
 or alternatively to require a second `augment` keyword in the header as
 `augment class augment C(final int x);`._
@@ -1107,21 +1114,21 @@ the same getter and/or setter. *(The `augment` modifier does not apply
 to parameters, so the declaring parameter cannot be marked as augmenting
 a variable.)*
 
-An in-body generative constructor declaration is an _initializing constructor
-declaration_ and is _complete_ if (any of):
+A non-primary generative constructor declaration is an _initializing
+constructor declaration_ and is _complete_ if (any of):
   * It has an `external` keyword.
   * It has an initializing formal parameter (`this.name`).
   * It has a super parameter (`super.name`).
-  * It has a body (`{...}` instead of).
+  * It has a body (`{...}` instead of `;`).
   * It has an initializer list (`: ...`).
 
-*(An in-body initializing constructor cannot have declaring parameters,
+*(A non-primary initializing constructor cannot have declaring parameters,
 those are only available to primary constructor declarations.
 Had they been allowed, they'd also make the constructor complete.)*
 
-An in-body generative constructor declaration is a _redirecting generative
+A non-primary generative constructor declaration is a _redirecting generative
 constructor declaration_ and is _complete_ if it has a redirection clause
-(`: this(args);` or (`: this.name(args);`).
+(`: this(args);` or `: this.name(args);`).
 
 *The declarations of a class or enum can contain both primary and non-primary
 declarations of the same constructor. The class has a primary constructor
@@ -1154,7 +1161,7 @@ class C {
 
 augment class C {
   augment C.generative() : this.other();
-  factory augment C.fact() = C.other;
+  augment factory C.fact() = C.other;
 }
 ```
 
@@ -1167,17 +1174,17 @@ class const D(int x) {
   augment const new(@Since("3.15") int x);
 }
 
-augment class D(final int x) {
+augment class const D(final int x) {
   augment this { print("Initialized D"); }
 
-  @Deprecated("Was a bad idea anyway");
-  augment D(int _);
+  @Deprecated("Was a bad idea anyway")
+  augment const D(int _);
 }
 ```
 
 #### Consistency rules for constructor declarations
 
-It's a **compile-time error** if the the declarations of a class or enum
+It's a **compile-time error** if the declarations of a class or enum
 contain constructor declarations where:
 
 *   There is an augmenting constructor declaration with no corresponding
@@ -1226,7 +1233,7 @@ contain constructor declarations where:
 
 *   Two different declarations of the same constructor both specify a
     default value of the same parameter.
-    *This is an error even in it is the same default value.
+    *This is an error even if it is the same default value.
     Parameter default values can be defined by the introductory declaration
     or by an augmenting declaration, but at most once.*
 
@@ -1267,10 +1274,22 @@ Then all non-`late` instance variable declarations of the class which have
 an initializer expression are processed in their source order.
 
 Each instance variable is initialized in turn, by evaluating its initializer
-expression. If the class has a primary constructor, the initializer expression
-is evaluated in the initializer list scope, otherwise it's evaluated in the
-class scope, and if the evaluation completes with a value, the instance
-variable is initialized to that value.
+expression.
+If the class or enum has a primary constructor, the initializer
+expression is evaluated in the initializer list scope, otherwise it's evaluated
+in the body scope of the surrounding class or enum
+*(extension and extension type declarations cannot contain instance variable
+declarations, mixins and mixin-application classes cannot have primary
+constructors)*.
+
+*If the class has a constant generative constructor, then it's still a compile-
+time error if the class has any non-`final` instance variables, and it's still
+a compile-time error if an instance variable has an initializer expression
+that is not a potentially constant expression.*
+
+*Whether the evaluation uses the body scope or the initializer list scope,
+which has the body scope as parent scope, it's still an error if the
+expression refers to any instance member in the body scope.*
 
 After all instance variable initializers have been executed,
 constructor execution continues with executing as in Dart before this feature,
@@ -1284,26 +1303,35 @@ might not be a primary constructor declaration._
 
 ### Augmenting extension types
 
-When introducing an extension type declaration, the parenthesized clause where
-the representation type is specified introduces a complete generative constructor
-that has a single parameter.
+An introductory extension type declaration must have a primary constructor
+clause, which must have precisely one parameter.
+Just like for a class or enum, that primary constructor clause
+is a constructor declaration. For an extension type, it is an introductory
+and _complete_ initializing constructor declaration.
 
-The extension type representation clause also introduces a complete getter
-for the representation variable.
+That primary constructor's parameter declaration is also an introductory and
+complete getter declaration for a getter with the same name and type as the
+parameter declaration. *This is just like a declaring final parameter of a
+primary constructor of a class declaration. The parameter of an extension type
+primary constructor is always declaring and final, whether it has an explicit
+`final` or not.*
 
-These complete members are declared by the representation type clause,
-which orders them _before_ any member declarations inside the extension
-type declaration.
+*This orders these declarations _before_ any member declarations inside the
+extension type declaration, and since they must be declared by the introductory
+extension type declaration, they are always introductory.*
 
 *When augmenting an extension type declaration, the representation
 type declaration cannot be repeated, an augmenting extension type
 declaration cannot have a primary constructor.*
 
-*In other words, we treat the representation field clause as declaring an
-implicit constructor and final field for the representation variable. Since they
-are both complete, they can't be augmented with bodies. The representation
-variable getter can be augmented, because it's a getter and not a field
-declaration, but the augmentation can't add a body.*
+> [!NOTE]
+> Since the representation type declaration on the introductory extension type
+> introduces a complete constructor, it is a known limitation that an augmentation
+> cannot later attach an implementation body to the primary constructor.
+> All implementation of the primary constructor must be given in the introductory
+> declaration.
+> To work around this, developers can declare a private primary constructor and
+> expose a public constructor to be augmented.
 
 ### Augmenting with metadata annotations
 
@@ -1571,7 +1599,7 @@ follows:
         the argument list *A* and type arguments *T* to the *augmented
         parameter list* of *C*<sub>*top*</sub> and type parameters of
         *C<sub>top</sub>*. This creates a runtime parameter scope which has the
-        runtime class scope as parent scope (the lexical scope of the class,
+        runtime body scope as parent scope (the lexical scope of the class,
         except that type parameters of the class are bound to the runtime type
         arguments of those parameters for the instance *o*).
     *   Execute the body *B* in this parameter scope, with `this` bound to *o*.
@@ -1635,10 +1663,14 @@ and assume the third point is always true.
     "_includes_" transitively even if it was only declared for
     direct part includes).
 
-*   Change restriction against declaring `toString` etc. in an `enum` to
-    having the introductory `enum` introduce those members as complete
-    declarations.
-    Then you can still `@something augment toString();` to add metadata.
+*   Remove restriction against declaring `toString` in an `enum`.
+    There is no existing rule against an `enum` overriding `toString`,
+    and augmentations shouldn't introduce a restriction.
+
+*   Change restriction against declaring `operator ==`, `hashCode`,
+    `index` and `values` in an `enum` to having the introductory
+    `enum` introduce those members as complete declarations.
+    Then you can still `@something augment get index;` to add metadata.
     (Existing language allows abstract declarations of all mentioned
     members except `values`.)
 


### PR DESCRIPTION
Defines interaction between primary constructors and augmentations as:
* Each declaration of a constructor can choose between being primary or in-body.
* If any declaration is primary, that constructor is primary for the class.
* If a class has a primary constructor, it cannot have other initializing constructors, and
* Instance variable initializers can refer to constructor parameters (if the current fragment (re-)declares the primary constructor signature, includin that parameter name). Initializers are resolved in the same scope in either case, but it's an error if the name isn't visibly in scope.

Clean up "before"/"after" in the presence of declarations with no names, like the new constructor syntax `factory(x) => ...`.

Remove incorrect restriction on declaring enum members named `toString`, `hashCode` and `==`.
You always could declare those, as long as they were abstract.

(I changed that to saying that the declarations are introduced by the introductory `enum` as complete declarations in the enum. That means you you _must_ put `augment` in front of abstract declarations. I think it's an improvement, and definitely better than the blanket restriction, but it's still more restrictive than current Dart, and we may want to decide if that's what we want. I think it is.)

