### PR TITLE
Update super parameter syntax for primary constructors

### DIFF
--- a/accepted/3.13/primary-constructors/feature-specification.md
+++ b/accepted/3.13/primary-constructors/feature-specification.md
@@ -599,6 +599,9 @@ constructors as well.
 <fieldFormalParameter> ::= // Modified rule.
      <type>? 'this' '.' <identifier> (<formalParameterPart> '?'?)?;
 
+<superFormalParameter> ::= // Modified rule.
+     <type>? 'super' '.' <identifier> (<formalParameterPart> '?'?)?;
+
 <declaringParameterList> ::= // New rule.
      '(' ')'
    | '(' <declaringFormalParameters> ','? ')'


### PR DESCRIPTION
By mistake, the grammar rule for super parameters was not updated, and hence the grammar allows a super parameter declaration like `final super.x`. This PR adds the missing rule update to the primary constructor feature specification.