### PR TITLE
Fix master URIs in specification documents

### DIFF
--- a/accepted/2.1/super-mixins/feature-specification.md
+++ b/accepted/2.1/super-mixins/feature-specification.md
@@ -147,7 +147,7 @@ superclass and mixin.
 Applications of generic mixin declarations may in some circumstances elide actual
 type arguments which will be filled in by an inference process as described
 in
-[this accompanying document](https://github.com/dart-lang/language/blob/master/accepted/2.1/super-mixins/mixin-inference.md)
+[this accompanying document](https://github.com/dart-lang/language/blob/main/accepted/2.1/super-mixins/mixin-inference.md)
 
 For example:
 

--- a/accepted/2.1/super-mixins/implementation-plan.md
+++ b/accepted/2.1/super-mixins/implementation-plan.md
@@ -3,8 +3,8 @@
 Relevant documents:
  - [Tracking issue](https://github.com/dart-lang/language/issues/12)
  - [Discussion issue](https://github.com/dart-lang/language/issues/7)
- - [Full proposal](https://github.com/dart-lang/language/blob/master/accepted/2.1/super-mixins/feature-specification.md)
- - [Mixin inference](https://github.com/dart-lang/language/blob/master/accepted/2.1/super-mixins/mixin-inference.md)
+ - [Full proposal](https://github.com/dart-lang/language/blob/main/accepted/2.1/super-mixins/feature-specification.md)
+ - [Mixin inference](https://github.com/dart-lang/language/blob/main/accepted/2.1/super-mixins/mixin-inference.md)
 
 ## Implementation and Release plan
 

--- a/accepted/2.1/super-mixins/mixin-inference.md
+++ b/accepted/2.1/super-mixins/mixin-inference.md
@@ -6,9 +6,9 @@ Status: Ready for comment
 
 This is an adaptation of the experimental super-mixin type argument inference
 described
-[here](https://github.com/dart-lang/sdk/blob/master/docs/language/informal/mixin-inference.md)
+[here](https://github.com/dart-lang/sdk/blob/main/docs/language/informal/mixin-inference.md)
 to use the new super-mixin declaration syntax proposed for addition to Dart 2.1
-[here](https://github.com/dart-lang/language/blob/master/accepted/2.1/super-mixins/feature-specification.md).
+[here](https://github.com/dart-lang/language/blob/main/accepted/2.1/super-mixins/feature-specification.md).
 
 ## Syntactic conventions
 

--- a/accepted/2.12/abstract-external-fields/implementation-plan.md
+++ b/accepted/2.12/abstract-external-fields/implementation-plan.md
@@ -5,7 +5,7 @@ Owner: eernst@google.com ([@eernstg](https://github.com/lrhn/) on GitHub)
 Relevant links:
 
 * [Tracking issue](https://github.com/dart-lang/sdk/issues/42560)
-* [Feature specification](https://github.com/dart-lang/language/blob/master/accepted/2.12/abstract-external-fields/feature-specification.md)
+* [Feature specification](https://github.com/dart-lang/language/blob/main/accepted/2.12/abstract-external-fields/feature-specification.md)
 
 ## Phase 0 (Preliminary steps)
 
@@ -16,7 +16,7 @@ The implementation of this feature is hidden behind an
 The flag `--enable-experiment=non-nullable`
 must be passed to tools in order to enable the feature.
 
-[experiment flag]: https://github.com/dart-lang/sdk/blob/master/docs/process/experimental-flags.md
+[experiment flag]: https://github.com/dart-lang/sdk/blob/main/docs/process/experimental-flags.md
 
 This means that the feature is considered to be part of the null-safety
 feature bundle, and it will be enabled by default along with null-safety.
@@ -24,7 +24,7 @@ feature bundle, and it will be enabled by default along with null-safety.
 ### Tests
 
 The language team adds
-[tests](https://github.com/dart-lang/sdk/tree/master/tests/language/external_abstract_fields)
+[tests](https://github.com/dart-lang/sdk/tree/main/tests/language/external_abstract_fields)
 for the feature. The Co19 team adds tests for the specification.
 
 ## Phase 1 (Front End Implementation)
@@ -76,7 +76,7 @@ Add a formal specification of this feature to the language specification.
 
 Cider and DartPad syntax highlighting uses codemirror, which should
 be updated to support the new syntax:
-https://github.com/codemirror/CodeMirror/blob/master/mode/dart/dart.js.
+https://github.com/codemirror/CodeMirror/blob/main/mode/dart/dart.js.
 
 ### IntelliJ
 
@@ -94,7 +94,7 @@ new syntax.
 ### Update github syntax highlighting
 
 Github's syntax highlighting should support the new syntax:
-https://github.com/dart-lang/dart-syntax-highlight/tree/master/grammars.
+https://github.com/dart-lang/dart-syntax-highlight/tree/main/grammars.
 
 When the grammar is updated, please create an issue on the
 Dart-Code/Dart-Code repository, such that the grammar can be

--- a/accepted/2.12/abstract-external-fields/implementation-plan.md
+++ b/accepted/2.12/abstract-external-fields/implementation-plan.md
@@ -76,7 +76,7 @@ Add a formal specification of this feature to the language specification.
 
 Cider and DartPad syntax highlighting uses codemirror, which should
 be updated to support the new syntax:
-https://github.com/codemirror/CodeMirror/blob/main/mode/dart/dart.js.
+https://github.com/codemirror/CodeMirror/blob/master/mode/dart/dart.js.
 
 ### IntelliJ
 
@@ -94,7 +94,7 @@ new syntax.
 ### Update github syntax highlighting
 
 Github's syntax highlighting should support the new syntax:
-https://github.com/dart-lang/dart-syntax-highlight/tree/main/grammars.
+https://github.com/dart-lang/dart-syntax-highlight/tree/master/grammars.
 
 When the grammar is updated, please create an issue on the
 Dart-Code/Dart-Code repository, such that the grammar can be

--- a/accepted/2.12/nnbd/feature-specification.md
+++ b/accepted/2.12/nnbd/feature-specification.md
@@ -204,13 +204,13 @@ Discussion issues on specific topics related to this proposal are [here](https:/
 The motivations for the feature along with the migration plan and strategy are
 discussed in more detail in
 the
-[roadmap](https://github.com/dart-lang/language/blob/master/accepted/2.12/nnbd/roadmap.md).
+[roadmap](https://github.com/dart-lang/language/blob/main/accepted/2.12/nnbd/roadmap.md).
 
 This proposal draws on the proposal that Patrice Chalin wrote
 up [here](https://github.com/dart-archive/dart_enhancement_proposals/issues/30),
 and on the proposal that Bob Nystrom wrote
 up
-[here](https://github.com/dart-lang/language/blob/master/resources/old-non-nullable-types.md).
+[here](https://github.com/dart-lang/language/blob/main/resources/old-non-nullable-types.md).
 
 
 ## Syntax
@@ -246,7 +246,7 @@ sequence to be written as `?..` indicating that the cascade is null-shorting.
 
 All of the syntax changes for this feature have been incorporated into
 the
-[formal grammar](https://github.com/dart-lang/language/blob/master/specification/dartLangSpec.tex),
+[formal grammar](https://github.com/dart-lang/language/blob/main/specification/dartLangSpec.tex),
 which serves as the canonical reference for the grammatical changes.
 
 ### Grammatical ambiguities and clarifications.
@@ -297,7 +297,7 @@ library section below.
 
 We modify the subtyping rules to account for nullability and legacy types as
 specified
-[here](https://github.com/dart-lang/language/blob/master/resources/type-system/subtyping.md).
+[here](https://github.com/dart-lang/language/blob/main/resources/type-system/subtyping.md).
 We write `S <: T` to mean that the type `S` is a subtype of `T` according to the
 rules specified there.
 
@@ -319,14 +319,14 @@ previous paragraph.
 We modify the upper and lower bound rules to account for nullability and legacy
 types as
 specified
-[here](https://github.com/dart-lang/language/blob/master/resources/type-system/upper-lower-bounds.md).
+[here](https://github.com/dart-lang/language/blob/main/resources/type-system/upper-lower-bounds.md).
 
 ### Type normalization
 
 We define a normalization procedure on types which defines a canonical
 representation for otherwise equivalent
 types
-[here](https://github.com/dart-lang/language/blob/master/resources/type-system/normalization.md).
+[here](https://github.com/dart-lang/language/blob/main/resources/type-system/normalization.md).
 This defines a procedure **NORM(`T`)** such that **NORM(`T`)** is syntactically
 equal to **NORM(`S`)** modulo replacement of primitive top types iff `S <: T`
 and `T <: S`.
@@ -523,7 +523,7 @@ definition if `T` is potentially non-nullable.
 A number of errors and warnings are updated to take reachability of statements
 into account.  Computation of code reachability
 is
-[specified separately](https://github.com/dart-lang/language/blob/master/resources/type-system/flow-analysis.md).
+[specified separately](https://github.com/dart-lang/language/blob/main/resources/type-system/flow-analysis.md).
 
 We say that a statement **may complete normally** if the specified control flow
 analysis determines that any control flow path may reach the end of the
@@ -831,7 +831,7 @@ parameter type.  Otherwise, the parameter type of the overriding method is
 
 Top level variable and local function inference is performed
 as
-[specified separately](https://github.com/dart-lang/language/blob/master/resources/type-system/inference.md).
+[specified separately](https://github.com/dart-lang/language/blob/main/resources/type-system/inference.md).
 Method body inference is not yet specified.
 
 If no type is specified in a catch clause, then the default type of the error
@@ -1072,7 +1072,7 @@ defined as follows.
 
 These are extended as
 per
-[separate proposal](https://github.com/dart-lang/language/blob/master/resources/type-system/flow-analysis.md).
+[separate proposal](https://github.com/dart-lang/language/blob/main/resources/type-system/flow-analysis.md).
 
 ## Helper predicates
 
@@ -1678,7 +1678,7 @@ values for their optional parameters.
 For migration, we support incremental adoption of non-nullability as described
 at a high level in
 the
-[roadmap](https://github.com/dart-lang/language/blob/master/accepted/2.12/nnbd/roadmap.md).
+[roadmap](https://github.com/dart-lang/language/blob/main/accepted/2.12/nnbd/roadmap.md).
 
 ### Opted in libraries.
 

--- a/accepted/2.13/nonfunction-type-aliases/implementation-plan.md
+++ b/accepted/2.13/nonfunction-type-aliases/implementation-plan.md
@@ -2,14 +2,14 @@
 
 Relevant documents:
  - [Tracking issue](https://github.com/dart-lang/language/issues/115)
- - [Feature specification](https://github.com/dart-lang/language/blob/master/accepted/2.13/nonfunction-type-aliases/feature-specification.md)
+ - [Feature specification](https://github.com/dart-lang/language/blob/main/accepted/2.13/nonfunction-type-aliases/feature-specification.md)
 
 ## Implementation and Release plan
 
 This feature is non-breaking, because it is concerned with the introduction of
 support for new syntactic forms.
 Still, we will introduce it using an
-[experiments flag](https://github.com/dart-lang/sdk/blob/master/docs/process/experimental-flags.md)
+[experiments flag](https://github.com/dart-lang/sdk/blob/main/docs/process/experimental-flags.md)
 in order to enable a controlled deployment.
 
 

--- a/accepted/2.14/small-features-21Q1/implementation-plan.md
+++ b/accepted/2.14/small-features-21Q1/implementation-plan.md
@@ -5,7 +5,7 @@ Owner: lrn@google.com ([@lrhn](https://github.com/lrhn/) on GitHub)
 Relevant links:
 
 * [Implementation issue](https://github.com/dart-lang/sdk/issues/44911)
-* [Proposal](https://github.com/dart-lang/language/blob/master/working/small-features-21q1/feature-specification.md)
+* [Proposal](https://github.com/dart-lang/language/blob/main/working/small-features-21q1/feature-specification.md)
 
 ## Phase 0 (Prerequisite)
 
@@ -15,7 +15,7 @@ The implementation of parts of this feature ("generic metadata" and "generic fun
 flag][]. Tools must be passed the flag
 `--enable-experiment=generic-metadata` to enable those features.
 
-[experiment flag]: https://github.com/dart-lang/sdk/blob/master/docs/process/experimental-flags.md
+[experiment flag]: https://github.com/dart-lang/sdk/blob/main/docs/process/experimental-flags.md
 
 While this feature is under development, individual tools may have incomplete or
 changing implementations behind the flag. When all tools have completely

--- a/accepted/2.14/triple-shift-operator/implementation-plan.md
+++ b/accepted/2.14/triple-shift-operator/implementation-plan.md
@@ -1,7 +1,7 @@
 # Implementation Plan for the `>>>` operator.
 
 Relevant documents:
-- [Feature specification](https://github.com/dart-lang/language/blob/master/accepted/2.14/triple-shift-operator/feature-specification.md)
+- [Feature specification](https://github.com/dart-lang/language/blob/main/accepted/2.14/triple-shift-operator/feature-specification.md)
 ## Implementation and Release plan
 
 ### Phase 0 (Preliminaries)

--- a/accepted/2.15/constructor-tearoffs/test-plan.md
+++ b/accepted/2.15/constructor-tearoffs/test-plan.md
@@ -164,11 +164,11 @@ The possible sources of tear-offs:
 
 
 
-[tear_off_test]: http://github.com/dart-lang/sdk/blob/master/tests/language/constructor/tear_off_test.dart
-[unnamed_new_error_test]: http://github.com/dart-lang/sdk/blob/master/tests/language/constructor/unnamed_new_error_test.dart
-[unnamed_new_test]: (http://github.com/dart-lang/sdk/blob/master/tests/language/constructor/unnamed_new_test.dart
-[explicit_instantiated_tearoff_test]: http://github.com/dart-lang/sdk/blob/master/tests/language/generic_methods/explicit_instantiated_tearoff_test.dart
-[explicit_instantiated_type_literal_error_test]: http://github.com/dart-lang/sdk/blob/master/tests/language/type_object/explicit_instantiated_type_literal_error_test.dart
-[explicit_instantiated_type_literal_test]: http://github.com/dart-lang/sdk/blob/master/tests/language/type_object/explicit_instantiated_type_literal_test.dart
-[aliased_constructor_tear_off_test]: http://github.com/dart-lang/sdk/blob/master/tests/language/typedef/aliased_constructor_tear_off_test.dart
-[aliased_type_literal_instantiation_test]: http://github.com/dart-lang/sdk/blob/master/tests/language/typedef/aliased_type_literal_instantiation_test.dart
+[tear_off_test]: http://github.com/dart-lang/sdk/blob/main/tests/language/constructor/tear_off_test.dart
+[unnamed_new_error_test]: http://github.com/dart-lang/sdk/blob/main/tests/language/constructor/unnamed_new_error_test.dart
+[unnamed_new_test]: (http://github.com/dart-lang/sdk/blob/main/tests/language/constructor/unnamed_new_test.dart
+[explicit_instantiated_tearoff_test]: http://github.com/dart-lang/sdk/blob/main/tests/language/generic_methods/explicit_instantiated_tearoff_test.dart
+[explicit_instantiated_type_literal_error_test]: http://github.com/dart-lang/sdk/blob/main/tests/language/type_object/explicit_instantiated_type_literal_error_test.dart
+[explicit_instantiated_type_literal_test]: http://github.com/dart-lang/sdk/blob/main/tests/language/type_object/explicit_instantiated_type_literal_test.dart
+[aliased_constructor_tear_off_test]: http://github.com/dart-lang/sdk/blob/main/tests/language/typedef/aliased_constructor_tear_off_test.dart
+[aliased_type_literal_instantiation_test]: http://github.com/dart-lang/sdk/blob/main/tests/language/typedef/aliased_type_literal_instantiation_test.dart

--- a/accepted/2.17/1847-finalization-registry/proposal.md
+++ b/accepted/2.17/1847-finalization-registry/proposal.md
@@ -449,7 +449,7 @@ way and consequently used as a finalization callback.
 This functionality though is outside of scope for this proposal and can be
 implemented independently at a later date.
 
-[dart_api.h]: https://github.com/dart-lang/sdk/blob/master/runtime/include/dart_api.h
+[dart_api.h]: https://github.com/dart-lang/sdk/blob/main/runtime/include/dart_api.h
 [weak handle]: https://github.com/dart-lang/sdk/blob/39a165647a7f2cf1ca8e81e696c552d25365c0c5/runtime/include/dart_api.h#L460-L494
 [finalizable handle]: https://github.com/dart-lang/sdk/blob/39a165647a7f2cf1ca8e81e696c552d25365c0c5/runtime/include/dart_api.h#L512-L550
 [MDN FinalizationRegistry]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry

--- a/accepted/2.18/horizontal-inference/feature-specification.md
+++ b/accepted/2.18/horizontal-inference/feature-specification.md
@@ -181,15 +181,15 @@ In this document we make use of the following terms:
     function literal.
 
 [language specification]: https://dart.dev/guides/language/spec
-[inference]: https://github.com/dart-lang/language/blob/master/resources/type-system/inference.md
-[flow analysis]: https://github.com/dart-lang/language/blob/master/resources/type-system/flow-analysis.md#flow-analysis
-[type schemas]: https://github.com/dart-lang/language/blob/master/resources/type-system/inference.md#type-schemas
-[type constraints]: https://github.com/dart-lang/language/blob/master/resources/type-system/inference.md#type-constraints
-[subtype constraint generation]: https://github.com/dart-lang/language/blob/master/resources/type-system/inference.md#subtype-constraint-generation
-[constraint solution for a type variable]: https://github.com/dart-lang/language/blob/master/resources/type-system/inference.md#constraint-solution-for-a-type-variable
-[constraint solution for a set of type variables]: https://github.com/dart-lang/language/blob/master/resources/type-system/inference.md#constraint-solution-for-a-set-of-type-variables
-[grounded constraint solution for a type variable]: https://github.com/dart-lang/language/blob/master/resources/type-system/inference.md#grounded-constraint-solution-for-a-type-variable
-[grounded constraint solution for a set of type variables]: https://github.com/dart-lang/language/blob/master/resources/type-system/inference.md#grounded-constraint-solution-for-a-set-of-type-variables
+[inference]: https://github.com/dart-lang/language/blob/main/resources/type-system/inference.md
+[flow analysis]: https://github.com/dart-lang/language/blob/main/resources/type-system/flow-analysis.md#flow-analysis
+[type schemas]: https://github.com/dart-lang/language/blob/main/resources/type-system/inference.md#type-schemas
+[type constraints]: https://github.com/dart-lang/language/blob/main/resources/type-system/inference.md#type-constraints
+[subtype constraint generation]: https://github.com/dart-lang/language/blob/main/resources/type-system/inference.md#subtype-constraint-generation
+[constraint solution for a type variable]: https://github.com/dart-lang/language/blob/main/resources/type-system/inference.md#constraint-solution-for-a-type-variable
+[constraint solution for a set of type variables]: https://github.com/dart-lang/language/blob/main/resources/type-system/inference.md#constraint-solution-for-a-set-of-type-variables
+[grounded constraint solution for a type variable]: https://github.com/dart-lang/language/blob/main/resources/type-system/inference.md#grounded-constraint-solution-for-a-type-variable
+[grounded constraint solution for a set of type variables]: https://github.com/dart-lang/language/blob/main/resources/type-system/inference.md#grounded-constraint-solution-for-a-set-of-type-variables
 
 ## Type inference algorithm for invocations
 

--- a/accepted/2.2/set-literals/feature-specification.md
+++ b/accepted/2.2/set-literals/feature-specification.md
@@ -15,9 +15,9 @@ have a [unified proposal][] that covers the behavior of all three. That proposal
 is now the source of truth. This document is useful for motivation, but may be
 otherwise out of date.**
 
-[spread collections]: https://github.com/dart-lang/language/blob/master/accepted/2.3/spread-collections/feature-specification.md
-[control flow collections]: https://github.com/dart-lang/language/tree/master/accepted/2.3/control-flow-collections/feature-specification.md
-[unified proposal]: https://github.com/dart-lang/language/tree/master/accepted/2.3/unified-collections/feature-specification.md
+[spread collections]: https://github.com/dart-lang/language/blob/main/accepted/2.3/spread-collections/feature-specification.md
+[control flow collections]: https://github.com/dart-lang/language/tree/main/accepted/2.3/control-flow-collections/feature-specification.md
+[unified proposal]: https://github.com/dart-lang/language/tree/main/accepted/2.3/unified-collections/feature-specification.md
 
 ## Overview
 

--- a/accepted/2.2/set-literals/implementation-plan.md
+++ b/accepted/2.2/set-literals/implementation-plan.md
@@ -2,7 +2,7 @@
 
 Relevant documents:
  - [Tracking issue](TODO)
- - [Full proposal](https://github.com/dart-lang/language/blob/master/accepted/2.2/set-literals/feature-specification.md)
+ - [Full proposal](https://github.com/dart-lang/language/blob/main/accepted/2.2/set-literals/feature-specification.md)
 
 ## Implementation and Release plan
 
@@ -10,7 +10,7 @@ Relevant documents:
 
 The implementation of this change will happen behind
 an
-[*experiments flag*](https://github.com/dart-lang/sdk/blob/master/docs/process/experimental-flags.md).
+[*experiments flag*](https://github.com/dart-lang/sdk/blob/main/docs/process/experimental-flags.md).
 Tools need to be passed the flag `--enable-experiment=set-literals` for the
 changes to be enabled.
 

--- a/accepted/2.3/control-flow-collections/feature-specification.md
+++ b/accepted/2.3/control-flow-collections/feature-specification.md
@@ -9,9 +9,9 @@ conditionals and repetition.
 
 **Note: Because this feature interacts heavily with [Set Literals][] and [Spread Collections][], which are all being implemented concurrently, we have a [unified proposal][] that covers the behavior of all three. That proposal is now the source of truth. This document is useful for motivation, but may be otherwise out of date.**
 
-[set literals]: https://github.com/dart-lang/language/blob/master/accepted/2.2/set-literals/feature-specification.md
-[spread collections]: https://github.com/dart-lang/language/blob/master/accepted/2.3/spread-collections/feature-specification.md
-[unified proposal]: https://github.com/dart-lang/language/tree/master/accepted/2.3/unified-collections/feature-specification.md
+[set literals]: https://github.com/dart-lang/language/blob/main/accepted/2.2/set-literals/feature-specification.md
+[spread collections]: https://github.com/dart-lang/language/blob/main/accepted/2.3/spread-collections/feature-specification.md
+[unified proposal]: https://github.com/dart-lang/language/tree/main/accepted/2.3/unified-collections/feature-specification.md
 
 ## Motivation
 
@@ -84,7 +84,7 @@ Widget build(BuildContext context) {
 It's arguably better than the above code, but it's not obvious or terse. Adding
 [spread syntax][spread] would let you do:
 
-[spread]: https://github.com/dart-lang/language/blob/master/accepted/2.3/spread-collections/feature-specification.md
+[spread]: https://github.com/dart-lang/language/blob/main/accepted/2.3/spread-collections/feature-specification.md
 
 ```dart
 Widget build(BuildContext context) {
@@ -732,7 +732,7 @@ elements to consider:
 
     See the [relevant proposal][const spread] for how these are handled.
 
-    [const spread]: https://github.com/dart-lang/language/blob/master/accepted/2.3/spread-collections/feature-specification.md#const-spreads
+    [const spread]: https://github.com/dart-lang/language/blob/main/accepted/2.3/spread-collections/feature-specification.md#const-spreads
 
 *   An **if element**:
 
@@ -1065,7 +1065,7 @@ Without [rest parameters][], `for` isn't useful and `if` probably isn't
 feasible for positional arguments. But even without rest params, it's possible
 to support `if` for named arguments.
 
-[rest parameters]: https://github.com/munificent/ui-as-code/blob/master/in-progress/parameter-freedom.md
+[rest parameters]: https://github.com/munificent/ui-as-code/blob/main/in-progress/parameter-freedom.md
 
 We can and should look at doing that as a separate proposal.
 

--- a/accepted/2.3/control-flow-collections/feature-specification.md
+++ b/accepted/2.3/control-flow-collections/feature-specification.md
@@ -1065,7 +1065,7 @@ Without [rest parameters][], `for` isn't useful and `if` probably isn't
 feasible for positional arguments. But even without rest params, it's possible
 to support `if` for named arguments.
 
-[rest parameters]: https://github.com/munificent/ui-as-code/blob/main/in-progress/parameter-freedom.md
+[rest parameters]: https://github.com/munificent/ui-as-code/blob/master/in-progress/parameter-freedom.md
 
 We can and should look at doing that as a separate proposal.
 

--- a/accepted/2.3/control-flow-collections/implementation-plan.md
+++ b/accepted/2.3/control-flow-collections/implementation-plan.md
@@ -5,7 +5,7 @@ Owner: rnystrom@google.com ([@munificent](https://github.com/munificent/) on Git
 Relevant links:
 
 * [Tracking issue](https://github.com/dart-lang/language/issues/78)
-* [Proposal](https://github.com/dart-lang/language/blob/master/working/control-flow-collections/feature-specification.md)
+* [Proposal](https://github.com/dart-lang/language/blob/main/working/control-flow-collections/feature-specification.md)
 
 ## Phase 0 (Prerequisite)
 
@@ -15,7 +15,7 @@ The implementation of this feature should be hidden behind an [experiment
 flag][]. Tools must be passed the flag
 `--enable-experiment=control-flow-collections` to enable the feature.
 
-[experiment flag]: https://github.com/dart-lang/sdk/blob/master/docs/process/experimental-flags.md
+[experiment flag]: https://github.com/dart-lang/sdk/blob/main/docs/process/experimental-flags.md
 
 While this feature is under development, individual tools may have incomplete or
 changing implementations behind the flag. When all tools have completely

--- a/accepted/2.3/spread-collections/feature-specification.md
+++ b/accepted/2.3/spread-collections/feature-specification.md
@@ -11,9 +11,9 @@ have a [unified proposal][] that covers the behavior of all three. That proposal
 is now the source of truth. This document is useful for motivation, but may be
 otherwise out of date.**
 
-[set literals]: https://github.com/dart-lang/language/blob/master/accepted/2.2/set-literals/feature-specification.md
-[control flow collections]: https://github.com/dart-lang/language/blob/master/accepted/2.3/control-flow-collections/feature-specification.md
-[unified proposal]: https://github.com/dart-lang/language/tree/master/accepted/2.3/unified-collections/feature-specification.md
+[set literals]: https://github.com/dart-lang/language/blob/main/accepted/2.2/set-literals/feature-specification.md
+[control flow collections]: https://github.com/dart-lang/language/blob/main/accepted/2.3/control-flow-collections/feature-specification.md
+[unified proposal]: https://github.com/dart-lang/language/tree/main/accepted/2.3/unified-collections/feature-specification.md
 
 ## Motivation
 
@@ -739,7 +739,7 @@ corpus where this syntax could be used by looking for calls to `.addAll()` on
 collection literals. I converted them to use the prefix and postfix syntax
 [here][spread examples].
 
-[spread examples]: https://github.com/dart-lang/language/tree/master/working/spread-collections/examples
+[spread examples]: https://github.com/dart-lang/language/tree/main/working/spread-collections/examples
 
 Only a few cases use `...?`. Some examples do have pretty complex expressions
 where it's easy to overlook a trailing `...`, like:

--- a/accepted/2.3/spread-collections/implementation-plan.md
+++ b/accepted/2.3/spread-collections/implementation-plan.md
@@ -5,7 +5,7 @@ Owner: rnystrom@google.com ([@munificent](https://github.com/munificent/) on Git
 Relevant links:
 
 * [Tracking issue](https://github.com/dart-lang/language/issues/47)
-* [Proposal](https://github.com/dart-lang/language/blob/master/accepted/2.3/spread-collections/feature-specification.md)
+* [Proposal](https://github.com/dart-lang/language/blob/main/accepted/2.3/spread-collections/feature-specification.md)
 
 ## Phase 0 (Prerequisite)
 
@@ -15,7 +15,7 @@ The implementation of this feature should be hidden behind an [experiment
 flag][]. Tools must be passed the flag `--enable-experiment=spread-collections`
 to enable the feature.
 
-[experiment flag]: https://github.com/dart-lang/sdk/blob/master/docs/process/experimental-flags.md
+[experiment flag]: https://github.com/dart-lang/sdk/blob/main/docs/process/experimental-flags.md
 
 While this feature is under development, individual tools may have incomplete or
 changing implementations behind the flag. When all tools have completely

--- a/accepted/2.3/spread-collections/performance.md
+++ b/accepted/2.3/spread-collections/performance.md
@@ -35,7 +35,7 @@ summzarize the trends.
 The benchmark is [here][code], and the full data is [here][sheet] (not visible
 outside of Google, sorry).
 
-[code]: https://github.com/dart-lang/language/tree/master/accepted/2.3/spread-collections/benchmarks/bin/profile.dart
+[code]: https://github.com/dart-lang/language/tree/main/accepted/2.3/spread-collections/benchmarks/bin/profile.dart
 [sheet]: https://docs.google.com/spreadsheets/d/1gomXf2pPnMl95iCIHSVElB3c9giGaXDRNDJuyABXcw4/edit#gid=0&fvid=1718348639
 
 ## Methodology

--- a/accepted/2.3/unified-collections/feature-specification.md
+++ b/accepted/2.3/unified-collections/feature-specification.md
@@ -7,7 +7,7 @@ collections feature. The source of truth on this topic at this time is the
 'Collection Literals' section of the [language specification][]
 ([PDF][language specification PDF]).**
 
-[language specification]: https://github.com/dart-lang/language/blob/master/specification/dartLangSpec.tex
+[language specification]: https://github.com/dart-lang/language/blob/main/specification/dartLangSpec.tex
 [language specification PDF]: https://spec.dart.dev/DartLangSpecDraft.pdf
 
 The Dart team is concurrently working on three proposals that affect collection
@@ -17,9 +17,9 @@ literals:
 * [Spread Collections][]
 * [Control Flow Collections][]
 
-[set literals]: https://github.com/dart-lang/language/blob/master/accepted/2.2/set-literals/feature-specification.md
-[spread collections]: https://github.com/dart-lang/language/blob/master/accepted/2.3/spread-collections/feature-specification.md
-[control flow collections]: https://github.com/dart-lang/language/blob/master/accepted/2.3/control-flow-collections/feature-specification.md
+[set literals]: https://github.com/dart-lang/language/blob/main/accepted/2.2/set-literals/feature-specification.md
+[spread collections]: https://github.com/dart-lang/language/blob/main/accepted/2.3/spread-collections/feature-specification.md
+[control flow collections]: https://github.com/dart-lang/language/blob/main/accepted/2.3/control-flow-collections/feature-specification.md
 
 These features interact in several ways, some of which weren't obvious at first.
 To make things easier on implementers and anyone else trying to understand the

--- a/accepted/2.5/constant-update-2018/implementation-plan.md
+++ b/accepted/2.5/constant-update-2018/implementation-plan.md
@@ -2,13 +2,13 @@
 
 Relevant documents:
  - [Tracking issue](https://github.com/dart-lang/language/issues/60)
- - [Full proposal](https://github.com/dart-lang/language/blob/master/accepted/2.5/constant-update-2018/feature-specification.md)
+ - [Full proposal](https://github.com/dart-lang/language/blob/main/accepted/2.5/constant-update-2018/feature-specification.md)
 
 ## Implementation and Release plan
 
 ### Release flags
 
-The implementation of these changes must happen behind an [*experiments flag*](https://github.com/dart-lang/sdk/blob/master/docs/process/experimental-flags.md).
+The implementation of these changes must happen behind an [*experiments flag*](https://github.com/dart-lang/sdk/blob/main/docs/process/experimental-flags.md).
 Tools need to be passed the flag `--enable-experiment=constant-update-2018`
 for the changes to be enabled.
 

--- a/accepted/2.5/contravariant-superinterface-2018/implementation-plan.md
+++ b/accepted/2.5/contravariant-superinterface-2018/implementation-plan.md
@@ -2,7 +2,7 @@
 
 Relevant documents:
  - [Tracking issue](https://github.com/dart-lang/language/issues/113)
- - [Feature specification](https://github.com/dart-lang/language/blob/master/accepted/2.5/contravariant-superinterface-2018/feature-specification.md)
+ - [Feature specification](https://github.com/dart-lang/language/blob/main/accepted/2.5/contravariant-superinterface-2018/feature-specification.md)
 
 
 ## Implementation and Release plan
@@ -10,7 +10,7 @@ Relevant documents:
 This feature is concerned with the introduction of one extra compile-time
 error, and the breakage has been estimated to be very low.
 Still, we will use an 
-[experiments flag](https://github.com/dart-lang/sdk/blob/master/docs/process/experimental-flags.md)
+[experiments flag](https://github.com/dart-lang/sdk/blob/main/docs/process/experimental-flags.md)
 in order to enable a controlled deployment.
 
 

--- a/accepted/2.7/static-extension-methods/implementation-plan.md
+++ b/accepted/2.7/static-extension-methods/implementation-plan.md
@@ -5,7 +5,7 @@ Owner: lrn@google.com ([@lrhn](https://github.com/lrhn/) on GitHub)
 Relevant links:
 
 * [Tracking issue](https://github.com/dart-lang/language/issues/41)
-* [Proposal](https://github.com/dart-lang/language/blob/master/accepted/2.7/static-extension-methods/feature-specification.md)
+* [Proposal](https://github.com/dart-lang/language/blob/main/accepted/2.7/static-extension-methods/feature-specification.md)
 
 ## Phase 0 (Prerequisite)
 
@@ -15,7 +15,7 @@ The implementation of this feature should be hidden behind an [experiment
 flag][]. Tools must be passed the flag
 `--enable-experiment=extension-methods` to enable the feature.
 
-[experiment flag]: https://github.com/dart-lang/sdk/blob/master/docs/process/experimental-flags.md
+[experiment flag]: https://github.com/dart-lang/sdk/blob/main/docs/process/experimental-flags.md
 
 While this feature is under development, individual tools may have incomplete or
 changing implementations behind the flag. When all tools have completely

--- a/accepted/2.8/language-versioning/feature-specification.md
+++ b/accepted/2.8/language-versioning/feature-specification.md
@@ -57,7 +57,7 @@ It does so by:
 
 ### Package Default Language Version
 
-A language tool (like a compiler or analyzer) needs to derive this information for *all* packages available to the program it is processing. To this end, we record a language version for each available package in the new [`.dart_tool/package_config.json`](https://github.com/dart-lang/language/blob/master/accepted/2.8/language-versioning/package-config-file-v2.md) file (which replaces `.packages` as the package configuration file), and this language version is used to define the *default* language version for all libraries in that package. Each individual library can override the default language version if necessary.
+A language tool (like a compiler or analyzer) needs to derive this information for *all* packages available to the program it is processing. To this end, we record a language version for each available package in the new [`.dart_tool/package_config.json`](https://github.com/dart-lang/language/blob/main/accepted/2.8/language-versioning/package-config-file-v2.md) file (which replaces `.packages` as the package configuration file), and this language version is used to define the *default* language version for all libraries in that package. Each individual library can override the default language version if necessary.
 
 The `.dart_tool/package_config.json` file is a JSON formatted text file which declares a number of named packages with a root and a package URI root directory for each. The SDK version for a specific package is added as an extra `languageVersion` property on the JSON object for the package.  The package configuration file is generated automatically by the `pub` tool as documented in the file’s specification.
 
@@ -268,14 +268,14 @@ The optimistic upgrade from version 2.5 to 2.9 will go through all the intermedi
 
 ## Revisions
 
-1.0: Initial version (adapted from [strawman proposal](<https://github.com/dart-lang/language/blob/master/working/0093%20-%20Gradual%20Language%20Change%20Migration/0094%20-%20Per%20Library%20Language%20Version%20Selection/strawman.md>)).
+1.0: Initial version (adapted from [strawman proposal](<https://github.com/dart-lang/language/blob/main/working/0093%20-%20Gradual%20Language%20Change%20Migration/0094%20-%20Per%20Library%20Language%20Version%20Selection/strawman.md>)).
 
 1.1: Update specification after rewiew.
 
 - Update `.packages` file format to contain entire SDK version.
 - Restrict override syntax to only `// @dart = 2.3` format.
 - Specify experiment flag behavior.
-- Change `*:defaultPackage` to `:defaultPackage` because `*` was already a valid package name in the [`.packages` file specification](<https://github.com/lrhn/dep-pkgspec/blob/master/DEP-pkgspec.md>).
+- Change `*:defaultPackage` to `:defaultPackage` because `*` was already a valid package name in the [`.packages` file specification](<https://github.com/lrhn/dep-pkgspec/blob/main/DEP-pkgspec.md>).
 
 1.2: Require language version markers in part files when the library has one.
 

--- a/accepted/2.8/language-versioning/feature-specification.md
+++ b/accepted/2.8/language-versioning/feature-specification.md
@@ -275,7 +275,7 @@ The optimistic upgrade from version 2.5 to 2.9 will go through all the intermedi
 - Update `.packages` file format to contain entire SDK version.
 - Restrict override syntax to only `// @dart = 2.3` format.
 - Specify experiment flag behavior.
-- Change `*:defaultPackage` to `:defaultPackage` because `*` was already a valid package name in the [`.packages` file specification](<https://github.com/lrhn/dep-pkgspec/blob/main/DEP-pkgspec.md>).
+- Change `*:defaultPackage` to `:defaultPackage` because `*` was already a valid package name in the [`.packages` file specification](<https://github.com/lrhn/dep-pkgspec/blob/master/DEP-pkgspec.md>).
 
 1.2: Require language version markers in part files when the library has one.
 

--- a/accepted/2.8/language-versioning/implementation-plan.md
+++ b/accepted/2.8/language-versioning/implementation-plan.md
@@ -5,7 +5,7 @@ Owner: lrn@google.com ([@lrhn](https://github.com/lrhn/) on GitHub)
 Relevant links:
 
 * [Tracking issue](https://github.com/dart-lang/language/issues/94)
-* [Proposal](https://github.com/dart-lang/language/blob/master/accepted/2.8/language-versioning/feature-specification.md)
+* [Proposal](https://github.com/dart-lang/language/blob/main/accepted/2.8/language-versioning/feature-specification.md)
 
 ## Phase 0 (Prerequisite)
 
@@ -15,7 +15,7 @@ This feature does not need an [experiment flag] for user consumption.
 
 We may want a flag for testing purposes, but the implementation teams should consider that internally.
 
-[experiment flag]: https://github.com/dart-lang/sdk/blob/master/docs/process/experimental-flags.md
+[experiment flag]: https://github.com/dart-lang/sdk/blob/main/docs/process/experimental-flags.md
 
 ### Tests
 

--- a/accepted/3.0/class-modifiers/feature-specification.md
+++ b/accepted/3.0/class-modifiers/feature-specification.md
@@ -39,8 +39,8 @@ This proposal is a blend of a few earlier proposals:
 * [Type modifiers][]
 * [Access modifiers using closed, sealed, open and interface][leaf proposal]
 
-[class capabilities]: https://github.com/dart-lang/language/blob/master/resources/class-capabilities/class-capabilities.md
-[type modifiers]: https://github.com/dart-lang/language/blob/master/inactive/type-modifiers/feature-specification.md
+[class capabilities]: https://github.com/dart-lang/language/blob/main/resources/class-capabilities/class-capabilities.md
+[type modifiers]: https://github.com/dart-lang/language/blob/main/inactive/type-modifiers/feature-specification.md
 [leaf proposal]: https://github.com/dart-lang/language/issues/2595
 
 The [type modifiers][] document has some motivation and discussion around
@@ -243,17 +243,17 @@ family of subtypes used for exhaustiveness checking. You put `sealed` on a
 supertype. Then you are only allowed to directly extend, implement, or mix in
 that supertype from within the same library.
 
-[sealed]: https://github.com/dart-lang/language/blob/master/accepted/future-releases/sealed-types/feature-specification.md
-[pattern matching features]: https://github.com/dart-lang/language/blob/master/accepted/3.0/patterns/feature-specification.md
+[sealed]: https://github.com/dart-lang/language/blob/main/accepted/future-releases/sealed-types/feature-specification.md
+[pattern matching features]: https://github.com/dart-lang/language/blob/main/accepted/3.0/patterns/feature-specification.md
 
 In return for that restriction, in a switch, if you cover all of those subtypes,
 then the compiler knows that you have [exhaustively][exhaustive] covered all
 possible instances of the supertype. This is a big part of enabling a
 [functional programming style][fp] in Dart.
 
-[exhaustive]: https://github.com/dart-lang/language/blob/master/accepted/3.0/patterns/exhaustiveness.md
+[exhaustive]: https://github.com/dart-lang/language/blob/main/accepted/3.0/patterns/exhaustiveness.md
 
-[fp]: https://github.com/dart-lang/language/blob/master/accepted/3.0/patterns/feature-specification.md#algebraic-datatypes
+[fp]: https://github.com/dart-lang/language/blob/main/accepted/3.0/patterns/feature-specification.md#algebraic-datatypes
 
 The `sealed` modifier prevents direct subtyping from outside of the library
 where the sealed type is defined. But it doesn't prevent you from subtyping

--- a/accepted/3.0/patterns/exhaustiveness.md
+++ b/accepted/3.0/patterns/exhaustiveness.md
@@ -13,8 +13,8 @@ of [switch statements and expressions][switch] as part of the proposed support
 for [pattern matching][patterns]. It also tries to provide an intuition for how
 the algorithm works.
 
-[switch]: https://github.com/dart-lang/language/blob/master/accepted/3.0/patterns/feature-specification.md#switch-statement
-[patterns]: https://github.com/dart-lang/language/blob/master/accepted/3.0/patterns/feature-specification.md
+[switch]: https://github.com/dart-lang/language/blob/main/accepted/3.0/patterns/feature-specification.md#switch-statement
+[patterns]: https://github.com/dart-lang/language/blob/main/accepted/3.0/patterns/feature-specification.md
 
 Exhaustiveness checking is about answering two questions:
 
@@ -60,7 +60,7 @@ Dart already supports exhaustiveness and reachability warnings in switch
 statements on `bool` and enum types. This document extends that to handle
 destructuring patterns and [algebraic datatype-style][adt] code.
 
-[adt]: https://github.com/dart-lang/language/blob/master/accepted/3.0/patterns/feature-specification.md#algebraic-datatypes
+[adt]: https://github.com/dart-lang/language/blob/main/accepted/3.0/patterns/feature-specification.md#algebraic-datatypes
 
 The approach is based on the paper ["Warnings for pattern matching"][maranget]
 (PDF) by Luc Maranget, modified to handle subtyping, named field destructuring,
@@ -75,7 +75,7 @@ for Checking Exhaustivity of Pattern Matching"][space paper] by [Fengyun Liu][].
 There is a [prototype implementation][prototype] of the algorithm with detailed
 comments and tests.
 
-[prototype]: https://github.com/dart-lang/language/tree/master/accepted/3.0/patterns/exhaustiveness_prototype
+[prototype]: https://github.com/dart-lang/language/tree/main/accepted/3.0/patterns/exhaustiveness_prototype
 
 ### Why check for exhaustiveness?
 
@@ -195,7 +195,7 @@ library where the sealed type is declared is allowed to define a new subtype of
 the sealed supertype (using `extends`, `implements`, `with`, or `on`). The
 supertype is also implicitly made abstract.
 
-[sealed]: https://github.com/dart-lang/language/blob/master/accepted/future-releases/sealed-types/feature-specification.md
+[sealed]: https://github.com/dart-lang/language/blob/main/accepted/future-releases/sealed-types/feature-specification.md
 
 Here is an example:
 

--- a/accepted/3.0/patterns/feature-specification.md
+++ b/accepted/3.0/patterns/feature-specification.md
@@ -9,7 +9,7 @@ Version 2.33 (see [CHANGELOG](#CHANGELOG) at end)
 Note: This proposal is broken into a couple of separate documents. See also
 [records][] and [exhaustiveness][].
 
-[records]: https://github.com/dart-lang/language/blob/master/accepted/3.0/records/feature-specification.md
+[records]: https://github.com/dart-lang/language/blob/main/accepted/3.0/records/feature-specification.md
 
 ## Summary
 
@@ -640,7 +640,7 @@ It is a compile-time error if:
 *Note that `mapPatternEntries` is not optional, which means it is an error for
 a map pattern to be empty.*
 
-[structurally equivalent]: https://github.com/dart-lang/language/blob/master/accepted/3.0/records/feature-specification.md#canonicalization
+[structurally equivalent]: https://github.com/dart-lang/language/blob/main/accepted/3.0/records/feature-specification.md#canonicalization
 
 #### Open and closed maps
 
@@ -1974,7 +1974,7 @@ To type check a pattern `p` being matched against a value of type `M`:
 
     2.  Type-check the subpattern using `N` as the matched value type.
 
-    [nonnull]: https://github.com/dart-lang/language/blob/master/accepted/2.12/nnbd/feature-specification.md#null-promotion
+    [nonnull]: https://github.com/dart-lang/language/blob/main/accepted/2.12/nnbd/feature-specification.md#null-promotion
 
 *   **Constant**: Type check the pattern's value in context type `M`. *The
     context type comes into play for things like type argument inference,
@@ -2492,7 +2492,7 @@ patterns is complex, so the proposal to define how it works is in a [separate
 document][exhaustiveness]. That tells us if the cases in a switch statement or
 expression are exhaustive or not.
 
-[exhaustiveness]: https://github.com/dart-lang/language/blob/master/accepted/3.0/patterns/exhaustiveness.md
+[exhaustiveness]: https://github.com/dart-lang/language/blob/main/accepted/3.0/patterns/exhaustiveness.md
 
 We don't want to require *all* switches to be exhaustive. The language currently
 does not require switch statements on, say, strings to be exhaustive, and

--- a/accepted/3.0/records/feature-specification.md
+++ b/accepted/3.0/records/feature-specification.md
@@ -418,7 +418,7 @@ class extends Record {
 
 Subtyping for record types has been incorporated into the main subtyping
 specification
-[here](https://github.com/dart-lang/language/blob/master/resources/type-system/subtyping.md).
+[here](https://github.com/dart-lang/language/blob/main/resources/type-system/subtyping.md).
 Briefly:
 
 The class `Record` is a subtype of `Object` and `dynamic` and a supertype of
@@ -434,7 +434,7 @@ no "row polymorphism" or "width subtyping".*
 
 Bounds computations for record types have been incorporated into the main
 specification
-[here](https://github.com/dart-lang/language/blob/master/resources/type-system/upper-lower-bounds.md).
+[here](https://github.com/dart-lang/language/blob/main/resources/type-system/upper-lower-bounds.md).
 Briefly:
 
 If two record types have the same shape, their least upper bound is a new

--- a/accepted/3.3/extension-types/feature-specification.md
+++ b/accepted/3.3/extension-types/feature-specification.md
@@ -12,8 +12,8 @@ This document is built on several earlier proposals of a similar feature
 [views][1] proposal as well as the [extension struct][2] proposal provide
 information about the process, including in their change logs.
 
-[1]: https://github.com/dart-lang/language/blob/master/working/1426-extension-types/feature-specification-views.md
-[2]: https://github.com/dart-lang/language/blob/master/working/extension_structs/overview.md
+[1]: https://github.com/dart-lang/language/blob/main/working/1426-extension-types/feature-specification-views.md
+[2]: https://github.com/dart-lang/language/blob/main/working/extension_structs/overview.md
 
 2024.05.21
   - Clarify that preclusion is caused by instance members and not by static

--- a/accepted/future-releases/0546-patterns/why-two-kinds-of-patterns.md
+++ b/accepted/future-releases/0546-patterns/why-two-kinds-of-patterns.md
@@ -6,7 +6,7 @@ irrefutable and refutable patterns into two separate kinds which it calls
 larger and means that some pattern syntax means different things in different
 contexts.
 
-[proposal]: https://github.com/dart-lang/language/blob/master/accepted/3.0/patterns/feature-specification.md
+[proposal]: https://github.com/dart-lang/language/blob/main/accepted/3.0/patterns/feature-specification.md
 
 That choice is close to [how pattern matching works in Swift][swift patterns],
 but is different from pattern matching in Rust, Scala, ML, and most other

--- a/accepted/future-releases/async-star-behavior/implementation-plan.md
+++ b/accepted/future-releases/async-star-behavior/implementation-plan.md
@@ -1,7 +1,7 @@
 # Implementation Plan for async-star/await-for behavior.
 
 Relevant documents:
-- [Feature specification](https://github.com/dart-lang/language/blob/master/accepted/future-releases/async-star-behavior/feature-specification.md)
+- [Feature specification](https://github.com/dart-lang/language/blob/main/accepted/future-releases/async-star-behavior/feature-specification.md)
 ## Implementation and Release plan
 
 ### Phase 0 (Preliminaries)

--- a/accepted/future-releases/primary-constructors/feature-specification.md
+++ b/accepted/future-releases/primary-constructors/feature-specification.md
@@ -1,3 +1,3 @@
 This document [has moved].
 
-[has moved]: https://github.com/dart-lang/language/blob/master/accepted/3.13/primary-constructors/feature-specification.md
+[has moved]: https://github.com/dart-lang/language/blob/main/accepted/3.13/primary-constructors/feature-specification.md

--- a/archive/sealed-types/feature-specification.md
+++ b/archive/sealed-types/feature-specification.md
@@ -7,7 +7,7 @@ Status: Abandoned
 **This proposal was superceded by the [class-modifiers][] proposal. Please refer
 to that document for more recent information.**
 
-[class-modifiers]: https://github.com/dart-lang/language/blob/master/accepted/3.0/class-modifiers/feature-specification.md
+[class-modifiers]: https://github.com/dart-lang/language/blob/main/accepted/3.0/class-modifiers/feature-specification.md
 
 Version 1.1 (see [Changelog](#changelog) at end)
 
@@ -18,11 +18,11 @@ of the rest of that proposal, but they aren't needed for pattern matching, so
 this proposal separates them out.) For motivation, see the previously linked
 documents.
 
-[exhaustiveness checking]: https://github.com/dart-lang/language/blob/master/accepted/3.0/patterns/exhaustiveness.md
+[exhaustiveness checking]: https://github.com/dart-lang/language/blob/main/accepted/3.0/patterns/exhaustiveness.md
 
-[pattern matching]: https://github.com/dart-lang/language/blob/master/accepted/3.0/patterns/feature-specification.md
+[pattern matching]: https://github.com/dart-lang/language/blob/main/accepted/3.0/patterns/feature-specification.md
 
-[type modifiers]: https://github.com/dart-lang/language/blob/master/inactive/type-modifiers/feature-specification.md
+[type modifiers]: https://github.com/dart-lang/language/blob/main/inactive/type-modifiers/feature-specification.md
 
 ## Introduction
 
@@ -171,7 +171,7 @@ It is a compile-time error to extend, implement, or mix in a type marked
 however to subtype a sealed type from another part file or [augmentation
 library][] within the same library.*
 
-[augmentation library]: https://github.com/dart-lang/language/blob/master/working/augmentation-libraries/feature-specification.md
+[augmentation library]: https://github.com/dart-lang/language/blob/main/working/augmentation-libraries/feature-specification.md
 
 A typedef can't be used to subvert this restriction. If a typedef refers to a
 sealed type, it is also a compile-time error to extend, implement or mix in that


### PR DESCRIPTION
This PR changes several URIs in specification documents which were broken because they referred to the `master` branch which has been renamed to `main` in the meantime. Some of these links failed to fetch anything, others would fetch the document from the obsolete `master` branch (which could have been updated on branch `main` after the rename, and we generally want the current version of these documents, not the one in `master`).