### PR TITLE
[flow analysis] Switch to associative promotion chain join.

### DIFF
--- a/lean/FlowAnalysis/PromotionChain.lean
+++ b/lean/FlowAnalysis/PromotionChain.lean
@@ -3,7 +3,7 @@ import Aesop
 import Batteries.Data.List.Basic
 import Batteries.Data.List.Lemmas
 public import FlowAnalysis.Types
-public import Mathlib.Data.Finset.Dedup
+public import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Set.Finite.Basic
 
 namespace FlowAnalysis
@@ -65,7 +65,8 @@ public theorem lt_of_mem_tail {T : τ} {ts : List τ} (hvalid : isPromotionChain
   aesop
 
 /-- The head of a promotion chain is not in the tail. -/
-lemma head_not_mem_tail {T : τ} {ts : List τ} (hvalid : isPromotionChain (T::ts)) : T ∉ ts := by
+public theorem head_not_mem_tail {T : τ} {ts : List τ} (hvalid : isPromotionChain (T::ts)) :
+    T ∉ ts := by
   have := hvalid.lt_of_mem_tail T
   grind
 
@@ -126,7 +127,7 @@ public theorem ext_iff {c₁ c₂ : PromotionChain} : c₁ = c₂ ↔ c₁.val =
 public def empty : PromotionChain := ⟨[], by simp⟩
 
 /-- Analogous to `List.take` but for promotion chains. -/
-public def take (n : Nat) (c : PromotionChain) : PromotionChain := .mk (c.val.take n) $ by
+public def take (n : Nat) (c : PromotionChain) : PromotionChain := .mk (c.val.take n) <| by
   suffices h : c.val.take n <+ c.val by apply isPromotionChain.sublist h c.property
   exact List.take_sublist n c.val
 
@@ -141,7 +142,7 @@ public theorem take_of_val {n : Nat} {c : PromotionChain}
 
 /-- Analogous to `List.drop` but for promotion chains. -/
 public def drop (n : Nat) (c : PromotionChain) :
-    PromotionChain := .mk (c.val.drop n) $ by
+    PromotionChain := .mk (c.val.drop n) <| by
   suffices h : c.val.drop n <+ c.val by apply isPromotionChain.sublist h c.property
   exact List.drop_sublist n c.val
 
@@ -183,12 +184,9 @@ public theorem val_single {T : τ} : (single T).val = [T] := by rfl
 public def strictly_bounded_by (c : PromotionChain) (T : τ) : Prop := isPromotionChain (T::c)
 
 /-- Analogous to `List.filter` but for promotion chains. -/
-public def filter (p : τ → Bool) (c : PromotionChain) : PromotionChain := .mk (c.val.filter p) $ by
-  rcases c with ⟨ts, hvalid⟩
-  rw [isPromotionChain.iff_pairwise]
-  apply List.Pairwise.filter
-  rw [←isPromotionChain.iff_pairwise]
-  simp [hvalid]
+public def filter (p : τ → Bool) (c : PromotionChain) : PromotionChain := .mk (c.val.filter p) <| by
+  suffices h : c.val.filter p <+ c.val by apply isPromotionChain.sublist h c.property
+  simp
 
 /--
 Simplification theorem relating the behavior of `PromotionChain.filter` to that of `List.filter`.
@@ -206,52 +204,24 @@ public theorem filter_of_val {p : τ → Bool} {c : PromotionChain}
     ⟨c.val.filter p, hvalid⟩ = c.filter p := by rfl
 
 /--
-If two promotion chains contain the same the set of types, then they are equal.
-
-We prove this as a private lemma, since clients will want to rewrite using `toFinset_inj`, below.
--/
-lemma eq_of_toFinset_eq : ∀ (c₁ c₂ : PromotionChain),
-    c₁.val.toFinset = c₂.val.toFinset → c₁ = c₂ := by
-  rintro ⟨ts₁, hvalid₁⟩ ⟨ts₂, hvalid₂⟩; simp
-  cases ts₁
-  case nil => simp; intro h; rw [←List.toFinset_eq_empty_iff]; aesop
-  case cons T₁ ts₁' =>
-    cases ts₂
-    case nil => simp
-    case cons T₂ ts₂' =>
-      simp
-      by_cases T₁ = T₂
-      case pos heq =>
-        subst heq
-        intro hinsert
-        suffices h : ts₁'.toFinset = ts₂'.toFinset by
-          have := eq_of_toFinset_eq ⟨ts₁', hvalid₁.of_cons⟩ ⟨ts₂', hvalid₂.of_cons⟩
-          simp_all
-        simp [Finset.ext_iff] at hinsert ⊢
-        intro T; specialize hinsert T
-        by_cases T = T₁
-        case neg hne => simp [hne] at hinsert; assumption
-        case pos heq => grind [hvalid₁.head_not_mem_tail, hvalid₂.head_not_mem_tail]
-      case neg hne =>
-        simp [hne]; intro hcontra; simp [Finset.ext_iff] at hcontra
-        have hT₁_lt_T₂ : T₁ < T₂ := by grind [isPromotionChain.lt_of_mem_tail hvalid₂]
-        have hT₂_lt_T₁ : T₂ < T₁ := by grind [isPromotionChain.lt_of_mem_tail hvalid₁]
-        grind
-
-/-- Two promotion chains are equal iff they contain the same set of types. -/
-public theorem toFinset_inj (c₁ c₂ : PromotionChain) :
-    c₁ = c₂ ↔ c₁.val.toFinset = c₂.val.toFinset := by
-  constructor
-  · intro rfl; rfl
-  · apply eq_of_toFinset_eq
-
-/--
 Two promotion chains are equal iff membership in one implies membership in the other (and vice
 versa).
 -/
 public theorem ext_iff_mem (c₁ c₂ : PromotionChain) :
     c₁ = c₂ ↔ ∀ T, T ∈ c₁.val ↔ T ∈ c₂.val := by
-  rw [toFinset_inj, Finset.ext_iff]; simp
+  constructor
+  · intro rfl; simp
+  · intro hmem
+    apply ext
+    apply List.Pairwise.eq_of_mem_iff (r := (fun T U => U < T))
+    · rw [←isPromotionChain.iff_pairwise]; aesop
+    · rw [←isPromotionChain.iff_pairwise]; aesop
+    · assumption
+
+/-- Two promotion chains are equal iff they contain the same set of types. -/
+public theorem toFinset_inj (c₁ c₂ : PromotionChain) :
+    c₁ = c₂ ↔ c₁.val.toFinset = c₂.val.toFinset := by
+  simp [ext_iff_mem, Finset.ext_iff]
 
 /--
 The sublist relation holds between two promotion chains iff membership in the former implies
@@ -281,8 +251,17 @@ additional legwork in the proofs below.
 public abbrev is_greatest_common_sublist (c c₁ c₂ : PromotionChain) : Prop :=
   c.is_common_sublist c₁ c₂ ∧ ∀ c' : PromotionChain, c'.is_common_sublist c₁ c₂ → c'.val <+ c.val
 
-/-- For computability, we define `c₁ join c₂` as a filter of `c₁`, removing any types that are not in `c₂`. -/
+/--
+For computability, we define `c₁.join c₂` as a filter of `c₁`, removing any types that are not in
+`c₂`.
+-/
 public def join (c₁ c₂ : PromotionChain) := c₁.filter (· ∈ c₂.val)
+
+/-- A type is in the join of two promotion chains iff it is in both chains. -/
+@[simp]
+public theorem mem_join (c₁ c₂ : PromotionChain) (T : τ) :
+    T ∈ (c₁.join c₂).val ↔ T ∈ c₁.val ∧ T ∈ c₂.val := by
+  simp [join]
 
 /--
 An equivalent definition, which we use in the spec (and in proofs below) is that the join of two
@@ -290,43 +269,21 @@ promotion chains is their unique greatest common sublist.
 -/
 public theorem join_is_greatest_common_sublist (c₁ c₂ : PromotionChain) :
     (c₁.join c₂).is_greatest_common_sublist c₁ c₂ := by
-  simp [join]
-  constructor
-  · constructor
-    · simp
-    · rw [sublist_iff_forall_mem]; simp
-  · rintro c' ⟨hc'_sublist_c₁, hc'_sublist_c₂⟩
-    rw [sublist_iff_forall_mem] at hc'_sublist_c₁ hc'_sublist_c₂ ⊢
-    intro T hT_in_c'
-    simp [hc'_sublist_c₁ T hT_in_c', hc'_sublist_c₂ T hT_in_c']
+  simp [is_greatest_common_sublist, is_common_sublist, sublist_iff_forall_mem]
+  aesop
 
 /--
 The computable definition of `join` above proves that a greatest common sublist always exists.
 -/
-lemma exists_is_greatest_common_sublist (c₁ c₂ : PromotionChain) :
-    ∃ c : PromotionChain, c.is_greatest_common_sublist c₁ c₂ := by
-  exists c₁.filter (· ∈ c₂.val)
-  apply join_is_greatest_common_sublist
+public theorem exists_is_greatest_common_sublist (c₁ c₂ : PromotionChain) :
+    ∃ c : PromotionChain, c.is_greatest_common_sublist c₁ c₂ :=
+  ⟨c₁.join c₂, join_is_greatest_common_sublist c₁ c₂⟩
 
 /-- The join is the unique greatest common sublist. -/
-public theorem is_greatest_common_sublist.unique (c₁ c₂ : PromotionChain) :
-    ∀ c : PromotionChain, c.is_greatest_common_sublist c₁ c₂ → c = c₁.join c₂ := by
-  intro c hc
-  let c' := c₁.join c₂
+public theorem is_greatest_common_sublist.unique {c c₁ c₂ : PromotionChain}
+    (h : c.is_greatest_common_sublist c₁ c₂) : c = c₁.join c₂ := by
   have hc' := join_is_greatest_common_sublist c₁ c₂
   rw [ext_iff_mem]; grind
-
-/-- A type is in the join of two promotion chains iff it is in both chains. -/
-@[simp]
-public theorem mem_join (c₁ c₂ : PromotionChain) (T : τ) :
-    T ∈ (c₁.join c₂).val ↔ T ∈ c₁.val ∧ T ∈ c₂.val := by
-  obtain ⟨⟨hjoin_sublist_c₁, hjoin_sublist_c₂⟩, hgreatest⟩ := join_is_greatest_common_sublist c₁ c₂
-  rw [PromotionChain.sublist_iff_forall_mem] at hjoin_sublist_c₁ hjoin_sublist_c₂
-  constructor
-  · grind
-  · simp; intro hT_in_c₁ hT_in_c₂
-    specialize hgreatest (.single T) (by simp_all [is_common_sublist])
-    rw [PromotionChain.sublist_iff_forall_mem] at hgreatest; simp at hgreatest; assumption
 
 /--
 The join of two promotion chains is equal to `c` iff all types `T` satisfy the `mem_join` relation
@@ -338,17 +295,17 @@ public theorem join_eq_iff_mem (c c₁ c₂ : PromotionChain) :
   · intro rfl T; simp
   · rw [ext_iff_mem]; simp
 
-/-- Joining a promotion chain with a sublist produces the sublist. -/
+/-- If `c₁` is a sublist of `c₂`, their join is `c₁`. -/
 @[simp]
-public theorem join_eq_left_of_sublist (c₁ c₂ : PromotionChain) :
-    c₁.val <+ c₂.val → c₁.join c₂ = c₁ := by
-  intro h; rw [join_eq_iff_mem]; intro T; grind
+public theorem join_eq_left_of_sublist {c₁ c₂ : PromotionChain} (h : c₁.val <+ c₂.val) :
+    c₁.join c₂ = c₁ := by
+  rw [join_eq_iff_mem]; intro T; grind
 
-/-- Joining a promotion chain with a sublist produces the sublist. -/
+/-- If `c₂` is a sublist of `c₁`, their join is `c₂`. -/
 @[simp]
-public theorem join_eq_right_of_sublist (c₁ c₂ : PromotionChain) :
-    c₂.val <+ c₁.val → c₁.join c₂ = c₂ := by
-  intro h; rw [join_eq_iff_mem]; intro T; grind
+public theorem join_eq_right_of_sublist {c₁ c₂ : PromotionChain} (h : c₂.val <+ c₁.val) :
+    c₁.join c₂ = c₂ := by
+  rw [join_eq_iff_mem]; intro T; grind
 
 /-- The join operation is idempotent (`join c c = c`). -/
 @[simp]
@@ -376,14 +333,13 @@ public instance join.instAssociative : Std.Associative (join (τ := τ)) where
 
 /-- Joining with an empty promotion chain produces the empty promotion chain. -/
 @[simp]
-public theorem empty_join :
-    ∀ c : PromotionChain, (∅ : PromotionChain).join c = ∅ := by
-  intro c; rw [join_eq_iff_mem]; simp
+public theorem empty_join (c : PromotionChain) : (∅ : PromotionChain).join c = ∅ := by
+  rw [join_eq_iff_mem]; simp
 
 /-- Joining with an empty promotion chain produces the empty promotion chain. -/
 @[simp]
-public theorem join_empty : ∀ c : PromotionChain, c.join ∅ = ∅ := by
-  intro c; rw [join_eq_iff_mem]; simp
+public theorem join_empty (c : PromotionChain) : c.join ∅ = ∅ := by
+  rw [join_eq_iff_mem]; simp
 
 /--
 If a promotion chain is not empty, then its list of types is not empty.
@@ -395,7 +351,9 @@ public theorem val_ne_nil_of_ne_empty {c : PromotionChain} : ¬c = ∅ → ¬c.v
   contrapose; rcases c; simp; intro rfl; simp
 
 /--
-If a promotion chain contains no types, then joining it with another chain produces the empty chain.
+If `c₁` contains no types, then `c₁.join c₂` is the empty chain.
+
+Variant of `empty_join` for use when emptiness is expressed as `c₁.val = []` rather than `c₁ = ∅`.
 -/
 @[simp]
 public theorem join_eq_empty_of_val_nil_left {c₁ c₂ : PromotionChain} :
@@ -403,10 +361,13 @@ public theorem join_eq_empty_of_val_nil_left {c₁ c₂ : PromotionChain} :
   intro h; simp [show c₁ = ∅ by grind]
 
 /--
-If a promotion chain contains no types, then joining it with another chain produces the empty chain.
+If `c₂` contains no types, then `c₁.join c₂` is the empty chain.
+
+Variant of `join_empty` for use when emptiness is expressed as `c₂.val = []` rather than `c₂ = ∅`.
 -/
 @[simp]
-public theorem join_eq_empty_of_val_nil_right {c₁ c₂ : PromotionChain} : c₂.val = [] → c₁.join c₂ = ∅ := by
+public theorem join_eq_empty_of_val_nil_right {c₁ c₂ : PromotionChain} :
+    c₂.val = [] → c₁.join c₂ = ∅ := by
   intro h; simp [show c₂ = ∅ by grind]
 
 end «PromotionChain»

--- a/lean/FlowAnalysis/PromotionChain.lean
+++ b/lean/FlowAnalysis/PromotionChain.lean
@@ -2,16 +2,14 @@ module
 import Aesop
 import Batteries.Data.List.Basic
 import Batteries.Data.List.Lemmas
-public meta import FlowAnalysis.SimpleTypes
 public import FlowAnalysis.Types
-import Mathlib.Tactic.Order
+public import Mathlib.Data.Finset.Dedup
+import Mathlib.Data.Set.Finite.Basic
 
 namespace FlowAnalysis
 
 -- Allows the use of `<+` notation for `List.Sublist`.
 open scoped List
-
-section
 
 variable {τ : Type} [DartTypeRepr τ]
 
@@ -46,27 +44,39 @@ theorem iff_pairwise_getElem (c : List τ) :
 
 /-- The empty list is a promotion chain. -/
 @[simp]
-theorem empty : isPromotionChain ([] : List τ) := by
+theorem nil : isPromotionChain ([] : List τ) := by
   simp [isPromotionChain]
 
 /-- A list with just one element is a promotion chain. -/
 @[simp]
-theorem single : ∀ T : τ, isPromotionChain [T] := by
+theorem singleton : ∀ T : τ, isPromotionChain [T] := by
   simp [isPromotionChain]
 
 /-- The tail of a promotion chain is also a promotion chain. -/
-theorem tail_valid {ts : List τ} : isPromotionChain ts → isPromotionChain ts.tail := by
-  simp [iff_isChain]
-  intro h
-  cases ts
-  case nil => simp
-  case cons T ts' => exact List.IsChain.of_cons h
+public theorem of_cons {T : τ} {ts : List τ} (hvalid : isPromotionChain (T::ts)) :
+    isPromotionChain ts := by
+  simp [iff_isChain] at hvalid ⊢
+  exact List.IsChain.of_cons hvalid
 
-/-- The head of a valid promotion chain is a strict supertype of every type in the tail. -/
-lemma head_bounds {T : τ} {ts : List τ} (hvalid : isPromotionChain (T::ts)) :
-    ∀ T', T' ∈ ts → T' < T := by
+/-- The head of a promotion chain is a strict supertype of every type in the tail. -/
+public theorem lt_of_mem_tail {T : τ} {ts : List τ} (hvalid : isPromotionChain (T::ts)) :
+    ∀ T' ∈ ts, T' < T := by
   simp [iff_pairwise] at hvalid
   aesop
+
+/-- The head of a promotion chain is not in the tail. -/
+lemma head_not_mem_tail {T : τ} {ts : List τ} (hvalid : isPromotionChain (T::ts)) : T ∉ ts := by
+  have := hvalid.lt_of_mem_tail T
+  grind
+
+/--
+Consing a type onto a promotion chain produces a promotion chain, provided that the new head is a
+strict supertype of all the other types.
+-/
+public theorem cons {T : τ} {ts : List τ} (hbounds : ∀ T' ∈ ts, T' < T)
+    (hvalid : isPromotionChain ts) :
+    isPromotionChain (T::ts) := by
+  simp [iff_pairwise] at hvalid ⊢; grind
 
 /--
 Any sublist of a promotion chain is also a promotion chain.
@@ -91,21 +101,63 @@ local notation "PromotionChain" => PromotionChain (τ := τ)
 
 namespace «PromotionChain»
 
+/--
+Simplification theorem: `isPromotionChain` applied to the types in a `PromotionChain` is trivially
+satisfied, since a `PromotionChain` can only be created if a witness to its validity is provided.
+-/
+@[simp]
+public theorem prop (c : PromotionChain) : isPromotionChain c.val := c.property
+
 /-- Extensionality: promotion chains may be proven equal by proving their lists equal. -/
 public theorem ext {c₁ c₂ : PromotionChain} : c₁.val = c₂.val → c₁ = c₂ := by
   intro h; apply Subtype.ext; assumption
 
+/-- Injection: if promotion chains are equal then their values are equal. -/
+public theorem val_inj {c₁ c₂ : PromotionChain} : c₁ = c₂ → c₁.val = c₂.val := by
+  intro rfl; rfl
+
+/-- Equality of promotion chains may be rewritten to equality of values and vice versa. -/
+public theorem ext_iff {c₁ c₂ : PromotionChain} : c₁ = c₂ ↔ c₁.val = c₂.val := by
+  constructor
+  · apply val_inj
+  · apply ext
+
 /-- The empty promotion chain. -/
 public def empty : PromotionChain := ⟨[], by simp⟩
 
+/-- Analogous to `List.take` but for promotion chains. -/
+public def take (n : Nat) (c : PromotionChain) : PromotionChain := .mk (c.val.take n) $ by
+  suffices h : c.val.take n <+ c.val by apply isPromotionChain.sublist h c.property
+  exact List.take_sublist n c.val
+
+/-- Simplification theorem relating the behavior of `PromotionChain.take` to that of `List.take`. -/
+@[simp]
+public theorem val_take {n : Nat} {c : PromotionChain} : (c.take n).val = c.val.take n := by rfl
+
+/-- Simplification theorem relating the behavior of `PromotionChain.take` to that of `List.take`. -/
+@[simp]
+public theorem take_of_val {n : Nat} {c : PromotionChain}
+    {hvalid : isPromotionChain (c.val.take n)} : ⟨c.val.take n, hvalid⟩ = c.take n := by rfl
+
+/-- Analogous to `List.drop` but for promotion chains. -/
 public def drop (n : Nat) (c : PromotionChain) :
     PromotionChain := .mk (c.val.drop n) $ by
   suffices h : c.val.drop n <+ c.val by apply isPromotionChain.sublist h c.property
   exact List.drop_sublist n c.val
 
+/-- `PromotionChain.drop 0` has no effect. -/
 @[simp]
-public theorem drop.val {n : Nat} {c : PromotionChain} :
-    (c.drop n).val = c.val.drop n := by rfl
+public theorem drop_zero (c : PromotionChain) : drop 0 c = c := by rfl
+
+/-- Simplification theorem relating the behavior of `PromotionChain.drop` to that of `List.drop`. -/
+@[simp]
+public theorem val_drop {n : Nat} {c : PromotionChain} : (c.drop n).val = c.val.drop n := by rfl
+
+/-- Simplification theorem relating the behavior of `PromotionChain.drop` to that of `List.drop`. -/
+@[simp]
+public theorem drop_of_val {n : Nat} {c : PromotionChain}
+    {hvalid : isPromotionChain (c.val.drop n)} :
+    ⟨c.val.drop n, hvalid⟩ = c.drop n := by rfl
 
 public instance instEmptyCollection : EmptyCollection (PromotionChain) where
   emptyCollection := empty
@@ -115,9 +167,9 @@ public theorem eq_empty {h : isPromotionChain []} : (⟨[], h⟩ : PromotionChai
   by rfl
 
 @[simp]
-public theorem empty_types : (∅ : PromotionChain).val = [] := by rfl
+public theorem val_empty : (∅ : PromotionChain).val = [] := by rfl
 
-public theorem empty_if_empty_types {c : PromotionChain} :
+public theorem empty_of_val_nil {c : PromotionChain} :
     c.val = [] → c = ∅ := by
   intro h; apply ext; simp_all
 
@@ -125,217 +177,236 @@ public theorem empty_if_empty_types {c : PromotionChain} :
 public def single (T : τ) : PromotionChain := ⟨[T], by simp⟩
 
 @[simp]
-public theorem single_types {T : τ} : (single T).val = [T] := by rfl
+public theorem val_single {T : τ} : (single T).val = [T] := by rfl
 
 /-- A promotion chain `c` is strictly bounded by `T` iff `T::c` is a promotion chain. -/
-public def strictlyBoundedBy (c : PromotionChain) (T : τ) : Prop := isPromotionChain (T::c)
+public def strictly_bounded_by (c : PromotionChain) (T : τ) : Prop := isPromotionChain (T::c)
 
-@[expose]
-public def joinPromotedTypes (ts₁ ts₂ : List τ) : List τ :=
-  match ts₁, ts₂ with
-    | T₁::ts₁', T₂::ts₂' => if T₁ = T₂ then
-        T₁ :: joinPromotedTypes ts₁' ts₂'
-      else match decide (T₁ ≤ T₂), decide (T₂ ≤ T₁) with
-        | true,  true  => joinPromotedTypes ts₁' ts₂'
-        | true,  false => joinPromotedTypes (T₁::ts₁') ts₂'
-        | false, true  => joinPromotedTypes ts₁' (T₂::ts₂')
-        | false, false => []
-    | _, _ => []
-
-@[simp]
-theorem joinPromotedTypes.idempotent (ts : List τ) :
-    joinPromotedTypes ts ts = ts := by
-  induction ts <;> simp [joinPromotedTypes]
-  case cons T ts' ih => assumption
-
-@[simp]
-public theorem joinPromotedTypes_left_empty {ts : List τ} :
-    joinPromotedTypes [] ts = [] := by
-  simp [joinPromotedTypes]
-
-@[simp]
-public theorem joinPromotedTypes_right_empty {ts : List τ} :
-    joinPromotedTypes ts [] = [] := by
-  simp [joinPromotedTypes]
-
-theorem joinPromotedTypes.commutative (ts₁ ts₂ : List τ) :
-    joinPromotedTypes ts₁ ts₂ = joinPromotedTypes ts₂ ts₁ := by
-  (cases ts₁ <;> try simp); case cons T₁ ts₁' =>
-  (cases ts₂ <;> try simp); case cons T₂ ts₂' =>
-  simp [joinPromotedTypes]
-  by_cases T₁ = T₂
-  case pos heq => subst heq; simp; apply commutative
-  case neg hne =>
-  simp [hne, Ne.symm hne]
-  by_cases T₁ ≤ T₂ <;> by_cases T₂ ≤ T₁ <;> simp_all <;> apply commutative
-
-instance joinPromotedTypes.instCommutative :
-    Std.Commutative (joinPromotedTypes (τ := τ)) where
-  comm := joinPromotedTypes.commutative
-
-@[simp]
-lemma joinPromotedTypes_sublist_left {ts₁ ts₂ : List τ} :
-    joinPromotedTypes ts₁ ts₂ <+ ts₁ := by
-  cases ts₁ <;> try simp_all
-  case cons T₁ ts₁' =>
-  cases ts₂ <;> try simp_all
-  case cons T₂ ts₂' =>
-  simp [joinPromotedTypes]
-  by_cases T₁ = T₂
-  case pos heq => simp [heq]; apply joinPromotedTypes_sublist_left
-  case neg hne =>
-  simp [hne]
-  by_cases T₂ ≤ T₁
-  case pos hge =>
-    simp [hge]
-    by_cases h : T₁ ≤ T₂ <;> simp [h] <;> calc
-      _ <+ ts₁' := by apply joinPromotedTypes_sublist_left
-      _ <+ T₁ :: ts₁' := by simp
-  case neg hnotGe =>
-    simp [hnotGe]
-    by_cases T₁ ≤ T₂
-    case pos hle => simp [hle]; apply joinPromotedTypes_sublist_left
-    case neg hnotLe => simp [hnotLe]
-
-@[simp]
-lemma joinPromotedTypes_sublist_right {ts₁ ts₂ : List τ} :
-    joinPromotedTypes ts₁ ts₂ <+ ts₂ := by
-  cases ts₁ <;> try simp_all
-  case cons T₁ ts₁' =>
-  cases ts₂ <;> try simp_all
-  case cons T₂ ts₂' =>
-  simp [joinPromotedTypes]
-  by_cases T₁ = T₂
-  case pos heq => simp [heq]; apply joinPromotedTypes_sublist_right
-  case neg hne =>
-  simp [hne]
-  by_cases T₂ ≤ T₁
-  case pos hge =>
-    simp [hge]
-    by_cases T₁ ≤ T₂
-    case pos hle => simp [hle]; calc
-      _ <+ ts₂' := by apply joinPromotedTypes_sublist_right
-      _ <+ T₂ :: ts₂' := by simp
-    case neg hnotLe => simp [hnotLe]; apply joinPromotedTypes_sublist_right
-  case neg hnotGe =>
-    simp [hnotGe]
-    by_cases T₁ ≤ T₂
-    case pos hle => simp [hle]; calc
-      _ <+ ts₂' := by apply joinPromotedTypes_sublist_right
-      _ <+ T₂ :: ts₂' := by simp
-    case neg hnotLe => simp [hnotLe]
-
-theorem isPromotionChain_join {ts₁ ts₂ : List τ} :
-    isPromotionChain ts₁ → isPromotionChain ts₂ →
-    isPromotionChain (joinPromotedTypes ts₁ ts₂) := by
-  intro hvalid₁ hvalid₂
-  apply isPromotionChain.sublist
-  case hsublist => exact joinPromotedTypes_sublist_left
-  case hvalid₂ => assumption
-
-public def join (c₁ c₂ : PromotionChain) :
-    PromotionChain :=
-  let ts := joinPromotedTypes c₁.val c₂.val
-  have hvalid : isPromotionChain ts := by
-    refine isPromotionChain_join c₁.property c₂.property
-  ⟨ts, hvalid⟩
-
-@[simp]
-public theorem join_idempotent (c : PromotionChain) :
-    c.join c = c := by
-  simp [join]
-
-@[simp]
-public theorem join.types {c₁ c₂ : PromotionChain} :
-    (c₁.join c₂).val = joinPromotedTypes c₁.val c₂.val := by
-  simp [join]
-
-/-- The join operation is idempotent (`join c c = c`). -/
-public instance instIdempotentOp_join :
-    Std.IdempotentOp (join (τ := τ)) where
-  idempotent := join_idempotent
-
-@[simp]
-public theorem join_left_empty :
-    ∀ c : PromotionChain, (∅ : PromotionChain).join c = ∅ := by
-  rintro ⟨ts, hvalid⟩
-  simp [join]
-
-@[simp]
-public theorem join_right_empty : ∀ c : PromotionChain, c.join ∅ = ∅ := by
-  rintro ⟨ts, hvalid⟩
-  simp [join]
-
-lemma bounded_skip_right {ts₁ ts₂' : List τ} {T₂ : τ}
-    (hbound : ∀ U, U ∈ ts₁ → U < T₂) :
-    joinPromotedTypes ts₁ (T₂ :: ts₂') = joinPromotedTypes ts₁ ts₂' := by
-  cases ts₁
-  case nil => simp
-  case cons T₁ ts₁' =>
-    specialize hbound T₁ (by simp)
-    simp [joinPromotedTypes.eq_1, show T₁ ≠ T₂ by order, show T₁ ≤ T₂ by order,
-      show ¬T₂ ≤ T₁ by order]
+/-- Analogous to `List.filter` but for promotion chains. -/
+public def filter (p : τ → Bool) (c : PromotionChain) : PromotionChain := .mk (c.val.filter p) $ by
+  rcases c with ⟨ts, hvalid⟩
+  rw [isPromotionChain.iff_pairwise]
+  apply List.Pairwise.filter
+  rw [←isPromotionChain.iff_pairwise]
+  simp [hvalid]
 
 /--
-Equivalent formation of joinPromotedTypes, to match the current implementation. TODO(paulberry):
-make the implementation align with the definition.
+Simplification theorem relating the behavior of `PromotionChain.filter` to that of `List.filter`.
 -/
-public theorem joinPromotedTypes.equiv {T₁ T₂ : τ} {ts₁' ts₂' : List τ}
-    (hvalid₁ : isPromotionChain (T₁::ts₁')) :
-    joinPromotedTypes (T₁ :: ts₁') (T₂ :: ts₂') =
-      if T₁ = T₂ then T₁ :: joinPromotedTypes ts₁' ts₂'
-      else
-        match decide (T₁ ≤ T₂), decide (T₂ ≤ T₁) with
-        | true, true => joinPromotedTypes ts₁' (T₂ :: ts₂')
-        | true, false => joinPromotedTypes (T₁ :: ts₁') ts₂'
-        | false, true => joinPromotedTypes ts₁' (T₂ :: ts₂')
-        | false, false => []
-    := by
-  simp [joinPromotedTypes]
-  by_cases T₁ = T₂
-  case pos heq => simp [heq]
-  case neg hne =>
-  simp [hne]
-  by_cases T₁ ≤ T₂
-  case neg => split <;> simp_all
-  case pos hle =>
-  simp [hle]
-  by_cases T₂ ≤ T₁
-  case neg => simp_all
-  case pos hge =>
-  simp [hge]
-  suffices h : ∀ U, U ∈ ts₁' → U < T₂ by rw [bounded_skip_right h]
-  intro U U_in_ts₁'
-  calc
-    _ < T₁ := isPromotionChain.head_bounds hvalid₁ U U_in_ts₁'
-    _ ≤ T₂ := by assumption
+@[simp]
+public theorem val_filter {p : τ → Bool} {c : PromotionChain} :
+    (c.filter p).val = c.val.filter p := by rfl
+
+/--
+Simplification theorem relating the behavior of `PromotionChain.filter` to that of `List.filter`.
+-/
+@[simp]
+public theorem filter_of_val {p : τ → Bool} {c : PromotionChain}
+    {hvalid : isPromotionChain (c.val.filter p)} :
+    ⟨c.val.filter p, hvalid⟩ = c.filter p := by rfl
+
+/--
+If two promotion chains contain the same the set of types, then they are equal.
+
+We prove this as a private lemma, since clients will want to rewrite using `toFinset_inj`, below.
+-/
+lemma eq_of_toFinset_eq : ∀ (c₁ c₂ : PromotionChain),
+    c₁.val.toFinset = c₂.val.toFinset → c₁ = c₂ := by
+  rintro ⟨ts₁, hvalid₁⟩ ⟨ts₂, hvalid₂⟩; simp
+  cases ts₁
+  case nil => simp; intro h; rw [←List.toFinset_eq_empty_iff]; aesop
+  case cons T₁ ts₁' =>
+    cases ts₂
+    case nil => simp
+    case cons T₂ ts₂' =>
+      simp
+      by_cases T₁ = T₂
+      case pos heq =>
+        subst heq
+        intro hinsert
+        suffices h : ts₁'.toFinset = ts₂'.toFinset by
+          have := eq_of_toFinset_eq ⟨ts₁', hvalid₁.of_cons⟩ ⟨ts₂', hvalid₂.of_cons⟩
+          simp_all
+        simp [Finset.ext_iff] at hinsert ⊢
+        intro T; specialize hinsert T
+        by_cases T = T₁
+        case neg hne => simp [hne] at hinsert; assumption
+        case pos heq => grind [hvalid₁.head_not_mem_tail, hvalid₂.head_not_mem_tail]
+      case neg hne =>
+        simp [hne]; intro hcontra; simp [Finset.ext_iff] at hcontra
+        have hT₁_lt_T₂ : T₁ < T₂ := by grind [isPromotionChain.lt_of_mem_tail hvalid₂]
+        have hT₂_lt_T₁ : T₂ < T₁ := by grind [isPromotionChain.lt_of_mem_tail hvalid₁]
+        grind
+
+/-- Two promotion chains are equal iff they contain the same set of types. -/
+public theorem toFinset_inj (c₁ c₂ : PromotionChain) :
+    c₁ = c₂ ↔ c₁.val.toFinset = c₂.val.toFinset := by
+  constructor
+  · intro rfl; rfl
+  · apply eq_of_toFinset_eq
+
+/--
+Two promotion chains are equal iff membership in one implies membership in the other (and vice
+versa).
+-/
+public theorem ext_iff_mem (c₁ c₂ : PromotionChain) :
+    c₁ = c₂ ↔ ∀ T, T ∈ c₁.val ↔ T ∈ c₂.val := by
+  rw [toFinset_inj, Finset.ext_iff]; simp
+
+/--
+The sublist relation holds between two promotion chains iff membership in the former implies
+membership in the latter.
+-/
+public theorem sublist_iff_forall_mem (c₁ c₂ : PromotionChain) :
+    c₁.val <+ c₂.val ↔ ∀ T, T ∈ c₁.val → T ∈ c₂.val := by
+  constructor
+  · intro hsublist T hT_in_c₁
+    apply hsublist.mem; assumption
+  · intro hsubset
+    suffices c₁ = c₂.filter (· ∈ c₁.val) by rw [this]; simp
+    simp_all [ext_iff_mem]
+
+/-- Define the notion of a common sublist of two promotion chains. -/
+public abbrev is_common_sublist (c c₁ c₂ : PromotionChain) : Prop :=
+    c.val <+ c₁.val ∧ c.val <+ c₂.val
+
+/--
+Define the notion of the greatest common sublist of two promotion chains.
+
+We define "greatest" in terms of the sublist operation (i.e., `c` is "greater" than `c'` iff `c'` is
+a sublist of `c`), since that gives us the sublist relations we need in the proofs below. We could,
+alternatively, have defined "greatest" strictly in terms of length, but that would have required
+additional legwork in the proofs below.
+-/
+public abbrev is_greatest_common_sublist (c c₁ c₂ : PromotionChain) : Prop :=
+  c.is_common_sublist c₁ c₂ ∧ ∀ c' : PromotionChain, c'.is_common_sublist c₁ c₂ → c'.val <+ c.val
+
+/-- For computability, we define `c₁ join c₂` as a filter of `c₁`, removing any types that are not in `c₂`. -/
+public def join (c₁ c₂ : PromotionChain) := c₁.filter (· ∈ c₂.val)
+
+/--
+An equivalent definition, which we use in the spec (and in proofs below) is that the join of two
+promotion chains is their unique greatest common sublist.
+-/
+public theorem join_is_greatest_common_sublist (c₁ c₂ : PromotionChain) :
+    (c₁.join c₂).is_greatest_common_sublist c₁ c₂ := by
+  simp [join]
+  constructor
+  · constructor
+    · simp
+    · rw [sublist_iff_forall_mem]; simp
+  · rintro c' ⟨hc'_sublist_c₁, hc'_sublist_c₂⟩
+    rw [sublist_iff_forall_mem] at hc'_sublist_c₁ hc'_sublist_c₂ ⊢
+    intro T hT_in_c'
+    simp [hc'_sublist_c₁ T hT_in_c', hc'_sublist_c₂ T hT_in_c']
+
+/--
+The computable definition of `join` above proves that a greatest common sublist always exists.
+-/
+lemma exists_is_greatest_common_sublist (c₁ c₂ : PromotionChain) :
+    ∃ c : PromotionChain, c.is_greatest_common_sublist c₁ c₂ := by
+  exists c₁.filter (· ∈ c₂.val)
+  apply join_is_greatest_common_sublist
+
+/-- The join is the unique greatest common sublist. -/
+public theorem is_greatest_common_sublist.unique (c₁ c₂ : PromotionChain) :
+    ∀ c : PromotionChain, c.is_greatest_common_sublist c₁ c₂ → c = c₁.join c₂ := by
+  intro c hc
+  let c' := c₁.join c₂
+  have hc' := join_is_greatest_common_sublist c₁ c₂
+  rw [ext_iff_mem]; grind
+
+/-- A type is in the join of two promotion chains iff it is in both chains. -/
+@[simp]
+public theorem mem_join (c₁ c₂ : PromotionChain) (T : τ) :
+    T ∈ (c₁.join c₂).val ↔ T ∈ c₁.val ∧ T ∈ c₂.val := by
+  obtain ⟨⟨hjoin_sublist_c₁, hjoin_sublist_c₂⟩, hgreatest⟩ := join_is_greatest_common_sublist c₁ c₂
+  rw [PromotionChain.sublist_iff_forall_mem] at hjoin_sublist_c₁ hjoin_sublist_c₂
+  constructor
+  · grind
+  · simp; intro hT_in_c₁ hT_in_c₂
+    specialize hgreatest (.single T) (by simp_all [is_common_sublist])
+    rw [PromotionChain.sublist_iff_forall_mem] at hgreatest; simp at hgreatest; assumption
+
+/--
+The join of two promotion chains is equal to `c` iff all types `T` satisfy the `mem_join` relation
+above.
+-/
+public theorem join_eq_iff_mem (c c₁ c₂ : PromotionChain) :
+    c₁.join c₂ = c ↔ ∀ T, T ∈ c₁.val ∧ T ∈ c₂.val ↔ T ∈ c.val := by
+  constructor
+  · intro rfl T; simp
+  · rw [ext_iff_mem]; simp
+
+/-- Joining a promotion chain with a sublist produces the sublist. -/
+@[simp]
+public theorem join_eq_left_of_sublist (c₁ c₂ : PromotionChain) :
+    c₁.val <+ c₂.val → c₁.join c₂ = c₁ := by
+  intro h; rw [join_eq_iff_mem]; intro T; grind
+
+/-- Joining a promotion chain with a sublist produces the sublist. -/
+@[simp]
+public theorem join_eq_right_of_sublist (c₁ c₂ : PromotionChain) :
+    c₂.val <+ c₁.val → c₁.join c₂ = c₂ := by
+  intro h; rw [join_eq_iff_mem]; intro T; grind
+
+/-- The join operation is idempotent (`join c c = c`). -/
+@[simp]
+public theorem join_self (c : PromotionChain) : c.join c = c := by
+  rw [join_eq_iff_mem]; grind
+
+public instance join.instIdempotentOp :
+    Std.IdempotentOp (join (τ := τ)) where
+  idempotent := join_self
+
+/-- The join operation is commutative (`c₁.join c₂ = c₂.join c₁`). -/
+public theorem join_comm (c₁ c₂ : PromotionChain) : c₁.join c₂ = c₂.join c₁ := by
+  rw [ext_iff_mem]; simp; aesop
+
+public instance join.instCommutative : Std.Commutative (join (τ := τ)) where
+  comm := join_comm
+
+/-- The join operation is associative (`(c₁.join c₂).join c₃ = c₁.join (c₂.join c₃)`) -/
+public theorem join_assoc (c₁ c₂ c₃ : PromotionChain) :
+    (c₁.join c₂).join c₃ = c₁.join (c₂.join c₃) := by
+  rw [ext_iff_mem]; simp; aesop
+
+public instance join.instAssociative : Std.Associative (join (τ := τ)) where
+  assoc := join_assoc
+
+/-- Joining with an empty promotion chain produces the empty promotion chain. -/
+@[simp]
+public theorem empty_join :
+    ∀ c : PromotionChain, (∅ : PromotionChain).join c = ∅ := by
+  intro c; rw [join_eq_iff_mem]; simp
+
+/-- Joining with an empty promotion chain produces the empty promotion chain. -/
+@[simp]
+public theorem join_empty : ∀ c : PromotionChain, c.join ∅ = ∅ := by
+  intro c; rw [join_eq_iff_mem]; simp
+
+/--
+If a promotion chain is not empty, then its list of types is not empty.
+
+This helps with grind-based proofs because it allows case splitting on whether `c = ∅`.
+-/
+@[grind =>]
+public theorem val_ne_nil_of_ne_empty {c : PromotionChain} : ¬c = ∅ → ¬c.val = [] := by
+  contrapose; rcases c; simp; intro rfl; simp
+
+/--
+If a promotion chain contains no types, then joining it with another chain produces the empty chain.
+-/
+@[simp]
+public theorem join_eq_empty_of_val_nil_left {c₁ c₂ : PromotionChain} :
+    c₁.val = [] → c₁.join c₂ = ∅ := by
+  intro h; simp [show c₁ = ∅ by grind]
+
+/--
+If a promotion chain contains no types, then joining it with another chain produces the empty chain.
+-/
+@[simp]
+public theorem join_eq_empty_of_val_nil_right {c₁ c₂ : PromotionChain} : c₂.val = [] → c₁.join c₂ = ∅ := by
+  intro h; simp [show c₂ = ∅ by grind]
 
 end «PromotionChain»
-end
-
-section
-
-/-- The join operation is *not* associative. -/
-public theorem PromotionChain.join_not_associative :
-    ¬∀ (τ : Type) [DartTypeRepr τ] (c₁ c₂ c₃ : PromotionChain (τ := τ)),
-      (c₁.join c₂).join c₃ = c₁.join (c₂.join c₃) := by
-  let Γ : DartTypeRepr SimpleType := inferInstance
-  let c₁ : PromotionChain := ⟨[Γ.Map Γ.ObjectQ Γ.int, Γ.Map Γ.int Γ.int],
-    by simp [isPromotionChain.iff_isChain, SimpleType.isSubtype]⟩
-  let c₂ : PromotionChain := ⟨[Γ.Map Γ.dynamic Γ.int, Γ.Map Γ.int Γ.int],
-    by simp [isPromotionChain.iff_isChain, SimpleType.isSubtype]⟩
-  let c₃ : PromotionChain := ⟨[Γ.Map Γ.int Γ.Object, Γ.Map Γ.int Γ.int],
-    by simp [isPromotionChain.iff_isChain, SimpleType.isSubtype]⟩
-  let c₁₂ : PromotionChain := ⟨[Γ.Map Γ.int Γ.int], by simp⟩
-  intro h
-  specialize h SimpleType c₁ c₂ c₃
-  rw [show c₁.join c₂ = c₁₂ by simp [c₁, c₂, c₁₂, PromotionChain.join,
-    PromotionChain.joinPromotedTypes, SimpleType.isSubtype]] at h
-  rw [show c₁₂.join c₃ = c₁₂ by simp [c₁₂, c₃, PromotionChain.join,
-    PromotionChain.joinPromotedTypes, SimpleType.isSubtype]] at h
-  rw [show c₂.join c₃ = ∅ by simp [c₂, c₃, PromotionChain.join,
-    PromotionChain.joinPromotedTypes, SimpleType.isSubtype]] at h
-  rw [show c₁.join ∅ = ∅ by simp] at h
-  injection h; contradiction
-
-end

--- a/resources/type-system/flow-analysis.md
+++ b/resources/type-system/flow-analysis.md
@@ -165,46 +165,14 @@ also a promotion chain.
 
 #### Joining of promotion chains
 
-The _join of promotion chains_ `c₁` and `c₂`, denoted `join(c₁, c₂)`, is defined
-as:
-- `join([], c₂) = []`
-- `join(c₁, []) = []`
-- `join([T₁]++c₁, [T₂]++c₂) =`
-  - `[T₁] ++ join(c₁, c₂)` if `T₁ = T₂`
-  - `join(c₁, c₂)` if `T₁ ≠ T₂ ∧ T₁ <: T₂ ∧ T₂ <: T₁`
-  - `join([T₁]++c₁, c₂)` if `T₁ ≠ T₂ ∧ T₁ <: T₂ ∧ ¬ T₂ <: T₁`
-  - `join(c₁, [T₂]++c₂)` if `T₁ ≠ T₂ ∧ ¬ T₁ <: T₂ ∧ T₂ <: T₁`
-  - `[]` if `T₁ ≠ T₂ ∧ ¬ T₁ <: T₂ ∧ ¬ T₂ <: T₁`
-
-By construction, the join of two promotion chains is always a subsequence of
-each of the input chains. That is, `subseq(join(c₁, c₂), c₁)` and
-`subseq(join(c₁, c₂), c₂)`. Therefore, if `c₁` and `c₂` are promotion chains,
-then so is `join(c₁, c₂)`.
+The _join of promotion chains_ `c₁` and `c₂`, denoted `join(c₁, c₂)`, is the
+maximal common subsequence of `c₁` and `c₂`.
 
 _We will use the join operation to combine the promotion chains at the point
 where two separate control flow paths rejoin (e.g., at the end of an `if`
-statement). Informally, the join of two promotion chains is a promotion chain
-that keeps whatever promotions are present in both control flow paths, with the
-exception that if at any point the types in the two chains become unrelated
-(neither `T₁ <: T₂` nor `T₂ <: T₁`), then further promotions are dropped._
+statement)._
 
-_See https://github.com/dart-lang/language/issues/4757 for a proposed
-improvement to this._
-
-The `join` relation is idempotent and commutative by construction. It is not
-associative.
-
-_For a counterexample to associativity, consider:_
-
-```
-c₁ = [Map<Object?, int>, Map<int, int>]
-c₂ = [Map<dynamic, int>, Map<int, int>]
-c₃ = [Map<int, Object>,  Map<int, int>]
-join(c₁, c₂) = [Map<int, int>]
-join(join(c₁, c₂), c₃) = [Map<int, int>]
-join(c₂, c₃) = []
-join(c₁, join(c₂, c₃)) = []
-```
+The `join` relation is idempotent, commutative, and associative.
 
 ### Models
 

--- a/resources/type-system/flow-analysis.md
+++ b/resources/type-system/flow-analysis.md
@@ -166,13 +166,24 @@ also a promotion chain.
 #### Joining of promotion chains
 
 The _join of promotion chains_ `c₁` and `c₂`, denoted `join(c₁, c₂)`, is the
-maximal common subsequence of `c₁` and `c₂`.
+greatest common subsequence of `c₁` and `c₂`.
+
+_Note: because all types in a promotion chain are ordered by strict subtyping
+(`<<:`), any types shared between `c₁` and `c₂` must appear in the exact same
+relative order in both chains. Therefore, the greatest common subsequence is
+unique (and contains all types present in both chains)._
+
+_Since `join(c₁, c₂)` is a subsequence of `c₁`, it is a promotion chain._
 
 _We will use the join operation to combine the promotion chains at the point
 where two separate control flow paths rejoin (e.g., at the end of an `if`
-statement)._
+statement). Informally, the join keeps exactly those promotions that are present
+on both conrol flow paths._
 
 The `join` relation is idempotent, commutative, and associative.
+
+_See https://github.com/dart-lang/language/issues/4757 for the discussion that
+motivated this definition._
 
 ### Models
 


### PR DESCRIPTION
Changes the flow analysis spec so that the join of promotion chains is now specified to be the greatest common subsequence of the two inputs, as discussed in https://github.com/dart-lang/language/issues/4757.

Adjusts the Lean proofs to establish:

- That a greatest common subsequence between any two promotion chains always exists.

- That the greatest common subsequence is unique. This justifies calling it "the join" of the two promotion chains, but leaves open the question of how to compute it.

- An equivalent procedural definition, based on filtering one chain and retaining those elements that are in the other. This establishes that the join operation is computable, though this definition is `O(m*n)` (where `m` and `n` are the lengths of the two chains); we will do better than that in the actual implementation.

- That the new join operation is idempotent, commutative, and associative.

I've also renamed several of the Lean theorems to better follow Mathlib conventions, and I've added some additional theorems that I believe will be useful in later proofs.

In a follow-up PR, I plan to introduce a correctness proof for the optimized implementation in
https://dart-review.googlesource.com/c/sdk/+/543721 (which is `O(m+n)` rather than `O(m*n)`, and avoids unnecessary list allocations).

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
