### PR TITLE
Specify error for pseudo-cyclic type parameter bounds

### DIFF
--- a/specification/dart.sty
+++ b/specification/dart.sty
@@ -478,10 +478,6 @@
 \newcommand{\MutualSubtypeStd}[2]{\MutualSubtype{\Delta}{#1}{#2}}
 \newcommand{\MutualSubtypeNE}[2]{\ensuremath{{#1}\,<:>\,{#2}}}
 
-% Judgment expressing that a type is a subtype of the union base type
-% of another.
-\newcommand\UnionBasedSubtype[2]{\ensuremath{#1\,\cup\!\EXTENDS\,\,\,#2}}
-
 % Judgment expressing that a supertype relation exists.
 \newcommand{\Supertype}[3]{\ensuremath{{#1}\vdash{#2}\,:>\,{#3}}}
 \newcommand{\SupertypeStd}[2]{\Supertype{\Delta}{#1}{#2}}

--- a/specification/dart.sty
+++ b/specification/dart.sty
@@ -478,6 +478,10 @@
 \newcommand{\MutualSubtypeStd}[2]{\MutualSubtype{\Delta}{#1}{#2}}
 \newcommand{\MutualSubtypeNE}[2]{\ensuremath{{#1}\,<:>\,{#2}}}
 
+% Judgment expressing that a type is a subtype of the union base type
+% of another.
+\newcommand\UnionBasedSubtype[2]{\ensuremath{#1\,\cup\!\EXTENDS\,\,\,#2}}
+
 % Judgment expressing that a supertype relation exists.
 \newcommand{\Supertype}[3]{\ensuremath{{#1}\vdash{#2}\,:>\,{#3}}}
 \newcommand{\SupertypeStd}[2]{\Supertype{\Delta}{#1}{#2}}

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -7474,7 +7474,8 @@ It is a \Error{compile-time error} if a generic declaration $D$ has
 type parameters and bounds
 \code{$X_1$\,\,\EXTENDS\,\,$B_1$,\,\dots,\,$X_s$\,\,\EXTENDS\,\,$B_s$} such that
 \UnionBasedSubtype{X_j}{X_{j+1}} for all $j \in 1 .. s - 1$,
-and \UnionBasedSubtype{X_s}{X_1}.
+and \UnionBasedSubtype{X_s}{X_1}
+\commentary{(that is, $B_s$ is $X_1$, possibly wrapped in some unions)}.
 These type parameters can be declared in any order,
 and there may be additional type parameters declared by $D$,
 the requirement is just that the cycle exists.

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -7491,8 +7491,9 @@ the requirement is just that the cycle exists.
   could just as well have omitted the bound because it is always satisfied.
   Similarly, a pseudo-circular declaration like
   \code{X\,\,\EXTENDS\,\,FutureOr<Y>, Y\,\,\EXTENDS\,\,X}
-  is satisfied when all type variables in the cycle have the same value,
-  at least when that type is a top type, which is not likely to be useful.
+  is satisfied when all type variables are bound to a top type,
+  or a couple of other cases involving bottom types and \code{Object},
+  which is not likely to be useful.
   We avoid these pseudo-cycle because they can introduce infinite loops
   into the computation of standard upper bounds and subtyping.%
 }

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -7464,9 +7464,11 @@ where $T$ is a type whose union base type
 (\ref{functions})
 is $Y$.
 \commentary{%
-  As an example, \UnionBasedSubtype{X}{X\code{?}} and
-  \UnionBasedSubtype{X}{\code{FutureOr<$X$>}}, but also
-  \UnionBasedSubtype{X}{\code{FutureOr<FutureOr<$X$?>{}>?}}.%
+  As an example, \UnionBasedSubtype{X}{X}
+  when \code{$X$\,\,\EXTENDS\,\,$X$?} and
+  when \code{$X$\,\,\EXTENDS\,\,FutureOr<$X$>}, and
+  \UnionBasedSubtype{X}{Y} when
+  \code{$X$\,\,\EXTENDS\,\,FutureOr<FutureOr<$Y$?>{}>?}.%
 }
 
 \LMHash{}%

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -7477,25 +7477,25 @@ It is a \Error{compile-time error} if a generic declaration
 has cyclic bounds.
 \commentary{%
   This prevents circular declarations like
-  \code{X\,\,\EXTENDS\,\,X}
+  \code{$X$\,\,\EXTENDS\,\,$X$}
   and
-  \code{X\,\,\EXTENDS\,\,Y, Y\,\,\EXTENDS\,\,X}.
+  \code{$X$\,\,\EXTENDS\,\,$Y$, $Y$\,\,\EXTENDS\,\,$X$}.
   It also prevents pseudo-circular declarations like
-  \code{X\,\,\EXTENDS\,\,X?}
+  \code{$X$\,\,\EXTENDS\,\,$X$?}
   and
-  \code{X\,\,\EXTENDS\,\,FutureOr<Y>, Y\,\,\EXTENDS\,\,X}.%
+  \code{$X$\,\,\EXTENDS\,\,FutureOr<$Y$>, $Y$\,\,\EXTENDS\,\,$X$}.%
 }
 
 \rationale{%
   A type parameter declaration like
-  \code{X\,\,\EXTENDS\,\,X} or 
-  \code{X\,\,\EXTENDS\,\,FutureOr<X>} or
-  \code{X\,\,\EXTENDS\,\,X?}
+  \code{$X$\,\,\EXTENDS\,\,$X$} or 
+  \code{$X$\,\,\EXTENDS\,\,FutureOr<$X$>} or
+  \code{$X$\,\,\EXTENDS\,\,$X$?}
   could just as well have omitted the bound because it is always satisfied.
   Similarly, a pseudo-circular declaration like
-  \code{X\,\,\EXTENDS\,\,FutureOr<Y>, Y\,\,\EXTENDS\,\,X}
+  \code{$X$\,\,\EXTENDS\,\,FutureOr<$Y$>, $Y$\,\,\EXTENDS\,\,$X$}
   is satisfied when all type variables are bound to a top type,
-  or a couple of other cases involving bottom types and \code{Object},
+  or a few other cases mainly involving bottom types and \code{Object},
   which is not likely to be useful.
   We avoid these cycles and pseudo-cycles because
   they can introduce infinite loops into the computation of

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -7486,7 +7486,8 @@ and $X_s$ union-extends $X_1$.
 
 \rationale{%
   A type parameter declaration like
-  \code{X\,\,\EXTENDS\,\,X} or \code{X\,\,\EXTENDS\,\,X?}
+  \code{X\,\,\EXTENDS\,\,X} or \code{X\,\,\EXTENDS\,\,X?} or
+  \code{X\,\,\EXTENDS\,\,FutureOr<X>}
   could just as well have omitted the bound because it is always satisfied.
   Similarly, a pseudo-circular declaration like
   \code{X\,\,\EXTENDS\,\,FutureOr<Y>, Y\,\,\EXTENDS\,\,X}

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -7443,14 +7443,6 @@ such that $T_j$ is not a subtype of $[T_1/X_1, \ldots, T_m/X_m]B_j$.
 A type parameter $T$ may be suffixed with an \EXTENDS{} clause
 that specifies the \Index{upper bound} for $T$.
 If no \EXTENDS{} clause is present, the upper bound is \code{Object?}.
-It is a \Error{compile-time error} if a type parameter is a supertype of
-its upper bound when that upper bound is itself a type variable.
-\commentary{%
-  This prevents circular declarations like
-  \code{X\,\,\EXTENDS\,\,X}
-  and
-  \code{X\,\,\EXTENDS\,\,Y, Y\,\,\EXTENDS\,\,X}.%
-}
 
 \LMHash{}%
 We need to define a special subset of the clauses \code{$X$\,\,\EXTENDS\,\,$B$}
@@ -7464,9 +7456,10 @@ where $T$ is a type whose union base type
 (\ref{functions})
 is $Y$.
 \commentary{%
-  As an example, \UnionBasedSubtype{X}{X}
-  when \code{$X$\,\,\EXTENDS\,\,$X$?} and
-  when \code{$X$\,\,\EXTENDS\,\,FutureOr<$X$>}, and
+  For example, \UnionBasedSubtype{X}{X}
+  when \code{$X$\,\,\EXTENDS\,\,$X$},
+  \code{$X$\,\,\EXTENDS\,\,$X$?},
+  or \code{$X$\,\,\EXTENDS\,\,FutureOr<$X$>}, and
   \UnionBasedSubtype{X}{Y} when
   \code{$X$\,\,\EXTENDS\,\,FutureOr<FutureOr<$Y$?>{}>?}.%
 }
@@ -7482,22 +7475,28 @@ These type parameters can be declared in any order,
 and there may be additional type parameters declared by $D$,
 the requirement is just that the cycle exists.
 \commentary{%
-  This prevents pseudo-circular declarations like
+  This prevents circular declarations like
+  \code{X\,\,\EXTENDS\,\,X}
+  and
+  \code{X\,\,\EXTENDS\,\,Y, Y\,\,\EXTENDS\,\,X}.
+  It also prevents pseudo-circular declarations like
   \code{X\,\,\EXTENDS\,\,X?}
   and
   \code{X\,\,\EXTENDS\,\,FutureOr<Y>, Y\,\,\EXTENDS\,\,X}.%
 }
 
 \rationale{%
-  A type parameter declaration like \code{X\,\,\EXTENDS\,\,X?}
+  A type parameter declaration like
+  \code{X\,\,\EXTENDS\,\,X} or \code{X\,\,\EXTENDS\,\,X?}
   could just as well have omitted the bound because it is always satisfied.
   Similarly, a pseudo-circular declaration like
   \code{X\,\,\EXTENDS\,\,FutureOr<Y>, Y\,\,\EXTENDS\,\,X}
   is satisfied when all type variables are bound to a top type,
   or a couple of other cases involving bottom types and \code{Object},
   which is not likely to be useful.
-  We avoid these pseudo-cycles because they can introduce infinite loops
-  into the computation of standard upper bounds and subtyping.%
+  We avoid these cycles and pseudo-cycles because
+  they can introduce infinite loops into the computation of
+  standard upper bounds and subtyping.%
 }
 
 \LMHash{}%

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -36,6 +36,10 @@
 % version of the language which will actually be specified by the next stable
 % release of this document.
 %
+% Aug 2026
+% - Define the union base type of a type, make union based cycles in type
+%   parameter declarations a compile-time error.
+%
 % Jul 2026
 % - Remove the getter/setter signature mismatch error. It is no longer required
 %   that the getter return type and setter parameter type are related in any way.
@@ -2160,15 +2164,14 @@ a function marked \code{\SYNC*} or \code{\ASYNC*} is \VOID.
 
 \LMHash{}%
 We define the
-\Index{union-free type derived from}
-a type $T$ as follows:
+\Index{union base type}
+of a type $T$ as follows:
 If $T$ is of the form \code{$S$?}\ or the form \code{FutureOr<$S$>}
-then the union-free type derived from $T$ is
-the union-free type derived from $S$.
-Otherwise, the union-free type derived from $T$ is $T$.
+then the union base type of $T$ is
+the union base type of $S$.
+Otherwise, the union base type of $T$ is $T$.
 \commentary{%
-  For example, the union-free type derived from
-  \code{FutureOr<int?>?} is \code{int}.%
+  For example, the union base type of \code{FutureOr<int?>?} is \code{int}.%
 }
 
 \LMHash{}%
@@ -2177,7 +2180,7 @@ We define the
     function!generator!element type}
 $f$ as follows:
 %
-Let $S$ be the union-free type derived from the declared return type of $f$.
+Let $S$ be the union base type of the declared return type of $f$.
 %
 If $f$ is a synchronous generator and
 $S$ implements \code{Iterable<$U$>} for some $U$
@@ -7439,15 +7442,58 @@ such that $T_j$ is not a subtype of $[T_1/X_1, \ldots, T_m/X_m]B_j$.
 \LMHash{}%
 A type parameter $T$ may be suffixed with an \EXTENDS{} clause
 that specifies the \Index{upper bound} for $T$.
-If no \EXTENDS{} clause is present, the upper bound is \code{Object}.
-It is a compile-time error if a type parameter is a supertype of its upper bound
-when that upper bound is itself a type variable.
-
+If no \EXTENDS{} clause is present, the upper bound is \code{Object?}.
+It is a \Error{compile-time error} if a type parameter is a supertype of
+its upper bound when that upper bound is itself a type variable.
 \commentary{%
   This prevents circular declarations like
-  \code{X \EXTENDS{} X}
+  \code{X\,\,\EXTENDS\,\,X}
   and
-  \code{X \EXTENDS{} Y, Y \EXTENDS{} X}.%
+  \code{X\,\,\EXTENDS\,\,Y, Y\,\,\EXTENDS\,\,X}.%
+}
+
+\LMHash{}%
+We need to define a special subset of the clauses \code{$X$\,\,\EXTENDS\,\,$B$}
+in order to avoid a certain kind of cycles.
+Let
+\IndexCustom{\UnionBasedSubtype{X}{Y}}{$\cup$@$X\,\,\,\textsf{U}\EXTENDS\,\,Y$}
+be the relation among type variables $X$ and $Y$ where
+\code{$X$\,\,\EXTENDS\,\,$Y$}, or
+\code{$X$\,\,\EXTENDS\,\,$T$}
+where $T$ is a type whose union base type
+(\ref{functions})
+is $Y$.
+\commentary{%
+  As an example, \UnionBasedSubtype{X}{X\code{?}} and
+  \UnionBasedSubtype{X}{\code{FutureOr<$X$>}}, but also
+  \UnionBasedSubtype{X}{\code{FutureOr<FutureOr<$X$?>{}>?}}.%
+}
+
+\LMHash{}%
+It is a \Error{compile-time error} if a generic declaration $D$ has
+type parameters and bounds
+\code{$X_1$\,\,\EXTENDS\,\,$B_1$,\,\dots,\,$X_s$\,\,\EXTENDS\,\,$B_s$} such that
+\UnionBasedSubtype{X_j}{X_{j+1}} for all $j \in 1 .. s - 1$,
+and \UnionBasedSubtype{X_s}{X_1}.
+These type parameters can be declared in any order,
+and there may be additional type parameters declared by $D$,
+the requirement is just that the cycle exists.
+\commentary{%
+  This prevents pseudo-circular declarations like
+  \code{X\,\,\EXTENDS\,\,X?}
+  and
+  \code{X\,\,\EXTENDS\,\,FutureOr<Y>, Y\,\,\EXTENDS\,\,X}.%
+}
+
+\rationale{%
+  A type parameter declaration like \code{X\,\,\EXTENDS\,\,X?}
+  could just as well have omitted the bound because it is always satisfied.
+  Similarly, a pseudo-circular declaration like
+  \code{X\,\,\EXTENDS\,\,FutureOr<Y>, Y\,\,\EXTENDS\,\,X}
+  is satisfied when all type variables in the cycle have the same value,
+  at least when that type is a top type, which is not likely to be useful.
+  We avoid these pseudo-cycle because they can introduce infinite loops
+  into the computation of standard upper bounds and subtyping.%
 }
 
 \LMHash{}%

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -7494,7 +7494,7 @@ the requirement is just that the cycle exists.
   is satisfied when all type variables are bound to a top type,
   or a couple of other cases involving bottom types and \code{Object},
   which is not likely to be useful.
-  We avoid these pseudo-cycle because they can introduce infinite loops
+  We avoid these pseudo-cycles because they can introduce infinite loops
   into the computation of standard upper bounds and subtyping.%
 }
 

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -7465,14 +7465,16 @@ is $Y$.
 }
 
 \LMHash{}%
-It is a \Error{compile-time error} if a generic declaration $D$ has
-type parameters and bounds
+A generic declaration $D$ has \Index{cyclic bounds} if it has
+type parameter declarations
 \code{$X_1$\,\,\EXTENDS\,\,$B_1$,\,\dots,\,$X_s$\,\,\EXTENDS\,\,$B_s$},
-declared in any textual order and potentially together with additional
+declared in any textual order and potentially along with additional
 type parameters,
 such that
 $X_j$ union-extends $X_{j+1}$ for all $j \in 1 .. s - 1$,
 and $X_s$ union-extends $X_1$.
+It is a \Error{compile-time error} if a generic declaration
+has cyclic bounds.
 \commentary{%
   This prevents circular declarations like
   \code{X\,\,\EXTENDS\,\,X}
@@ -7486,8 +7488,9 @@ and $X_s$ union-extends $X_1$.
 
 \rationale{%
   A type parameter declaration like
-  \code{X\,\,\EXTENDS\,\,X} or \code{X\,\,\EXTENDS\,\,X?} or
-  \code{X\,\,\EXTENDS\,\,FutureOr<X>}
+  \code{X\,\,\EXTENDS\,\,X} or 
+  \code{X\,\,\EXTENDS\,\,FutureOr<X>} or
+  \code{X\,\,\EXTENDS\,\,X?}
   could just as well have omitted the bound because it is always satisfied.
   Similarly, a pseudo-circular declaration like
   \code{X\,\,\EXTENDS\,\,FutureOr<Y>, Y\,\,\EXTENDS\,\,X}

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -7457,8 +7457,8 @@ is $Y$.
 \commentary{%
   For example, $X$ union-extends $X$
   when $X$ is declared as
-  \code{$X$\,\,\EXTENDS\,\,$X$},
-  \code{$X$\,\,\EXTENDS\,\,$X$?}, or
+  \code{$X$\,\,\EXTENDS\,\,$X$}, as
+  \code{$X$\,\,\EXTENDS\,\,$X$?}, or as
   \code{$X$\,\,\EXTENDS\,\,FutureOr<$X$>}, and
   $X$ union-extends $Y$ when $X$ is declared as
   \code{$X$\,\,\EXTENDS\,\,FutureOr<FutureOr<$Y$?>{}>?}.%
@@ -7467,13 +7467,12 @@ is $Y$.
 \LMHash{}%
 It is a \Error{compile-time error} if a generic declaration $D$ has
 type parameters and bounds
-\code{$X_1$\,\,\EXTENDS\,\,$B_1$,\,\dots,\,$X_s$\,\,\EXTENDS\,\,$B_s$} such that
-\UnionBasedSubtype{X_j}{X_{j+1}} for all $j \in 1 .. s - 1$,
-and \UnionBasedSubtype{X_s}{X_1}
-\commentary{(that is, $B_s$ is $X_1$, possibly wrapped in some unions)}.
-These type parameters can be declared in any order,
-and there may be additional type parameters declared by $D$,
-the requirement is just that the cycle exists.
+\code{$X_1$\,\,\EXTENDS\,\,$B_1$,\,\dots,\,$X_s$\,\,\EXTENDS\,\,$B_s$},
+declared in any textual order and potentially together with additional
+type parameters,
+such that
+$X_j$ union-extends $X_{j+1}$ for all $j \in 1 .. s - 1$,
+and $X_s$ union-extends $X_1$.
 \commentary{%
   This prevents circular declarations like
   \code{X\,\,\EXTENDS\,\,X}

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -7445,22 +7445,22 @@ that specifies the \Index{upper bound} for $T$.
 If no \EXTENDS{} clause is present, the upper bound is \code{Object?}.
 
 \LMHash{}%
-We need to define a special subset of the clauses \code{$X$\,\,\EXTENDS\,\,$B$}
-in order to avoid a certain kind of cycles.
-Let
-\IndexCustom{\UnionBasedSubtype{X}{Y}}{$\cup$@$X\,\,\,\textsf{U}\EXTENDS\,\,Y$}
-be the relation among type variables $X$ and $Y$ where
-\code{$X$\,\,\EXTENDS\,\,$Y$}, or
+We say that
+\IndexCustom{$X$ union-extends $Y$}{union-extends}
+when $X$ and $Y$ are type variables,
+and $X$ is declared as
 \code{$X$\,\,\EXTENDS\,\,$T$}
 where $T$ is a type whose union base type
 (\ref{functions})
 is $Y$.
+
 \commentary{%
-  For example, \UnionBasedSubtype{X}{X}
-  when \code{$X$\,\,\EXTENDS\,\,$X$},
-  when \code{$X$\,\,\EXTENDS\,\,$X$?},
-  and when \code{$X$\,\,\EXTENDS\,\,FutureOr<$X$>}, and
-  \UnionBasedSubtype{X}{Y} when
+  For example, $X$ union-extends $X$
+  when $X$ is declared as
+  \code{$X$\,\,\EXTENDS\,\,$X$},
+  \code{$X$\,\,\EXTENDS\,\,$X$?}, or
+  \code{$X$\,\,\EXTENDS\,\,FutureOr<$X$>}, and
+  $X$ union-extends $Y$ when $X$ is declared as
   \code{$X$\,\,\EXTENDS\,\,FutureOr<FutureOr<$Y$?>{}>?}.%
 }
 

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -7458,8 +7458,8 @@ is $Y$.
 \commentary{%
   For example, \UnionBasedSubtype{X}{X}
   when \code{$X$\,\,\EXTENDS\,\,$X$},
-  \code{$X$\,\,\EXTENDS\,\,$X$?},
-  or \code{$X$\,\,\EXTENDS\,\,FutureOr<$X$>}, and
+  when \code{$X$\,\,\EXTENDS\,\,$X$?},
+  and when \code{$X$\,\,\EXTENDS\,\,FutureOr<$X$>}, and
   \UnionBasedSubtype{X}{Y} when
   \code{$X$\,\,\EXTENDS\,\,FutureOr<FutureOr<$Y$?>{}>?}.%
 }


### PR DESCRIPTION
For background and discussion, please see dart-lang/language#433.

This PR introduces a compile-time error for type parameters and their bounds when they form a union type based cycle. For example, not just `X extends X` and `Y extends Z, Z extends Y` are errors (as they have always been), but also `X extends X?` and `Y extends FutureOr<Z>, Z extends Y`. That is, we make it an error to form a cycle even when union types are stripped off first. This is done because it allows us to avoid some known sources of infinite looping in the subtype and standard upper bound algorithms.

Following https://github.com/dart-lang/language/issues/433#issuecomment-2415818156, this PR also renames "union-free type derived from a type" to "union base type of a type".