### PR TITLE
Revert "Include NORM in the algorithm that decides "same type""

### DIFF
--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -23507,7 +23507,7 @@ that it has been resolved to denote.
 
 \LMHash{}%
 Moreover, it is assumed that
-type inference and instantiation to bound has taken place
+type inference and instantiation to bound has taken place 
 such that none of the types enountered are raw.
 
 \LMHash{}%
@@ -23528,9 +23528,8 @@ of type variables declared in that type.
 
 \LMHash{}%
 We can now define what it means to be the same type.
-Two types $S_0$ and $T_0$ are the same type when
-$S$ is \NormalizedTypeOf{S_0}, $T$ is \NormalizedTypeOf{T_0},
-and at least one of the following criteria holds:
+Two types $S$ and $T$ are the same type when
+at least one of the following criteria holds:
 
 \begin{itemize}
 \item $S$ is \VOID{} and $T$ is \VOID.

--- a/specification/dartLangSpec.tex
+++ b/specification/dartLangSpec.tex
@@ -23507,7 +23507,7 @@ that it has been resolved to denote.
 
 \LMHash{}%
 Moreover, it is assumed that
-type inference and instantiation to bound has taken place 
+type inference and instantiation to bound has taken place
 such that none of the types enountered are raw.
 
 \LMHash{}%


### PR DESCRIPTION
Reverts dart-lang/language#4734

With the notion of equality which is used with the broadest possible set of situations, we should not normalize the operands. In particular, we can distinguish `Object` and `FutureOr<Object>` as follows, which implies that we should not consider those types to be the same type:

```dart
import 'dart:async';

Future<X> f<X>() {
  print(X);
  return Future<Never>.error(0);
}

void main() {
  Object o1 = 42;
  FutureOr<Object> o2 = 42;
  
  o1 = f(); // Prints 'dynamic'.
  o2 = f(); // Prints 'Object'.
}
```