### PR TITLE
Include NORM in the algorithm that decides "same type"

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -23507,7 +23507,7 @@ that it has been resolved to denote.
 
 \LMHash{}%
 Moreover, it is assumed that
-type inference and instantiation to bound has taken place 
+type inference and instantiation to bound has taken place
 such that none of the types enountered are raw.
 
 \LMHash{}%
@@ -23528,8 +23528,9 @@ of type variables declared in that type.
 
 \LMHash{}%
 We can now define what it means to be the same type.
-Two types $S$ and $T$ are the same type when
-at least one of the following criteria holds:
+Two types $S_0$ and $T_0$ are the same type when
+$S$ is \NormalizedTypeOf{S_0}, $T$ is \NormalizedTypeOf{T_0},
+and at least one of the following criteria holds:
 
 \begin{itemize}
 \item $S$ is \VOID{} and $T$ is \VOID.


### PR DESCRIPTION
This PR corrects the definition of 'same type' in the language specification such that it includes the type normalization step which is specified in https://github.com/dart-lang/language/blob/main/accepted/2.12/nnbd/feature-specification.md#runtime-type-equality-operator.