### PR TITLE
Restrict permissions in Dart CI workflow

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [main]
 
+# All permissions not specified are set to 'none'.
+permissions:
+  contents: read
+
 env:
   PUB_ENVIRONMENT: bot.github
 


### PR DESCRIPTION
Declare `contents: read` permissions explicitly in `.github/workflows/dart.yml` to satisfy least-privilege security checks (zizmor `excessive-permissions`).