### PR TITLE
Generalize record literal inference to handle union types

### DIFF
--- a/accepted/3.0/records/feature-specification.md
+++ b/accepted/3.0/records/feature-specification.md
@@ -513,11 +513,16 @@ entries is semantically irrelevant, and all invocations and record literals with
 the same named entries (possibly in different orders or locations) and the same
 positional entries are considered equivalent.
 
+We need to introduce the _union-free type schema_ derived from a given type
+schema `S`: The union-free type schema derived from `S?` and from `FutureOr<S>`
+is the union-free type schema derived from `S`. For any other type schema `S`,
+the union-free type schema derived from `S` is `S`.
+
 Given a type schema `K` and a record expression `E` of the general form `(e1,
 ..., en, d1 : e{n+1}, ..., dm : e{n+m})` inference proceeds as follows.
 
-If `K` is a record type schema of the form `(K1, ..., Kn, {d1 : K{n+1}, ....,
-dm : K{n+m}})` then:
+If the union-free type schema derived from `K` is a record type schema of the
+form `(K1, ..., Kn, {d1 : K{n+1}, ...., dm : K{n+m}})` then:
   - Each `ei` is inferred with context type schema `Ki` to have type `Si`
     - Let `Ri` be the greatest closure of `Ki`
     - If `Si` is a subtype of `Ri` then let `Ti` be `Si`


### PR DESCRIPTION
This PR adds the notion of 'union-free type schema' derived from a given type schema (as a slight generalization of the 'union-free type' in the language specification) to the feature specification of records, and uses it to provide a better context type to each component of a record literal during inference.

This is, in principle, a breaking change. It should be language versioned. The first action will be to use the specification update to guide an implementation and assess the breakage. The PR may then be landed if the breakage is negligible; in case of significant breakage, the way ahead will need to be discussed further.