### PR TITLE
Remove the getter/setter signature mismatch error

### DIFF
--- a/accepted/2.12/nnbd/feature-specification.md
+++ b/accepted/2.12/nnbd/feature-specification.md
@@ -6,6 +6,10 @@ Status: Draft
 
 ## CHANGELOG
 
+2026.07.22
+  - Remove the compile-time error for a getter/setter pair where the return type
+    of the getter is not a subtype of the parameter type of the setter.
+
 2025.06.16
   - Add an exception for extension members in the error about nullable
     receivers.
@@ -613,7 +617,7 @@ It is an error for the initializer expression of a `late` local variable to use
 a prefix `await` expression that is not nested inside of another function
 expression.
 
-It is an error for a class with a generative `const` constructor to have a 
+It is an error for a class with a generative `const` constructor to have a
 `late final` instance variable.
 
 It is not a compile time error to write to a `final` non-local or instance
@@ -645,11 +649,6 @@ where the cases are dispatched based on expressions `e0`...`ek`:
     enum cases, either explicitly or via a default.
   - If `T` is `Q?` where `Q` is an enum type, it is a warning if the switch does
     not handle all enum cases and `null`, either explicitly or via a default.
-
-It is an error if a class has a setter and a getter with the same basename where
-the return type of the getter is not a subtype of the argument type of the
-setter.  Note that this error specifically requires subtyping and not
-assignability and hence makes no exception for `dynamic`.
 
 If the static type of `e` is `void`, the expression `await e` is a compile-time
 error. *This implies that
@@ -1583,7 +1582,7 @@ read.
     again.
 
 Let _D_ be a `late` and `final` non-local variable declaration named `v`
-without an initializing expression.  
+without an initializing expression.
 It is a run-time error, to invoke the setter `v=` which is
 implicitly induced by _D_ if a value has previously been assigned to `v`
 (which could be due to an initializing formal or a constructor initializer

--- a/accepted/2.12/nnbd/feature-specification.md
+++ b/accepted/2.12/nnbd/feature-specification.md
@@ -606,7 +606,8 @@ unreachable.
 It is an error if the static type of `e` in the expression `throw e` is not
 assignable to `Object`.
 
-It is not an error for the body of a `late` field to reference `this`.
+It is not an error for the initializing expression of a `late` instance 
+variable to reference `this`.
 
 It is an error for a variable to be declared as `late` in any of the following
 positions: in a formal parameter list of any kind; in a catch clause; in the
@@ -620,9 +621,9 @@ expression.
 It is an error for a class with a generative `const` constructor to have a
 `late final` instance variable.
 
-It is not a compile time error to write to a `final` non-local or instance
+*It is not a compile-time error to write to a `final` non-local or instance
 variable if that variable is declared `late` and does not have an initializer.
-For local variables, see the section below.
+For local variables, see the section below.*
 
 It is an error if the object being iterated over by a `for-in` loop has a static
 type which is not `dynamic`, and is not a subtype of `Iterable<dynamic>`.

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -36,6 +36,10 @@
 % version of the language which will actually be specified by the next stable
 % release of this document.
 %
+% Jul 2026
+% - Remove the getter/setter signature mismatch error. It is no longer required
+%   that the getter return type and setter parameter type are related in any way.
+%
 % Jan 2026
 % - Specify that collection elements are allowed to have type `void` in a
 %   collection literal where the corresponding actual type argument is `void`.
@@ -3825,10 +3829,6 @@ does not consist of exactly one required formal parameter $p$.
 
 \LMHash{}%
 It is a compile-time error if a setter declares a return type other than \VOID.
-It is a compile-time error if a class has
-a setter named \code{$v$=} with argument type $T$ and
-a getter named $v$ with return type $S$,
-and $S$ may not be assigned to $T$.
 
 \commentary{%
   The rules for when a setter correctly overrides another member


### PR DESCRIPTION
This is the specification update that corresponds to the implementation issue https://github.com/dart-lang/sdk/issues/58578. It updates the NNBD feature specification to remove the getter/setter type mismatch error, and it updates dartLangSpec.tex as well.

The feature has been implemented and released, that is, there is no need to change any tools in response to this spec update.