### PR TITLE
[flow anaylsis] Fix `join` notation.

### DIFF
--- a/resources/type-system/flow-analysis.md
+++ b/resources/type-system/flow-analysis.md
@@ -200,10 +200,10 @@ _For a counterexample to associativity, consider:_
 c₁ = [Map<Object?, int>, Map<int, int>]
 c₂ = [Map<dynamic, int>, Map<int, int>]
 c₃ = [Map<int, Object>,  Map<int, int>]
-c₁.join c₂ = [Map<int, int>]
-(c₁.join c₂).join c₃ = [Map<int, int>]
-c₂.join c₃ = []
-c₁.join (c₂.join c₃) = []
+join(c₁, c₂) = [Map<int, int>]
+join(join(c₁, c₂), c₃) = [Map<int, int>]
+join(c₂, c₃) = []
+join(c₁, join(c₂, c₃)) = []
 ```
 
 ### Models
@@ -315,7 +315,7 @@ We also make use of the following auxiliary functions:
   - `VM3 = VariableModel(d3, p3, s3, a3, u3, c3)` where
    - `d3 = d1 = d2`
      - Note that all models must agree on the declared type of a variable
-   - `p3 = p1.join p2`
+   - `p3 = join(p1, p2)`
    - `s3 = s1 U s2`
      - The set of test sites is the union of the test sites on either path
    - `a3 = a1 && a2`


### PR DESCRIPTION
In https://github.com/dart-lang/language/pull/4754#discussion_r3874208402, I claimed to have switched entirely from the Lean-inspired `c₁.join c₂` notation to `join(c₁, c₂)`, but apparently I missed a few spots.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
