### PR TITLE
Fix [has moved] link for primary constructors

### DIFF
--- a/accepted/future-releases/primary-constructors/feature-specification.md
+++ b/accepted/future-releases/primary-constructors/feature-specification.md
@@ -1,3 +1,3 @@
 This document [has moved].
 
-[has moved]: https://github.com/dart-lang/language/blob/master/accepted/3.13/primary-constructors/feature-specification.md
+[has moved]: https://github.com/dart-lang/language/blob/main/accepted/3.13/primary-constructors/feature-specification.md


### PR DESCRIPTION
The current link leads to a non-existent page.